### PR TITLE
Cut unit runtime

### DIFF
--- a/docs/testing-v2/hook-profiling.md
+++ b/docs/testing-v2/hook-profiling.md
@@ -1,8 +1,8 @@
 # Test Suite v2 hook profiling
 
-See the committed before/after summary in [unit-test-optimization-report.html](unit-test-optimization-report.html).
+See the committed before/after summary and measurement caveats in [unit-test-optimization-report.html](unit-test-optimization-report.html).
 
-Run:
+Run from a checkout with dependencies installed:
 
 ```bash
 npm run test:v2:profile-hooks -- [vitest file/project args]
@@ -21,6 +21,10 @@ npm run test:v2:profile-hooks -- tests2/core/team-manager.test.ts
 npm run test:v2:profile-hooks -- --project v2-integration tests2/integration/gateway-fixture-leak.test.ts
 node scripts/testing-v2/profile-hooks.mjs --from-json .profiles/testing-v2/hook-profile/<run>/vitest.json
 ```
+
+## Reading the report
+
+Use `report.md` for review comments and `report.json` for scripted comparisons. Compare wall time, summed file runtime, summed file residual, slowest files, largest residual files, slowest tests, and integration cleanup counters before changing fixtures or cleanup behavior. Commit distilled summaries or HTML reports under `docs/`; do not commit raw `.profiles/` artifacts.
 
 ## Hook attribution limits
 

--- a/docs/testing-v2/unit-test-optimization-report.html
+++ b/docs/testing-v2/unit-test-optimization-report.html
@@ -5,6 +5,14 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Unit Test Optimization Report</title>
   <style>
+    :root {
+      --chart-1: oklch(0.52 0.18 250);
+      --chart-3: oklch(0.50 0.16 145);
+      --positive: oklch(0.55 0.15 145);
+      --warning: oklch(0.62 0.15 75);
+      --info: oklch(0.57 0.14 245);
+    }
+
     * {
       box-sizing: border-box;
     }
@@ -295,7 +303,7 @@
       </div>
       <h1>Before/after unit-test performance report</h1>
       <p class="lede">
-        This report summarizes the optimization work for the v2 unit-test runtime goal. The branch reduces repeated git/worktree setup, avoids unnecessary cleanup/reset work, moves pure validation out of route-level fixtures, and keeps real-spawn coverage where process fidelity matters.
+        This report summarizes the latest v2 unit-test runtime cuts. The branch restores the bundle-size guard, trims git-heavy integration fixtures, preserves conservative cleanup, defers heavy imports in focused tests, and documents how to capture the next comparable full-suite profile.
       </p>
     </header>
 
@@ -304,28 +312,28 @@
       <div class="grid">
         <article class="metric warn span-4">
           <div>
-            <strong>~10.4 min</strong>
-            <span>Baseline profiled unit run from the goal spec</span>
+            <strong>~606.5 s</strong>
+            <span>Latest full-suite profiled baseline</span>
           </div>
-          <small>858 spec files, 7,450 test executions</small>
+          <small>859 files, 7,466 tests, one bundle-size failure</small>
         </article>
         <article class="metric pass span-4">
           <div>
-            <strong>~533 s</strong>
-            <span>Implementation-gate unit-test pass on this branch</span>
+            <strong>~463.64 KB</strong>
+            <span><code>app-session-runtime</code> raw chunk after the bundle fix</span>
           </div>
-          <small>Local capped unit run also passed at ~537 s</small>
+          <small>Down from 604.43 KB and back under the 600 KB raw budget</small>
         </article>
         <article class="metric pass span-4">
           <div>
-            <strong>10 files / 89 tests</strong>
-            <span>Focused combined validation passed</span>
+            <strong>42.12 s</strong>
+            <span>Targeted merged validation run</span>
           </div>
-          <small>Build, check, browser, and e2e also passed in the latest gate</small>
+          <small>17 files / 142 tests covering the optimized hotspot paths</small>
         </article>
       </div>
       <p class="footer-note">
-        Baseline and branch timings were collected under different run modes, so the safest comparison is directional at full-suite level and exact for the per-file before/after measurements below.
+        The implementation gate passed the full workflow, including build and type-check validation. A fresh full-suite after profile is still owed from a dependency-ready checkout; no full-suite savings are inferred from the targeted run.
       </p>
     </section>
 
@@ -334,133 +342,93 @@
       <div class="grid">
         <article class="metric span-4">
           <div>
-            <strong>~8.4 min</strong>
-            <span>Summed hook worker time</span>
+            <strong>~40.9 min</strong>
+            <span>Summed module/file runtime</span>
           </div>
         </article>
         <article class="metric span-4">
           <div>
-            <strong>~5.4 min</strong>
-            <span><code>afterEach</code> worker time</span>
+            <strong>~9.6 min</strong>
+            <span>Summed hook time</span>
           </div>
-          <small>64.7% of hook time</small>
+          <small>Dominated by repo-heavy integration setup and cleanup</small>
         </article>
         <article class="metric span-4">
           <div>
-            <strong>~2.4 min</strong>
-            <span><code>beforeAll</code> worker time</span>
+            <strong>~4.4 min</strong>
+            <span>Summed collect/import time</span>
           </div>
-          <small>Mostly gateway/server graph import and heavy file fixtures</small>
+          <small>Server-heavy graphs visible in focused core/dom tests</small>
         </article>
       </div>
       <table style="margin-top: 1rem;">
         <thead>
           <tr>
-            <th>Hotspot</th>
-            <th>Baseline cost</th>
-            <th>Primary cause</th>
+            <th>Hotspot group</th>
+            <th>Baseline symptom</th>
+            <th>Optimization direction</th>
           </tr>
         </thead>
         <tbody>
           <tr>
-            <td><code>tests2/core/team-manager.test.ts</code> <code>afterEach</code></td>
-            <td>~1.9 min</td>
-            <td>Repeated real git repo/worktree creation and cleanup.</td>
+            <td>Repo/git-heavy integration suites</td>
+            <td>Base-ref, commit-file-diffs, sidebar GitHub link, multi-repo flow, and PR walkthrough were among the slowest files.</td>
+            <td>Reuse cheaper fixture shapes and move pure validation/error-shape checks out of route-level git setup.</td>
           </tr>
           <tr>
-            <td><code>tests2/integration/base-ref-api.test.ts</code> <code>afterEach</code></td>
-            <td>~26 s</td>
-            <td>Route-level validation cases recreating git-heavy fixtures.</td>
+            <td>Cleanup residuals</td>
+            <td>Repeated integration cleanup dominated several <code>afterEach</code> totals.</td>
+            <td>Track uncertain cleanup and skip no-op work only when state is known clean.</td>
           </tr>
           <tr>
-            <td><code>tests2/integration/proposal-edit-api.test.ts</code> <code>beforeAll</code></td>
-            <td>~25 s</td>
-            <td>Server-heavy import/setup path still visible after lower-risk fixes.</td>
+            <td>Collection/import hotspots</td>
+            <td>Small tests paid for broad server/gateway imports before assertions ran.</td>
+            <td>Defer heavy imports until the assertions that need them.</td>
           </tr>
         </tbody>
       </table>
     </section>
 
     <section>
-      <h2>Measured per-file wins</h2>
-      <div class="bar-list" aria-label="Per-file runtime reductions">
-        <div class="bar-row">
-          <div class="bar-label"><code>git-status-native</code></div>
-          <div class="bar-track"><div class="bar-fill" style="width: 89.3%;"></div></div>
-          <div class="delta">-89%</div>
-        </div>
-        <div class="bar-row">
-          <div class="bar-label"><code>shared-worktree-guard</code></div>
-          <div class="bar-track"><div class="bar-fill" style="width: 90.3%;"></div></div>
-          <div class="delta">-90%</div>
-        </div>
-        <div class="bar-row">
-          <div class="bar-label"><code>goal-push-safety</code></div>
-          <div class="bar-track"><div class="bar-fill" style="width: 93.9%;"></div></div>
-          <div class="delta">-94%</div>
-        </div>
-        <div class="bar-row">
-          <div class="bar-label"><code>PR walkthrough API</code></div>
-          <div class="bar-track"><div class="bar-fill" style="width: 87.1%;"></div></div>
-          <div class="delta">-87%</div>
-        </div>
-        <div class="bar-row">
-          <div class="bar-label"><code>local-sub-agent-push-policy</code></div>
-          <div class="bar-track"><div class="bar-fill" style="width: 44.2%;"></div></div>
-          <div class="delta">-44%</div>
-        </div>
-        <div class="bar-row">
-          <div class="bar-label"><code>dev-boot</code> focused path</div>
-          <div class="bar-track"><div class="bar-fill" style="width: 99.3%;"></div></div>
-          <div class="delta">-99%</div>
-        </div>
-      </div>
-
-      <table style="margin-top: 1rem;">
+      <h2>Optimized hotspot coverage</h2>
+      <table>
         <thead>
           <tr>
             <th>Area</th>
-            <th>Before</th>
-            <th>After</th>
-            <th>Change</th>
+            <th>Runtime cut</th>
+            <th>Coverage retained</th>
           </tr>
         </thead>
         <tbody>
           <tr>
-            <td><code>git-status-native</code></td>
-            <td>64.6 s</td>
-            <td>6.9 s</td>
-            <td>57.7 s faster</td>
+            <td><code>base-ref-api</code></td>
+            <td>Reduced repeated repository setup and cleanup in route-level cases.</td>
+            <td>Representative API coverage for base-ref behavior stays in integration tests.</td>
           </tr>
           <tr>
-            <td><code>shared-worktree-guard</code></td>
-            <td>51.6 s</td>
-            <td>5.0 s</td>
-            <td>46.6 s faster</td>
+            <td><code>commit-file-diffs-api</code></td>
+            <td>Trimmed git fixture setup for commit diff scenarios.</td>
+            <td>Real route behavior remains covered where file diffs depend on repository state.</td>
           </tr>
           <tr>
-            <td><code>goal-push-safety</code></td>
-            <td>52.4 s</td>
-            <td>3.2 s</td>
-            <td>49.2 s faster</td>
+            <td>Sidebar GitHub link</td>
+            <td>Reworked the fixture path used for fork/GitHub-link assertions.</td>
+            <td>Route-level smoke coverage remains for GitHub-link behavior.</td>
           </tr>
           <tr>
-            <td>PR walkthrough API</td>
-            <td>51.0 s</td>
-            <td>6.6 s</td>
-            <td>44.4 s faster</td>
+            <td>Multi-repo flow</td>
+            <td>Consolidated the multi-repo integration flow to avoid repeated heavy setup.</td>
+            <td>End-to-end multi-repo routing behavior remains represented.</td>
           </tr>
           <tr>
-            <td><code>local-sub-agent-push-policy</code></td>
-            <td>93.6 s in gate context; 7.7 s isolated</td>
-            <td>4.3 s</td>
-            <td>3.4 s faster than isolated; 89.3 s faster than gate context</td>
+            <td>PR Walkthrough</td>
+            <td>Optimized suite setup and replaced the Vite-unsafe optional module import template.</td>
+            <td>PR Walkthrough route behavior and optional module loading remain covered.</td>
           </tr>
           <tr>
-            <td><code>dev-boot</code></td>
-            <td>20.3 s isolated</td>
-            <td>~0.14 s focused; ~1.3 s full file</td>
-            <td>Large setup/import trim while preserving coverage</td>
+            <td>Bundle-size guard</td>
+            <td><code>app-session-runtime</code> dropped from 604.43 KB raw to ~463.64 KB raw.</td>
+            <td>The 600 KB raw chunk budget remains unchanged.</td>
           </tr>
         </tbody>
       </table>
@@ -470,20 +438,20 @@
       <h2>What changed</h2>
       <div class="grid">
         <article class="span-6 status">
+          <h3>Bundle boundary</h3>
+          <p class="note"><code>header-toast</code> was split away from the app render graph so session/runtime callers no longer pull <code>render.ts</code> into <code>app-session-runtime</code>.</p>
+        </article>
+        <article class="span-6 status">
           <h3>Git and worktree fixtures</h3>
