### PR TITLE
Wire test:unit to the lane-parallel runner + fix dom teardown flake

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "test:v2:coverage-delta": "node scripts/testing-v2/coverage-delta.mjs",
     "test:v2:browser-chaos": "node scripts/testing-v2/browser-chaos.mjs",
     "test:v2:profile-hooks": "node scripts/testing-v2/profile-hooks.mjs",
-    "test:unit": "npm run test:v2:core",
+    "test:unit": "npm run test:v2:core:lanes",
     "test:browser": "npm run test:v2:browser",
     "test:bundle": "node scripts/testing-v2/run-bundle-check.mjs",
     "test:e2e": "npm run test:e2e:v2",

--- a/src/ui/components/review/AnnotationPopover.ts
+++ b/src/ui/components/review/AnnotationPopover.ts
@@ -1,5 +1,5 @@
 import { html, LitElement, css } from "lit";
-import { customElement, property, query } from "lit/decorators.js";
+import { property, query } from "lit/decorators.js";
 import { icon } from "@mariozechner/mini-lit";
 import { Copy, Check } from "lucide";
 
@@ -75,7 +75,6 @@ export function closeAnnotationPopover(): void {
   if (_singleton && _singleton.isConnected) _singleton.open = false;
 }
 
-@customElement("annotation-popover")
 export class AnnotationPopover extends LitElement {
   @property({ type: Boolean, reflect: true }) open = false;
   /** DOMRect of the selection range (viewport coordinates). */
@@ -561,6 +560,16 @@ export class AnnotationPopover extends LitElement {
       </div>
     `;
   }
+}
+
+// Guarded registration (not @customElement): keeps this module import-safe when
+// `customElements` is transiently undefined — a lazy import resolving in the
+// happy-dom teardown gap (v2-dom pool:forks/isolate:false window churn) otherwise
+// throws an unhandled "customElements is not defined" that fails the run despite
+// every test passing. In the browser customElements is always present, so this
+// registers identically to @customElement.
+if (typeof customElements !== "undefined" && !customElements.get("annotation-popover")) {
+  customElements.define("annotation-popover", AnnotationPopover);
 }
 
 declare global {

--- a/src/ui/components/review/ReviewDocument.ts
+++ b/src/ui/components/review/ReviewDocument.ts
@@ -1,5 +1,5 @@
 import { html, LitElement } from "lit";
-import { customElement, property, state } from "lit/decorators.js";
+import { property, state } from "lit/decorators.js";
 import { marked } from "marked";
 import { createTextAnnotator, type TextAnnotator } from "@recogito/text-annotator";
 import "@recogito/text-annotator/text-annotator.css";
@@ -145,7 +145,6 @@ export function renderReviewMarkdownToHtml(markdown: string): string {
  * text selection and highlighting. Does NOT use Shadow DOM so the annotator
  * can access the rendered DOM directly.
  */
-@customElement("review-document")
 export class ReviewDocument extends LitElement {
   @property({ type: String }) markdown = "";
   @property({ type: String }) sessionId = "";
@@ -1012,6 +1011,16 @@ export class ReviewDocument extends LitElement {
       <!-- Annotation popover is mounted as a singleton in <body>; see _syncPopover. -->
     `;
   }
+}
+
+// Guarded registration (not @customElement): keeps this module import-safe when
+// `customElements` is transiently undefined — a lazy import resolving in the
+// happy-dom teardown gap (v2-dom pool:forks/isolate:false window churn) otherwise
+// throws an unhandled "customElements is not defined" that fails the run despite
+// every test passing. In the browser customElements is always present, so this
+// registers identically to @customElement.
+if (typeof customElements !== "undefined" && !customElements.get("review-document")) {
+  customElements.define("review-document", ReviewDocument);
 }
 
 declare global {

--- a/src/ui/components/review/ReviewPane.ts
+++ b/src/ui/components/review/ReviewPane.ts
@@ -1,5 +1,5 @@
 import { html, LitElement } from "lit";
-import { customElement, property, state } from "lit/decorators.js";
+import { property, state } from "lit/decorators.js";
 import {
   buildReviewDecisionPayloadForDocument,
   getAnnotationBucketForDocument,
@@ -20,7 +20,6 @@ import "./review-pane.css";
  * Renders a horizontal tab bar, the active `<review-document>`, and a bottom
  * action bar. Uses light DOM for consistent styling with the app theme.
  */
-@customElement("review-pane")
 export class ReviewPane extends LitElement {
   @property({ attribute: false })
   documents: Map<string, ReviewDocumentModel> = new Map();
@@ -384,6 +383,16 @@ export class ReviewPane extends LitElement {
       </div>
     `;
   }
+}
+
+// Guarded registration (not @customElement): keeps this module import-safe when
+// `customElements` is transiently undefined — a lazy import resolving in the
+// happy-dom teardown gap (v2-dom pool:forks/isolate:false window churn) otherwise
+// throws an unhandled "customElements is not defined" that fails the run despite
+// every test passing. In the browser customElements is always present, so this
+// registers identically to @customElement.
+if (typeof customElements !== "undefined" && !customElements.get("review-pane")) {
+  customElements.define("review-pane", ReviewPane);
 }
 
 declare global {


### PR DESCRIPTION
Follow-up to #996. Flips `test:unit` to the ledger-native lane-parallel runner and removes the one blocker that kept that unsafe — an intermittent happy-dom teardown flake in the dom lane.

## `test:unit` → lane runner
`test:unit` now runs **core / integration / dom as separate concurrent vitest processes** (each ≤2 forks, ledger-arbitrated). Wall: **~631s → ~277–355s** on an idle box (−44%…−56%); even under heavy contention serial-sum ~1081s collapses to ~553s. Concurrency-safe — one ledger reservation per run, shrinks under peer load, never oversubscribes (mechanics in #996).

## Fix: dom `customElements is not defined` teardown rejection
The three review components (`AnnotationPopover` / `ReviewDocument` / `ReviewPane`) are lazy lit components. Under the v2-dom tier's `pool:forks, isolate:false` window churn, a lazy import resolving in the happy-dom **teardown gap** re-evaluated the module when the `customElements` global was momentarily gone → unhandled rejection that failed the run **even though every dom test passed**. Intermittent; lane isolation surfaced it more often (the single-process run happened not to hit it).

**Fix:** register those three elements via a **guarded `customElements.define`** instead of the `@customElement` decorator, so module eval is import-safe when `customElements` is transiently undefined. The v2-dom registry-bridge still records the real define during live evals (nothing changes for tests that render them), and in the browser `customElements` is always present so registration is identical to `@customElement`. The dom tier only imports these modules for their pure sanitizer helpers — it never renders the elements.

## Validation
- dom lane **3/3 green, 0 rejections**
- full `npm run test:unit` (now the lane runner): **EXIT 0**, core + integration + dom all PASS, **0** `onTaskUpdate`/`onUnhandledError`
- `tsc -p tsconfig.web.json --noEmit` clean
- bundle-size (from #996) skips deterministically in the unit lane; guarded in `test:bundle`

## Notes
- No behaviour change in the browser/product — the guard registers identically when `customElements` exists.
- Sub-5-min is still gated on the Vitest 4.x fork-lift (#8297) or cutting integration's per-test work — separate follow-ups.

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)