### PR TITLE
perf(gateway): faster shutdown (no pool drain) + boot/shutdown instrumentation

### DIFF
--- a/src/server/agent/bobbit-archive.ts
+++ b/src/server/agent/bobbit-archive.ts
@@ -60,6 +60,7 @@ export const GATEWAY_OWNED_FILES: readonly string[] = [
 	"state/mcp-extensions/",      // src/server/agent/tool-activation.ts, rpc-bridge.ts
 	"state/html-snapshots/",      // server.ts
 	"state/gate-diagnostics/",    // src/server/agent/gate-diagnostics-cleanup.ts
+	"state/boot-timings.log",     // src/server/boot-profile.ts (boot/shutdown timing tee)
 	"state/proposal-drafts/",     // server.ts / session-manager.ts
 	"state/pr-walkthrough/",      // src/server/pr-walkthrough/routes.ts persisted walkthrough payloads
 	"state/model-name-*",         // src/server/agent/session-manager.ts per-session model-name files

--- a/src/server/agent/project-context-manager.ts
+++ b/src/server/agent/project-context-manager.ts
@@ -7,6 +7,7 @@ import type { SearchResults, SearchResult } from "../search/types.js";
 import type { ProjectConfigStore } from "./project-config-store.js";
 import type { Clock, CommandRunner, FsLike } from "../gateway-deps.js";
 import type { RemoteGitPolicy } from "../skills/git.js";
+import { bootLog, SLOW_PHASE_MS } from "../boot-profile.js";
 
 /**
  * Minimal session-resolver surface needed by the search orphan filter.
@@ -72,9 +73,18 @@ export class ProjectContextManager {
 
   /** Initialize contexts for all registered projects. */
   initAll(): void {
-    for (const project of this.registry.list()) {
+    const t0 = Date.now();
+    const projects = this.registry.list();
+    for (const project of projects) {
+      const pt0 = Date.now();
       this.getOrCreate(project.id);
+      const dt = Date.now() - pt0;
+      // Per-project context open (loads goals/sessions/costs/workflows/tools
+      // from disk) is synchronous and blocks gateway construction. Log slow
+      // ones so a single heavy project is visible in boot logs.
+      if (dt >= SLOW_PHASE_MS) bootLog(`[boot] context open: project=${project.id} in ${dt}ms`);
     }
+    bootLog(`[boot] initAll opened ${projects.length} project context(s) in ${Date.now() - t0}ms`);
   }
 
   /** Get or lazily create a ProjectContext. */

--- a/src/server/agent/worktree-pool.ts
+++ b/src/server/agent/worktree-pool.ts
@@ -899,7 +899,13 @@ export class WorktreePool {
 		}
 	}
 
-	/** Clean up all pool entries. Call on shutdown. */
+	/**
+	 * Clean up all pool entries (worktree remove + branch delete). NOT called on
+	 * gateway shutdown anymore — shutdown intentionally leaves pool worktrees on
+	 * disk for `reclaimOrphaned` to re-adopt on the next boot. Only explicit
+	 * teardown drains: project removal (`removeWorktreePool`) and Settings →
+	 * Maintenance cleanup.
+	 */
 	async drain(): Promise<void> {
 		const diagEnabled = cpuDiagnosticsEnabled();
 		const diagStart = diagEnabled ? performance.now() : 0;

--- a/src/server/boot-profile.ts
+++ b/src/server/boot-profile.ts
@@ -1,0 +1,83 @@
+/**
+ * Boot/shutdown timing tee.
+ *
+ * The gateway logs boot- and shutdown-phase timings to stdout, which the dev
+ * harness inherits into the operator's terminal. An agent session running
+ * *inside* the gateway cannot read that terminal, so these same lines are also
+ * appended to `<stateDir>/boot-timings.log`. That gives a readable, persistent
+ * record of the most recent boot + shutdown cycle for post-restart diagnosis.
+ *
+ * Best-effort only: any filesystem error is swallowed so instrumentation can
+ * never affect gateway startup/shutdown behaviour.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { bobbitStateDir } from "./bobbit-dir.js";
+
+const MAX_BYTES = 256 * 1024;
+
+/** Phase-timer log threshold: only phases at/above this are logged. */
+export const SLOW_PHASE_MS = 50;
+
+function logFilePath(): string | null {
+	try {
+		return path.join(bobbitStateDir(), "boot-timings.log");
+	} catch {
+		return null;
+	}
+}
+
+function append(line: string): void {
+	const p = logFilePath();
+	if (!p) return;
+	try {
+		// Ensure the state dir exists so the earliest boot lines aren't dropped
+		// on a fresh install (append would otherwise ENOENT and be swallowed).
+		fs.mkdirSync(path.dirname(p), { recursive: true });
+		// Bound the file so repeated restarts can't grow it without limit: once it
+		// exceeds MAX_BYTES, keep only the trailing half (from the next line break,
+		// so we never leave a partial fragment as the first line) before appending.
+		try {
+			const st = fs.statSync(p);
+			if (st.size > MAX_BYTES) {
+				const buf = fs.readFileSync(p);
+				let tail = buf.subarray(buf.length - Math.floor(MAX_BYTES / 2));
+				const nl = tail.indexOf(0x0a); // drop the leading partial line
+				if (nl >= 0 && nl + 1 < tail.length) tail = tail.subarray(nl + 1);
+				fs.writeFileSync(p, tail);
+			}
+		} catch { /* file may not exist yet */ }
+		fs.appendFileSync(p, `${new Date().toISOString()} ${line}\n`);
+	} catch { /* best-effort */ }
+}
+
+/**
+ * Build an async phase timer that logs `<prefix> <name> in <ms>` (tee'd to the
+ * timings file) when a phase takes at least SLOW_PHASE_MS. Shared by the
+ * pre-listen boot path and the shutdown path so the two timers can't drift.
+ */
+export function makePhaseTimer(prefix: string): <T>(name: string, fn: () => T | Promise<T>) => Promise<T> {
+	return async <T>(name: string, fn: () => T | Promise<T>): Promise<T> => {
+		const t0 = Date.now();
+		try {
+			return await fn();
+		} finally {
+			const dt = Date.now() - t0;
+			if (dt >= SLOW_PHASE_MS) bootLog(`${prefix} ${name} in ${dt}ms`);
+		}
+	};
+}
+
+/** Log a boot/shutdown line to stdout AND append it to the timings file. */
+export function bootLog(line: string): void {
+	console.log(line);
+	append(line);
+}
+
+/** Write a cycle separator (boot/shutdown start) to stdout and the file. */
+export function bootMark(marker: string): void {
+	const line = `===== ${marker} =====`;
+	console.log(line);
+	append(line);
+}

--- a/src/server/cli.ts
+++ b/src/server/cli.ts
@@ -12,6 +12,7 @@ import { loadOrCreateToken, readToken } from "./auth/token.js";
 import { ensureTlsCert } from "./auth/tls.js";
 import { loadDesecConfig, updateDesecIp } from "./auth/desec.js";
 import { createGateway } from "./server.js";
+import { bootLog, bootMark } from "./boot-profile.js";
 import { loopbackForBind } from "./cli-loopback.js";
 import { resolveCliGatewayDeps } from "./cli-gateway-deps.js";
 
@@ -126,6 +127,8 @@ function parseArgs(argv: string[]): CliArgs {
 }
 
 async function main() {
+	// Wall-clock anchor for boot instrumentation — process-start (approx) to listen.
+	const bootWallT0 = Date.now();
 	const args = parseArgs(process.argv.slice(2));
 
 	// --show-token: print token and exit
@@ -193,6 +196,9 @@ async function main() {
 		updateDesecIp(desecConfig, args.host); // fire and forget
 	}
 
+	bootMark(`BOOT ${new Date().toISOString()}`);
+	bootLog(`[boot] prologue (binaries/token/tls) in ${Date.now() - bootWallT0}ms`);
+	const ctorT0 = Date.now();
 	const gateway = createGateway({
 		host: args.host,
 		port: args.port,
@@ -205,8 +211,12 @@ async function main() {
 		tls,
 		forceAuth: args.forceAuth,
 	}, resolveCliGatewayDeps());
+	bootLog(`[boot] createGateway construction in ${Date.now() - ctorT0}ms`);
 
+	const startT0 = Date.now();
 	const actualPort = await gateway.start();
+	bootLog(`[boot] gateway.start() (pre-listen critical path) in ${Date.now() - startT0}ms`);
+	bootLog(`[boot] TOTAL process-start \u2192 listening in ${Date.now() - bootWallT0}ms`);
 
 	// Collect reachable addresses for display
 	const interfaces = os.networkInterfaces();

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -31,6 +31,7 @@ import {
 	normalizeAgentDirInput,
 } from "./bobbit-dir.js";
 import { recordBootTiming, readBootTimings, BOOT_TIMING_FILE } from "./dev-boot-timing.js";
+import { bootLog, bootMark, makePhaseTimer, SLOW_PHASE_MS } from "./boot-profile.js";
 import { touchGatewayRestartSentinel } from "./harness-signal.js";
 import { isSetupComplete } from "./setup-status.js";
 export { isSetupComplete };
@@ -1821,6 +1822,18 @@ export interface GatewayConfig {
 }
 
 export function createGateway(config: GatewayConfig, deps?: GatewayDeps) {
+	// Construction checkpoint timer — createGateway runs fully synchronously
+	// before start(), and earlier profiling showed ~19s of unattributed time
+	// here. Log cumulative elapsed at each major subsystem so the heavy step is
+	// visible. Cheap; best-effort file tee via bootLog.
+	const __ckT0 = Date.now();
+	let __ckLast = __ckT0;
+	const ck = (label: string): void => {
+		const now = Date.now();
+		const delta = now - __ckLast;
+		__ckLast = now;
+		if (delta >= SLOW_PHASE_MS) bootLog(`[boot] ctor ${label} +${delta}ms (@${now - __ckT0}ms)`);
+	};
 	const hasExplicitAgentBridgeFactory = !!deps?.agentBridgeFactory;
 	const previousRpcBridgeFactory = hasExplicitAgentBridgeFactory ? getRegisteredRpcBridgeFactory() : null;
 	if (deps?.agentBridgeFactory) {
@@ -1928,11 +1941,14 @@ export function createGateway(config: GatewayConfig, deps?: GatewayDeps) {
 	}
 
 	// Run one-time migration from centralized to per-project state
+	ck("pre-migration-setup");
 	migrateToPerProjectState(stateDir, projectRegistry, getProjectRoot(), { centralConfigDir: configDir });
+	ck("migrateToPerProjectState");
 
 	// Recover data lost by the original migration bug (unconditional rename
 	// when central dir == default project dir). Must run before stores load.
 	recoverPreMigrationData(stateDir);
+	ck("recoverPreMigrationData");
 
 	// One-shot project.yaml migration: synthesize components[] for legacy
 	// single-repo projects. Idempotent. Must run BEFORE ProjectContext
@@ -1941,6 +1957,7 @@ export function createGateway(config: GatewayConfig, deps?: GatewayDeps) {
 	migrateAllProjectYaml(
 		projectRegistry.list().map(p => ({ id: p.id, name: p.name, rootPath: p.rootPath })),
 	);
+	ck("migrateAllProjectYaml");
 
 	const projectConfigStore = new ProjectConfigStore(configDir, gatewayDeps.fsImpl);
 
@@ -1955,6 +1972,7 @@ export function createGateway(config: GatewayConfig, deps?: GatewayDeps) {
 		worktreeSetupRuntime,
 	});
 	projectContextManager.initAll();
+	ck("initAll");
 
 	// Migrate inline token values from project.yaml → secrets.json (one-time)
 	for (const p of projectRegistry.list()) {
@@ -1995,6 +2013,7 @@ export function createGateway(config: GatewayConfig, deps?: GatewayDeps) {
 		} catch { /* ignore parse errors */ }
 	}
 
+	ck("token-migration-loop");
 	const colorStore = new ColorStore(stateDir);
 	const prStatusStore = new PrStatusStore(stateDir, gatewayDeps.fsImpl);
 	const preferencesStore = new PreferencesStore(stateDir, gatewayDeps.fsImpl);
@@ -2006,7 +2025,9 @@ export function createGateway(config: GatewayConfig, deps?: GatewayDeps) {
 	const roleStore = new RoleStore(configDir);
 	const roleManager = new RoleManager(roleStore);
 	const toolManager = new ToolManager(configDir);
+	ck("stores-pre-tooldocs");
 	toolManager.generateDetailDocs(stateDir);
+	ck("generateDetailDocs");
 	// Extension host (design docs/design/extension-host.md §4b): the action
 	// dispatcher lives for the gateway process lifetime; its module cache is
 	// dropped synchronously by invalidateResolverCaches() on pack mutations.
@@ -2031,6 +2052,7 @@ export function createGateway(config: GatewayConfig, deps?: GatewayDeps) {
 	// Slice B1: warm the process-singleton pack store (file-backed, pack-namespaced
 	// persistence behind `host.store.*` + the /api/ext/store/:op endpoint).
 	getPackStore();
+	ck("getPackStore");
 	const groupPolicyStore = new ToolGroupPolicyStore(configDir);
 	const sandboxTokenStore = new SandboxTokenStore();
 	const cookieStore = new CookieStore(stateDir);
@@ -2067,6 +2089,7 @@ export function createGateway(config: GatewayConfig, deps?: GatewayDeps) {
 	}
 
 	const builtinConfigProvider = new BuiltinConfigProvider(config.builtinsDir);
+	ck("stores+SessionManager");
 	// Wire builtin defaults into stores (in-memory only, no disk writes).
 	// Direct store lookups (roleStore.get()) transparently fall back to
 	// builtins, so no seeding to disk is needed. Workflows are project-
@@ -2560,6 +2583,7 @@ export function createGateway(config: GatewayConfig, deps?: GatewayDeps) {
 	});
 	sessionManager.setOrchestrationCore(orchestrationCore);
 
+	ck("pre-TeamManager");
 	const teamManager = new TeamManager(sessionManager, {
 		colorStore,
 		taskManager: new TaskManager(taskStore),
@@ -3121,7 +3145,9 @@ export function createGateway(config: GatewayConfig, deps?: GatewayDeps) {
 		});
 	}
 
+	ck("pre-VerificationHarness");
 	verificationHarness = new VerificationHarness(stateDir, undefined, broadcastToGoal, roleStore, preferencesStore, sessionManager, teamManager, projectConfigStore, projectContextManager, configCascade, { commandRunner: gatewayDeps.commandRunner, commandStepRunner: gatewayDeps.commandStepRunner, clock: gatewayDeps.clock, skipLlmReview: gatewayRuntimeFlags.skipLlmReview });
+	ck("new VerificationHarness");
 	teamManager.setVerificationHarness(verificationHarness);
 	verificationHarness.setTeamLeadNotifier((goalId, message) => {
 		const team = teamManager.getTeamState(goalId);
@@ -3171,6 +3197,8 @@ export function createGateway(config: GatewayConfig, deps?: GatewayDeps) {
 		});
 	});
 
+	ck("post-VerificationHarness-to-return");
+	bootLog(`[boot] ctor total (createGateway body) ${Date.now() - __ckT0}ms`);
 	return {
 		server,
 		deps: gatewayDeps,
@@ -3183,18 +3211,23 @@ export function createGateway(config: GatewayConfig, deps?: GatewayDeps) {
 		projectContextManager,
 		get extensionChannels() { return extensionChannelServices; },
 		async start(): Promise<number> {
+			// Phase timer for the pre-listen critical path: everything awaited here
+			// blocks `server.listen()`, i.e. delays the UI becoming reachable.
+			// Log each phase (>=50ms) so a slow cold-start is diagnosable from logs.
+			const bootStart = Date.now();
+			const bootPhase = makePhaseTimer("[boot] pre-listen");
 			// Check internet and auto-configure AI Gateway if offline
 			// Runs before session restore so models.json is written before
 			// any agent subprocesses start.
-			await startupAigwCheck(preferencesStore);
+			await bootPhase("aigw-check", () => startupAigwCheck(preferencesStore));
 			writeContextWindowOverrides();
 			writeOpenAIModelAdditions();
-			await initExtensionChannelsOnce();
+			await bootPhase("extension-channels", () => initExtensionChannelsOnce());
 
 			// Initialize MCP servers (skip when disabled by gateway runtime config)
 			if (!gatewayRuntimeFlags.skipMcp) {
 				try {
-					await sessionManager.initMcp(headquartersDir());
+					await bootPhase("mcp-init", () => sessionManager.initMcp(headquartersDir()));
 				} catch (err) {
 					console.error('[mcp] MCP init failed:', (err as Error).message);
 				}
@@ -3371,13 +3404,14 @@ export function createGateway(config: GatewayConfig, deps?: GatewayDeps) {
 			sessionManager.subscribeSandboxRecovery();
 
 			// Restore persisted sessions before accepting connections
-			await sessionManager.restoreSessions();
+			await bootPhase("restore-sessions", () => sessionManager.restoreSessions());
 
 			// One-shot legacy cost backfill: stamp `goalId` on cost entries
 			// that pre-date the forward-stamp fix (commit a4050f59). Runs
 			// once per project context after sessions are restored so the
 			// resolver can see live PersistedSession records. Idempotent.
 			const agentSessionsRoot = path.join(globalAgentDir(), "sessions");
+			const costBackfillStart = Date.now();
 			try {
 				for (const ctx of projectContextManager.all()) {
 					backfillLegacyCostGoalIds({
@@ -3389,12 +3423,17 @@ export function createGateway(config: GatewayConfig, deps?: GatewayDeps) {
 			} catch (err) {
 				console.warn("[cost-backfill] boot backfill failed (non-fatal):", err);
 			}
+			{
+				const dt = Date.now() - costBackfillStart;
+				if (dt >= SLOW_PHASE_MS) bootLog(`[boot] pre-listen cost-backfill in ${dt}ms`);
+			}
+			bootLog(`[boot] pre-listen phases complete in ${Date.now() - bootStart}ms`);
 
 			// NOTE: Orphaned worktree cleanup and non-interactive session cleanup
 			// are no longer automatic on startup. Use the Settings → Maintenance UI
 			// or the /api/maintenance/* endpoints to preview and clean up manually.
 
-			sessionManager.startPurgeSchedule();
+			await bootPhase("startPurgeSchedule", () => sessionManager.startPurgeSchedule());
 
 			// Initialize worktree pools for all git-repo projects
 			// (pre-creates worktrees in the background so new sessions start instantly).
@@ -3510,7 +3549,7 @@ export function createGateway(config: GatewayConfig, deps?: GatewayDeps) {
 								});
 							}
 						}
-						console.log(`[boot] sweeper start (${sweepProjects.length} projects)`);
+						bootLog(`[boot] sweeper start (${sweepProjects.length} projects)`);
 						const result = await sweepOrphanedWorktrees({
 							projects: sweepProjects,
 							goals: sweepGoals,
@@ -3518,7 +3557,7 @@ export function createGateway(config: GatewayConfig, deps?: GatewayDeps) {
 							teams: sweepTeams,
 							staff: sweepStaff,
 						});
-						console.log(`[boot] sweeper done in ${Date.now() - tStart}ms (reclaimed=${result.reclaimed} cleaned=${result.cleaned} repaired=${result.repaired})`);
+						bootLog(`[boot] sweeper done in ${Date.now() - tStart}ms (reclaimed=${result.reclaimed} cleaned=${result.cleaned} repaired=${result.repaired})`);
 					} catch (err) {
 						console.warn(`[boot] sweeper failed in ${Date.now() - tStart}ms (non-fatal):`, err);
 					}
@@ -3564,9 +3603,9 @@ export function createGateway(config: GatewayConfig, deps?: GatewayDeps) {
 								// pool entries land under <gitRoot>-wt/, not <projectDir>-wt/.
 								const poolRepoPath = isMulti ? repoPath : await getRepoRoot(repoPath);
 								sessionManager.initWorktreePoolForProject(ctx.project.id, poolRepoPath, () => pcs.getComponents(), poolSize, wtRoot, () => pcs.get("base_ref"), () => pcs.get("worktree_setup_timeout_ms") || undefined, ctx.project.rootPath);
-								console.log(`[boot] pool ready: project=${ctx.project.id} in ${Date.now() - tStart}ms`);
+								bootLog(`[boot] pool ready: project=${ctx.project.id} in ${Date.now() - tStart}ms`);
 							} else {
-								console.log(`[boot] pool skipped (not a git repo): project=${ctx.project.id} in ${Date.now() - tStart}ms`);
+								bootLog(`[boot] pool skipped (not a git repo): project=${ctx.project.id} in ${Date.now() - tStart}ms`);
 							}
 						} catch (err) {
 							console.warn(`[boot] pool init failed: project=${ctx.project.id} in ${Date.now() - tStart}ms (non-fatal):`, err);
@@ -3574,24 +3613,29 @@ export function createGateway(config: GatewayConfig, deps?: GatewayDeps) {
 					}));
 				})();
 				await Promise.all([transcriptBackfillTask, sweeperTask, poolInitTask]);
-				console.log(`[boot] background tasks complete in ${Date.now() - t0}ms`);
+				bootLog(`[boot] background tasks complete in ${Date.now() - t0}ms`);
 			};
 
 			// Wire goal-manager resolvers so goals claim through the pool first and
 			// resolve components / project root for multi-repo goal creation.
 			// Hidden contexts (synthetic system project) have no goals to wire.
-			for (const ctx of projectContextManager.visible()) {
-				wireGoalManagerResolvers(ctx, { sessionManager, projectContextManager, projectRegistry });
-			}
+			await bootPhase("wireGoalManagerResolvers", () => {
+				for (const ctx of projectContextManager.visible()) {
+					wireGoalManagerResolvers(ctx, { sessionManager, projectContextManager, projectRegistry });
+				}
+			});
 
 			// Now that sessions are live, re-subscribe to team events
 			// (must happen after restoreSessions so session objects exist)
-			teamManager.resubscribeTeamEvents();
+			await bootPhase("resubscribeTeamEvents", () => teamManager.resubscribeTeamEvents());
 
 			// Resume any verifications that were interrupted by a server restart (fire-and-forget)
-			verificationHarness.resumeInterruptedVerifications().catch(err => {
-				console.error("[verification] Error resuming interrupted verifications:", err);
+			await bootPhase("resumeInterruptedVerifications-sync", () => {
+				verificationHarness.resumeInterruptedVerifications().catch(err => {
+					console.error("[verification] Error resuming interrupted verifications:", err);
+				});
 			});
+			bootLog(`[boot] start() reached listen() at ${Date.now() - bootStart}ms`);
 
 			// Port 0 = let OS assign a free port; skip the auto-increment loop
 			if (config.port === 0) {
@@ -3636,6 +3680,11 @@ export function createGateway(config: GatewayConfig, deps?: GatewayDeps) {
 			throw new Error(`All ports ${config.port}-${maxPort} in use`);
 		},
 		async shutdown() {
+			const shutdownStart = Date.now();
+			bootMark(`SHUTDOWN ${new Date().toISOString()}`);
+			// Phase timer: log each teardown phase so a slow shutdown is diagnosable
+			// from the logs without a profiler. Cheap (Date.now + one appended line).
+			const phase = makePhaseTimer("[shutdown]");
 			try {
 				// Stop accepting NEW connections AND forcibly terminate existing
 				// keep-alive connections BEFORE we tear down the state stores.
@@ -3654,18 +3703,36 @@ export function createGateway(config: GatewayConfig, deps?: GatewayDeps) {
 				triggerEngine.stop();
 				inboxNudger.stop();
 				wss.close();
-				await disposeExtensionChannelServices(extensionChannelServices, "gateway-shutdown");
+				await phase("extension-channels", () => disposeExtensionChannelServices(extensionChannelServices, "gateway-shutdown"));
 				try { getCpuDiagnostics().shutdown(); } catch { /* best-effort */ }
 				try { verificationHarness?.shutdown(); } catch { /* best-effort */ }
-				for (const pool of sessionManager.getAllWorktreePools().values()) {
-					await pool.drain();
-				}
-				await sessionManager.shutdown();
-				await projectContextManager.closeAll();
+				// Worktree pools are intentionally NOT drained on shutdown.
+				//
+				// Pool entries are pre-built worktrees on `pool/_pool-*` branches
+				// created `pushPolicy: "local-only"` — they never exist on the remote.
+				// The old `drain()` here ran, serially across every project's pool,
+				// `git worktree remove --force` + `git branch -D` + a pointless
+				// `git push origin --delete` (a network round-trip, up to a 15s
+				// timeout each, to delete a branch that was never pushed). That both
+				// slowed shutdown AND destroyed exactly the worktrees the next boot
+				// then had to rebuild from scratch (`git worktree add` + `npm ci`),
+				// leaving new sessions on the cold path for minutes after start.
+				//
+				// Leaving them on disk lets `WorktreePool.reclaimOrphaned` re-adopt
+				// them instantly at the next boot (the sweeper skips pool branches,
+				// and reclaim is capped at the pool's target size, so they don't
+				// accumulate). Explicit teardown still drains: project removal
+				// (`removeWorktreePool`) and the Settings → Maintenance cleanup.
+				await phase("session-manager", () => sessionManager.shutdown());
+				await phase("project-contexts", () => projectContextManager.closeAll());
 				if (sandboxManager) {
-					await sandboxManager.shutdownAll();
+					await phase("sandbox-manager", () => sandboxManager!.shutdownAll());
 				}
-				await sessionManager.cleanupSandboxNetwork();
+				await phase("sandbox-network", () => sessionManager.cleanupSandboxNetwork());
+				bootLog(`[shutdown] complete in ${Date.now() - shutdownStart}ms`);
+			} catch (err) {
+				bootLog(`[shutdown] aborted after ${Date.now() - shutdownStart}ms: ${err instanceof Error ? err.message : String(err)}`);
+				throw err;
 			} finally {
 				restoreExplicitRpcBridgeFactory();
 			}

--- a/tests/worktree-pool.test.ts
+++ b/tests/worktree-pool.test.ts
@@ -464,6 +464,87 @@ describe("WorktreePool — components[*].worktreeSetupCommand is the source of t
 	});
 });
 
+describe("Restart round-trip: pool worktrees left in place are reclaimed, not rebuilt", () => {
+	// Pins the shutdown fix: the gateway must NOT drain worktree pools on
+	// shutdown. Pool entries are local-only `pool/_pool-*` worktrees; leaving
+	// them on disk lets the next boot's reclaimOrphaned() re-adopt them
+	// instantly instead of destroying them (git worktree remove + branch -D +
+	// pointless remote delete) and rebuilding from scratch (worktree add + npm
+	// ci) over the minutes after start.
+	const originalNoPush = process.env.BOBBIT_TEST_NO_PUSH;
+	const originalSkipNpm = process.env.BOBBIT_SKIP_NPM_CI;
+	before(() => {
+		process.env.BOBBIT_TEST_NO_PUSH = "1";
+		process.env.BOBBIT_SKIP_NPM_CI = "1";
+	});
+	after(() => {
+		if (originalNoPush === undefined) delete process.env.BOBBIT_TEST_NO_PUSH;
+		else process.env.BOBBIT_TEST_NO_PUSH = originalNoPush;
+		if (originalSkipNpm === undefined) delete process.env.BOBBIT_SKIP_NPM_CI;
+		else process.env.BOBBIT_SKIP_NPM_CI = originalSkipNpm;
+	});
+
+	it("a fresh pool reclaims the worktrees an abandoned (undrained) pool left behind", async () => {
+		const repo = await makeRepo();
+		try {
+			// Boot #1: fill the pool to two ready worktrees.
+			const pool1 = new WorktreePool({ repoPath: repo, targetSize: 2 });
+			pool1.startFilling();
+			for (let i = 0; i < 100 && pool1.size < 2; i++) await new Promise(r => setTimeout(r, 100));
+			assert.equal(pool1.size, 2, "pool should fill to two entries on first boot");
+			const firstBootPaths = pool1.snapshotEntries().entries.map(e => e.worktreePath).sort();
+			const firstBootBranches = pool1.snapshotEntries().entries.map(e => e.branchName).sort();
+
+			// Shutdown WITHOUT draining: simply abandon the in-memory pool object.
+			// The worktrees remain on disk (this is the invariant under test).
+			for (const p of firstBootPaths) {
+				assert.ok(fs.existsSync(p), `worktree ${p} must survive an undrained shutdown`);
+			}
+
+			// Boot #2: a fresh pool over the same repo reclaims — no rebuild.
+			const pool2 = new WorktreePool({ repoPath: repo, targetSize: 2 });
+			await (pool2 as any).reclaimOrphaned();
+			const secondBootPaths = pool2.snapshotEntries().entries.map(e => e.worktreePath).sort();
+			const secondBootBranches = pool2.snapshotEntries().entries.map(e => e.branchName).sort();
+
+			assert.deepEqual(secondBootPaths, firstBootPaths, "second boot must reclaim the exact worktrees left in place");
+			assert.deepEqual(secondBootBranches, firstBootBranches, "second boot must reclaim the same pool branches (no new ones built)");
+		} finally {
+			await rmRepo(repo);
+		}
+	});
+});
+
+describe("Regression: gateway shutdown must not drain worktree pools", () => {
+	it("server.ts shutdown() does not call .drain() and documents why", () => {
+		const serverTs = fs.readFileSync(path.resolve(__dirname, "..", "src", "server", "server.ts"), "utf-8");
+		// Brace-match the shutdown() body (opening `{` to its matching close) so we
+		// scan exactly the method — not a fixed-size window that can spill into the
+		// next declaration or truncate as shutdown() grows. Inner braces
+		// (template `${…}`, arrow bodies) are balanced, so depth-counting lands on
+		// the true close.
+		const start = serverTs.indexOf("async shutdown()");
+		assert.ok(start >= 0, "shutdown() method must exist in server.ts");
+		const braceStart = serverTs.indexOf("{", start);
+		assert.ok(braceStart > start, "shutdown() opening brace not found");
+		let depth = 0, end = -1;
+		for (let i = braceStart; i < serverTs.length; i++) {
+			const c = serverTs[i];
+			if (c === "{") depth++;
+			else if (c === "}" && --depth === 0) { end = i; break; }
+		}
+		assert.ok(end > braceStart, "shutdown() closing brace not found");
+		const body = serverTs.slice(braceStart, end + 1);
+		// Draining on shutdown destroys pool worktrees the next boot must rebuild —
+		// see the restart round-trip suite above.
+		assert.equal(/\.drain\s*\(/.test(body), false,
+			"gateway shutdown() must not drain worktree pools — leave them on disk for reclaimOrphaned() on next boot");
+		// Pin the WHY so a future edit can't silently reintroduce the drain.
+		assert.match(body, /intentionally NOT drained on shutdown/,
+			"shutdown() must document why pools are not drained (guards against silent reintroduction)");
+	});
+});
+
 describe("Regression: rename helpers and claimUnnamed must stay deleted", () => {
 	it("no source file references renameSessionFromPool / claimUnnamed / UnnamedClaim", () => {
 		const srcRoot = path.resolve(__dirname, "..", "src");


### PR DESCRIPTION
## Why

Gateway startup and shutdown are slow. Instrumenting the boot/shutdown path (see below) confirmed the shutdown cost and a big post-start regression both trace to the **worktree pool being destroyed on shutdown and rebuilt on boot**.

## What

### 1. Shutdown no longer drains worktree pools
`gateway.shutdown()` previously drained every project's pool, serially: `git worktree remove --force` + `git branch -D` + **`git push origin --delete`**. Pool entries live on **local-only** `pool/_pool-*` branches (never pushed), so the remote-delete was a pure-waste network round-trip (up to a 15s timeout each). Worse, it destroyed exactly the worktrees the next boot then rebuilt from scratch (`git worktree add` + `npm ci`), leaving new sessions on the cold path for **minutes** after start.

Now shutdown leaves pool worktrees on disk; `WorktreePool.reclaimOrphaned` re-adopts them **instantly** on next boot. This is safe: pool branches are local-only, the boot sweeper skips pool branches, and reclaim is capped at the pool's target size. Explicit teardown still drains — project removal (`removeWorktreePool`) and Settings → Maintenance cleanup.

### 2. Boot/shutdown timing instrumentation
New `boot-profile.ts` tees `[boot]`/`[shutdown]` phase lines to `<stateDir>/boot-timings.log` — a persisted, size-bounded (256 KiB) record so a slow cold-start is diagnosable without a profiler (and readable by an in-gateway agent). Adds: pre-listen phase timers, `createGateway` construction checkpoints, project-context `initAll`, and shutdown phase timers. All ungated lines are single per-boot milestones/summaries; per-phase detail is gated at ≥50ms; the tee is fully best-effort (never affects startup/shutdown).

## Measured (real workload, ~37 sessions)
- **Shutdown**: multi-second pool drain → **sub-100ms**.
- Instrumentation surfaced the full boot breakdown (construction ~11s, session restore ~17s, mcp ~2.5s, an ~8s event-loop tail) — used to target further work.

> Note: a deferred-session-restore experiment was explored on top of this and **intentionally left out** of this PR (it under-delivered on a team/goal-heavy workload and needs a different approach).

## Reviews
Independently reviewed by three agents (correctness, code-quality/intent, tests): no CRITICAL/HIGH issues; confirmed no-drain is safe, no unhandled-rejection risk, logging-policy compliant. Applied their cheap fixes (shared phase-timer helper, `SLOW_PHASE_MS` constant, complete-record logging, mkdir-before-append, sturdier brace-matched shutdown source guard).

### Known follow-ups (not blockers)
- Pool worktrees can accumulate on disk if `worktree_pool_size` is **reduced** or a pool entry becomes un-adoptable, since shutdown no longer GCs them and the sweeper skips pool branches (cleanable via Settings → Maintenance today). A bounded pool prune is a good follow-up. Separately, the sweeper reclaims ~189 orphaned worktrees every boot — worth a dedicated worktree-GC investigation.
- Additional recommended tests: `drain()` is destructive; reclaim caps at target across repeated cycles; an end-to-end real shutdown→reboot→reclaim.

## Testing
- `npm run check` clean.
- `tests/worktree-pool.test.ts` — 19/19 (incl. new restart round-trip + shutdown-no-drain source guard).
- Full `npm run test:unit` running.

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)