### PR TITLE
Fix headset sidebar clipping

### DIFF
--- a/public/accessory-focus-preview.html
+++ b/public/accessory-focus-preview.html
@@ -297,7 +297,22 @@ function updateCustomStyle(id, sprite) {
   if (id === "headset") {
     const busyTranslatePx = fineYOffsetBusy * 4;
     const idleTransformYPx = (fineYOffsetIdle - fineYOffsetBusy) * 4;
-    const hiddenShadow = pixelsToBoxShadow(sprite.pixels.filter(([x, y]) => x <= 6 || (x === 7 && y === 0)));
+    const hiddenPixelMap = new Map(sprite.pixels.map(([x, y, color]) => [`${x},${y}`, color]));
+    const hiddenPixels = sprite.pixels
+      .filter(([x, y]) => (x <= 6 && y !== 7) || (x === 7 && (y === 0 || y === 1)) || (x === 8 && y === 1))
+      .map(([x, y, color]) => [x, y, color]);
+    const setHiddenPixel = (x, y, color) => {
+      const existing = hiddenPixels.find((pixel) => pixel[0] === x && pixel[1] === y);
+      if (existing) existing[2] = color;
+      else hiddenPixels.push([x, y, color]);
+    };
+    setHiddenPixel(2, 4, hiddenPixelMap.get("2,4") || "#000");
+    setHiddenPixel(2, 5, hiddenPixelMap.get("2,5") || "#000");
+    setHiddenPixel(8, 6, "#000");
+    setHiddenPixel(9, 6, "#000");
+    setHiddenPixel(7, 7, "#f97316");
+    setHiddenPixel(8, 7, "#1f2937");
+    const hiddenShadow = pixelsToBoxShadow(hiddenPixels);
     rules.push(`.${cls} .${divClass} { translate: 0 ${busyTranslatePx}px !important; }`);
     rules.push(`@keyframes blob-headset-shadow {
 \t0% { box-shadow:\n\t\t${shadow};\n\t}

--- a/src/ui/app.css
+++ b/src/ui/app.css
@@ -2591,6 +2591,8 @@ html {
 		4px 1px 0 #000,
 		5px 1px 0 #000,
 		6px 1px 0 #000,
+		7px 1px 0 #4b5563,
+		8px 1px 0 #000,
 		0px 2px 0 #000,
 		1px 2px 0 #1f2937,
 		2px 2px 0 #000,
@@ -2599,11 +2601,17 @@ html {
 		-1px 4px 0 #000,
 		0px 4px 0 #374151,
 		1px 4px 0 #4b5563,
+		2px 4px 0 #000,
 		-1px 5px 0 #000,
 		0px 5px 0 #1f2937,
 		1px 5px 0 #374151,
+		2px 5px 0 #000,
 		0px 6px 0 #000,
-		1px 6px 0 #000;
+		1px 6px 0 #000,
+		8px 6px 0 #000,
+		9px 6px 0 #000,
+		7px 7px 0 #f97316,
+		8px 7px 0 #1f2937;
 	}
 	/* Back to normal after rightward hops. */
 	57% { box-shadow:
@@ -2672,6 +2680,8 @@ html {
 		4px 1px 0 #000,
 		5px 1px 0 #000,
 		6px 1px 0 #000,
+		7px 1px 0 #4b5563,
+		8px 1px 0 #000,
 		0px 2px 0 #000,
 		1px 2px 0 #1f2937,
 		2px 2px 0 #000,
@@ -2680,11 +2690,17 @@ html {
 		-1px 4px 0 #000,
 		0px 4px 0 #374151,
 		1px 4px 0 #4b5563,
+		2px 4px 0 #000,
 		-1px 5px 0 #000,
 		0px 5px 0 #1f2937,
 		1px 5px 0 #374151,
+		2px 5px 0 #000,
 		0px 6px 0 #000,
-		1px 6px 0 #000;
+		1px 6px 0 #000,
+		8px 6px 0 #000,
+		9px 6px 0 #000,
+		7px 7px 0 #f97316,
+		8px 7px 0 #1f2937;
 	}
 	/* Back to normal after up-right glance. */
 	65% { box-shadow:
@@ -2753,6 +2769,8 @@ html {
 		4px 1px 0 #000,
 		5px 1px 0 #000,
 		6px 1px 0 #000,
+		7px 1px 0 #4b5563,
+		8px 1px 0 #000,
 		0px 2px 0 #000,
 		1px 2px 0 #1f2937,
 		2px 2px 0 #000,
@@ -2761,11 +2779,17 @@ html {
 		-1px 4px 0 #000,
 		0px 4px 0 #374151,
 		1px 4px 0 #4b5563,
+		2px 4px 0 #000,
 		-1px 5px 0 #000,
 		0px 5px 0 #1f2937,
 		1px 5px 0 #374151,
+		2px 5px 0 #000,
 		0px 6px 0 #000,
-		1px 6px 0 #000;
+		1px 6px 0 #000,
+		8px 6px 0 #000,
+		9px 6px 0 #000,
+		7px 7px 0 #f97316,
+		8px 7px 0 #1f2937;
 	}
 	/* Back to normal. */
 	98% { box-shadow:

--- a/src/ui/bobbit-render.ts
+++ b/src/ui/bobbit-render.ts
@@ -774,18 +774,38 @@ export function renderSidebarBobbitCanvas(opts: SidebarBobbitOptions): TemplateR
 	let accUrl = "";
 	let accCssW = 0;
 	let accCssH = 0;
+	let accLeft = 0;
+	let sidebarOriginX = 0;
+	const sidebarContainerWidth = 20;
 	if (hasAccessory) {
 		const spriteData = SPRITE_ACCESSORIES[acc.id];
 		if (spriteData && spriteData.pixels.length > 0) {
-			let minY = Infinity, maxX = -Infinity, maxY = -Infinity;
+			let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
 			for (const [x, y] of spriteData.pixels) {
+				if (x < minX) minX = x;
 				if (y < minY) minY = y;
 				if (x > maxX) maxX = x;
 				if (y > maxY) maxY = y;
 			}
+			const xShift = Math.min(0, minX);
 			const yShift = Math.min(0, minY);
-			const srcW = maxX + 1;
+			const srcW = maxX - xShift + 1;
 			const srcH = maxY - yShift + 1;
+
+			// Preserve coordinate alignment between body + accessory, but use spare
+			// sidebar wrapper width when an accessory has left-of-body pixels (e.g.
+			// headset at x=-1). Other accessories keep the historical x=0 body origin
+			// so right-hand tools don't shift further into the clipped edge.
+			if (xShift < 0) {
+				const groupRight = Math.max(BODY_WIDTH, maxX + 1);
+				const groupWidth = (groupRight - xShift) * S;
+				const groupLeft = groupWidth <= sidebarContainerWidth
+					? (sidebarContainerWidth - groupWidth) / 2
+					: 0;
+				sidebarOriginX = groupLeft - xShift * S;
+			}
+			accLeft = sidebarOriginX + xShift * S;
+
 			// CSS geometry is derived from the (static) pixel bounds — cheap to
 			// recompute. Only the data-URL encode is cached, keyed by accessory
 			// id alone since each accessory's pixels are immutable.
@@ -800,7 +820,7 @@ export function renderSidebarBobbitCanvas(opts: SidebarBobbitOptions): TemplateR
 				accCtx.imageSmoothingEnabled = false;
 				for (const [x, y, color] of spriteData.pixels) {
 					accCtx.fillStyle = color;
-					accCtx.fillRect(x * HI, (y - yShift) * HI, HI, HI);
+					accCtx.fillRect((x - xShift) * HI, (y - yShift) * HI, HI, HI);
 				}
 				cached = accCanvas.toDataURL();
 				sidebarAccessoryUrlCache.set(acc.id, cached);
@@ -842,8 +862,8 @@ export function renderSidebarBobbitCanvas(opts: SidebarBobbitOptions): TemplateR
 	// Accessory transform — smooth variants
 	const isBandanaStyle = acc.id === "bandana";
 	const isCrown = acc.id === "crown";
-	// The headset seats half a sprite-pixel DOWN (mirrors the bandana's -0.5 up
-	// seat and the nurse-cap's blob `translate: 0 2px`).
+	// The headset seats half a sprite-pixel DOWN in sidebar canvas, mirroring its
+	// deliberately lower chat seating.
 	const isHeadset = acc.id === "headset";
 	const accFilter = hueRotate && status !== "starting" && status !== "terminated" && acc.id !== "flask"
 		? `filter:hue-rotate(${-hueRotate}deg);`
@@ -861,25 +881,25 @@ export function renderSidebarBobbitCanvas(opts: SidebarBobbitOptions): TemplateR
 	const eyeTop = innerTop;
 	const accTop = addsHeight ? `${acc.yOffset}px` : "0px";
 	const containerHeight = addsHeight ? "19px" : "15px";
-	const containerWidth = "20px";
+	const containerWidth = `${sidebarContainerWidth}px`;
 
 	// Body layer: high-res canvas img displayed at CSS target size, smooth downsampling
-	const bodyLayer = html`<img src="${bodyUrl}" width="${BODY_WIDTH * HI}" height="${BODY_HEIGHT * HI}" style="position:absolute;left:0;top:${innerTop};width:${cssW}px;height:${cssH}px;will-change:transform;${bodyTransform}">`;
+	const bodyLayer = html`<img src="${bodyUrl}" width="${BODY_WIDTH * HI}" height="${BODY_HEIGHT * HI}" style="position:absolute;left:${sidebarOriginX}px;top:${innerTop};width:${cssW}px;height:${cssH}px;will-change:transform;${bodyTransform}">`;
 
 	// Unread blink layer: a copy of the body with eyes blinked, stacked on top
 	// and animated via CSS to flick visible for a brief moment each cycle.
 	const blinkLayer = unread && blinkUrl
-		? html`<img src="${blinkUrl}" width="${BODY_WIDTH * HI}" height="${BODY_HEIGHT * HI}" class="bobbit-sidebar-unread-blink" style="position:absolute;left:0;top:${innerTop};width:${cssW}px;height:${cssH}px;will-change:opacity,transform;${bodyTransform}">`
+		? html`<img src="${blinkUrl}" width="${BODY_WIDTH * HI}" height="${BODY_HEIGHT * HI}" class="bobbit-sidebar-unread-blink" style="position:absolute;left:${sidebarOriginX}px;top:${innerTop};width:${cssW}px;height:${cssH}px;will-change:opacity,transform;${bodyTransform}">`
 		: "";
 
 	// Eye layer (only when selected)
 	const eyeLayer = isSelected && eyeUrl
-		? html`<img src="${eyeUrl}" width="${BODY_WIDTH * HI}" height="${BODY_HEIGHT * HI}" style="position:absolute;left:0;top:${eyeTop};width:${cssW}px;height:${cssH}px;will-change:transform;${eyeAnim}">`
+		? html`<img src="${eyeUrl}" width="${BODY_WIDTH * HI}" height="${BODY_HEIGHT * HI}" style="position:absolute;left:${sidebarOriginX}px;top:${eyeTop};width:${cssW}px;height:${cssH}px;will-change:transform;${eyeAnim}">`
 		: "";
 
 	// Accessory layer
 	const accessoryLayer = accUrl
-		? html`<img src="${accUrl}" style="position:absolute;left:0;top:${accTop};width:${accCssW}px;height:${accCssH}px;will-change:transform;${accTransform}${accFilter}">`
+		? html`<img src="${accUrl}" style="position:absolute;left:${accLeft}px;top:${accTop};width:${accCssW}px;height:${accCssH}px;will-change:transform;${accTransform}${accFilter}">`
 		: "";
 
 	return html`<span style="display:inline-flex;align-items:center;justify-content:center;width:${containerWidth};height:${containerHeight};flex-shrink:0;position:relative;overflow:hidden;margin-top:1px;${filterStyle}${bobAnim}${cancelAnim}${idleAnim}">${bodyLayer}${blinkLayer}${eyeLayer}${accessoryLayer}</span>`;

--- a/src/ui/bobbit-sprite-data.ts
+++ b/src/ui/bobbit-sprite-data.ts
@@ -519,10 +519,10 @@ export const ACCESSORY_NURSE_CAP: AccessorySpriteData = {
  * windscreen in front of the mouth. Sidebar coordinates (yOffset=2,
  * addsHeight=true, blobYAdjust=2).
  *
- * Seated half a sprite-pixel DOWN in chat (`translate: 0 2px`) and sidebar
- * canvas (`translateY(0.5 * S)`). Neutral greys only (NOT in the flask
- * exception set) so it is counter-hue-rotated and stays neutral across every
- * session palette.
+ * Seated a quarter sprite-pixel DOWN in chat (`translate: 0 1px`) and a half
+ * sprite-pixel DOWN in sidebar canvas (`translateY(0.5 * S)`). Neutral greys
+ * only (NOT in the flask exception set) so it is counter-hue-rotated and stays
+ * neutral across every session palette.
  */
 export const ACCESSORY_HEADSET: AccessorySpriteData = {
   id: 'headset',

--- a/tests2/core/headset-accessory.test.ts
+++ b/tests2/core/headset-accessory.test.ts
@@ -76,7 +76,8 @@ describe("headset accessory", () => {
 		// Seats a quarter sprite-pixel DOWN via the independent translate lever.
 		assert.match(css, /\.bobbit-headset \.bobbit-blob__headset[\s\S]*?translate:\s*0 1px/, "downward seat translate");
 		assert.match(css, /blob-headset-shadow/, "headset hides the far/right ear cup during right-facing busy phases");
-		assert.match(css, /Looking up-right[\s\S]*?60% \{ box-shadow:[\s\S]*?0px 6px 0 #000,[\s\S]*?1px 6px 0 #000;\r?\n\t\}/, "headset hides the far/right ear cup during up-right busy phase");
+		assert.match(css, /Facing right[\s\S]*?7px 1px 0 #4b5563,[\s\S]*?8px 1px 0 #000,[\s\S]*?2px 4px 0 #000,[\s\S]*?2px 5px 0 #000,[\s\S]*?8px 6px 0 #000,[\s\S]*?9px 6px 0 #000,[\s\S]*?7px 7px 0 #f97316,[\s\S]*?8px 7px 0 #1f2937/, "right-facing headset keeps the selected rim and mic pixels");
+		assert.match(css, /Looking up-right[\s\S]*?60% \{ box-shadow:[\s\S]*?7px 1px 0 #4b5563,[\s\S]*?8px 1px 0 #000,[\s\S]*?2px 4px 0 #000,[\s\S]*?2px 5px 0 #000,[\s\S]*?8px 6px 0 #000,[\s\S]*?9px 6px 0 #000,[\s\S]*?7px 7px 0 #f97316,[\s\S]*?8px 7px 0 #1f2937;\r?\n\t\}/, "headset hides the far/right ear cup during up-right busy phase but keeps selected rim/mic pixels");
 		assert.doesNotMatch(css, /blob-headset-idle-shadow/, "sleeping idle headset should not hide either ear cup");
 
 		// DOM templates (chat blob + idle blob, streaming container).
@@ -85,6 +86,14 @@ describe("headset accessory", () => {
 		assert.ok(chatDivs.length >= 2, "headset div in both bobbit-render templates");
 		// Sidebar canvas seat special-case (+0.5 sprite px).
 		assert.match(render, /isHeadset/, "sidebar accTransform seat special-case");
+		// Sidebar canvas must preserve negative accessory x pixels by rasterizing
+		// from minX and shifting the shared body/accessory origin together.
+		assert.match(render, /let minX = Infinity/, "sidebar accessory bounds track minX");
+		assert.match(render, /const xShift = Math\.min\(0, minX\)/, "sidebar accessory keeps negative x extent");
+		assert.match(render, /const srcW = maxX - xShift \+ 1/, "sidebar accessory canvas includes negative x pixels");
+		assert.match(render, /fillRect\(\(x - xShift\) \* HI/, "sidebar accessory rasterization offsets by minX");
+		assert.match(render, /left:\$\{sidebarOriginX\}px/, "sidebar body layers share adjusted x origin");
+		assert.match(render, /left:\$\{accLeft\}px/, "sidebar accessory layer uses minX-aware left edge");
 		assert.match(read("src/ui/components/StreamingMessageContainer.ts"), /bobbit-blob__headset/);
 
 		// Role-manager inline display rules (per-blob gating, no html-class leak).


### PR DESCRIPTION
## Summary
- preserve negative-x accessory pixels in the sidebar canvas renderer
- keep selected headset pixels visible during right-facing phases
- update the accessory focus editor preview and headset pinning tests

## Tests
- npx vitest run tests2/core/headset-accessory.test.ts
- npm run check

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)