-          <p class="note">Repeated real-git setup was replaced or narrowed where tests were validating API/status behavior rather than git mechanics. Real worktree coverage remains for the cases that require it.</p>
+          <p class="note">Hotspot integration suites now use cheaper fixture shapes while keeping representative route-level coverage for behavior that depends on real repository state.</p>
         </article>
         <article class="span-6 status">
-          <h3>Integration harness cleanup</h3>
-          <p class="note">Dirty/versioned cleanup avoids expensive no-op sweeps and default-project resets, while final leak assertions and conservative fallback cleanup remain in place.</p>
+          <h3>Cleanup correctness</h3>
+          <p class="note">The in-process harness tracks uncertain cleanup and keeps regression coverage for sweeps that must still run when state is uncertain.</p>
         </article>
         <article class="span-6 status">
-          <h3>Validation extraction</h3>
-          <p class="note">Pure grammar and error-shape checks moved out of expensive route-level fixtures, leaving representative integration coverage for real repository behavior.</p>
-        </article>
-        <article class="span-6 status">
-          <h3>Failed-suite fixes</h3>
-          <p class="note">Branch validation includes fixes needed to keep the optimized suites green under focused and broader gate runs.</p>
+          <h3>Import deferral</h3>
+          <p class="note">Core/dom tests that only need narrow assertions defer server-heavy imports until the assertion path needs them.</p>
         </article>
       </div>
     </section>
@@ -491,28 +459,60 @@
     <section>
       <h2>Validation evidence</h2>
       <div class="status-grid">
-        <div class="status"><b>Passed:</b> implementation-gate <code>npm run test:unit</code> at ~533 s.</div>
-        <div class="status"><b>Passed:</b> local capped unit run at ~537 s.</div>
-        <div class="status"><b>Passed:</b> latest gate build/check/browser/e2e validation.</div>
-        <div class="status"><b>Passed:</b> focused combined validation covering 10 files and 89 tests.</div>
+        <div class="status"><b>Passed:</b> implementation gate full workflow after the merged runtime-cut changes.</div>
+        <div class="status"><b>Passed:</b> targeted merged run covering 17 hotspot files / 142 tests in 42.12 s.</div>
+        <div class="status"><b>Passed:</b> <code>npm run build</code> during implementation validation.</div>
+        <div class="status"><b>Passed:</b> <code>npm run check</code> during implementation validation.</div>
       </div>
-      <p class="footer-note">The branch did not land a Vitest server/verification graph prebundle. The safer outcome was to keep source execution and bank the fixture, cleanup, and process-spawn reductions.</p>
+      <p class="footer-note">A documentation-agent attempt to rerun the profiler failed before collection because this worktree could not resolve the <code>vitest</code> package. Treat that as an environment caveat, not a test result.</p>
+    </section>
+
+    <section>
+      <h2>Repeatable profiling workflow</h2>
+      <p class="lede">Run from a checkout with dependencies installed. Keep raw artifacts under <code>.profiles/</code>; commit only distilled docs or reports.</p>
+      <table style="margin-top: 1rem;">
+        <thead>
+          <tr>
+            <th>Goal</th>
+            <th>Command</th>
+            <th>Use</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Full suite timing</td>
+            <td><code>npm run test:v2:profile-hooks -- --top 30</code></td>
+            <td>Primary before/after comparison for wall time, summed file runtime, residuals, and cleanup counters.</td>
+          </tr>
+          <tr>
+            <td>Single integration hotspot</td>
+            <td><code>npm run test:v2:profile-hooks -- --project v2-integration tests2/integration/base-ref-api.test.ts --top 20</code></td>
+            <td>Focused validation while preserving the profiler's report shape.</td>
+          </tr>
+          <tr>
+            <td>Parse an existing JSON artifact</td>
+            <td><code>node scripts/testing-v2/profile-hooks.mjs --from-json .profiles/testing-v2/hook-profile/&lt;run&gt;/vitest.json --top 30</code></td>
+            <td>Regenerate <code>report.md</code> / <code>report.json</code> without rerunning tests.</td>
+          </tr>
+        </tbody>
+      </table>
+      <p class="footer-note">Vitest JSON does not provide stable per-hook timings. The profiler's file residual is directional and may include hooks, module evaluation, fixtures, and reporter overhead.</p>
     </section>
 
     <section class="callout">
-      <h2>Remaining opportunities</h2>
+      <h2>Remaining measurement caveats</h2>
       <ul>
-        <li>Continue reducing <code>proposal-edit-api</code> <code>beforeAll</code> cost, which remains a visible server-heavy setup hotspot.</li>
-        <li>Audit remaining real git/worktree files for cases that can reuse fixture repos or move pure semantics to cheaper unit coverage.</li>
-        <li>Add optional CI budget thresholds once a stable post-optimization baseline is available on the target runner class.</li>
-        <li>Trend integration harness cleanup stats in future hook-profile reports: snapshots, sweeps, skipped sweeps, default resets/restores, and entity deletes.</li>
+        <li>The targeted 42.12 s run is not a substitute for a full-suite after profile.</li>
+        <li>Machine load affects wall-clock comparisons; use summed file runtime and residuals alongside wall time.</li>
+        <li>Cleanup counters are available only for integration harness paths that emit stats into <code>BOBBIT_V2_HOOK_PROFILE_DIR</code>.</li>
+        <li>Do not skip uncertain cleanup to improve timings; leak detection and conservative sweeps are part of the invariant.</li>
       </ul>
     </section>
 
     <section>
       <h2>Conclusion</h2>
       <p class="lede">
-        The branch addresses the measured hotspots without removing leak safety or real process fidelity. The strongest wins are in git/worktree-heavy files and no-op cleanup avoidance; remaining work is concentrated in server-heavy setup paths and broader trend/budget automation.
+        The branch restores the bundle guard and addresses the measured git/repo, cleanup, and import hotspots without weakening coverage or leak safety. The next durable deliverable is an apples-to-apples full-suite after profile from a dependency-ready checkout.
       </p>
     </section>
   </main>

--- a/src/app/api.ts
+++ b/src/app/api.ts
@@ -19,7 +19,7 @@ import { clearGoalChildrenFetchedCache } from "./render-helpers.js";
 import { needsHumanAttentionOnIdleTransition, needsImmediateHumanAttention } from "./notification-policy.js";
 import { errorFromResponse, errorDetails } from "./error-helpers.js";
 import { dispatchGateStatusCacheUpdated } from "./gate-status-events.js";
-import { showHeaderToast } from "./render.js";
+import { showHeaderToast } from "./header-toast.js";
 export { errorFromResponse, errorDetails };
 // `dialogs.ts` is heavy (~90 kB) and only needed once the user opens a dialog;
 // route these through `dialogs-lazy.js` so it stays out of the eager

--- a/src/app/header-toast.ts
+++ b/src/app/header-toast.ts
@@ -1,0 +1,63 @@
+import { icon } from "@mariozechner/mini-lit";
+import { html } from "lit";
+import { X } from "lucide";
+import { renderApp } from "./state.js";
+
+// Header-only "Link copied" toast — separate state + testid so it doesn't
+// collide with the proposal-toast testid used by the proposal panels' own
+// toast (the session header is rendered alongside open proposal panels).
+let _headerToastText = "";
+let _headerToastTimer: ReturnType<typeof setTimeout> | null = null;
+export function showHeaderToast(text: string): void {
+	_headerToastText = text;
+	if (_headerToastTimer) clearTimeout(_headerToastTimer);
+	_headerToastTimer = setTimeout(() => {
+		_headerToastText = "";
+		_headerToastTimer = null;
+		renderApp();
+	}, 2500);
+	renderApp();
+}
+
+// Persistent launcher feedback — deliberately NOT sharing `_headerToastText`
+// (which auto-clears after 2500ms). A launcher `pending` state must stay visible
+// until the launch resolves; an `error` must persist until the user dismisses it.
+let _launcherFeedback: { kind: "pending" | "error"; message: string } | null = null;
+
+export function headerToast() {
+	const transient = _headerToastText
+		? html`<div class="review-toast" data-testid="header-toast">${_headerToastText}</div>`
+		: "";
+	const launcher = launcherFeedbackToast();
+	if (!transient && !launcher) return "";
+	return html`${transient}${launcher}`;
+}
+
+function launcherFeedbackToast() {
+	if (!_launcherFeedback) return "";
+	const { kind, message } = _launcherFeedback;
+	if (kind === "pending") {
+		return html`<div class="review-toast launcher-feedback" data-testid="launcher-feedback" data-kind="pending">
+			<svg class="animate-spin shrink-0" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 12a9 9 0 1 1-6.219-8.56"></path></svg>
+			<span>${message}</span>
+		</div>`;
+	}
+	return html`<div class="review-toast launcher-feedback" data-testid="launcher-feedback" data-kind="error">
+		<span>${message}</span>
+		<button type="button" class="launcher-feedback-dismiss" data-testid="launcher-feedback-dismiss" title="Dismiss"
+			@click=${() => { _launcherFeedback = null; renderApp(); }}>${icon(X, "xs")}</button>
+	</div>`;
+}
+
+window.addEventListener("bobbit-launcher-feedback", (event: Event) => {
+	const detail = (event as CustomEvent<{ kind?: string; message?: string }>).detail;
+	if (!detail) return;
+	if (detail.kind === "resolved") {
+		_launcherFeedback = null;
+		renderApp();
+		return;
+	}
+	if ((detail.kind !== "pending" && detail.kind !== "error") || !detail.message) return;
+	_launcherFeedback = { kind: detail.kind, message: detail.message };
+	renderApp();
+});

--- a/src/app/render.ts
+++ b/src/app/render.ts
@@ -22,6 +22,8 @@ import {
 	type Project,
 } from "./state.js";
 import { fetchProjects, gatewayFetch, retryLoadSessions, resumeGoalWithDialog, isGoalPauseResumeActionPending } from "./api.js";
+import { headerToast, showHeaderToast } from "./header-toast.js";
+export { showHeaderToast } from "./header-toast.js";
 import { clearAllAnnotations, getDocumentAnnotationCount, markReviewSubmitted, flushPendingWrites } from "../ui/components/review/AnnotationStore.js";
 import { loadReviewSources } from "./review-sources-lazy.js";
 import { backToSessions, createAndConnectSession } from "./session-manager.js";
@@ -790,64 +792,6 @@ function renderMobileLanding() {
 		</div>
 	`;
 }
-
-// Header-only "Link copied" toast — separate state + testid so it doesn't
-// collide with the proposal-toast testid used by the proposal panels' own
-// toast (the session header is rendered alongside open proposal panels).
-let _headerToastText = "";
-let _headerToastTimer: ReturnType<typeof setTimeout> | null = null;
-export function showHeaderToast(text: string): void {
-	_headerToastText = text;
-	if (_headerToastTimer) clearTimeout(_headerToastTimer);
-	_headerToastTimer = setTimeout(() => {
-		_headerToastText = "";
-		_headerToastTimer = null;
-		renderApp();
-	}, 2500);
-	renderApp();
-}
-// Persistent launcher feedback — deliberately NOT sharing `_headerToastText`
-// (which auto-clears after 2500ms). A launcher `pending` state must stay visible
-// until the launch resolves; an `error` must persist until the user dismisses it.
-let _launcherFeedback: { kind: "pending" | "error"; message: string } | null = null;
-
-function headerToast() {
-	const transient = _headerToastText
-		? html`<div class="review-toast" data-testid="header-toast">${_headerToastText}</div>`
-		: "";
-	const launcher = launcherFeedbackToast();
-	if (!transient && !launcher) return "";
-	return html`${transient}${launcher}`;
-}
-
-function launcherFeedbackToast() {
-	if (!_launcherFeedback) return "";
-	const { kind, message } = _launcherFeedback;
-	if (kind === "pending") {
-		return html`<div class="review-toast launcher-feedback" data-testid="launcher-feedback" data-kind="pending">
-			<svg class="animate-spin shrink-0" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 12a9 9 0 1 1-6.219-8.56"></path></svg>
-			<span>${message}</span>
-		</div>`;
-	}
-	return html`<div class="review-toast launcher-feedback" data-testid="launcher-feedback" data-kind="error">
-		<span>${message}</span>
-		<button type="button" class="launcher-feedback-dismiss" data-testid="launcher-feedback-dismiss" title="Dismiss"
-			@click=${() => { _launcherFeedback = null; renderApp(); }}>${icon(X, "xs")}</button>
-	</div>`;
-}
-
-window.addEventListener("bobbit-launcher-feedback", (event: Event) => {
-	const detail = (event as CustomEvent<{ kind?: string; message?: string }>).detail;
-	if (!detail) return;
-	if (detail.kind === "resolved") {
-		_launcherFeedback = null;
-		renderApp();
-		return;
-	}
-	if ((detail.kind !== "pending" && detail.kind !== "error") || !detail.message) return;
-	_launcherFeedback = { kind: detail.kind, message: detail.message };
-	renderApp();
-});
 
 interface OpenHeaderSessionActionsPopover {
 	sessionId: string;

--- a/src/app/session-manager.ts
+++ b/src/app/session-manager.ts
@@ -27,7 +27,7 @@ import { showConnectionError, confirmAction, showOAuthExpiryModal } from "./dial
 import { teardownMobileScrollTracking } from "./mobile-header.js";
 import { storage } from "./storage.js";
 import { markSessionVisited } from "./render-helpers.js";
-import { showHeaderToast } from "./render.js";
+import { showHeaderToast } from "./header-toast.js";
 import { setSelectedWorkflowId, showProposalToast, resetProposalAnnCount, resetProjectProposalPanel } from "./proposal-panels-lazy.js";
 import { clearProposalAnnotations } from "../ui/components/review/proposal-annotations.js";
 import { loadReviewSources } from "./review-sources-lazy.js";

--- a/src/app/settings-page.ts
+++ b/src/app/settings-page.ts
@@ -8,7 +8,7 @@ import { Select, type SelectOption } from "@mariozechner/mini-lit/dist/Select.js
 import { html } from "lit";
 import { live } from "lit/directives/live.js";
 import { ArrowLeft, Brain, Bug, Check, FlaskConical, Image as ImageIcon, Loader2, Plus, RotateCcw, Sparkles, Trash2, X } from "lucide";
-import { showHeaderToast } from "./render.js";
+import { showHeaderToast } from "./header-toast.js";
 import {
 	getShortcuts,
 	formatBinding,

--- a/src/app/sidebar.ts
+++ b/src/app/sidebar.ts
@@ -20,7 +20,7 @@ import {
 	type Goal,
 	type Project,
 } from "./state.js";
-import { showHeaderToast } from "./render.js";
+import { showHeaderToast } from "./header-toast.js";
 import { HEADQUARTERS_PROJECT_ID, isHeadquartersProject, projectIconComponent, projectIconKind, projectIconTestId } from "./headquarters.js";
 import { createAndConnectSession, connectToSession } from "./session-manager.js";
 import { cwdCombobox } from "./cwd-combobox.js";

--- a/src/server/pr-walkthrough/routes.ts
+++ b/src/server/pr-walkthrough/routes.ts
@@ -993,9 +993,19 @@ function typedRouteError(err: unknown): { status: number; extra: Record<string, 
 	};
 }
 
+const optionalPrModuleLoaders: Record<string, () => Promise<any>> = {
+	"card-synthesis": () => import("./card-synthesis.js"),
+	"export-mapper": () => import("./export-mapper.js"),
+	"git-changeset": () => import("./git-changeset.js"),
+	"github-adapter": () => import("./github-adapter.js"),
+	"walkthrough-store": () => import("./walkthrough-store.js"),
+};
+
 async function optionalPrModule(name: string): Promise<any | undefined> {
+	const load = optionalPrModuleLoaders[name];
+	if (!load) return undefined;
 	try {
-		return await import(`./${name}.js`);
+		return await load();
 	} catch (err: any) {
 		if (err?.code === "ERR_MODULE_NOT_FOUND" || /Cannot find module|module not found/i.test(String(err?.message))) return undefined;
 		throw err;

--- a/tests2/core/gateway-deps-default-real.test.ts
+++ b/tests2/core/gateway-deps-default-real.test.ts
@@ -2,7 +2,7 @@ import os from "node:os";
 import path from "node:path";
 import fs from "node:fs";
 import { afterEach, describe, expect, it } from "vitest";
-import { createGateway, defaultRpcBridgeFactory, realClock, realCommandRunner, realFetch, realFs } from "../../src/server/server.js";
+import { defaultRpcBridgeFactory, realClock, realCommandRunner, realFetch, realFs, resolveGatewayDeps } from "../../src/server/gateway-deps.js";
 import { getRegisteredRpcBridgeFactory, registerRpcBridgeFactory, type RpcBridgeFactory } from "../../src/server/agent/rpc-bridge.js";
 
 import { guardProcessEnv } from "./helpers/env-guard.js";
@@ -23,21 +23,17 @@ afterEach(() => {
 });
 
 describe("GatewayDeps default-real wiring", () => {
-	it("resolves real deps when createGateway is called without deps", async () => {
-		const dir = setTempBobbitDir();
-		const gateway = createGateway({ host: "127.0.0.1", port: 0, authToken: "token", defaultCwd: dir });
-		try {
-			expect(gateway.deps.clock).toBe(realClock);
-			expect(gateway.deps.commandRunner).toBe(realCommandRunner);
-			expect(gateway.deps.fetchImpl).toBe(realFetch);
-			expect(gateway.deps.fsImpl).toBe(realFs);
-			expect(gateway.deps.agentBridgeFactory).toBe(defaultRpcBridgeFactory);
-		} finally {
-			await gateway.shutdown();
-		}
+	it("resolves real deps when no deps are provided", () => {
+		const deps = resolveGatewayDeps();
+		expect(deps.clock).toBe(realClock);
+		expect(deps.commandRunner).toBe(realCommandRunner);
+		expect(deps.fetchImpl).toBe(realFetch);
+		expect(deps.fsImpl).toBe(realFs);
+		expect(deps.agentBridgeFactory).toBe(defaultRpcBridgeFactory);
 	});
 
 	it("honors the deprecated registerRpcBridgeFactory alias when no explicit dep is provided", async () => {
+		const { createGateway } = await import("../../src/server/server.js");
 		const dir = setTempBobbitDir();
 		const aliasFactory: RpcBridgeFactory = () => null;
 		registerRpcBridgeFactory(aliasFactory);
@@ -51,6 +47,7 @@ describe("GatewayDeps default-real wiring", () => {
 	});
 
 	it("explicit agentBridgeFactory overrides the alias and is restored on shutdown", async () => {
+		const { createGateway } = await import("../../src/server/server.js");
 		const dir = setTempBobbitDir();
 		const aliasFactory: RpcBridgeFactory = () => null;
 		const explicitFactory: RpcBridgeFactory = () => null;

--- a/tests2/core/headquarters-no-worktree-runtime.test.ts
+++ b/tests2/core/headquarters-no-worktree-runtime.test.ts
@@ -8,7 +8,7 @@
 import { guardProcessEnv } from "./helpers/env-guard.js";
 guardProcessEnv();
 
-import { afterEach, describe, it, vi } from "vitest";
+import { afterEach, beforeAll, describe, it, vi } from "vitest";
 import assert from "node:assert/strict";
 import fs from "node:fs";
 import path from "node:path";
@@ -29,22 +29,36 @@ process.env.BOBBIT_AGENT_DIR = agentDir;
 process.env.BOBBIT_TEST_NO_REMOTE = "1";
 process.env.BOBBIT_TEST_NO_EXTERNAL = "1";
 
-const { HEADQUARTERS_PROJECT_ID, HEADQUARTERS_PROJECT_NAME, ProjectRegistry } = await import("../../src/server/agent/project-registry.ts");
-const { ProjectContextManager } = await import("../../src/server/agent/project-context-manager.ts");
-const { GoalManager } = await import("../../src/server/agent/goal-manager.ts");
-const { GoalStore } = await import("../../src/server/agent/goal-store.ts");
-const { SessionManager } = await import("../../src/server/agent/session-manager.ts");
-const { StaffManager } = await import("../../src/server/agent/staff-manager.ts");
-const { registerRpcBridgeFactory } = await import("../../src/server/agent/rpc-bridge.ts");
-const { initPromptDirs } = await import("../../src/server/agent/system-prompt.ts");
-const { resetAgentDirStateForTests } = await import("../../src/server/bobbit-dir.ts");
-const { loadOrCreateToken } = await import("../../src/server/auth/token.ts");
-loadOrCreateToken(); // seed admin token so direct-agent spawns find it (mirrors server boot)
+let HEADQUARTERS_PROJECT_ID = "headquarters";
+let HEADQUARTERS_PROJECT_NAME = "Headquarters";
+let ProjectRegistry: any;
+let ProjectContextManager: any;
+let GoalManager: any;
+let GoalStore: any;
+let SessionManager: any;
+let StaffManager: any;
+let registerRpcBridgeFactory: (factory: any) => void = () => {};
 
-// Ensure the agent-dir singleton reflects THIS file's BOBBIT_DIR even when a
-// fork-mate initialised it first (isolate:false shared fork).
-resetAgentDirStateForTests?.();
-initPromptDirs(stateDir);
+beforeAll(async () => {
+	const projectRegistry = await import("../../src/server/agent/project-registry.ts");
+	HEADQUARTERS_PROJECT_ID = projectRegistry.HEADQUARTERS_PROJECT_ID;
+	HEADQUARTERS_PROJECT_NAME = projectRegistry.HEADQUARTERS_PROJECT_NAME;
+	ProjectRegistry = projectRegistry.ProjectRegistry;
+	({ ProjectContextManager } = await import("../../src/server/agent/project-context-manager.ts"));
+	({ GoalManager } = await import("../../src/server/agent/goal-manager.ts"));
+	({ GoalStore } = await import("../../src/server/agent/goal-store.ts"));
+	({ SessionManager } = await import("../../src/server/agent/session-manager.ts"));
+	({ StaffManager } = await import("../../src/server/agent/staff-manager.ts"));
+	({ registerRpcBridgeFactory } = await import("../../src/server/agent/rpc-bridge.ts"));
+	const { initPromptDirs } = await import("../../src/server/agent/system-prompt.ts");
+	const { resetAgentDirStateForTests } = await import("../../src/server/bobbit-dir.ts");
+	const { loadOrCreateToken } = await import("../../src/server/auth/token.ts");
+	loadOrCreateToken(); // seed admin token so direct-agent spawns find it (mirrors server boot)
+	// Ensure the agent-dir singleton reflects THIS file's BOBBIT_DIR even when a
+	// fork-mate initialised it first (isolate:false shared fork).
+	resetAgentDirStateForTests?.();
+	initPromptDirs(stateDir);
+});
 
 const managers: any[] = [];
 

--- a/tests2/core/pr-walkthrough-export-mapper.test.ts
+++ b/tests2/core/pr-walkthrough-export-mapper.test.ts
@@ -322,6 +322,30 @@ describe("PR walkthrough GitHub adapter", () => {
 		);
 	});
 
+	it("preserves GitHub permission errors and bearer auth without the REST gateway", async () => {
+		let authorization: string | undefined;
+		await assert.rejects(
+			resolveGithubPr({
+				prUrl: "https://github.com/acme/widgets/pull/42",
+				apiBaseUrl: "https://api.github.test",
+				token: "mock-token",
+				fetch: async (_url, init) => {
+					authorization = init?.headers?.Authorization;
+					return {
+						ok: false,
+						status: 403,
+						statusText: "Forbidden",
+						headers: { get: (name: string) => name.toLowerCase() === "x-ratelimit-remaining" ? "5" : null },
+						json: async () => ({ message: "Forbidden" }),
+						text: async () => JSON.stringify({ message: "Forbidden" }),
+					};
+				},
+			}),
+			(error: unknown) => error instanceof GithubPrAdapterError && error.status === 403 && error.code === "github_permission_denied" && error.warnings.some(warning => warning.code === "github_permission_denied"),
+		);
+		assert.equal(authorization, "Bearer mock-token");
+	});
+
 	it("parses GitHub PR URLs and origin remotes", () => {
 		assert.deepEqual(parseGithubPrReference({ prUrl: "https://github.com/SuuBro/bobbit/pull/1842" }), {
 			owner: "SuuBro",

--- a/tests2/core/pr-walkthrough-local-resolver.test.ts
+++ b/tests2/core/pr-walkthrough-local-resolver.test.ts
@@ -1,0 +1,119 @@
+import { EventEmitter } from "node:events";
+import { PassThrough } from "node:stream";
+import type { ChildProcess } from "node:child_process";
+import { describe, expect, it } from "vitest";
+
+import { resolveLocalChangeset } from "../../src/server/pr-walkthrough/git-changeset.ts";
+import type { CommandRunner, ExecFileResult } from "../../src/server/gateway-deps.ts";
+
+const BASE_SHA = "a".repeat(40);
+const HEAD_SHA = "b".repeat(40);
+
+function fakeGitRunner(options: {
+	diff?: string;
+	nameStatus?: string;
+	shortstat?: string;
+	failBase?: boolean;
+	failHead?: boolean;
+} = {}): CommandRunner {
+	return {
+		async execFile(file, args): Promise<ExecFileResult> {
+			expect(file).toBe("git");
+			if (args[0] === "rev-parse") {
+				const ref = String(args[2] ?? "");
+				if (ref.includes("not-a-sha") || (options.failBase && ref.startsWith("base")) || (options.failHead && ref.startsWith("head"))) {
+					throw new Error(`bad ref: ${ref}`);
+				}
+				return { stdout: ref.startsWith("head") || ref.startsWith(HEAD_SHA) ? `${HEAD_SHA}\n` : `${BASE_SHA}\n`, stderr: "" };
+			}
+			if (args.includes("--shortstat")) return { stdout: options.shortstat ?? "", stderr: "" };
+			if (args.includes("--name-status")) return { stdout: options.nameStatus ?? "", stderr: "" };
+			throw new Error(`unexpected git execFile args: ${args.join(" ")}`);
+		},
+		spawn(file, args) {
+			expect(file).toBe("git");
+			expect(args).toContain("diff");
+			const child = new EventEmitter() as ChildProcess;
+			const stdout = new PassThrough();
+			const stderr = new PassThrough();
+			let closed = false;
+			const close = () => {
+				if (closed) return;
+				closed = true;
+				child.emit("close", 0, null);
+			};
+			Object.assign(child, {
+				stdout,
+				stderr,
+				killed: false,
+				kill: () => {
+					(child as any).killed = true;
+					stdout.end();
+					stderr.end();
+					queueMicrotask(close);
+					return true;
+				},
+			});
+			queueMicrotask(() => {
+				if (closed) return;
+				stdout.write(options.diff ?? "");
+				if ((child as any).killed) return;
+				stdout.end();
+				stderr.end();
+				close();
+			});
+			return child;
+		},
+	};
+}
+
+describe("PR walkthrough local resolver", () => {
+	it("rejects invalid base refs before parsing diffs", async () => {
+		await expect(resolveLocalChangeset({
+			cwd: "/repo",
+			baseSha: "not-a-sha",
+			headSha: "head",
+			commandRunner: fakeGitRunner(),
+		})).rejects.toThrow(/Invalid baseSha ref "not-a-sha"/);
+	});
+
+	it("resolves empty local diffs without review cards", async () => {
+		const result = await resolveLocalChangeset({
+			cwd: "/repo",
+			baseSha: "base",
+			headSha: "head",
+			commandRunner: fakeGitRunner(),
+		});
+
+		expect(result.changeset.filesChanged).toBe(0);
+		expect(result.files).toHaveLength(0);
+		expect(result.warnings).toHaveLength(0);
+	});
+
+	it("returns truncation warnings for oversized local diffs without relying on real git", async () => {
+		const largeDiff = [
+			"diff --git a/large.txt b/large.txt",
+			"index 1111111..2222222 100644",
+			"--- a/large.txt",
+			"+++ b/large.txt",
+			"@@ -1 +1,200 @@",
+			...Array.from({ length: 200 }, (_, index) => `+line ${index} ${"x".repeat(24)}`),
+			"",
+		].join("\n");
+
+		const result = await resolveLocalChangeset({
+			cwd: "/repo",
+			baseSha: "base",
+			headSha: "head",
+			limits: { maxDiffBytes: 512 },
+			commandRunner: fakeGitRunner({
+				diff: largeDiff,
+				nameStatus: "M\tlarge.txt\n",
+				shortstat: "1 file changed, 200 insertions(+)\n",
+			}),
+		});
+
+		expect(result.warnings.some(warning => warning.code === "diff-truncated")).toBe(true);
+		expect(result.changeset.filesChanged).toBe(1);
+	});
+});

--- a/tests2/core/pr-walkthrough-trusted-hosts.test.ts
+++ b/tests2/core/pr-walkthrough-trusted-hosts.test.ts
@@ -214,6 +214,10 @@ describe("parseGithubRef enterprise resolve path", () => {
 		assert.equal(gh?.number, "3");
 		assert.equal(parseGithubRefForTesting("https://github.example.com/acme/widgets/pull/3", undefined, "/tmp", []), undefined);
 	});
+
+	it("drops unsafe PR metadata URLs before local-SHA GitHub fallback persists them", () => {
+		assert.equal(parseGithubRefForTesting("javascript:alert(1)", 42, "/tmp", []), undefined);
+	});
 });
 
 describe("resolveGithubPr host routing and token scoping", () => {

--- a/tests2/core/runSubgoalStep-dependsOn-blocking.test.ts
+++ b/tests2/core/runSubgoalStep-dependsOn-blocking.test.ts
@@ -20,10 +20,17 @@
  *   - When all of a step's deps are already merged, it spawns immediately
  *     (never blocked).
  */
-import { describe, it, afterAll } from "vitest";
+import { describe, it, afterAll, beforeAll } from "vitest";
 import assert from "node:assert/strict";
 
-import { buildFixture, buildActive, buildSubgoalStep } from "../../tests/helpers/run-subgoal-step-fixture.ts";
+type RunSubgoalFixtureModule = typeof import("../../tests/helpers/run-subgoal-step-fixture.ts");
+let buildFixture: RunSubgoalFixtureModule["buildFixture"];
+let buildActive: RunSubgoalFixtureModule["buildActive"];
+let buildSubgoalStep: RunSubgoalFixtureModule["buildSubgoalStep"];
+
+beforeAll(async () => {
+	({ buildFixture, buildActive, buildSubgoalStep } = await import("../../tests/helpers/run-subgoal-step-fixture.ts"));
+});
 
 const sleep = (ms: number) => new Promise(r => setTimeout(r, ms));
 

--- a/tests2/core/runSubgoalStep-merge-then-archive.test.ts
+++ b/tests2/core/runSubgoalStep-merge-then-archive.test.ts
@@ -14,10 +14,17 @@
  *   - Return passed=false; do NOT auto-archive, do NOT auto-resolve
  *     (anti-pattern §9). Output references manual recovery.
  */
-import { describe, it, afterAll } from "vitest";
+import { describe, it, afterAll, beforeAll } from "vitest";
 import assert from "node:assert/strict";
 
-import { buildFixture, buildActive, buildSubgoalStep } from "../../tests/helpers/run-subgoal-step-fixture.ts";
+type RunSubgoalFixtureModule = typeof import("../../tests/helpers/run-subgoal-step-fixture.ts");
+let buildFixture: RunSubgoalFixtureModule["buildFixture"];
+let buildActive: RunSubgoalFixtureModule["buildActive"];
+let buildSubgoalStep: RunSubgoalFixtureModule["buildSubgoalStep"];
+
+beforeAll(async () => {
+	({ buildFixture, buildActive, buildSubgoalStep } = await import("../../tests/helpers/run-subgoal-step-fixture.ts"));
+});
 
 describe("runSubgoalStep — merge + archive flow", () => {
 	it("ready-to-merge passes → mergeChild + teardownTeam + archiveAfterMerge in order", async () => {

--- a/tests2/core/shared-worktree-guard-repro.test.ts
+++ b/tests2/core/shared-worktree-guard-repro.test.ts
@@ -26,12 +26,12 @@ process.env.BOBBIT_TEST_NO_PUSH = "1";
 process.env.BOBBIT_SKIP_NPM_CI = "1";
 
 const execFile = promisify(execFileCb);
-const { SessionManager } = await import("../../src/server/agent/session-manager.ts");
-const { SessionStore } = await import("../../src/server/agent/session-store.ts");
-const { GoalManager } = await import("../../src/server/agent/goal-manager.ts");
-const { GoalStore } = await import("../../src/server/agent/goal-store.ts");
-const { handleSetupFailure } = await import("../../src/server/agent/session-setup.ts");
-const { initPromptDirs } = await import("../../src/server/agent/system-prompt.ts");
+let SessionManager: any;
+let SessionStore: any;
+let GoalManager: any;
+let GoalStore: any;
+let handleSetupFailure: any;
+let initPromptDirs: (stateDir: string) => void;
 
 type TestRepo = { repo: string; tmp: string };
 
@@ -149,6 +149,12 @@ function cleanupManager(manager: any): void {
 
 describe("shared worktree guard reproductions", () => {
 	beforeAll(async () => {
+		({ SessionManager } = await import("../../src/server/agent/session-manager.ts"));
+		({ SessionStore } = await import("../../src/server/agent/session-store.ts"));
+		({ GoalManager } = await import("../../src/server/agent/goal-manager.ts"));
+		({ GoalStore } = await import("../../src/server/agent/goal-store.ts"));
+		({ handleSetupFailure } = await import("../../src/server/agent/session-setup.ts"));
+		({ initPromptDirs } = await import("../../src/server/agent/system-prompt.ts"));
 		realRepoTemplate = await createRepoTemplate();
 	});
 

--- a/tests2/core/verification-command-restart-lifecycle.test.ts
+++ b/tests2/core/verification-command-restart-lifecycle.test.ts
@@ -4,15 +4,23 @@
 // Review: unparsed import name in `node:test` import list | test-context helper (t.skip/t.todo/...) — vitest has no per-context equivalent
 
 import { spawn, type ChildProcess } from "node:child_process";
-import { test, type TestContext, onTestFinished } from "vitest";
+import { beforeAll, test, type TestContext, onTestFinished } from "vitest";
 import assert from "node:assert/strict";
 import fs from "node:fs";
 import path from "node:path";
 
 import { makeTmpDir } from "../../tests/helpers/tmp.ts";
-import { VerificationHarness, type ActiveVerification } from "../../src/server/agent/verification-harness.js";
-import { killTreeByPid } from "../../src/server/agent/spawn-tree.js";
-import { GIT_BASH } from "../../src/server/agent/shell-util.js";
+import type { ActiveVerification } from "../../src/server/agent/verification-harness.js";
+
+let VerificationHarness: typeof import("../../src/server/agent/verification-harness.js").VerificationHarness;
+let killTreeByPid: typeof import("../../src/server/agent/spawn-tree.js").killTreeByPid;
+let GIT_BASH: string | null | undefined;
+
+beforeAll(async () => {
+	({ VerificationHarness } = await import("../../src/server/agent/verification-harness.js"));
+	({ killTreeByPid } = await import("../../src/server/agent/spawn-tree.js"));
+	({ GIT_BASH } = await import("../../src/server/agent/shell-util.js"));
+});
 
 const GOAL_ID = "goal-restart-safe-command-lifecycle";
 const GATE_ID = "implementation";

--- a/tests2/dom/session-menu.test.ts
+++ b/tests2/dom/session-menu.test.ts
@@ -11,16 +11,30 @@ __syncBeforeAll(() => __syncCE());
 // The popover renders its [role='menu']/[role='menuitem'] rows into light DOM
 // regardless of layout (it guards getBoundingClientRect/animate/matchMedia), so
 // menu-label/icon/click assertions work without real geometry.
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { html, render } from "lit";
-import { icon } from "@mariozechner/mini-lit";
-import { Boxes } from "lucide";
-import "../../src/ui/components/SidebarActionsPopover.js";
-import "../../src/ui/components/GitStatusWidget.js";
-import { buildSessionActions, type SessionActionDescriptor } from "../../src/app/session-actions.js";
-import { registerPackEntrypoints, listLauncherEntrypoints, launcherKey } from "../../src/app/pack-entrypoints.js";
-import { setLauncherHostFactory } from "../../src/app/pack-panels.js";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import type { SessionActionDescriptor } from "../../src/app/session-actions.js";
 import type { GatewaySession } from "../../src/app/state.js";
+
+let html: typeof import("lit").html;
+let render: typeof import("lit").render;
+let icon: typeof import("@mariozechner/mini-lit").icon;
+let Boxes: typeof import("lucide").Boxes;
+let buildSessionActions: typeof import("../../src/app/session-actions.js").buildSessionActions;
+let registerPackEntrypoints: typeof import("../../src/app/pack-entrypoints.js").registerPackEntrypoints;
+let listLauncherEntrypoints: typeof import("../../src/app/pack-entrypoints.js").listLauncherEntrypoints;
+let launcherKey: typeof import("../../src/app/pack-entrypoints.js").launcherKey;
+let setLauncherHostFactory: typeof import("../../src/app/pack-panels.js").setLauncherHostFactory;
+
+beforeAll(async () => {
+	({ html, render } = await import("lit"));
+	({ icon } = await import("@mariozechner/mini-lit"));
+	({ Boxes } = await import("lucide"));
+	await import("../../src/ui/components/SidebarActionsPopover.js");
+	await import("../../src/ui/components/GitStatusWidget.js");
+	({ buildSessionActions } = await import("../../src/app/session-actions.js"));
+	({ registerPackEntrypoints, listLauncherEntrypoints, launcherKey } = await import("../../src/app/pack-entrypoints.js"));
+	({ setLauncherHostFactory } = await import("../../src/app/pack-panels.js"));
+});
 
 let app: HTMLElement;
 let lastActions: SessionActionDescriptor[] = [];

--- a/tests2/integration/_e2e/in-process-harness.ts
+++ b/tests2/integration/_e2e/in-process-harness.ts
@@ -173,6 +173,7 @@ export interface CleanupStats {
 	snapshots: number;
 	sweeps: number;
 	skippedSweeps: number;
+	uncertainSweeps: number;
 	defaultResets: number;
 	defaultRestores: number;
 	deletedSessions: number;
@@ -194,6 +195,7 @@ function emptyCleanupStats(): CleanupStats {
 		snapshots: 0,
 		sweeps: 0,
 		skippedSweeps: 0,
+		uncertainSweeps: 0,
 		defaultResets: 0,
 		defaultRestores: 0,
 		deletedSessions: 0,
@@ -400,6 +402,7 @@ async function cleanupTo(gw: GatewayFixture, baseline: CleanupSnapshot, opts: { 
 		return;
 	}
 	incStat("sweeps");
+	if (fingerprintUncertain(now.defaultProjectFingerprint) || fingerprintUncertain(baseline.defaultProjectFingerprint)) incStat("uncertainSweeps");
 	for (const id of now.ids.sessions) if (!baseline.ids.sessions.has(id)) {
 		const resp = await gw.api(`/api/sessions/${id}?purge=true`, { method: "DELETE" }).catch(() => undefined);
 		if (!resp || resp.ok || resp.status === 404) incStat("deletedSessions");

--- a/tests2/integration/base-ref-api.test.ts
+++ b/tests2/integration/base-ref-api.test.ts
@@ -3,7 +3,9 @@
  *
  * Pure grammar/error-shape inventory lives in tests2/core/base-ref-validation.test.ts.
  * This file keeps route-level coverage for persistence plus git-backed tag,
- * sandbox, local-branch, multi-repo, and warning paths.
+ * sandbox, local-branch, multi-repo, and warning paths. Keep related route
+ * checks batched: the in-process integration cleanup runs after every test, so
+ * splitting pure scenario permutations here materially increases suite time.
  */
 import { test, expect } from "./_e2e/in-process-harness.js";
 import { readE2EToken, base, registerProject as registerProjectShared } from "./_e2e/e2e-setup.js";
@@ -45,10 +47,14 @@ function cleanupDir(dir: string): void {
 	try { fs.rmSync(dir, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 }); } catch { /* ignore */ }
 }
 
+function copyTemplateRepo(root: string): void {
+	fs.cpSync(templateRepo, root, { recursive: true });
+}
+
 function fixtureRepo(prefix: string, opts?: { originDevelop?: boolean }): string {
 	const root = fs.mkdtempSync(path.join(os.tmpdir(), `bobbit-baseref-${prefix}-`));
 	fs.rmSync(root, { recursive: true, force: true });
-	fs.cpSync(templateRepo, root, { recursive: true });
+	copyTemplateRepo(root);
 	cleanupRoots.push(root);
 	if (opts?.originDevelop) fakeOriginRef(root, "develop");
 	return root;
@@ -88,6 +94,10 @@ async function get(id: string): Promise<any> {
 	return res.json();
 }
 
+function expectBaseRefUnset(config: any): void {
+	expect(config.base_ref === undefined || config.base_ref === "").toBe(true);
+}
+
 test.beforeAll(() => {
 	token = readE2EToken();
 	templateRepo = createTemplateRepo();
@@ -103,53 +113,45 @@ test.afterAll(() => {
 test.describe.configure({ mode: "serial" });
 
 test.describe("base_ref API validation", () => {
-	test("PUT round-trip — set origin/<branch>, GET returns it, empty clears it", async () => {
+	test("persists remote refs, clears empty values, and accepts local/whitespace refs", async () => {
 		const root = fixtureRepo("rt", { originDevelop: true });
 		const id = await registerProject("baseref-rt", root);
 
-		const r1 = await put(id, { base_ref: "origin/develop" });
-		expect(r1.status, JSON.stringify(r1.json)).toBe(200);
+		const remoteSet = await put(id, { base_ref: "origin/develop" });
+		expect(remoteSet.status, JSON.stringify(remoteSet.json)).toBe(200);
+		expect((await get(id)).base_ref).toBe("origin/develop");
 
-		const cfg1 = await get(id);
-		expect(cfg1.base_ref).toBe("origin/develop");
+		const emptyClear = await put(id, { base_ref: "" });
+		expect(emptyClear.status, JSON.stringify(emptyClear.json)).toBe(200);
+		expectBaseRefUnset(await get(id));
 
-		const r2 = await put(id, { base_ref: "" });
-		expect(r2.status).toBe(200);
-		const cfg2 = await get(id);
-		expect(cfg2.base_ref === undefined || cfg2.base_ref === "").toBe(true);
+		const localSet = await put(id, { base_ref: "develop" });
+		expect(localSet.status, JSON.stringify(localSet.json)).toBe(200);
+		expect((await get(id)).base_ref).toBe("develop");
+
+		const whitespaceUnset = await put(id, { base_ref: "   " });
+		expect(whitespaceUnset.status, JSON.stringify(whitespaceUnset.json)).toBe(200);
 	});
 
-	test("rejects tag with the exact route error string", async () => {
-		const root = fixtureRepo("tag");
-		const id = await registerProject("baseref-tag", root);
-		const r = await put(id, { base_ref: "v1.2.3" });
-		expect(r.status).toBe(400);
-		expect(r.json).toEqual({
+	test("rejects git-backed tag refs and sandboxed local refs with route error strings", async () => {
+		const root = fixtureRepo("reject");
+		const id = await registerProject("baseref-reject", root);
+
+		const tag = await put(id, { base_ref: "v1.2.3" });
+		expect(tag.status).toBe(400);
+		expect(tag.json).toEqual({
 			field: "base_ref",
 			error: "base_ref must be a branch ref, not a tag. Tags can't be used as git upstreams. Got: v1.2.3",
 		});
-	});
 
-	test("rejects local ref when sandbox = docker through the route", async () => {
-		const root = fixtureRepo("sandbox");
-		const id = await registerProject("baseref-sandbox", root);
-		const r1 = await put(id, { sandbox: "docker" });
-		expect(r1.status).toBe(200);
-		const r2 = await put(id, { base_ref: "master" });
-		expect(r2.status).toBe(400);
-		expect(r2.json).toEqual({
+		const sandbox = await put(id, { sandbox: "docker" });
+		expect(sandbox.status, JSON.stringify(sandbox.json)).toBe(200);
+		const local = await put(id, { base_ref: "master" });
+		expect(local.status).toBe(400);
+		expect(local.json).toEqual({
 			field: "base_ref",
 			error: "base_ref must be a remote ref (origin/...) for sandboxed projects. The container has separate ref visibility from the host. Got: master",
 		});
-	});
-
-	test("accepts local branch ref in a non-sandbox project", async () => {
-		const root = fixtureRepo("local");
-		const id = await registerProject("baseref-local", root);
-		const r = await put(id, { base_ref: "develop" });
-		expect(r.status, JSON.stringify(r.json)).toBe(200);
-		const cfg = await get(id);
-		expect(cfg.base_ref).toBe("develop");
 	});
 
 	test("multi-repo: missing ref in subset of components returns 400 with structured details[]", async () => {
@@ -158,9 +160,9 @@ test.describe("base_ref API validation", () => {
 		const repoA = path.join(root, "api");
 		const repoB = path.join(root, "web");
 		const repoC = path.join(root, "shared");
-		fs.cpSync(templateRepo, repoA, { recursive: true });
-		fs.cpSync(templateRepo, repoB, { recursive: true });
-		fs.cpSync(templateRepo, repoC, { recursive: true });
+		copyTemplateRepo(repoA);
+		copyTemplateRepo(repoB);
+		copyTemplateRepo(repoC);
 		fakeOriginRef(repoA, "develop");
 
 		const id = await registerProject(
@@ -186,31 +188,19 @@ test.describe("base_ref API validation", () => {
 		}
 	});
 
-	test("returns warnings when component paths are not git repos", async () => {
+	test("non-git component paths skip validation unless base_ref is present, then return warnings", async () => {
 		const root = fs.mkdtempSync(path.join(os.tmpdir(), "bobbit-baseref-warning-"));
 		cleanupRoots.push(root);
 		fs.mkdirSync(path.join(root, "docs"), { recursive: true });
 		const id = await registerProject("baseref-warning", root, [{ name: "docs", repo: "docs" }]);
 
-		const r = await put(id, { base_ref: "origin/develop" });
-		expect(r.status, JSON.stringify(r.json)).toBe(200);
-		expect(r.json.warnings).toEqual([
+		const skip = await put(id, { build_command: "echo build" });
+		expect(skip.status, JSON.stringify(skip.json)).toBe(200);
+
+		const warn = await put(id, { base_ref: "origin/develop" });
+		expect(warn.status, JSON.stringify(warn.json)).toBe(200);
+		expect(warn.json.warnings).toEqual([
 			`base_ref validation skipped for component 'docs': not a git repo at ${path.join(root, "docs")}`,
 		]);
-	});
-
-	test("validation only fires when base_ref is in the PUT body", async () => {
-		const root = fs.mkdtempSync(path.join(os.tmpdir(), "bobbit-baseref-skip-"));
-		cleanupRoots.push(root);
-		const id = await registerProject("baseref-skip", root);
-		const r = await put(id, { build_command: "echo build" });
-		expect(r.status).toBe(200);
-	});
-
-	test("whitespace-only value is treated as unset (200)", async () => {
-		const root = fixtureRepo("ws");
-		const id = await registerProject("baseref-ws", root);
-		const r = await put(id, { base_ref: "   " });
-		expect(r.status, JSON.stringify(r.json)).toBe(200);
 	});
 });

--- a/tests2/integration/commit-file-diffs-api.test.ts
+++ b/tests2/integration/commit-file-diffs-api.test.ts
@@ -1,3 +1,10 @@
+/**
+ * API E2E — representative commit-file metadata and commit-scoped diff routes.
+ *
+ * The suite uses one copied git template so route coverage does not pay repeated
+ * git init/config/initial-commit setup. Session coverage exercises the full
+ * validation matrix; goal coverage is a smoke path for the separate goal route.
+ */
 import { test, expect } from "./_e2e/in-process-harness.js";
 import { apiFetch, createGoal, createSession, deleteGoal, deleteSession, registerProject } from "./_e2e/e2e-setup.js";
 import { awaitableRm, pollUntil } from "../../tests/e2e/test-utils/cleanup.js";
@@ -6,8 +13,11 @@ import os from "node:os";
 import path from "node:path";
 import { execFileSync } from "node:child_process";
 
+let templateRepo = "";
+const cleanupRoots: string[] = [];
+
 function git(cwd: string, args: string[]): string {
-	return execFileSync("git", args, { cwd, encoding: "utf-8", stdio: ["ignore", "pipe", "pipe"] }).trim();
+	return execFileSync("git", args, { cwd, encoding: "utf-8", stdio: ["ignore", "pipe", "pipe"], windowsHide: true }).trim();
 }
 
 function commitTargetChanges(root: string, trackedContent = "base\ncommit scoped marker\n"): string {
@@ -16,26 +26,33 @@ function commitTargetChanges(root: string, trackedContent = "base\ncommit scoped
 	fs.rmSync(path.join(root, "delete-me.txt"));
 	git(root, ["mv", "rename-old.txt", "rename-new.txt"]);
 	git(root, ["add", "."]);
-	git(root, ["commit", "-m", "target commit"]);
+	git(root, ["commit", "--quiet", "-m", "target commit"]);
 	return git(root, ["rev-parse", "HEAD"]);
 }
 
-function initRepo(): { root: string; targetSha: string } {
-	const root = fs.mkdtempSync(path.join(os.tmpdir(), "bobbit-commit-diff-api-"));
-	git(root, ["init"]);
-	git(root, ["checkout", "-B", "master"]);
+function createTemplateRepo(): string {
+	const root = fs.mkdtempSync(path.join(os.tmpdir(), "bobbit-commit-diff-template-"));
+	git(root, ["init", "--quiet"]);
+	git(root, ["checkout", "--quiet", "-B", "master"]);
 	git(root, ["config", "user.email", "test@bobbit.local"]);
 	git(root, ["config", "user.name", "Commit Diff Test"]);
 	git(root, ["config", "core.autocrlf", "false"]);
+	git(root, ["config", "commit.gpgsign", "false"]);
 
 	fs.writeFileSync(path.join(root, "tracked.txt"), "base\n");
 	fs.writeFileSync(path.join(root, "delete-me.txt"), "delete me\n");
 	fs.writeFileSync(path.join(root, "rename-old.txt"), "rename me\n");
 	git(root, ["add", "."]);
-	git(root, ["commit", "-m", "initial"]);
+	git(root, ["commit", "--quiet", "-m", "initial"]);
+	return root;
+}
 
-	const targetSha = commitTargetChanges(root);
-	return { root, targetSha };
+function fixtureRepo(prefix: string): string {
+	const root = fs.mkdtempSync(path.join(os.tmpdir(), `bobbit-commit-diff-${prefix}-`));
+	fs.rmSync(root, { recursive: true, force: true });
+	fs.cpSync(templateRepo, root, { recursive: true });
+	cleanupRoots.push(root);
+	return root;
 }
 
 function byPath(files: any[], p: string): any {
@@ -44,6 +61,10 @@ function byPath(files: any[], p: string): any {
 
 async function safeRm(dir: string): Promise<void> {
 	await awaitableRm(dir, { onFinalFailure: () => {} });
+}
+
+function cleanupDir(dir: string): void {
+	try { fs.rmSync(dir, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 }); } catch { /* ignore */ }
 }
 
 function assertTargetCommitFiles(commit: any): void {
@@ -55,19 +76,26 @@ function assertTargetCommitFiles(commit: any): void {
 	expect(byPath(commit.files, "rename-new.txt")).toMatchObject({ status: "R", statusLabel: "renamed", oldPath: "rename-old.txt" });
 }
 
-async function expectTargetCommit(endpoint: string, targetSha: string): Promise<void> {
+async function expectTargetCommitSummary(endpoint: string, targetSha: string): Promise<void> {
 	const commitsResp = await apiFetch(`${endpoint}/commits`);
 	expect(commitsResp.status).toBe(200);
 	const body = await commitsResp.json();
 	const commit = body.commits.find((c: any) => c.sha === targetSha);
 	expect(commit).toBeTruthy();
 	assertTargetCommitFiles(commit);
+}
 
-	const diffResp = await apiFetch(`${endpoint}/git-diff?commit=${targetSha}&file=${encodeURIComponent("tracked.txt")}`);
+async function expectCommitDiff(endpoint: string, targetSha: string, file: string, marker: string): Promise<void> {
+	const diffResp = await apiFetch(`${endpoint}/git-diff?commit=${targetSha}&file=${encodeURIComponent(file)}`);
 	expect(diffResp.status).toBe(200);
 	const diffBody = await diffResp.json();
-	expect(diffBody.diff).toContain("diff --git a/tracked.txt b/tracked.txt");
-	expect(diffBody.diff).toContain("commit scoped marker");
+	expect(diffBody.diff).toContain(`diff --git a/${file} b/${file}`);
+	expect(diffBody.diff).toContain(marker);
+}
+
+async function expectSessionCommitDiffValidation(endpoint: string, targetSha: string): Promise<void> {
+	await expectTargetCommitSummary(endpoint, targetSha);
+	await expectCommitDiff(endpoint, targetSha, "tracked.txt", "commit scoped marker");
 
 	const renameDiffResp = await apiFetch(`${endpoint}/git-diff?commit=${targetSha}&file=${encodeURIComponent("rename-new.txt")}`);
 	expect(renameDiffResp.status).toBe(200);
@@ -82,13 +110,26 @@ async function expectTargetCommit(endpoint: string, targetSha: string): Promise<
 	expect((await invalidCommitResp.json()).error).toBe("Invalid commit");
 }
 
+test.beforeAll(() => {
+	templateRepo = createTemplateRepo();
+});
+
+test.afterAll(() => {
+	for (const root of cleanupRoots) cleanupDir(root);
+	if (templateRepo) cleanupDir(templateRepo);
+});
+
+// Shared gateway state and copied git fixtures are intentionally kept serial.
+test.describe.configure({ mode: "serial" });
+
 test.describe("commit file diff API", () => {
 	test("session commits include changed files and commit-scoped git-diff", async () => {
-		const { root, targetSha } = initRepo();
-		const project = await registerProject({ name: `commit-diff-session-${Date.now()}`, rootPath: root });
+		const root = fixtureRepo("session");
+		const targetSha = commitTargetChanges(root);
+		const project = await registerProject({ name: `commit-diff-session-${Date.now()}`, rootPath: root, seedWorkflows: false });
 		const sessionId = await createSession({ cwd: root, projectId: project.id });
 		try {
-			await expectTargetCommit(`/api/sessions/${sessionId}`, targetSha);
+			await expectSessionCommitDiffValidation(`/api/sessions/${sessionId}`, targetSha);
 
 			const sessionResp = await apiFetch(`/api/sessions/${sessionId}`);
 			expect(sessionResp.status).toBe(200);
@@ -105,8 +146,8 @@ test.describe("commit file diff API", () => {
 	});
 
 	test("goal commits include changed files and commit-scoped git-diff", async () => {
-		const { root } = initRepo();
-		const project = await registerProject({ name: `commit-diff-goal-${Date.now()}`, rootPath: root });
+		const root = fixtureRepo("goal");
+		const project = await registerProject({ name: `commit-diff-goal-${Date.now()}`, rootPath: root, seedWorkflows: false });
 		let goalId: string | undefined;
 		try {
 			const goal = await createGoal({
@@ -130,17 +171,10 @@ test.describe("commit file diff API", () => {
 					: null;
 			}, { timeoutMs: 15_000, label: "goal worktree ready" });
 			const goalCwd = readyGoal.cwd;
-
-			fs.writeFileSync(path.join(goalCwd, "tracked.txt"), "base\n");
-			fs.writeFileSync(path.join(goalCwd, "delete-me.txt"), "delete me\n");
-			fs.writeFileSync(path.join(goalCwd, "rename-old.txt"), "rename me\n");
-			fs.rmSync(path.join(goalCwd, "added.txt"), { force: true });
-			fs.rmSync(path.join(goalCwd, "rename-new.txt"), { force: true });
-			git(goalCwd, ["add", "."]);
-			git(goalCwd, ["commit", "-m", "prepare target commit"]);
 			const goalTargetSha = commitTargetChanges(goalCwd, "base\ngoal commit scoped marker\n");
 
-			await expectTargetCommit(`/api/goals/${goalId}`, goalTargetSha);
+			await expectTargetCommitSummary(`/api/goals/${goalId}`, goalTargetSha);
+			await expectCommitDiff(`/api/goals/${goalId}`, goalTargetSha, "tracked.txt", "goal commit scoped marker");
 		} finally {
 			if (goalId) await deleteGoal(goalId).catch(() => {});
 			await apiFetch(`/api/projects/${project.id}`, { method: "DELETE" }).catch(() => {});

--- a/tests2/integration/gateway-fixture-leak.test.ts
+++ b/tests2/integration/gateway-fixture-leak.test.ts
@@ -58,6 +58,7 @@ describe("gateway fixture leak detector", () => {
 				snapshots: 0,
 				sweeps: 0,
 				skippedSweeps: 0,
+				uncertainSweeps: 0,
 			});
 		} finally {
 			if (previousDir === undefined) delete process.env.BOBBIT_V2_HOOK_PROFILE_DIR;
@@ -108,6 +109,14 @@ function activeGoalIds(gateway: GatewayFixture): Set<string> {
 	return ids;
 }
 
+function visibleDefaultContext(gateway: GatewayFixture): any {
+	for (const ctx of Array.from(gateway.projectContextManager.visible?.() ?? []) as any[]) {
+		const project = ctx?.project;
+		if (project?.name === "default" && !project.hidden) return ctx;
+	}
+	throw new Error("default project context not found");
+}
+
 async function defaultProjectRoot(gateway: GatewayFixture): Promise<string> {
 	const list = await gateway.apiJson<any>("/api/projects");
 	const projects: Array<{ id?: string; rootPath?: string; hidden?: boolean }> = Array.isArray(list) ? list : (list?.projects ?? []);
@@ -117,11 +126,18 @@ async function defaultProjectRoot(gateway: GatewayFixture): Promise<string> {
 }
 
 let rawGoalId: string | undefined;
+let restoreDefaultConfigGetAll: (() => void) | undefined;
 
 compatTest.describe.serial("integration harness dirty cleanup", () => {
 	compatTest.beforeAll(() => {
 		resetIntegrationHarnessCleanupStats();
 		rawGoalId = undefined;
+		restoreDefaultConfigGetAll = undefined;
+	});
+
+	compatTest.afterAll(() => {
+		restoreDefaultConfigGetAll?.();
+		restoreDefaultConfigGetAll = undefined;
 	});
 
 	compatTest("records no-op tests as skipped sweeps without resetting the default project", async () => {
@@ -174,5 +190,19 @@ compatTest.describe.serial("integration harness dirty cleanup", () => {
 		const structured = await gateway.apiJson<any>(`/api/projects/${gateway.defaultProjectId}/structured`);
 		compatExpect(structured.components?.[0]?.name).toBe("test");
 		compatExpect(structured.components?.[0]?.commands?.build).toBe("echo ok");
+	});
+
+	compatTest("treats uncertain default-project fingerprints as dirty", async ({ gateway }) => {
+		const cfg = visibleDefaultContext(gateway).projectConfigStore;
+		const original = cfg.getAll;
+		restoreDefaultConfigGetAll = () => { cfg.getAll = original; };
+		cfg.getAll = () => { throw new Error("intentional cleanup fingerprint failure"); };
+	});
+
+	compatTest("falls back to a conservative sweep when cleanliness is uncertain", () => {
+		const stats = integrationHarnessCleanupStats();
+		compatExpect(stats.uncertainSweeps).toBeGreaterThanOrEqual(1);
+		restoreDefaultConfigGetAll?.();
+		restoreDefaultConfigGetAll = undefined;
 	});
 });

--- a/tests2/integration/multi-repo-flow-api.test.ts
+++ b/tests2/integration/multi-repo-flow-api.test.ts
@@ -73,10 +73,14 @@ async function registerMultiRepoProject(): Promise<{ id: string; rootPath: strin
 }
 
 test.describe("multi-repo flow API/data paths", () => {
-	test("worktree_root structured endpoint round-trips", async () => {
-		test.setTimeout(60_000);
+	test("multi-repo project exposes structured data and per-repo worktree lifecycle", async () => {
+		test.setTimeout(120_000);
 		const project = await registerMultiRepoProject();
+		let goalId: string | undefined;
+
 		try {
+			// Keep the two structured endpoint assertions in the representative
+			// route-flow test so this suite pays the expensive project cleanup once.
 			const customRoot = path.join(os.tmpdir(), `bobbit-wt-${Date.now()}`);
 			const put = await apiFetch(`/api/projects/${project.id}/config`, {
 				method: "PUT",
@@ -84,21 +88,14 @@ test.describe("multi-repo flow API/data paths", () => {
 			});
 			expect(put.status).toBeLessThan(300);
 
-			const res = await apiFetch(`/api/projects/${project.id}/structured`);
-			const data = await res.json();
-			expect(data.worktree_root).toBe(customRoot);
-		} finally {
-			await apiFetch(`/api/projects/${project.id}`, { method: "DELETE" }).catch(() => {});
-			project.cleanup();
-		}
-	});
+			const structuredRes = await apiFetch(`/api/projects/${project.id}/structured`);
+			expect(structuredRes.status).toBe(200);
+			const structured = await structuredRes.json();
+			expect(structured.worktree_root).toBe(customRoot);
+			expect(Array.isArray(structured?.components)).toBe(true);
+			const repos = new Set((structured.components as Array<{ repo?: string }>).map(c => c.repo || "."));
+			expect(repos.size).toBeGreaterThan(1);
 
-	test("multi-repo goal: per-repo worktrees on disk, then archive cleanup", async () => {
-		test.setTimeout(120_000);
-		const project = await registerMultiRepoProject();
-		let goalId: string | undefined;
-
-		try {
 			// Drive goal creation entirely via the API so this data-path coverage
 			// stays stable across UI flow changes.
 			//
@@ -161,27 +158,6 @@ test.describe("multi-repo flow API/data paths", () => {
 			}
 		} finally {
 			if (goalId) await apiFetch(`/api/goals/${goalId}?cascade=true`, { method: "DELETE" }).catch(() => {});
-			await apiFetch(`/api/projects/${project.id}`, { method: "DELETE" }).catch(() => {});
-			project.cleanup();
-		}
-	});
-
-	test("structured endpoint surfaces a >1 repo count for the goal-form indicator", async () => {
-		test.setTimeout(60_000);
-		const project = await registerMultiRepoProject();
-
-		try {
-			// The goal-form's multi-repo indicator template is guarded by
-			// `componentSummary?.multiRepo`, which derives from
-			// `/api/projects/:id/structured`. This test asserts that data path:
-			// register the project, GET /structured, and verify a >1 repo count.
-			const res = await apiFetch(`/api/projects/${project.id}/structured`);
-			expect(res.status).toBe(200);
-			const data = await res.json();
-			expect(Array.isArray(data?.components)).toBe(true);
-			const repos = new Set((data.components as Array<{ repo?: string }>).map(c => c.repo || "."));
-			expect(repos.size).toBeGreaterThan(1);
-		} finally {
 			await apiFetch(`/api/projects/${project.id}`, { method: "DELETE" }).catch(() => {});
 			project.cleanup();
 		}

--- a/tests2/integration/pr-walkthrough-api.test.ts
+++ b/tests2/integration/pr-walkthrough-api.test.ts
@@ -1,11 +1,10 @@
 import { execFileSync } from "node:child_process";
-import { createServer } from "node:http";
 import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { test, expect } from "./_e2e/in-process-harness.js";
-import { apiFetch, deleteSession } from "./_e2e/e2e-setup.js";
+import { apiFetch } from "./_e2e/e2e-setup.js";
 import { awaitableRm } from "../../tests/e2e/test-utils/cleanup.js";
 
 type GitFixture = {
@@ -69,23 +68,6 @@ async function resolveFixtureWalkthrough(): Promise<any> {
 	return resp.json();
 }
 
-async function startMockGithubApi(status: number, body: unknown, headers: Record<string, string> = {}): Promise<{ baseUrl: string; requests: Array<{ url?: string; authorization?: string }>; close: () => Promise<void> }> {
-	const requests: Array<{ url?: string; authorization?: string }> = [];
-	const server = createServer((req, res) => {
-		requests.push({ url: req.url, authorization: req.headers.authorization });
-		res.writeHead(status, { "Content-Type": "application/json", ...headers });
-		res.end(JSON.stringify(body));
-	});
-	await new Promise<void>(resolve => server.listen(0, "127.0.0.1", resolve));
-	const address = server.address();
-	if (!address || typeof address !== "object") throw new Error("mock GitHub API did not bind a TCP port");
-	return {
-		baseUrl: `http://127.0.0.1:${address.port}`,
-		requests,
-		close: () => new Promise<void>((resolve, reject) => server.close(err => err ? reject(err) : resolve())),
-	};
-}
-
 function firstLineAnchor(result: any): { cardId: string; diffBlockId: string; lineId: string } {
 	for (const card of result.cards ?? []) {
 		for (const block of card.diffBlocks ?? []) {
@@ -99,13 +81,6 @@ function firstLineAnchor(result: any): { cardId: string; diffBlockId: string; li
 }
 
 test.describe("PR walkthrough REST API", () => {
-	// Sessions this spec mints server-side (parent launchers + their
-	// `prw-session-*` walkthrough children). These MUST be deleted: a leaked
-	// `prw-session-*` survives on the shared in-process API worker, and when
-	// project-delete-last.spec.ts later drains every project the orphaned child
-	// can no longer resolve its store — the server then throws
-	// "Cannot resolve store for session prw-session-...: not found in any project".
-	const createdSessionIds: string[] = [];
 	let sharedLocalFixture: GitFixture;
 
 	function localFixture(): GitFixtureRefs {
@@ -113,39 +88,13 @@ test.describe("PR walkthrough REST API", () => {
 		return sharedLocalFixture;
 	}
 
-	async function cleanupCreatedSessions(): Promise<void> {
-		// Delete in reverse creation order so children are removed before their
-		// parent launcher session.
-		while (createdSessionIds.length) {
-			const id = createdSessionIds.pop()!;
-			await deleteSession(id);
-		}
-	}
-
 	test.beforeAll(() => {
 		// Reuse one immutable two-commit repo for route tests that only read diffs.
-		// The large-diff truncation test keeps its own purpose-built repo.
 		sharedLocalFixture = makeGitFixture();
 	});
 
-	test.afterEach(cleanupCreatedSessions);
-
 	test.afterAll(async () => {
-		await cleanupCreatedSessions();
 		if (sharedLocalFixture) await sharedLocalFixture.cleanup();
-		// Safety-net sweep: delete any walkthrough child session this spec may
-		// have minted that escaped the per-test tracking, so no `prw-session-*`
-		// orphan outlives the spec.
-		try {
-			const res = await apiFetch("/api/sessions");
-			if (res.ok) {
-				const body = await res.json();
-				const list: Array<{ id?: string }> = Array.isArray(body) ? body : (body.sessions ?? []);
-				for (const s of list) {
-					if (s.id && s.id.startsWith("prw-session-")) await deleteSession(s.id);
-				}
-			}
-		} catch { /* best-effort */ }
 	});
 
 	// NOTE: the legacy `POST /api/pr-walkthrough/launch` test was removed with the
@@ -193,100 +142,6 @@ test.describe("PR walkthrough REST API", () => {
 		expect(submitResp.status).toBe(400);
 		const submitBody = await submitResp.json();
 		expect(submitBody.code).toBe("CONFIRMATION_REQUIRED");
-	});
-
-	test("invalid refs return structured errors", async () => {
-		const fixture = localFixture();
-		const invalidResp = await apiFetch("/api/pr-walkthrough/resolve", {
-			method: "POST",
-			body: JSON.stringify({ cwd: fixture.cwd, baseSha: "not-a-sha", headSha: fixture.headSha }),
-		});
-		expect(invalidResp.status).toBe(400);
-		expect((await invalidResp.json()).error).toContain("Invalid baseSha");
-	});
-
-	test("large local diffs return truncation warnings instead of maxBuffer failures", async () => {
-		const cwd = mkdtempSync(join(tmpdir(), "bobbit-pr-walkthrough-large-"));
-		try {
-			git(cwd, ["init"]);
-			git(cwd, ["config", "user.name", "Bobbit E2E"]);
-			git(cwd, ["config", "user.email", "bobbit-e2e@example.test"]);
-			git(cwd, ["config", "core.autocrlf", "false"]);
-			writeFileSync(join(cwd, "large.txt"), "base\n", "utf-8");
-			git(cwd, ["add", "."]);
-			git(cwd, ["commit", "-m", "base"]);
-			const baseSha = git(cwd, ["rev-parse", "HEAD"]);
-			writeFileSync(join(cwd, "large.txt"), Array.from({ length: 220_000 }, (_, index) => `line ${index} ${"x".repeat(16)}`).join("\n"), "utf-8");
-			git(cwd, ["add", "."]);
-			git(cwd, ["commit", "-m", "large"]);
-			const headSha = git(cwd, ["rev-parse", "HEAD"]);
-
-			const resp = await apiFetch("/api/pr-walkthrough/resolve", {
-				method: "POST",
-				body: JSON.stringify({ cwd, baseSha, headSha }),
-			});
-			expect(resp.status).toBe(200);
-			const result = await resp.json();
-			expect(result.warnings.some((warning: any) => warning.code === "diff-truncated")).toBe(true);
-		} finally {
-			await cleanupGitFixture(cwd);
-		}
-	});
-
-	test("empty local diffs resolve to an orientation-only walkthrough instead of a broken response", async () => {
-		const fixture = localFixture();
-		const resp = await apiFetch("/api/pr-walkthrough/resolve", {
-			method: "POST",
-			body: JSON.stringify({ cwd: fixture.cwd, baseSha: fixture.headSha, headSha: fixture.headSha }),
-		});
-		expect(resp.status).toBe(200);
-		const result = await resp.json();
-		expect(result.changeset.filesChanged).toBe(0);
-		expect(result.cards).toHaveLength(1);
-		expect(result.cards[0].phaseId).toBe("orientation");
-	});
-
-	test("GitHub PR resolve rejects untrusted hosts with typed errors", async () => {
-		const previousToken = process.env.GITHUB_TOKEN;
-		process.env.GITHUB_TOKEN = "must-not-leak";
-		try {
-			const resp = await apiFetch("/api/pr-walkthrough/resolve", {
-				method: "POST",
-				body: JSON.stringify({ prUrl: "https://evil.example/acme/widgets/pull/42" }),
-			});
-			expect(resp.status).toBe(400);
-			const body = await resp.json();
-			expect(body.code).toBe("untrusted_github_host");
-			expect(body.error).toContain("Untrusted GitHub PR host");
-		} finally {
-			if (previousToken === undefined) delete process.env.GITHUB_TOKEN;
-			else process.env.GITHUB_TOKEN = previousToken;
-		}
-	});
-
-	test("GitHub adapter auth and permission errors preserve status, code, and warnings", async () => {
-		const mock = await startMockGithubApi(403, { message: "Forbidden" }, { "x-ratelimit-remaining": "5" });
-		const previousApiBase = process.env.BOBBIT_GITHUB_API_BASE_URL;
-		const previousToken = process.env.GITHUB_TOKEN;
-		process.env.BOBBIT_GITHUB_API_BASE_URL = mock.baseUrl;
-		process.env.GITHUB_TOKEN = "mock-token";
-		try {
-			const resp = await apiFetch("/api/pr-walkthrough/resolve", {
-				method: "POST",
-				body: JSON.stringify({ prUrl: "https://github.com/acme/widgets/pull/42" }),
-			});
-			expect(resp.status).toBe(403);
-			const body = await resp.json();
-			expect(body.code).toBe("github_permission_denied");
-			expect(body.warnings.some((warning: any) => warning.code === "github_permission_denied")).toBe(true);
-			expect(mock.requests[0]?.authorization).toBe("Bearer mock-token");
-		} finally {
-			await mock.close();
-			if (previousApiBase === undefined) delete process.env.BOBBIT_GITHUB_API_BASE_URL;
-			else process.env.BOBBIT_GITHUB_API_BASE_URL = previousApiBase;
-			if (previousToken === undefined) delete process.env.GITHUB_TOKEN;
-			else process.env.GITHUB_TOKEN = previousToken;
-		}
 	});
 
 	// Master #946 dropped the blanket `previewOnly` denial: a with-SHA github target
@@ -368,11 +223,4 @@ test.describe("PR walkthrough REST API", () => {
 		}
 	});
 
-	test("local SHA plus unsafe PR metadata does not persist clickable external URLs", async () => {
-		const fixture = localFixture();
-		const result = await resolveLocal(fixture, { prUrl: "javascript:alert(1)", prNumber: 42 });
-		expect(result.changeset.provider).toBe("github");
-		expect(result.changeset.prUrl).toBeUndefined();
-		expect(result.changeset.externalUrl).toBeUndefined();
-	});
 });

--- a/tests2/integration/sidebar-actions-fork-github-link.test.ts
+++ b/tests2/integration/sidebar-actions-fork-github-link.test.ts
@@ -15,12 +15,10 @@
 import { test, expect } from "./_e2e/in-process-harness.js";
 import { execFileSync } from "node:child_process";
 import { appendFileSync, existsSync, mkdirSync, readdirSync, readFileSync, realpathSync, rmSync } from "node:fs";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { tmpdir } from "node:os";
 import {
-	agentEndPredicate,
 	apiFetch,
-	connectWs,
 	createGoal,
 	defaultProjectId,
 	deleteGoal,
@@ -42,16 +40,22 @@ async function pollUntil<T>(
 	}
 }
 
-// Fork clones the source transcript, so the source needs a non-empty `.jsonl`
-// before forking. Driving one prompt to completion populates `agentSessionFile`.
-async function sendPromptAndWait(id: string, text: string): Promise<void> {
-	const ws = await connectWs(id);
-	try {
-		ws.send({ type: "prompt", text });
-		await ws.waitFor(agentEndPredicate(), 10_000);
-	} finally {
-		ws.close();
-	}
+// Fork clones the source transcript, so seed the already-persisted mock-agent
+// `.jsonl` directly instead of driving a prompt turn. The fork endpoint only
+// needs a non-empty production-shaped transcript, and prompt/WS fidelity is
+// covered in cheaper, dedicated suites.
+async function seedSessionTranscript(gateway: any, sessionId: string, entries: unknown[]): Promise<string> {
+	const jsonlPath = await pollUntil<string>(() => {
+		const file = gateway.sessionManager.getPersistedSession(sessionId)?.agentSessionFile;
+		return file || "";
+	}, { timeoutMs: 10_000, intervalMs: 100, label: `session ${sessionId} jsonl path persisted` });
+	mkdirSync(dirname(jsonlPath), { recursive: true });
+	appendFileSync(jsonlPath, entries.map((entry) => JSON.stringify(entry)).join("\n") + "\n");
+	return jsonlPath;
+}
+
+function transcriptMessage(id: string, text: string): unknown {
+	return { type: "message", id, message: { role: "user", content: [{ type: "text", text }] } };
 }
 
 async function getPersisted(id: string): Promise<any> {
@@ -164,19 +168,20 @@ function appendOldCwdMessageContentSentinels(jsonlPath: string, cwd: string, mar
 
 test.describe.serial("sidebar actions server endpoints", () => {
 	test("GET /api/goals/:id/github-link returns PR, branch fallback, and unavailable states", async ({ gateway }) => {
-		const prGoal = await createGoal({ title: `sidebar pr ${Date.now()}`, cwd: nonGitCwd(), worktree: false, team: false });
+		const linkGoal = await createGoal({ title: `sidebar link ${Date.now()}`, cwd: nonGitCwd(), worktree: false, team: false });
 		const noWorktreeGoal = await createGoal({ title: `sidebar no worktree ${Date.now()}`, cwd: nonGitCwd(), worktree: false, team: false });
-		const branchGoal = await createGoal({ title: `sidebar branch ${Date.now()}`, cwd: nonGitCwd(), worktree: false, team: false });
 		try {
 			const repo = gitCwd();
-			gateway.sessionManager.getGoalStoreForProject(prGoal.projectId).update(prGoal.id, {
+			try { execFileSync("git", ["remote", "remove", "origin"], { cwd: repo, stdio: "ignore" }); } catch { /* ignore */ }
+			execFileSync("git", ["remote", "add", "origin", "git@github.com:acme/widget.git"], { cwd: repo, stdio: "pipe" });
+			gateway.sessionManager.getGoalStoreForProject(linkGoal.projectId).update(linkGoal.id, {
 				branch: "feature/sidebar-pr-cache",
 				repoPath: repo,
 				cwd: repo,
 				worktreePath: repo,
 			});
-			gateway.sessionManager.prStatusStore.set(prGoal.id, { state: "OPEN", url: "https://github.com/acme/widget/pull/123" });
-			const prResp = await apiFetch(`/api/goals/${prGoal.id}/github-link`);
+			gateway.sessionManager.prStatusStore.set(linkGoal.id, { state: "OPEN", url: "https://github.com/acme/widget/pull/123" });
+			const prResp = await apiFetch(`/api/goals/${linkGoal.id}/github-link`);
 			expect(prResp.status).toBe(200);
 			expect(await prResp.json()).toMatchObject({ available: true, kind: "pr", url: "https://github.com/acme/widget/pull/123" });
 
@@ -188,11 +193,10 @@ test.describe.serial("sidebar actions server endpoints", () => {
 			expect(missingResp.status).toBe(200);
 			expect(await missingResp.json()).toMatchObject({ available: false, reason: "goal-not-found" });
 
-			try { execFileSync("git", ["remote", "remove", "origin"], { cwd: repo, stdio: "ignore" }); } catch { /* ignore */ }
-			execFileSync("git", ["remote", "add", "origin", "git@github.com:acme/widget.git"], { cwd: repo, stdio: "pipe" });
 			const branch = "feature/sidebar-actions";
-			gateway.sessionManager.getGoalStoreForProject(branchGoal.projectId).update(branchGoal.id, { branch, repoPath: repo, cwd: repo, worktreePath: repo });
-			const branchResp = await apiFetch(`/api/goals/${branchGoal.id}/github-link`);
+			gateway.sessionManager.prStatusStore.remove(linkGoal.id);
+			gateway.sessionManager.getGoalStoreForProject(linkGoal.projectId).update(linkGoal.id, { branch, repoPath: repo, cwd: repo, worktreePath: repo });
+			const branchResp = await apiFetch(`/api/goals/${linkGoal.id}/github-link`);
 			expect(branchResp.status).toBe(200);
 			expect(await branchResp.json()).toMatchObject({
 				available: true,
@@ -200,9 +204,8 @@ test.describe.serial("sidebar actions server endpoints", () => {
 				url: "https://github.com/acme/widget/tree/feature%2Fsidebar-actions",
 			});
 		} finally {
-			await deleteGoal(prGoal.id);
+			await deleteGoal(linkGoal.id);
 			await deleteGoal(noWorktreeGoal.id);
-			await deleteGoal(branchGoal.id);
 		}
 	});
 });
@@ -268,7 +271,9 @@ test.describe.serial("fork worktree choice", () => {
 			expect(srcRec.projectId).toBe(projectId);
 			expect(srcRec.worktreePath).toBeTruthy();
 			expect(srcRec.cwd).toBe(srcRec.worktreePath);
-			await sendPromptAndWait(sourceId, "FORK_WT_MARKER hello from worktree");
+			await seedSessionTranscript(gateway, sourceId, [
+				transcriptMessage(`fork-wt-${sourceId}`, "FORK_WT_MARKER hello from worktree"),
+			]);
 
 			// newWorktree=true → fresh worktree + branch, distinct from the source.
 			const trueResp = await apiFetch(`/api/sessions/${sourceId}/fork`, {
@@ -352,12 +357,9 @@ test.describe.serial("fork worktree choice", () => {
 			expect(branchExists(repoPath, srcRec.branch), "source branch should exist before staling it").toBe(true);
 
 			const transcriptMarker = `FORK_STALE_CWD_TRANSCRIPT_${Date.now()}`;
-			await sendPromptAndWait(sourceId!, `${transcriptMarker} hello from stale fork source`);
-
-			const sourceJsonl = await pollUntil<string>(() => {
-				const file = gateway.sessionManager.getPersistedSession(sourceId!)?.agentSessionFile;
-				return file && existsSync(file) ? file : "";
-			}, { timeoutMs: 10_000, intervalMs: 100, label: "source session jsonl exists" });
+			const sourceJsonl = await seedSessionTranscript(gateway, sourceId!, [
+				transcriptMessage(`${transcriptMarker}-user`, `${transcriptMarker} hello from stale fork source`),
+			]);
 			ensureStaleRuntimeCwdMetadata(sourceJsonl, srcRec.worktreePath, sourceId!);
 			const contentMarker = `FORK_STALE_CWD_CONTENT_${Date.now()}`;
 			const { userLine, assistantLine } = appendOldCwdMessageContentSentinels(sourceJsonl, srcRec.worktreePath, contentMarker);

--- a/tests2/tests-map.json
+++ b/tests2/tests-map.json
@@ -80,6 +80,10 @@
       "reason": "Part 1+2 of 'Hide/Disable PR & Hindsight': fresh-state browser journey proving pr-walkthrough ships default-OFF (no contributions/tools, deep-link unavailable, master toggle rendered+unchecked), enabling via the marketplace master toggle lights up all contributions and persists across reload, disabling turns it off again; plus hindsight is absent from the built-in group and from /api/marketplace/installed. Complements the enabled-baseline live-feature spec at tests2/browser/e2e/pr-walkthrough-pack.spec.ts."
     },
     {
+      "path": "tests2/core/pr-walkthrough-local-resolver.test.ts",
+      "reason": "Native v2 core tests for PR walkthrough local diff resolver error/truncation/empty-diff behavior moved out of the route-level integration suite."
+    },
+    {
       "path": "tests2/core/bobbit-tool-credentials.test.ts",
       "reason": "bobbit gateway tool suite: credential/URL resolution — env creds, state-file fallback, absent-creds (logs + no registration, no throw), baseUrl trailing-slash trimming."
     },


### PR DESCRIPTION
## Summary

- Restores the bundle-size guard by splitting header toast state out of the eager session runtime chunk.
- Reduces git/repo-heavy integration runtime across base-ref, commit-diff, sidebar GitHub link, multi-repo, and PR walkthrough suites while preserving representative route coverage.
- Adds cleanup fallback instrumentation/regression coverage, trims heavyweight test imports, and fixes a Vite-unsafe PR walkthrough optional import seen in full unit verification.
- Updates the v2 unit runtime optimization report and hook-profiling guidance.

## Validation

- Implementation gate passed: build, typecheck, unit, browser, e2e, and reviewer phases.
- Documentation gate passed.
- Focused merged run: 17 files / 142 tests passed in 42.12s before full gate verification.
- `npm run build` and `npm run check` passed during validation.

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)