### PR TITLE
Speed up browser and E2E test tiers

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "test:v2:core": "vitest run --config vitest.config.ts --silent=passed-only",
     "test:v2:changed": "vitest --config vitest.config.ts --changed --silent=passed-only",
     "test:v2:browser": "playwright test --config playwright-v2.config.ts --project browser-v2 && node scripts/testing-v2/assert-budget.mjs browser --report .profiles/testing-v2/budgets/playwright-report.json",
-    "test:e2e:v2": "npm run build --silent && node scripts/testing-v2/run-e2e-v2.mjs",
+    "test:e2e:v2": "node scripts/testing-v2/ensure-dist.mjs && node scripts/testing-v2/run-e2e-v2.mjs",
     "test:v2:coverage-delta": "node scripts/testing-v2/coverage-delta.mjs",
     "test:v2:browser-chaos": "node scripts/testing-v2/browser-chaos.mjs",
     "test:v2:profile-hooks": "node scripts/testing-v2/profile-hooks.mjs",

--- a/playwright-v2.config.ts
+++ b/playwright-v2.config.ts
@@ -14,6 +14,7 @@ import { createRequire } from "node:module";
 import { existsSync, mkdirSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
+import { seedTransformCacheForRunDir } from "./scripts/testing-v2/pwtest-cache.js";
 
 function e2eTempRoot(): string {
 	if (existsSync("/.dockerenv")) return "/tmp";
@@ -51,6 +52,12 @@ function prepareV2RuntimeCaches(): void {
 	process.env.BOBBIT_E2E_PWTEST_CACHE_DIR = runCacheRoot;
 	mkdirSync(runCacheRoot, { recursive: true });
 	mkdirSync(transformCacheDir, { recursive: true });
+	// Warm-start the per-run transform cache from the last published snapshot
+	// (`<base>/pwtest-transform-cache-v2/latest`). Entries are content-hashed so
+	// reuse is safe; per-run dirs only isolate WRITES. Fail-open: any copy error
+	// just means a cold cache. The matching publish happens in
+	// tests2/browser-global-teardown.ts.
+	seedTransformCacheForRunDir(runCacheRoot);
 }
 
 prepareV2RuntimeCaches();
@@ -116,7 +123,7 @@ export default {
 		["json", { outputFile: ".profiles/testing-v2/budgets/playwright-report.json" }],
 	] as Array<[string, unknown?]>,
 	globalSetup: "./tests2/browser-global-setup.ts",
-	globalTeardown: "./tests/e2e/e2e-teardown.ts",
+	globalTeardown: "./tests2/browser-global-teardown.ts",
 	use: {
 		video: "off",
 		trace: "off",

--- a/scripts/testing-v2/assert-budget.mjs
+++ b/scripts/testing-v2/assert-budget.mjs
@@ -22,7 +22,7 @@
  * ─── Programmatic (imported by run-v2.mjs) ───
  *   createCpuSampler(rootPid, { intervalMs? }) -> { stop() -> {cpuMs, peakProcesses, samples} }
  *   assertBudget({ scope, wallMs, cpuMs, rawCpuMs?, cpuCeilingMs?, cpuOverCount?, pilot?,
- *                  underLoad?, argv?, reservations?, rootPid?, processCount? })
+ *                  underLoad?, argv?, reservations?, rootPid?, processCount?, perSpec? })
  *       -> { pass, violations, caps, artifactPath, wallMs, cpuMs }
  *       WALL is the only hard gate; CPU is recorded for observability and NEVER gates.
  *   resolveCaps(scope, pilot?, underLoadOverride?) -> { tier, maxWallMs, maxCpuMs, underLoad?, pilot }
@@ -32,6 +32,9 @@
  *       clamps a process-tree reading to the physical ceiling (cores × wall).
  *   isUnderLoad(override?) -> boolean
  *   treeCpuMs(rootPid) -> number    (single cumulative snapshot)
+ *   perSpecWallFromReport(report) -> { 'path/spec.ts': totalMs, ... }
+ *   evaluatePerSpecBudget(report, { perSpecMaxMs, perSpecGrandfather? })
+ *       -> { perFileMs, warns, violations }   (pure; tier2 per-spec WALL budget)
  *
  * Artifacts: .profiles/testing-v2/budgets/<timestamp>-<scope>.json
  */
@@ -286,6 +289,63 @@ function wallFromReport(reportPath) {
 	return null;
 }
 
+// ────────────────────── per-spec wall budget (tier2) ──────────────────────
+// Design: WALL-only, no CPU gating. A Playwright JSON report's suites/specs
+// tree is folded into per-FILE total wall (sum of every test result's duration,
+// including retries). Files over tiers.tier2.perSpecMaxMs fail the gate unless
+// grandfathered in tiers.tier2.perSpecGrandfather (map of spec-file -> observed
+// ms at grandfathering time), which downgrades them to a warning. Suite-level
+// budget behaviour is unchanged; this is an ADDITIONAL check.
+
+const normSpecPath = (p) => String(p).replace(/\\/g, "/");
+
+/** Pure: fold a Playwright JSON report into { 'spec/file.ts': totalMs }. */
+export function perSpecWallFromReport(report) {
+	const perFileMs = Object.create(null);
+	const walkSuite = (suite, inheritedFile) => {
+		if (!suite || typeof suite !== "object") return;
+		const suiteFile = suite.file ? normSpecPath(suite.file) : inheritedFile;
+		for (const spec of suite.specs || []) {
+			const file = spec.file ? normSpecPath(spec.file) : suiteFile;
+			if (!file) continue;
+			let ms = 0;
+			for (const test of spec.tests || []) {
+				for (const result of test.results || []) {
+					if (Number.isFinite(result?.duration)) ms += result.duration;
+				}
+			}
+			perFileMs[file] = (perFileMs[file] || 0) + ms;
+		}
+		for (const child of suite.suites || []) walkSuite(child, suiteFile);
+	};
+	for (const suite of report?.suites || []) walkSuite(suite, null);
+	return perFileMs;
+}
+
+/**
+ * Pure: classify per-spec wall against the budget.
+ * Returns { perFileMs, warns, violations } where warns/violations are
+ * [{ file, ms, grandfatheredMs? }]. Grandfathered over-budget files WARN only;
+ * everything else over budget is a VIOLATION. Under-budget files pass silently.
+ */
+export function evaluatePerSpecBudget(report, { perSpecMaxMs, perSpecGrandfather = {} } = {}) {
+	const perFileMs = perSpecWallFromReport(report);
+	const warns = [];
+	const violations = [];
+	if (!Number.isFinite(perSpecMaxMs) || perSpecMaxMs <= 0) return { perFileMs, warns, violations };
+	const grandfather = Object.create(null);
+	for (const [k, v] of Object.entries(perSpecGrandfather || {})) grandfather[normSpecPath(k)] = v;
+	for (const [file, msRaw] of Object.entries(perFileMs)) {
+		const ms = Math.round(msRaw);
+		if (ms <= perSpecMaxMs) continue;
+		if (file in grandfather) warns.push({ file, ms, grandfatheredMs: grandfather[file] });
+		else violations.push({ file, ms });
+	}
+	warns.sort((a, b) => b.ms - a.ms);
+	violations.sort((a, b) => b.ms - a.ms);
+	return { perFileMs, warns, violations };
+}
+
 /** Latest CPU sample artifact for a scope, if run-v2 (or a prior run) left one. */
 function latestSampleCpu(scope) {
 	if (!existsSync(SAMPLE_DIR)) return null;
@@ -309,9 +369,18 @@ function timestamp() {
 
 // ─────────────────────────────── core assert ───────────────────────────────
 
-export function assertBudget({ scope, wallMs = null, cpuMs = null, rawCpuMs = null, cpuCeilingMs = null, cpuOverCount = false, pilot = false, underLoad = undefined, argv = null, reservations = null, rootPid = null, processCount = null, wallSource = null, cpuSource = null }) {
+export function assertBudget({ scope, wallMs = null, cpuMs = null, rawCpuMs = null, cpuCeilingMs = null, cpuOverCount = false, pilot = false, underLoad = undefined, argv = null, reservations = null, rootPid = null, processCount = null, wallSource = null, cpuSource = null, perSpec = null }) {
 	const caps = resolveCaps(scope, pilot, underLoad);
 	const violations = [];
+
+	// Per-spec wall budget (tier2): non-grandfathered over-budget spec files are
+	// hard violations; grandfathered ones were already warned by the CLI. Absent
+	// perSpec (all other callers) behaviour is unchanged.
+	if (perSpec && Array.isArray(perSpec.violations)) {
+		for (const v of perSpec.violations) {
+			violations.push(`per-spec wall ${(v.ms / 1000).toFixed(1)}s > cap ${(perSpec.maxMs / 1000).toFixed(1)}s for ${v.file} (not grandfathered)`);
+		}
+	}
 
 	// In pilot mode the tier cap acts as a generous ceiling for a partial suite;
 	// a subset should stay well under it, so we still check but never invent a
@@ -351,6 +420,9 @@ export function assertBudget({ scope, wallMs = null, cpuMs = null, rawCpuMs = nu
 		underLoad: caps.underLoad ?? isUnderLoad(underLoad),
 		wallSource,
 		cpuSource,
+		perSpec: perSpec
+			? { maxMs: perSpec.maxMs ?? null, warns: perSpec.warns ?? [], violations: perSpec.violations ?? [] }
+			: null,
 		budget: { maxWallMs: caps.maxWallMs, maxCpuMs: caps.maxCpuMs, label: caps.label },
 		rootPid,
 		processCount,
@@ -425,6 +497,18 @@ function cli() {
 	const clamped = clampCpuMs(cpuMs, cores, wallMs);
 	if (clamped.overCount) cpuSource = `${cpuSource || "cpu"} (clamped cores×wall)`;
 
+	// Per-spec wall budget: only for the tier2/browser scope with a Playwright
+	// JSON report and a configured tiers.tier2.perSpecMaxMs. WALL-only, no CPU.
+	let perSpec = null;
+	if (SCOPE_TIER[opts.scope] === "tier2" && opts.report) {
+		const reportAbs = isAbsolute(opts.report) ? opts.report : join(REPO_ROOT, opts.report);
+		const rep = readJsonSafe(reportAbs);
+		const tier2 = readBudgets().tiers?.tier2 || {};
+		if (rep && Number.isFinite(tier2.perSpecMaxMs)) {
+			perSpec = { maxMs: tier2.perSpecMaxMs, ...evaluatePerSpecBudget(rep, tier2) };
+		}
+	}
+
 	const result = assertBudget({
 		scope: opts.scope,
 		wallMs,
@@ -435,6 +519,7 @@ function cli() {
 		pilot: opts.pilot,
 		wallSource,
 		cpuSource,
+		perSpec,
 	});
 
 	const caps = result.caps;
@@ -442,6 +527,17 @@ function cli() {
 	console.log(`  wall: ${wallMs != null ? (wallMs / 1000).toFixed(1) + "s" : "n/a"} (cap ${(caps.maxWallMs / 1000).toFixed(0)}s)  [${wallSource || "unmeasured"}]`);
 	console.log(`  cpu:  ${clamped.cpuMs != null ? (clamped.cpuMs / 60000).toFixed(2) + " CPU-min" : "n/a"} (observability-only, not gated; physical ceiling ${clamped.ceilingMs != null ? (clamped.ceilingMs / 60000).toFixed(2) + " CPU-min = " + cores + "×" + (wallMs / 1000).toFixed(0) + "s" : "n/a"})  [${cpuSource || "unmeasured"}]${clamped.overCount ? ` (raw ${(clamped.rawCpuMs / 60000).toFixed(2)} over-counted, clamped)` : ""}`);
 	console.log(`  artifact: ${result.artifactPath}`);
+
+	if (perSpec) {
+		const fileCount = Object.keys(perSpec.perFileMs).length;
+		console.log(`  per-spec: ${fileCount} spec file(s), cap ${(perSpec.maxMs / 1000).toFixed(0)}s each — ${perSpec.violations.length} violation(s), ${perSpec.warns.length} grandfathered warn(s)`);
+		for (const w of perSpec.warns) {
+			console.warn(`  per-spec WARN (grandfathered): ${w.file} — ${(w.ms / 1000).toFixed(1)}s > cap ${(perSpec.maxMs / 1000).toFixed(0)}s (grandfathered at ${(w.grandfatheredMs / 1000).toFixed(1)}s)`);
+		}
+		for (const v of perSpec.violations) {
+			console.error(`  per-spec VIOLATION: ${v.file} — ${(v.ms / 1000).toFixed(1)}s > cap ${(perSpec.maxMs / 1000).toFixed(0)}s (not grandfathered)`);
+		}
+	}
 
 	if (!result.pass) {
 		console.error(`assert-budget: FAIL — ${result.violations.join("; ")}`);

--- a/scripts/testing-v2/ensure-dist.mjs
+++ b/scripts/testing-v2/ensure-dist.mjs
@@ -1,0 +1,155 @@
+/**
+ * Content-addressed `npm run build` skip for the e2e/browser test tiers.
+ *
+ * `npm run test:e2e:v2` used to run `npm run build` unconditionally (~26s warm,
+ * minutes cold) while tests2/browser-global-setup.ts only built dist when it was
+ * MISSING — silently testing a stale build. Both now funnel through
+ * ensureDistBuild(): a sha256 key over the full build input set is compared
+ * against dist/.build-manifest.json; on match the build is skipped, on any
+ * mismatch or manifest/validation error the build runs (fail-closed) and the
+ * manifest is rewritten atomically.
+ *
+ * The input set mirrors package.json's `build` pipeline
+ * (`build:packs` → `build:server` → `build:ui`):
+ *   - build:packs  — market-packs/** sources + scripts/build-market-packs.mjs
+ *   - build:server — src/** (tsconfig.server.json includes src/server + src/shared),
+ *                    defaults/** (copy-defaults.mjs), market-packs/** again
+ *                    (copy-builtin-packs.mjs), tsconfig.server.json
+ *   - build:ui     — vite build: index.html, src/**, public/**, vite.config.ts,
+ *                    tsconfig.json
+ *   - shared       — package.json (the build scripts themselves),
+ *                    package-lock.json (toolchain/deps), and this script.
+ *
+ * Pattern mirrors scripts/testing-v2/server-prebundle.mjs
+ * (computeServerPrebundleKey / validateServerPrebundle).
+ * Pinned by tests2/core/ensure-dist-build-key.test.ts.
+ */
+import { execSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { existsSync, readFileSync, readdirSync, renameSync, rmSync, writeFileSync } from "node:fs";
+import { dirname, join, relative, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(HERE, "..", "..");
+const MANIFEST_SCHEMA = 1;
+
+/** Directories walked recursively (every file participates in the key). */
+const INPUT_DIRS = ["src", "defaults", "market-packs", "public"];
+/** Individual input files (missing entries are skipped so fixture repos work). */
+const INPUT_FILES = [
+	"index.html",
+	"package.json",
+	"package-lock.json",
+	"vite.config.ts",
+	"tsconfig.json",
+	"tsconfig.server.json",
+	"scripts/copy-defaults.mjs",
+	"scripts/copy-builtin-packs.mjs",
+	"scripts/build-market-packs.mjs",
+];
+/** Never part of the build input set even when nested under an input dir. */
+const SKIP_DIR_NAMES = new Set(["node_modules", "dist", ".vite", ".git"]);
+
+function toPosixPath(file) {
+	return file.replace(/\\/g, "/");
+}
+
+function walkFiles(root) {
+	const out = [];
+	const walk = (dir) => {
+		for (const entry of readdirSync(dir, { withFileTypes: true })) {
+			if (entry.isDirectory()) {
+				if (!SKIP_DIR_NAMES.has(entry.name)) walk(join(dir, entry.name));
+			} else if (entry.isFile()) {
+				out.push(join(dir, entry.name));
+			}
+		}
+	};
+	walk(root);
+	return out;
+}
+
+/**
+ * Content-addressed key over the full `npm run build` input set: sorted
+ * repo-relative POSIX path + file bytes for every input, plus this script's own
+ * source (so key-derivation changes invalidate cached builds).
+ */
+export function computeDistBuildKey(repoRoot = REPO_ROOT) {
+	const files = [
+		...INPUT_DIRS.map((dir) => join(repoRoot, dir)).filter(existsSync).flatMap(walkFiles),
+		...INPUT_FILES.map((file) => join(repoRoot, ...file.split("/"))).filter(existsSync),
+	]
+		.map((file) => ({ file, key: toPosixPath(relative(repoRoot, file)) }))
+		.sort((a, b) => a.key.localeCompare(b.key));
+	const hash = createHash("sha256");
+	for (const { file, key } of files) {
+		hash.update(key);
+		hash.update("\0");
+		hash.update(readFileSync(file));
+		hash.update("\0");
+	}
+	hash.update("__ensure-dist-self__");
+	hash.update("\0");
+	hash.update(readFileSync(fileURLToPath(import.meta.url)));
+	return hash.digest("hex").slice(0, 24);
+}
+
+function manifestPathFor(repoRoot) {
+	return join(repoRoot, "dist", ".build-manifest.json");
+}
+
+/**
+ * Fail-closed validation: the manifest must parse, match schema + key, and the
+ * critical build artifacts (dist/server/cli.js, dist/ui/index.html) must exist.
+ * Any read/parse error means "rebuild".
+ */
+export function validateDistBuild(repoRoot, key) {
+	try {
+		const manifest = JSON.parse(readFileSync(manifestPathFor(repoRoot), "utf8"));
+		if (manifest.schema !== MANIFEST_SCHEMA) return false;
+		if (typeof manifest.key !== "string" || manifest.key.length === 0 || manifest.key !== key) return false;
+		if (!existsSync(join(repoRoot, "dist", "server", "cli.js"))) return false;
+		if (!existsSync(join(repoRoot, "dist", "ui", "index.html"))) return false;
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * Skip `npm run build` when dist already matches the current input key;
+ * otherwise build and publish a fresh manifest atomically (write tmp + rename).
+ */
+export function ensureDistBuild({ repoRoot = REPO_ROOT } = {}) {
+	const key = computeDistBuildKey(repoRoot);
+	if (validateDistBuild(repoRoot, key)) {
+		console.log(`[ensure-dist] dist build cache hit: ${key}`);
+		return { key, cacheHit: true };
+	}
+	console.log(`[ensure-dist] dist build cache miss (key ${key}); running npm run build...`);
+	execSync("npm run build", { cwd: repoRoot, stdio: "inherit" });
+	// build:packs rewrites the committed market-packs bundles, which are part of
+	// the input set — recompute so the manifest keys the POST-build inputs.
+	const finalKey = computeDistBuildKey(repoRoot);
+	for (const artifact of [join("dist", "server", "cli.js"), join("dist", "ui", "index.html")]) {
+		if (!existsSync(join(repoRoot, artifact))) {
+			throw new Error(`[ensure-dist] build completed but expected artifact is missing: ${artifact}`);
+		}
+	}
+	const manifestPath = manifestPathFor(repoRoot);
+	const tempPath = `${manifestPath}.tmp-${process.pid}-${Math.random().toString(36).slice(2, 8)}`;
+	writeFileSync(tempPath, `${JSON.stringify({ schema: MANIFEST_SCHEMA, key: finalKey, createdAt: new Date().toISOString() }, null, 2)}\n`);
+	try {
+		rmSync(manifestPath, { force: true });
+		renameSync(tempPath, manifestPath);
+	} catch (error) {
+		rmSync(tempPath, { force: true });
+		throw error;
+	}
+	return { key: finalKey, cacheHit: false };
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+	ensureDistBuild();
+}

--- a/scripts/testing-v2/pwtest-cache.ts
+++ b/scripts/testing-v2/pwtest-cache.ts
@@ -1,0 +1,142 @@
+/**
+ * Persistent Playwright transform-cache seed/publish helpers (v2 browser runs).
+ *
+ * Playwright's transform cache (PWTEST_CACHE_DIR) is content-hashed per source
+ * file, so reusing entries across runs is always safe. Per-run cache dirs exist
+ * only to avoid cross-run WRITE races on shared machines. These helpers keep the
+ * per-run write isolation but let runs warm-start:
+ *
+ *   - seedTransformCache(latestDir, runDir): copy the published `latest`
+ *     snapshot into a fresh run dir before the run starts.
+ *   - publishTransformCache(runDir, latestDir): after the run, copy the run dir
+ *     to a pid-tagged temp sibling, then atomically rename it over `latest`.
+ *     A concurrent publisher losing the rename race just discards its temp dir.
+ *
+ * Every step is fail-open: the cache is an optimization, never a correctness
+ * dependency, so any FS error degrades to a cold cache rather than a failure.
+ */
+import { cpSync, existsSync, readdirSync, renameSync, rmSync } from "node:fs";
+import { basename, dirname, join } from "node:path";
+
+/**
+ * Injectable fs seam for publishTransformCache — lets the unit test simulate a
+ * concurrent publisher winning the rename race deterministically. Production
+ * callers never pass this.
+ */
+export interface PublishFsOps {
+	cpSync: typeof cpSync;
+	rmSync: typeof rmSync;
+	renameSync: typeof renameSync;
+	existsSync: typeof existsSync;
+	readdirSync: (dir: string) => unknown[];
+}
+
+const REAL_FS_OPS: PublishFsOps = { cpSync, rmSync, renameSync, existsSync, readdirSync };
+
+/** Directory name of the shared v2 transform-cache namespace. */
+export const V2_TRANSFORM_CACHE_SEGMENT = "pwtest-transform-cache-v2";
+
+/** Published warm-start snapshot sibling of the per-run dirs. */
+export const LATEST_SEGMENT = "latest";
+
+/** `latest` snapshot path for a given per-run cache dir (its sibling). */
+export function latestTransformCacheDir(runDir: string): string {
+	return join(dirname(runDir), LATEST_SEGMENT);
+}
+
+/**
+ * Seed a fresh per-run cache dir from the published `latest` snapshot.
+ * Fail-open: partial copies are fine (entries are content-hashed), and any
+ * error just means a cold start. Returns true when a seed copy was attempted
+ * and completed without error.
+ */
+export function seedTransformCache(latestDir: string, runDir: string): boolean {
+	try {
+		if (!latestDir || !runDir || latestDir === runDir) return false;
+		if (!existsSync(latestDir)) return false;
+		// force:false + errorOnExist:false — never clobber files already written
+		// into the run dir; silently skip collisions.
+		cpSync(latestDir, runDir, { recursive: true, force: false, errorOnExist: false });
+		return true;
+	} catch (err) {
+		// Partial copy is still a valid (smaller) warm start.
+		console.log(`[pwtest-cache] transform-cache seed skipped (cold start): ${(err as Error)?.message ?? err}`);
+		return false;
+	}
+}
+
+/**
+ * Publish a per-run cache dir as the new `latest` snapshot.
+ *
+ * Algorithm (each step fail-open):
+ *   1. Skip when the run dir is missing or empty.
+ *   2. cpSync(runDir -> `<latest>-<tag>-tmp`).
+ *   3. rmSync(latest) then renameSync(tmp -> latest). rename is atomic on the
+ *      same volume; a concurrent publisher that wins the race makes our rename
+ *      fail, in which case we discard our tmp dir.
+ *
+ * Returns true only when `latest` was replaced by this call.
+ */
+export function publishTransformCache(
+	runDir: string,
+	latestDir: string,
+	tag: string = String(process.pid),
+	ops: Partial<PublishFsOps> = {},
+): boolean {
+	const fs = { ...REAL_FS_OPS, ...ops };
+	if (!runDir || !latestDir || runDir === latestDir) return false;
+	try {
+		if (!fs.existsSync(runDir) || fs.readdirSync(runDir).length === 0) return false;
+	} catch {
+		return false;
+	}
+	const tmpDir = `${latestDir}-${tag}-tmp`;
+	try {
+		fs.cpSync(runDir, tmpDir, { recursive: true, force: true });
+	} catch (err) {
+		console.log(`[pwtest-cache] transform-cache publish skipped (copy failed): ${(err as Error)?.message ?? err}`);
+		try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch {}
+		return false;
+	}
+	try { fs.rmSync(latestDir, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 }); } catch {}
+	try {
+		fs.renameSync(tmpDir, latestDir);
+		return true;
+	} catch {
+		// A concurrent publisher won the rename race (or latest could not be
+		// replaced). Their snapshot is equally warm — drop ours.
+		try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch {}
+		return false;
+	}
+}
+
+/**
+ * Env-gated publish used by the v2 browser global teardown.
+ *
+ * Publishes only when this run OWNS its per-run cache dir
+ * (BOBBIT_E2E_PWTEST_CACHE_OWNED === "1") and the dir lives inside the v2
+ * transform-cache namespace. BOBBIT_KEEP_PWTEST_CACHE=1 keeps its existing
+ * meaning (the per-run dir is not deleted by the legacy teardown) and does NOT
+ * suppress publishing — a kept run dir is still a valid snapshot source.
+ */
+export function publishTransformCacheFromEnv(env: NodeJS.ProcessEnv = process.env): boolean {
+	if (env.BOBBIT_E2E_PWTEST_CACHE_OWNED !== "1") return false;
+	const runDir = env.BOBBIT_V2_PWTEST_RUN_CACHE_ROOT?.trim() || env.BOBBIT_E2E_PWTEST_CACHE_DIR?.trim();
+	if (!runDir) return false;
+	// Only the v2 namespace participates; legacy per-run dirs are untouched.
+	if (basename(dirname(runDir)) !== V2_TRANSFORM_CACHE_SEGMENT) return false;
+	if (basename(runDir) === LATEST_SEGMENT) return false;
+	return publishTransformCache(runDir, latestTransformCacheDir(runDir));
+}
+
+/**
+ * Env-gated seed used by playwright-v2.config.ts after creating the run dir.
+ * Seeds only dirs inside the v2 transform-cache namespace (never `latest`
+ * itself, never externally-supplied cache dirs elsewhere on disk).
+ */
+export function seedTransformCacheForRunDir(runDir: string): boolean {
+	if (!runDir) return false;
+	if (basename(dirname(runDir)) !== V2_TRANSFORM_CACHE_SEGMENT) return false;
+	if (basename(runDir) === LATEST_SEGMENT) return false;
+	return seedTransformCache(latestTransformCacheDir(runDir), runDir);
+}

--- a/scripts/testing-v2/run-e2e-v2.mjs
+++ b/scripts/testing-v2/run-e2e-v2.mjs
@@ -156,12 +156,14 @@ async function runGroupA(specs) {
 	if (specs.length === 0) return { label: "A/node", code: 0, wallMs: 0, skipped: true };
 	// tsx --test, force-exit so lingering handles never hang the lane.
 	// RESOURCE CAP: node:test defaults to ~CPU-count concurrent FILES. These are
-	// worktree/pool/sandbox specs that each boot a gateway AND create git worktrees
-	// whose setup runs `npm ci` — running many at once spawns a SWARM of concurrent
-	// npm ci + gateway boots that can exhaust the box (suspected cause of the
-	// crash + interrupted-npm-ci node_modules corruption on 2026-07-08). Serialise
-	// by default (override with E2E_V2_NODE_CONCURRENCY).
-	const nodeConc = process.env.E2E_V2_NODE_CONCURRENCY || "1";
+	// worktree/pool/sandbox specs that each boot a gateway AND create git worktrees.
+	// Worktree setup does NOT run `npm ci` here (verified 2026-07-16): every
+	// worktree-provisioning Group A test sets BOBBIT_SKIP_NPM_CI=1, and the rest
+	// never configure an npm-ci setup command — so the per-file cost is a gateway
+	// boot plus git worktree creation, not an npm-ci swarm. Default to 2 concurrent
+	// files to cut wall time while keeping gateway-boot load modest (override with
+	// E2E_V2_NODE_CONCURRENCY).
+	const nodeConc = process.env.E2E_V2_NODE_CONCURRENCY || "2";
 	const args = ["--test", "--test-force-exit", `--test-concurrency=${nodeConc}`, ...specs];
 	return run(process.platform === "win32" ? "npx.cmd" : "npx", ["tsx", ...args], {
 		env: { ...EXTERNAL_FREE_ENV, NODE_ENV: "test" },

--- a/scripts/testing-v2/unit-inventory-audit.mjs
+++ b/scripts/testing-v2/unit-inventory-audit.mjs
@@ -101,7 +101,7 @@ const FILESYSTEM_MUTATORS = new Set([
 	"unlinkSync", "utimes", "utimesSync", "writeFile", "writeFileSync",
 ]);
 
-function concurrentPathOwnershipViolations(source, file) {
+function concurrentPathOwnershipViolations(source, file, messageLabel = "concurrent isolate:false filesystem path") {
 	const sourceFile = ts.createSourceFile(file, source, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS);
 	const declarations = new Map();
 	const declarationNodes = new Map();
@@ -186,7 +186,7 @@ function concurrentPathOwnershipViolations(source, file) {
 	const unsafeNames = [...declarations.keys()].filter((name) => isUnsafe(analyse(name)) && (mutated(name) || externallyOwned(name)));
 	const violation = (node, label) => {
 		const line = sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile)).line + 1;
-		return `${file}:${line} — concurrent isolate:false filesystem path ${label} uses Date.now() as its only owner token and is mutated or cleaned; use mkdtempSync, process.pid, randomUUID()/UUID, or place it beneath a clearly unique owner root`;
+		return `${file}:${line} — ${messageLabel} ${label} uses Date.now() as its only owner token and is mutated or cleaned; use mkdtempSync, process.pid, randomUUID()/UUID, or place it beneath a clearly unique owner root`;
 	};
 	const violations = unsafeNames.map((name) => violation(declarationNodes.get(name) ?? declarations.get(name), JSON.stringify(name)));
 	for (const call of calls) {
@@ -264,6 +264,50 @@ const declarationSemanticsPreserved = unmappedDeclarations.length === 0 && inval
 const childProcessImports = currentUnit.flatMap((file) => childProcessValueImports(fs.readFileSync(file, "utf-8"), file));
 const concurrentPathViolations = [...execution.core, ...execution.integration]
 	.flatMap((file) => concurrentPathOwnershipViolations(fs.readFileSync(file, "utf-8"), file));
+
+// E2E/browser tiers get the SAME unsafe rule (Date.now()-only owner token on a
+// shared/mutated temp path) with a distinct label. Pre-existing offenders are
+// FROZEN below (file:line) so the audit lands green while pinning that NO NEW
+// violations appear — fix an entry, then delete it; never add entries.
+const E2E_FIXTURE_PATH_GRANDFATHER = Object.freeze([
+	"tests/e2e/pool-claim-restart-resume.spec.ts:50",
+	"tests/e2e/pool-flow.spec.ts:41",
+	"tests/e2e/port-auto-increment.spec.ts:24",
+	"tests/e2e/provider-turn-hooks.spec.ts:101",
+	"tests/e2e/ui/add-project-helpers.ts:52",
+	"tests/e2e/ui/add-project-symlink.spec.ts:33",
+	"tests/e2e/ui/marketplace.spec.ts:73",
+	"tests/e2e/ui/project-management.spec.ts:17",
+	"tests/e2e/ui/sidebar-archived-per-project.spec.ts:13",
+	"tests/e2e/ui/sidebar-keyboard-nav.spec.ts:23",
+	"tests/e2e/ui/sidebar-unified-tree.spec.ts:161",
+	"tests2/browser/fixtures/project-drag-reorder.spec.ts:64",
+	"tests2/browser/journeys/prompt-interaction.journey.spec.ts:166",
+]);
+function listTestSources(root, extensions) {
+	if (!fs.existsSync(root)) return [];
+	const files = [];
+	const stack = [root];
+	while (stack.length) {
+		const dir = stack.pop();
+		for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+			const full = path.join(dir, entry.name);
+			if (entry.isDirectory()) stack.push(full);
+			else if (extensions.some((ext) => entry.name.endsWith(ext))) files.push(full.split(path.sep).join("/"));
+		}
+	}
+	return files.sort();
+}
+const e2eBrowserSources = [
+	...listTestSources("tests/e2e", [".ts", ".mjs"]),
+	...listTestSources("tests2/browser", [".ts"]),
+];
+const allE2eFixtureViolations = e2eBrowserSources
+	.flatMap((file) => concurrentPathOwnershipViolations(fs.readFileSync(file, "utf-8"), file, "concurrent e2e fixture path"));
+const grandfatheredE2eFixtureViolations = allE2eFixtureViolations
+	.filter((entry) => E2E_FIXTURE_PATH_GRANDFATHER.some((frozen) => entry.startsWith(`${frozen} —`)));
+const concurrentE2eFixtureViolations = allE2eFixtureViolations
+	.filter((entry) => !grandfatheredE2eFixtureViolations.includes(entry));
 const approvedE2e = [...APPROVED_E2E_VITEST_PATHS].sort();
 const e2eOwnershipExact = JSON.stringify(currentE2eVitestFiles) === JSON.stringify(approvedE2e);
 const scheduledInventoryPreserved = currentUnit.length + currentE2eVitestFiles.length === currentInventory.length;
@@ -286,6 +330,8 @@ const report = {
 	isolatedFiles: execution.isolated,
 	childProcessValueImports: childProcessImports,
 	concurrentPathOwnershipViolations: concurrentPathViolations,
+	concurrentE2eFixturePathViolations: concurrentE2eFixtureViolations,
+	grandfatheredE2eFixturePathViolations: grandfatheredE2eFixtureViolations,
 	baseStaticTestDeclarations: baseDeclarations,
 	currentStaticDeclarationsInBaseFiles: currentDeclarations,
 	allCurrentStaticTestDeclarations: allCurrentDeclarations,
@@ -307,7 +353,8 @@ const report = {
 		&& scheduledInventoryPreserved
 		&& e2eOwnershipExact
 		&& childProcessImports.length === 0
-		&& concurrentPathViolations.length === 0,
+		&& concurrentPathViolations.length === 0
+		&& concurrentE2eFixtureViolations.length === 0,
 };
 
 const json = `${JSON.stringify(report, null, 2)}\n`;

--- a/tests/e2e/continue-archived-multi-repo.spec.ts
+++ b/tests/e2e/continue-archived-multi-repo.spec.ts
@@ -7,9 +7,10 @@ import { test, expect } from "./in-process-harness.js";
 import { agentEndPredicate, apiFetch, connectWs, registerProject } from "./e2e-setup.js";
 import { awaitableRm, pollUntil } from "./test-utils/cleanup.js";
 import { appendFileSync, existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, realpathSync } from "node:fs";
-import { execFileSync } from "node:child_process";
 import { homedir, tmpdir } from "node:os";
 import { join, normalize } from "node:path";
+import { prepareGitTemplate, copyGitTemplate } from "../../tests2/harness/git-template.js";
+import { runFixtureCommand } from "../../tests2/harness/spawn-with-retry.js";
 
 // Exercise the same host-side pool path normal worktree sessions use, while
 // still accepting the cold createWorktreeSet fallback if the pool is empty.
@@ -27,18 +28,18 @@ async function sendPromptAndWait(id: string, text: string): Promise<void> {
 	}
 }
 
-function initRepo(repoPath: string): void {
-	mkdirSync(repoPath, { recursive: true });
-	execFileSync("git", ["init", "--initial-branch=master"], { cwd: repoPath, stdio: "pipe" });
-	execFileSync("git", ["config", "user.email", "test@test.com"], { cwd: repoPath, stdio: "pipe" });
-	execFileSync("git", ["config", "user.name", "Test"], { cwd: repoPath, stdio: "pipe" });
-	execFileSync("git", ["config", "commit.gpgsign", "false"], { cwd: repoPath, stdio: "pipe" });
-	execFileSync("git", ["commit", "--allow-empty", "-m", "init"], { cwd: repoPath, stdio: "pipe" });
+// Repos come from the immutable committed template (master + README.md +
+// .gitattributes + one commit); nothing here asserts on tree contents.
+async function initRepo(repoPath: string): Promise<void> {
+	await prepareGitTemplate();
+	copyGitTemplate(repoPath);
 }
 
-function branchExists(repoPath: string, branch: string): boolean {
+// attempts: 1 — a missing branch is an accepted outcome for this probe;
+// retrying would only change timing, not semantics.
+async function branchExists(repoPath: string, branch: string): Promise<boolean> {
 	try {
-		execFileSync("git", ["rev-parse", "--verify", `refs/heads/${branch}`], { cwd: repoPath, stdio: "pipe" });
+		await runFixtureCommand("git", ["rev-parse", "--verify", `refs/heads/${branch}`], { cwd: repoPath, attempts: 1 });
 		return true;
 	} catch {
 		return false;
@@ -116,8 +117,8 @@ test.describe("Continue-Archived multi-repo worktree support", () => {
 
 		try {
 			mkdirSync(rootPath, { recursive: true });
-			initRepo(apiRepo);
-			initRepo(webRepo);
+			await initRepo(apiRepo);
+			await initRepo(webRepo);
 			expect(existsSync(join(rootPath, ".git")), "project root must be a non-git multi-repo container").toBe(false);
 
 			const project = await registerProject({
@@ -152,8 +153,8 @@ test.describe("Continue-Archived multi-repo worktree support", () => {
 			expect(existsSync(srcRec.worktreePath), "source worktree container should exist before archive").toBe(true);
 			expect(existsSync(join(srcRec.worktreePath, "api")), "source api worktree should exist before archive").toBe(true);
 			expect(existsSync(join(srcRec.worktreePath, "web")), "source web worktree should exist before archive").toBe(true);
-			expect(branchExists(apiRepo, srcRec.branch), "source branch should exist in api repo").toBe(true);
-			expect(branchExists(webRepo, srcRec.branch), "source branch should exist in web repo").toBe(true);
+			expect(await branchExists(apiRepo, srcRec.branch), "source branch should exist in api repo").toBe(true);
+			expect(await branchExists(webRepo, srcRec.branch), "source branch should exist in web repo").toBe(true);
 
 			const transcriptMarker = `MULTI_REPO_CONTINUE_ARCHIVED_MARKER_${Date.now()}`;
 			await sendPromptAndWait(srcId, `${transcriptMarker} hello from multi-repo source`);
@@ -199,8 +200,8 @@ test.describe("Continue-Archived multi-repo worktree support", () => {
 			expect(existsSync(newRec.worktreePath), "continued worktree container should exist").toBe(true);
 			expect(existsSync(join(newRec.worktreePath, "api")), "continued api worktree should exist").toBe(true);
 			expect(existsSync(join(newRec.worktreePath, "web")), "continued web worktree should exist").toBe(true);
-			expect(branchExists(apiRepo, newRec.branch), "continued branch should exist in api repo").toBe(true);
-			expect(branchExists(webRepo, newRec.branch), "continued branch should exist in web repo").toBe(true);
+			expect(await branchExists(apiRepo, newRec.branch), "continued branch should exist in api repo").toBe(true);
+			expect(await branchExists(webRepo, newRec.branch), "continued branch should exist in web repo").toBe(true);
 
 			const sessionsDir = globalAgentSessionsDir();
 			const projectSlugFile = findClonedJsonl(join(sessionsDir, `--${slugifyCwd(rootPath)}--`), newId);

--- a/tests/e2e/continue-archived-worktree-invalid-base.spec.ts
+++ b/tests/e2e/continue-archived-worktree-invalid-base.spec.ts
@@ -5,10 +5,11 @@
 import { test, expect } from "./in-process-harness.js";
 import { apiFetch, connectWs, agentEndPredicate, defaultProjectId, registerProject } from "./e2e-setup.js";
 import { pollUntil } from "./test-utils/cleanup.js";
-import { existsSync, mkdirSync, realpathSync, rmSync } from "node:fs";
-import { execFileSync } from "node:child_process";
+import { existsSync, realpathSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { prepareGitTemplate, copyGitTemplate } from "../../tests2/harness/git-template.js";
+import { runFixtureCommand } from "../../tests2/harness/spawn-with-retry.js";
 
 test.use({ enableWorktreePool: false });
 
@@ -22,41 +23,41 @@ async function sendPromptAndWait(id: string, text: string): Promise<void> {
 	}
 }
 
-function initRepo(repoPath: string): void {
-	mkdirSync(repoPath, { recursive: true });
-	execFileSync("git", ["init", "--initial-branch=master"], { cwd: repoPath, stdio: "pipe" });
-	execFileSync("git", ["config", "user.email", "test@test.com"], { cwd: repoPath });
-	execFileSync("git", ["config", "user.name", "Test"], { cwd: repoPath });
-	execFileSync("git", ["config", "commit.gpgsign", "false"], { cwd: repoPath });
-	execFileSync("git", ["commit", "--allow-empty", "-m", "init"], { cwd: repoPath, stdio: "pipe" });
+// Repo comes from the immutable committed template (master + README.md +
+// .gitattributes + one commit); nothing here asserts on tree contents.
+async function initRepo(repoPath: string): Promise<void> {
+	await prepareGitTemplate();
+	copyGitTemplate(repoPath);
 }
 
-function branchExists(repoPath: string, branch: string): boolean {
+// attempts: 1 for probes/best-effort helpers whose failure is an accepted
+// outcome — retrying would only change timing, not semantics.
+async function branchExists(repoPath: string, branch: string): Promise<boolean> {
 	try {
-		execFileSync("git", ["rev-parse", "--verify", `refs/heads/${branch}`], { cwd: repoPath, stdio: "pipe" });
+		await runFixtureCommand("git", ["rev-parse", "--verify", `refs/heads/${branch}`], { cwd: repoPath, attempts: 1 });
 		return true;
 	} catch {
 		return false;
 	}
 }
 
-function deleteBranchIfPresent(repoPath: string, branch: string): void {
+async function deleteBranchIfPresent(repoPath: string, branch: string): Promise<void> {
 	try {
-		execFileSync("git", ["branch", "-D", branch], { cwd: repoPath, stdio: "pipe" });
+		await runFixtureCommand("git", ["branch", "-D", branch], { cwd: repoPath, attempts: 1 });
 	} catch {
 		// Best-effort cleanup; assertions below verify the intended stale state.
 	}
 }
 
-function removeWorktreeIfPresent(repoPath: string, worktreePath: string): void {
+async function removeWorktreeIfPresent(repoPath: string, worktreePath: string): Promise<void> {
 	try {
-		execFileSync("git", ["worktree", "remove", "--force", worktreePath], { cwd: repoPath, stdio: "pipe" });
+		await runFixtureCommand("git", ["worktree", "remove", "--force", worktreePath], { cwd: repoPath, attempts: 1 });
 	} catch {
 		// It may already have been removed by archive cleanup.
 	}
 	rmSync(worktreePath, { recursive: true, force: true });
 	try {
-		execFileSync("git", ["worktree", "prune"], { cwd: repoPath, stdio: "pipe" });
+		await runFixtureCommand("git", ["worktree", "prune"], { cwd: repoPath, attempts: 1 });
 	} catch {
 		// Best-effort cleanup.
 	}
@@ -72,7 +73,7 @@ test.describe("Continue-Archived worktree base-ref failure", () => {
 		let unexpectedContinuedId: string | undefined;
 
 		try {
-			initRepo(repoPath);
+			await initRepo(repoPath);
 			defaultId = await defaultProjectId();
 			const project = await registerProject({ name: `cont-wt-invalid-base-${Date.now()}`, rootPath: repoPath });
 			projectId = project.id;
@@ -99,7 +100,7 @@ test.describe("Continue-Archived worktree base-ref failure", () => {
 			expect(archiveResp.ok).toBe(true);
 
 			const staleBaseRef = `stale-continue-base-${Date.now()}`;
-			execFileSync("git", ["branch", staleBaseRef, "master"], { cwd: repoPath, stdio: "pipe" });
+			await runFixtureCommand("git", ["branch", staleBaseRef, "master"], { cwd: repoPath });
 			const putBaseRef = await apiFetch(`/api/projects/${projectId}/config`, {
 				method: "PUT",
 				body: JSON.stringify({ base_ref: staleBaseRef }),
@@ -112,13 +113,13 @@ test.describe("Continue-Archived worktree base-ref failure", () => {
 				expect(defaultCfg.base_ref, "stale-base setup must not poison the harness default project").not.toBe(staleBaseRef);
 			}
 
-			removeWorktreeIfPresent(repoPath, srcRec.worktreePath);
-			deleteBranchIfPresent(repoPath, srcRec.branch);
-			deleteBranchIfPresent(repoPath, staleBaseRef);
+			await removeWorktreeIfPresent(repoPath, srcRec.worktreePath);
+			await deleteBranchIfPresent(repoPath, srcRec.branch);
+			await deleteBranchIfPresent(repoPath, staleBaseRef);
 
 			expect(existsSync(srcRec.worktreePath), "source worktree must be stale before continue").toBe(false);
-			expect(branchExists(repoPath, srcRec.branch), "source branch must be stale before continue").toBe(false);
-			expect(branchExists(repoPath, staleBaseRef), "configured base_ref must be stale before continue").toBe(false);
+			expect(await branchExists(repoPath, srcRec.branch), "source branch must be stale before continue").toBe(false);
+			expect(await branchExists(repoPath, staleBaseRef), "configured base_ref must be stale before continue").toBe(false);
 
 			const cont = await apiFetch(`/api/sessions/${srcId}/continue`, {
 				method: "POST",

--- a/tests/e2e/continue-archived-worktree-pool.spec.ts
+++ b/tests/e2e/continue-archived-worktree-pool.spec.ts
@@ -7,10 +7,11 @@ import { test, expect } from "./in-process-harness.js";
 import { agentEndPredicate, apiFetch, connectWs, registerProject } from "./e2e-setup.js";
 import { pollUntil } from "./test-utils/cleanup.js";
 import { waitForPool } from "./test-utils/pool-polling.mjs";
-import { appendFileSync, existsSync, mkdirSync, readFileSync, readdirSync, realpathSync, rmSync } from "node:fs";
-import { execFileSync } from "node:child_process";
+import { appendFileSync, existsSync, readFileSync, readdirSync, realpathSync, rmSync } from "node:fs";
 import { homedir, tmpdir } from "node:os";
 import { dirname, join, normalize } from "node:path";
+import { prepareGitTemplate, copyGitTemplate } from "../../tests2/harness/git-template.js";
+import { runFixtureCommand } from "../../tests2/harness/spawn-with-retry.js";
 
 // This spec intentionally exercises the host-side worktree pool.
 test.use({ enableWorktreePool: true });
@@ -28,18 +29,18 @@ async function sendPromptAndWait(id: string, text: string): Promise<void> {
 	}
 }
 
-function initRepo(repoPath: string): void {
-	mkdirSync(repoPath, { recursive: true });
-	execFileSync("git", ["init", "--initial-branch=master"], { cwd: repoPath, stdio: "pipe" });
-	execFileSync("git", ["config", "user.email", "test@test.com"], { cwd: repoPath, stdio: "pipe" });
-	execFileSync("git", ["config", "user.name", "Test"], { cwd: repoPath, stdio: "pipe" });
-	execFileSync("git", ["config", "commit.gpgsign", "false"], { cwd: repoPath, stdio: "pipe" });
-	execFileSync("git", ["commit", "--allow-empty", "-m", "init"], { cwd: repoPath, stdio: "pipe" });
+// Repo comes from the immutable committed template (master + README.md +
+// .gitattributes + one commit); nothing here asserts on tree contents.
+async function initRepo(repoPath: string): Promise<void> {
+	await prepareGitTemplate();
+	copyGitTemplate(repoPath);
 }
 
-function branchExists(repoPath: string, branch: string): boolean {
+// attempts: 1 — a missing branch is an accepted outcome for this probe;
+// retrying would only change timing, not semantics.
+async function branchExists(repoPath: string, branch: string): Promise<boolean> {
 	try {
-		execFileSync("git", ["rev-parse", "--verify", `refs/heads/${branch}`], { cwd: repoPath, stdio: "pipe" });
+		await runFixtureCommand("git", ["rev-parse", "--verify", `refs/heads/${branch}`], { cwd: repoPath, attempts: 1 });
 		return true;
 	} catch {
 		return false;
@@ -118,7 +119,7 @@ test.describe("Continue-Archived worktree pool", () => {
 		let newId: string | undefined;
 
 		try {
-			initRepo(repoPath);
+			await initRepo(repoPath);
 			const project = await registerProject({ name: `cont-wt-pool-${Date.now()}`, rootPath: repoPath });
 			projectId = project.id;
 
@@ -167,7 +168,7 @@ test.describe("Continue-Archived worktree pool", () => {
 			const readyBeforeContinue = await readyPoolEntry(gateway, projectId);
 			expect(readyBeforeContinue.branchName).toMatch(/^pool\/_pool-/);
 			expect(existsSync(readyBeforeContinue.worktreePath), "captured ready pool worktree should exist before continue").toBe(true);
-			expect(branchExists(repoPath, readyBeforeContinue.branchName), "captured ready pool branch should exist before continue").toBe(true);
+			expect(await branchExists(repoPath, readyBeforeContinue.branchName), "captured ready pool branch should exist before continue").toBe(true);
 
 			const continueResp = await apiFetch(`/api/sessions/${srcId}/continue`, {
 				method: "POST",
@@ -196,7 +197,7 @@ test.describe("Continue-Archived worktree pool", () => {
 			expect(normalize(newRec.worktreePath)).toBe(normalize(expectedClaimedPath));
 			expect(newRec.cwd).toBe(newRec.worktreePath);
 			expect(existsSync(newRec.worktreePath), "continued session worktree should exist at the claimed pool path").toBe(true);
-			expect(branchExists(repoPath, expectedBranch), "continued session branch should exist").toBe(true);
+			expect(await branchExists(repoPath, expectedBranch), "continued session branch should exist").toBe(true);
 
 			const sessionsDir = globalAgentSessionsDir();
 			const projectSlugFile = findClonedJsonl(join(sessionsDir, `--${slugifyCwd(repoPath)}--`), newId);
@@ -216,7 +217,7 @@ test.describe("Continue-Archived worktree pool", () => {
 
 			// Reproducer: with bypassWorktreePool still true, Continue-Archived takes
 			// the cold createWorktree path and leaves this captured pool entry intact.
-			expect(branchExists(repoPath, readyBeforeContinue.branchName), "continued session must claim the ready pool branch and rename it").toBe(false);
+			expect(await branchExists(repoPath, readyBeforeContinue.branchName), "continued session must claim the ready pool branch and rename it").toBe(false);
 			expect(existsSync(readyBeforeContinue.worktreePath), "continued session must move the ready pool worktree to the session path").toBe(false);
 		} finally {
 			if (newId) await apiFetch(`/api/sessions/${newId}`, { method: "DELETE" }).catch(() => {});

--- a/tests/e2e/continue-archived-worktree-stale-source.spec.ts
+++ b/tests/e2e/continue-archived-worktree-stale-source.spec.ts
@@ -5,10 +5,11 @@
 import { test, expect } from "./in-process-harness.js";
 import { apiFetch, connectWs, agentEndPredicate, registerProject } from "./e2e-setup.js";
 import { pollUntil } from "./test-utils/cleanup.js";
-import { appendFileSync, existsSync, mkdirSync, readdirSync, readFileSync, realpathSync, rmSync } from "node:fs";
-import { execFileSync } from "node:child_process";
+import { appendFileSync, existsSync, readdirSync, readFileSync, realpathSync, rmSync } from "node:fs";
 import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
+import { prepareGitTemplate, copyGitTemplate } from "../../tests2/harness/git-template.js";
+import { runFixtureCommand } from "../../tests2/harness/spawn-with-retry.js";
 
 test.use({ enableWorktreePool: false });
 
@@ -22,41 +23,41 @@ async function sendPromptAndWait(id: string, text: string): Promise<void> {
 	}
 }
 
-function initRepo(repoPath: string): void {
-	mkdirSync(repoPath, { recursive: true });
-	execFileSync("git", ["init", "--initial-branch=master"], { cwd: repoPath, stdio: "pipe" });
-	execFileSync("git", ["config", "user.email", "test@test.com"], { cwd: repoPath, stdio: "pipe" });
-	execFileSync("git", ["config", "user.name", "Test"], { cwd: repoPath, stdio: "pipe" });
-	execFileSync("git", ["config", "commit.gpgsign", "false"], { cwd: repoPath, stdio: "pipe" });
-	execFileSync("git", ["commit", "--allow-empty", "-m", "init"], { cwd: repoPath, stdio: "pipe" });
+// Repo comes from the immutable committed template (master + README.md +
+// .gitattributes + one commit); nothing here asserts on tree contents.
+async function initRepo(repoPath: string): Promise<void> {
+	await prepareGitTemplate();
+	copyGitTemplate(repoPath);
 }
 
-function branchExists(repoPath: string, branch: string): boolean {
+// attempts: 1 for probes/best-effort helpers whose failure is an accepted
+// outcome — retrying would only change timing, not semantics.
+async function branchExists(repoPath: string, branch: string): Promise<boolean> {
 	try {
-		execFileSync("git", ["rev-parse", "--verify", `refs/heads/${branch}`], { cwd: repoPath, stdio: "pipe" });
+		await runFixtureCommand("git", ["rev-parse", "--verify", `refs/heads/${branch}`], { cwd: repoPath, attempts: 1 });
 		return true;
 	} catch {
 		return false;
 	}
 }
 
-function deleteBranchIfPresent(repoPath: string, branch: string): void {
+async function deleteBranchIfPresent(repoPath: string, branch: string): Promise<void> {
 	try {
-		execFileSync("git", ["branch", "-D", branch], { cwd: repoPath, stdio: "pipe" });
+		await runFixtureCommand("git", ["branch", "-D", branch], { cwd: repoPath, attempts: 1 });
 	} catch {
 		// Best-effort cleanup; assertions verify the stale state.
 	}
 }
 
-function removeWorktreeIfPresent(repoPath: string, worktreePath: string): void {
+async function removeWorktreeIfPresent(repoPath: string, worktreePath: string): Promise<void> {
 	try {
-		execFileSync("git", ["worktree", "remove", "--force", worktreePath], { cwd: repoPath, stdio: "pipe" });
+		await runFixtureCommand("git", ["worktree", "remove", "--force", worktreePath], { cwd: repoPath, attempts: 1 });
 	} catch {
 		// It may already have been removed by archive cleanup.
 	}
 	rmSync(worktreePath, { recursive: true, force: true });
 	try {
-		execFileSync("git", ["worktree", "prune"], { cwd: repoPath, stdio: "pipe" });
+		await runFixtureCommand("git", ["worktree", "prune"], { cwd: repoPath, attempts: 1 });
 	} catch {
 		// Best-effort cleanup.
 	}
@@ -136,7 +137,7 @@ test.describe("Continue-Archived stale worktree source", () => {
 		let newId: string | undefined;
 
 		try {
-			initRepo(repoPath);
+			await initRepo(repoPath);
 			const project = await registerProject({ name: `cont-wt-stale-source-${Date.now()}`, rootPath: repoPath });
 			projectId = project.id;
 
@@ -157,7 +158,7 @@ test.describe("Continue-Archived stale worktree source", () => {
 			expect(srcRec.cwd).toBe(srcRec.worktreePath);
 			expect(srcRec.branch).toBe(`session/${srcId.slice(0, 8)}`);
 			expect(existsSync(srcRec.worktreePath), "source worktree should exist before staling it").toBe(true);
-			expect(branchExists(repoPath, srcRec.branch), "source branch should exist before staling it").toBe(true);
+			expect(await branchExists(repoPath, srcRec.branch), "source branch should exist before staling it").toBe(true);
 
 			const transcriptMarker = `STALE_SOURCE_CONTINUE_TRANSCRIPT_${Date.now()}`;
 			const proposalMarker = `STALE_SOURCE_CONTINUE_PROPOSAL_${Date.now()}`;
@@ -203,10 +204,10 @@ test.describe("Continue-Archived stale worktree source", () => {
 			expect(readRuntimeCwdRecords(archivedSourceJsonl), "archived source transcript should retain stale system cwd metadata").toContainEqual({ type: "system", cwd: srcRec.worktreePath });
 			expect(readRuntimeCwdRecords(archivedSourceJsonl), "archived source transcript should retain stale Pi-style session cwd metadata").toContainEqual({ type: "session", cwd: srcRec.worktreePath });
 
-			removeWorktreeIfPresent(repoPath, srcRec.worktreePath);
-			deleteBranchIfPresent(repoPath, srcRec.branch);
+			await removeWorktreeIfPresent(repoPath, srcRec.worktreePath);
+			await deleteBranchIfPresent(repoPath, srcRec.branch);
 			expect(existsSync(srcRec.worktreePath), "source worktree must be stale before continue").toBe(false);
-			expect(branchExists(repoPath, srcRec.branch), "source branch must be stale before continue").toBe(false);
+			expect(await branchExists(repoPath, srcRec.branch), "source branch must be stale before continue").toBe(false);
 
 			const cont = await apiFetch(`/api/sessions/${srcId}/continue`, {
 				method: "POST",
@@ -233,11 +234,11 @@ test.describe("Continue-Archived stale worktree source", () => {
 			expect(newRec.worktreePath).not.toBe(srcRec.worktreePath);
 			expect(newRec.cwd).toBe(newRec.worktreePath);
 			expect(existsSync(newRec.worktreePath), "continued session worktree should exist").toBe(true);
-			expect(branchExists(repoPath, newRec.branch), "continued session branch should exist").toBe(true);
+			expect(await branchExists(repoPath, newRec.branch), "continued session branch should exist").toBe(true);
 
 			// The deleted archived source must remain stale; continue must not revive it.
 			expect(existsSync(srcRec.worktreePath), "continue must not recreate the deleted source worktree").toBe(false);
-			expect(branchExists(repoPath, srcRec.branch), "continue must not recreate the deleted source branch").toBe(false);
+			expect(await branchExists(repoPath, srcRec.branch), "continue must not recreate the deleted source branch").toBe(false);
 
 			const projSlugDir = join(sessionsDir, `--${slugifyCwd(repoPath)}--`);
 			const wtSlugDir = join(sessionsDir, `--${slugifyCwd(newRec.worktreePath)}--`);

--- a/tests/e2e/goal-archive-branch-cleanup.spec.ts
+++ b/tests/e2e/goal-archive-branch-cleanup.spec.ts
@@ -22,11 +22,13 @@
  * from other workers.
  */
 import { test, expect } from "./in-process-harness-realpush.js";
-import { execFileSync, execFile as execFileCb } from "node:child_process";
+import { execFile as execFileCb } from "node:child_process";
 import { promisify } from "node:util";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { prepareGitTemplate, copyGitTemplate } from "../../tests2/harness/git-template.js";
+import { runFixtureCommand } from "../../tests2/harness/spawn-with-retry.js";
 import { apiFetch } from "./e2e-setup.js";
 import { pollUntil } from "./test-utils/cleanup.js";
 
@@ -41,17 +43,18 @@ test.describe("orphan remote branch cleanup — Bug 1 (team goal archive)", () =
 	let projectId: string;
 
 	test.beforeAll(async () => {
-		// 1. Local bare-repo "origin" + a clone with an initial master commit.
+		// 1. Local bare-repo "origin" + a working repo with an initial master
+		//    commit. The working repo comes from the immutable committed template
+		//    (master + README.md + .gitattributes + one commit, identity already
+		//    configured); wiring it to the bare origin stays real git.
 		tmpRoot = mkdtempSync(join(tmpdir(), "bobbit-bare-"));
 		bareRepo = join(tmpRoot, "origin.git");
 		workRepo = join(tmpRoot, "work");
-		execFileSync("git", ["init", "--bare", "-b", "master", bareRepo]);
-		execFileSync("git", ["clone", bareRepo, workRepo]);
-		// Identity is required for the empty commit on some CI images.
-		execFileSync("git", ["-C", workRepo, "config", "user.email", "test@bobbit.local"]);
-		execFileSync("git", ["-C", workRepo, "config", "user.name", "bobbit-e2e"]);
-		execFileSync("git", ["-C", workRepo, "commit", "--allow-empty", "-m", "init"]);
-		execFileSync("git", ["-C", workRepo, "push", "-u", "origin", "master"]);
+		await runFixtureCommand("git", ["init", "--bare", "-b", "master", bareRepo]);
+		await prepareGitTemplate();
+		copyGitTemplate(workRepo);
+		await runFixtureCommand("git", ["remote", "add", "origin", bareRepo], { cwd: workRepo });
+		await runFixtureCommand("git", ["push", "-u", "origin", "master"], { cwd: workRepo });
 
 		// 2. Register the clone as a project via REST. We talk to the
 		//    realpush harness's gateway via the standard apiFetch helper.
@@ -129,7 +132,7 @@ test.describe("orphan remote branch cleanup — Bug 1 (team goal archive)", () =
 		}, { timeoutMs: 30_000, intervalMs: 500, label: `goal branch ${branch} pushed to origin` });
 		expect(lsBefore, `branch ${branch} should have been pushed`).toContain(branch);
 
-		execFileSync("git", ["-C", workRepo, "push", "origin", "--delete", branch]);
+		await runFixtureCommand("git", ["push", "origin", "--delete", branch], { cwd: workRepo });
 		const { stdout: lsAfterPredelete } = await execFileAsync(
 			"git", ["ls-remote", "--heads", bareRepo, branch],
 			{ encoding: "utf-8" },

--- a/tests/e2e/multi-repo-pool.spec.ts
+++ b/tests/e2e/multi-repo-pool.spec.ts
@@ -19,14 +19,18 @@ import { waitForPool, pollSessionUntil, pollSessionUntilArchived } from "./test-
 import fs from "node:fs";
 import path from "node:path";
 import os from "node:os";
-import { execFileSync } from "node:child_process";
+import { prepareGitTemplate, copyGitTemplate } from "../../tests2/harness/git-template.js";
+import { runFixtureCommand } from "../../tests2/harness/spawn-with-retry.js";
 
-function gitInit(dir: string): void {
-	fs.mkdirSync(dir, { recursive: true });
-	execFileSync("git", ["init", "--initial-branch=master"], { cwd: dir });
-	execFileSync("git", ["config", "user.email", "test@bobbit.local"], { cwd: dir });
-	execFileSync("git", ["config", "user.name", "test"], { cwd: dir });
-	execFileSync("git", ["commit", "--allow-empty", "-m", "init"], { cwd: dir });
+// Repos come from the immutable committed template (master + README.md +
+// .gitattributes + one commit); nothing in this spec asserts on tree contents.
+async function gitInit(dir: string): Promise<void> {
+	await prepareGitTemplate();
+	copyGitTemplate(dir);
+}
+
+async function gitStdout(args: readonly string[], cwd: string): Promise<string> {
+	return (await runFixtureCommand("git", args, { cwd })).stdout;
 }
 
 test.describe.serial("multi-repo worktree pool E2E", () => {
@@ -35,8 +39,8 @@ test.describe.serial("multi-repo worktree pool E2E", () => {
 
 	test.beforeAll(async () => {
 		root = fs.mkdtempSync(path.join(os.tmpdir(), "bobbit-mr-pool-"));
-		gitInit(path.join(root, "api"));
-		gitInit(path.join(root, "web"));
+		await gitInit(path.join(root, "api"));
+		await gitInit(path.join(root, "web"));
 
 		const reg = await apiFetch("/api/projects", {
 			method: "POST",
@@ -106,7 +110,7 @@ test.describe.serial("multi-repo worktree pool E2E", () => {
 
 		// Each per-repo worktree should be on the goal's branch.
 		for (const wt of [apiWt, webWt]) {
-			const stdout = execFileSync("git", ["rev-parse", "--abbrev-ref", "HEAD"], { cwd: wt, encoding: "utf-8" });
+			const stdout = await gitStdout(["rev-parse", "--abbrev-ref", "HEAD"], wt);
 			expect(stdout.trim()).toBe(branch);
 		}
 	});
@@ -114,9 +118,9 @@ test.describe.serial("multi-repo worktree pool E2E", () => {
 	test("multi-repo session lifecycle: branch + dir stable across creation, prompt, restart, archive", async ({ gateway }) => {
 		// Use a fresh project so the pool state for this test is independent.
 		const lifecycleRoot = fs.mkdtempSync(path.join(os.tmpdir(), "bobbit-mr-life-"));
-		gitInit(path.join(lifecycleRoot, "api"));
-		gitInit(path.join(lifecycleRoot, "web"));
-		gitInit(path.join(lifecycleRoot, "data"));
+		await gitInit(path.join(lifecycleRoot, "api"));
+		await gitInit(path.join(lifecycleRoot, "web"));
+		await gitInit(path.join(lifecycleRoot, "data"));
 
 		const reg = await apiFetch("/api/projects", {
 			method: "POST",
@@ -168,20 +172,20 @@ test.describe.serial("multi-repo worktree pool E2E", () => {
 		for (const r of repos) {
 			const wt = path.join(container, r);
 			expect(fs.existsSync(wt), `${r} worktree must exist at ${wt}`).toBe(true);
-			const head = execFileSync("git", ["rev-parse", "--abbrev-ref", "HEAD"], { cwd: wt, encoding: "utf-8" }).trim();
+			const head = (await gitStdout(["rev-parse", "--abbrev-ref", "HEAD"], wt)).trim();
 			expect(head).toBe(branch);
 		}
 
 		// Capture pre-restart per-repo fingerprints. Use the branch's own
 		// reflog only (NOT --all) so background pool replenishment doesn't
 		// pollute the snapshot.
-		const beforeReflogs = repos.map(r => {
+		const beforeReflogs = await Promise.all(repos.map(async r => {
 			try {
-				return execFileSync("git", ["reflog", "show", "--no-abbrev", branch!], {
-					cwd: path.join(container, r), encoding: "utf-8", stdio: ["ignore", "pipe", "pipe"],
-				});
+				return (await runFixtureCommand("git", ["reflog", "show", "--no-abbrev", branch!], {
+					cwd: path.join(container, r), attempts: 1,
+				})).stdout;
 			} catch { return ""; }
-		});
+		}));
 
 		// 3. PATCH title — metadata only, branch must NOT change.
 		const patch = await apiFetch(`/api/sessions/${sessionId}`, {
@@ -232,13 +236,13 @@ test.describe.serial("multi-repo worktree pool E2E", () => {
 		for (let i = 0; i < repos.length; i++) {
 			const wt = path.join(container, repos[i]);
 			expect(fs.existsSync(wt)).toBe(true);
-			const head = execFileSync("git", ["rev-parse", "--abbrev-ref", "HEAD"], { cwd: wt, encoding: "utf-8" }).trim();
+			const head = (await gitStdout(["rev-parse", "--abbrev-ref", "HEAD"], wt)).trim();
 			expect(head).toBe(branch);
 			let reflogAfter = "";
 			try {
-				reflogAfter = execFileSync("git", ["reflog", "show", "--no-abbrev", branch!], {
-					cwd: wt, encoding: "utf-8", stdio: ["ignore", "pipe", "pipe"],
-				});
+				reflogAfter = (await runFixtureCommand("git", ["reflog", "show", "--no-abbrev", branch!], {
+					cwd: wt, attempts: 1,
+				})).stdout;
 			} catch { /* may be empty */ }
 			expect(reflogAfter).toBe(beforeReflogs[i]);
 		}
@@ -263,9 +267,7 @@ test.describe.serial("multi-repo worktree pool E2E", () => {
 
 		for (const r of repos) {
 			const repoRoot = path.join(lifecycleRoot, r);
-			const legacy = execFileSync("git", ["branch", "--list"], {
-				cwd: repoRoot, encoding: "utf-8",
-			}).trim();
+			const legacy = (await gitStdout(["branch", "--list"], repoRoot)).trim();
 			expect(legacy, `${r} must not have any session/new-session-* ghost branch`).not.toMatch(/session\/new-session-/);
 			expect(legacy, `${r} must not have any session/<slug>-<id8> ghost from the legacy rename path`).not.toMatch(new RegExp(`session/[a-z0-9-]+-${branch!.slice("session/".length)}`));
 		}

--- a/tests/e2e/ui/base-ref-detect.spec.ts
+++ b/tests/e2e/ui/base-ref-detect.spec.ts
@@ -12,10 +12,11 @@
 import { test, expect } from "../gateway-harness.js";
 import { apiFetch } from "../e2e-setup.js";
 import { openApp, navigateToHash } from "./ui-helpers.js";
-import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { execFileSync } from "node:child_process";
+import { prepareGitTemplate, copyGitTemplate } from "../../../tests2/harness/git-template.js";
+import { runFixtureCommand } from "../../../tests2/harness/spawn-with-retry.js";
 
 type BrowserPage = Parameters<typeof openApp>[0];
 
@@ -25,27 +26,22 @@ type BrowserPage = Parameters<typeof openApp>[0];
  * `git symbolic-ref refs/remotes/origin/HEAD` (the resolved fallback) both
  * return a concrete `origin/master`.
  */
-function gitInitWithRemote(dir: string): void {
+async function gitInitWithRemote(dir: string): Promise<void> {
 	const remoteDir = `${dir}-origin.git`;
 	mkdirSync(remoteDir, { recursive: true });
-	execFileSync("git", ["init", "--bare", "--quiet", remoteDir]);
+	await runFixtureCommand("git", ["init", "--bare", "--quiet", remoteDir]);
 	// Ensure the remote's HEAD symref resolves to master regardless of the
 	// host git's init.defaultBranch.
-	execFileSync("git", ["symbolic-ref", "HEAD", "refs/heads/master"], { cwd: remoteDir });
+	await runFixtureCommand("git", ["symbolic-ref", "HEAD", "refs/heads/master"], { cwd: remoteDir });
 
-	mkdirSync(dir, { recursive: true });
-	execFileSync("git", ["init", "--quiet"], { cwd: dir });
-	execFileSync("git", ["config", "user.email", "test@bobbit.local"], { cwd: dir });
-	execFileSync("git", ["config", "user.name", "test"], { cwd: dir });
-	execFileSync("git", ["config", "commit.gpgsign", "false"], { cwd: dir });
-	execFileSync("git", ["checkout", "--quiet", "-b", "master"], { cwd: dir });
-	writeFileSync(join(dir, "README.md"), "x\n");
-	execFileSync("git", ["add", "."], { cwd: dir });
-	execFileSync("git", ["commit", "--quiet", "-m", "init"], { cwd: dir });
-	execFileSync("git", ["remote", "add", "origin", remoteDir], { cwd: dir });
-	execFileSync("git", ["push", "--quiet", "-u", "origin", "master"], { cwd: dir });
+	// Working repo comes from the immutable committed template (master +
+	// README.md + .gitattributes + one commit) instead of a bespoke init dance.
+	await prepareGitTemplate();
+	copyGitTemplate(dir);
+	await runFixtureCommand("git", ["remote", "add", "origin", remoteDir], { cwd: dir });
+	await runFixtureCommand("git", ["push", "--quiet", "-u", "origin", "master"], { cwd: dir });
 	// Populate the local refs/remotes/origin/HEAD that resolveRemotePrimary reads.
-	execFileSync("git", ["remote", "set-head", "origin", "master"], { cwd: dir });
+	await runFixtureCommand("git", ["remote", "set-head", "origin", "master"], { cwd: dir });
 }
 
 function uniqueProjectDir(prefix: string): string {
@@ -89,7 +85,7 @@ test.describe("Settings → Base Ref detect-from-remote", () => {
 		const projectIds: string[] = [];
 		try {
 			const dir = uniqueProjectDir("blank");
-			gitInitWithRemote(dir);
+			await gitInitWithRemote(dir);
 			const projectId = await createProject(`baseref-detect-${Date.now()}`, dir);
 			projectIds.push(projectId);
 			await blankBaseRef(projectId);

--- a/tests/e2e/ui/base-ref-settings.spec.ts
+++ b/tests/e2e/ui/base-ref-settings.spec.ts
@@ -11,23 +11,19 @@ import { openApp, navigateToHash } from "./ui-helpers.js";
 import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { execFileSync } from "node:child_process";
+import { prepareGitTemplate, copyGitTemplate } from "../../../tests2/harness/git-template.js";
+import { runFixtureCommand } from "../../../tests2/harness/spawn-with-retry.js";
 
 type BrowserPage = Parameters<typeof openApp>[0];
 
-function gitInit(dir: string, opts?: { tags?: string[]; remoteRefs?: string[] }): void {
-	mkdirSync(dir, { recursive: true });
-	execFileSync("git", ["init", "--quiet"], { cwd: dir });
-	execFileSync("git", ["config", "user.email", "test@bobbit.local"], { cwd: dir });
-	execFileSync("git", ["config", "user.name", "test"], { cwd: dir });
-	execFileSync("git", ["config", "commit.gpgsign", "false"], { cwd: dir });
-	execFileSync("git", ["checkout", "--quiet", "-b", "master"], { cwd: dir });
-	writeFileSync(join(dir, "README.md"), "x\n");
-	execFileSync("git", ["add", "."], { cwd: dir });
-	execFileSync("git", ["commit", "--quiet", "-m", "init"], { cwd: dir });
-	const head = execFileSync("git", ["rev-parse", "HEAD"], { cwd: dir, encoding: "utf-8" }).trim();
+// Base repo comes from the immutable committed template (master + README.md +
+// .gitattributes + one commit); tags and fake remote refs stay real git.
+async function gitInit(dir: string, opts?: { tags?: string[]; remoteRefs?: string[] }): Promise<void> {
+	await prepareGitTemplate();
+	copyGitTemplate(dir);
+	const head = (await runFixtureCommand("git", ["rev-parse", "HEAD"], { cwd: dir })).stdout.trim();
 	for (const t of opts?.tags ?? []) {
-		execFileSync("git", ["tag", t], { cwd: dir });
+		await runFixtureCommand("git", ["tag", t], { cwd: dir });
 	}
 	for (const r of opts?.remoteRefs ?? []) {
 		const refPath = join(dir, ".git", "refs", "remotes", "origin", r);
@@ -97,7 +93,7 @@ test.describe("Settings → Base Ref field", () => {
 		const projectIds: string[] = [];
 		try {
 			const dir = uniqueProjectDir("happy");
-			gitInit(dir, { remoteRefs: ["develop"] });
+			await gitInit(dir, { remoteRefs: ["develop"] });
 			const project = await createProject(`baseref-ui-happy-${Date.now()}`, dir);
 			projectIds.push(project.id);
 
@@ -127,17 +123,17 @@ test.describe("Settings → Base Ref field", () => {
 		const projectIds: string[] = [];
 		try {
 			const tagDir = uniqueProjectDir("tag");
-			gitInit(tagDir, { tags: ["v1.2.3"] });
+			await gitInit(tagDir, { tags: ["v1.2.3"] });
 			const tagProject = await createProject(`baseref-ui-tag-${Date.now()}`, tagDir);
 			projectIds.push(tagProject.id);
 
 			const grammarDir = uniqueProjectDir("grammar");
-			gitInit(grammarDir);
+			await gitInit(grammarDir);
 			const grammarProject = await createProject(`baseref-ui-grammar-${Date.now()}`, grammarDir);
 			projectIds.push(grammarProject.id);
 
 			const sandboxDir = uniqueProjectDir("sandbox");
-			gitInit(sandboxDir);
+			await gitInit(sandboxDir);
 			const sandboxProject = await createProject(`baseref-ui-sandbox-${Date.now()}`, sandboxDir);
 			projectIds.push(sandboxProject.id);
 			// Pre-set sandbox=docker via API so the UI only needs to drive base_ref.
@@ -151,9 +147,9 @@ test.describe("Settings → Base Ref field", () => {
 			const repoA = join(root, "api");
 			const repoB = join(root, "web");
 			const repoC = join(root, "shared");
-			gitInit(repoA, { remoteRefs: ["develop"] });
-			gitInit(repoB); // missing origin/develop
-			gitInit(repoC); // missing origin/develop
+			await gitInit(repoA, { remoteRefs: ["develop"] });
+			await gitInit(repoB); // missing origin/develop
+			await gitInit(repoC); // missing origin/develop
 			const multiProject = await createProject(
 				`baseref-ui-multi-${Date.now()}`,
 				root,

--- a/tests/e2e/ui/multi-repo-flow.spec.ts
+++ b/tests/e2e/ui/multi-repo-flow.spec.ts
@@ -12,27 +12,25 @@ import { openApp } from "./ui-helpers.js";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { execFileSync } from "node:child_process";
+import { prepareGitTemplate, copyGitTemplate } from "../../../tests2/harness/git-template.js";
+import { runFixtureCommand } from "../../../tests2/harness/spawn-with-retry.js";
 
-function gitInit(dir: string): void {
-	fs.mkdirSync(dir, { recursive: true });
-	execFileSync("git", ["init", "--quiet"], { cwd: dir });
-	execFileSync("git", ["config", "user.email", "test@bobbit.local"], { cwd: dir });
-	execFileSync("git", ["config", "user.name", "test"], { cwd: dir });
-	fs.writeFileSync(path.join(dir, "README.md"), "fixture\n");
-	execFileSync("git", ["add", "."], { cwd: dir });
-	execFileSync("git", ["commit", "-m", "init", "--quiet"], { cwd: dir });
+// Base repo comes from the immutable committed template (master + README.md +
+// .gitattributes + one commit); the bare-clone origin wiring stays real git.
+async function gitInit(dir: string): Promise<void> {
+	await prepareGitTemplate();
+	copyGitTemplate(dir);
 	// Ensure an `origin` exists so worktree push targets resolve. Fake it via
 	// a bare clone alongside.
 	const bare = `${dir}-bare`;
-	execFileSync("git", ["clone", "--bare", "--quiet", dir, bare], { stdio: "pipe" });
-	execFileSync("git", ["remote", "add", "origin", bare], { cwd: dir });
+	await runFixtureCommand("git", ["clone", "--bare", "--quiet", dir, bare]);
+	await runFixtureCommand("git", ["remote", "add", "origin", bare], { cwd: dir });
 }
 
 async function registerMultiRepoProject(): Promise<{ id: string; rootPath: string; cleanup: () => void }> {
 	const root = fs.mkdtempSync(path.join(os.tmpdir(), "bobbit-mr-ui-"));
-	gitInit(path.join(root, "api"));
-	gitInit(path.join(root, "web"));
+	await gitInit(path.join(root, "api"));
+	await gitInit(path.join(root, "web"));
 	fs.mkdirSync(path.join(root, "shared"), { recursive: true });  // data-only repo
 
 	const res = await apiFetch("/api/projects", {

--- a/tests/e2e/worktree-root-override.spec.ts
+++ b/tests/e2e/worktree-root-override.spec.ts
@@ -11,19 +11,16 @@ import { test, expect } from "./in-process-harness.js";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { execFileSync } from "node:child_process";
 
 import { worktreeRoot, branchContainer } from "../../src/server/skills/worktree-paths.js";
 import { createWorktree, createWorktreeSet, cleanupWorktree } from "../../src/server/skills/git.js";
+import { prepareGitTemplate, copyGitTemplate } from "../../tests2/harness/git-template.js";
 
-function gitInit(dir: string): void {
-	fs.mkdirSync(dir, { recursive: true });
-	execFileSync("git", ["init", "--quiet", "-b", "master"], { cwd: dir });
-	execFileSync("git", ["config", "user.email", "t@b.local"], { cwd: dir });
-	execFileSync("git", ["config", "user.name", "t"], { cwd: dir });
-	fs.writeFileSync(path.join(dir, "README.md"), "x\n");
-	execFileSync("git", ["add", "."], { cwd: dir });
-	execFileSync("git", ["commit", "-m", "init", "--quiet"], { cwd: dir });
+// Repos come from the immutable committed template (master + README.md +
+// .gitattributes + one commit); nothing here asserts on tree contents.
+async function gitInit(dir: string): Promise<void> {
+	await prepareGitTemplate();
+	copyGitTemplate(dir);
 }
 
 test("absolute worktree_root override is used as-is", () => {
@@ -47,7 +44,7 @@ test("single-repo createWorktree honors worktreeRoot override on disk", async ()
 	const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "bobbit-wtr-single-"));
 	const repo = path.join(tmp, "repo");
 	const override = path.join(tmp, "custom-wt");
-	gitInit(repo);
+	await gitInit(repo);
 
 	const branch = `feat/wtr-${Date.now()}`;
 	process.env.BOBBIT_TEST_NO_PUSH = "1";
@@ -68,9 +65,9 @@ test("multi-repo createWorktreeSet honors worktreeRoot override (claim + cleanup
 	const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "bobbit-wtr-multi-"));
 	const rootPath = path.join(tmp, "proj");
 	fs.mkdirSync(rootPath);
-	gitInit(path.join(rootPath, "api"));
-	gitInit(path.join(rootPath, "web"));
-	gitInit(path.join(rootPath, "shared"));
+	await gitInit(path.join(rootPath, "api"));
+	await gitInit(path.join(rootPath, "web"));
+	await gitInit(path.join(rootPath, "shared"));
 	const override = path.join(tmp, "shared-wt");
 
 	const branch = `goal/wtr-${Date.now()}`;

--- a/tests2/browser-global-setup.ts
+++ b/tests2/browser-global-setup.ts
@@ -4,10 +4,12 @@
  * Mirrors tests/e2e/e2e-global-setup.ts but:
  *   - Skips the no-new-sleeps guard (run separately by the e2e suite)
  *   - Skips BOBBIT_E2E_SKIP_GUARDS logic (not needed here)
- *   - Builds dist/server and dist/ui if either is missing
+ *   - Ensures dist/server and dist/ui match the current build inputs via the
+ *     content-addressed manifest (scripts/testing-v2/ensure-dist.mjs) — a
+ *     stale dist is rebuilt, a fresh one is reused
  */
 import { execSync } from "node:child_process";
-import { existsSync, realpathSync } from "node:fs";
+import { realpathSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -21,8 +23,6 @@ export default function globalSetup() {
 	}
 
 	const projectRoot = join(import.meta.dirname, "..");
-	const serverEntry = join(projectRoot, "dist", "server", "cli.js");
-	const uiDir = join(projectRoot, "dist", "ui");
 
 	// Disable external services in browser tests.
 	process.env.NODE_ENV = "test";
@@ -31,17 +31,10 @@ export default function globalSetup() {
 	process.env.NODE_DISABLE_COMPILE_CACHE = "1";
 	delete process.env.NODE_COMPILE_CACHE;
 
-	const needServer = !existsSync(serverEntry);
-	const needUI = !existsSync(uiDir);
-
-	if (needServer && needUI) {
-		console.log("[v2-browser-setup] Building server and UI...");
-		execSync("npm run build", { cwd: projectRoot, stdio: "inherit" });
-	} else if (needServer) {
-		console.log("[v2-browser-setup] Building server...");
-		execSync("npm run build:server", { cwd: projectRoot, stdio: "inherit" });
-	} else if (needUI) {
-		console.log("[v2-browser-setup] Building UI...");
-		execSync("npm run build:ui", { cwd: projectRoot, stdio: "inherit" });
-	}
+	// Content-addressed build skip: rebuilds when any build input changed,
+	// reuses dist when the manifest key matches (fail-closed on any error).
+	execSync(`node "${join(projectRoot, "scripts", "testing-v2", "ensure-dist.mjs")}"`, {
+		cwd: projectRoot,
+		stdio: "inherit",
+	});
 }

--- a/tests2/browser-global-teardown.ts
+++ b/tests2/browser-global-teardown.ts
@@ -1,0 +1,26 @@
+/**
+ * Global teardown for v2 browser runs (playwright-v2.config.ts).
+ *
+ * FIRST publishes this run's Playwright transform cache as the shared
+ * `latest` snapshot (so the next run warm-starts instead of re-transforming
+ * ~566 files), THEN delegates to the legacy e2e teardown, which — unchanged —
+ * deletes the per-run cache dir and cleans up ephemeral state/Docker.
+ *
+ * The publish is fail-open and env-gated (BOBBIT_E2E_PWTEST_CACHE_OWNED=1,
+ * v2 namespace only); BOBBIT_KEEP_PWTEST_CACHE=1 keeps its existing
+ * "don't delete the per-run dir" semantics in the delegated teardown.
+ * tests/e2e/e2e-teardown.ts itself is NOT modified so legacy e2e runs are
+ * unaffected.
+ */
+import legacyTeardown from "../tests/e2e/e2e-teardown.js";
+import { publishTransformCacheFromEnv } from "../scripts/testing-v2/pwtest-cache.js";
+
+export default async function globalTeardown(): Promise<void> {
+	try {
+		publishTransformCacheFromEnv();
+	} catch (err) {
+		// Fail-open: publishing is an optimization only.
+		console.log(`[v2-browser-teardown] transform-cache publish failed (ignored): ${(err as Error)?.message ?? err}`);
+	}
+	await legacyTeardown();
+}

--- a/tests2/browser/_helpers/stable-wait.ts
+++ b/tests2/browser/_helpers/stable-wait.ts
@@ -1,0 +1,74 @@
+/**
+ * Observable-state wait helpers for tier-2 browser fixture specs.
+ *
+ * These replace arbitrary `page.waitForTimeout(...)` sleeps with waits on
+ * real, observable conditions so tests settle deterministically under CPU
+ * contention instead of racing a wall-clock guess.
+ */
+import type { Page } from "@playwright/test";
+
+/**
+ * Wait until a scroll container's `scrollTop` AND `scrollHeight` are stable
+ * across two consecutive samples ~`sampleMs` apart.
+ *
+ * Use this after an action that may trigger asynchronous scroll adjustment
+ * (scroll events, ResizeObserver re-pins, browser scroll clamping) — it
+ * returns once the container has demonstrably settled, so a follow-up
+ * "scrollTop did (not) change" assertion reads post-settle state.
+ */
+export async function waitForStableScroll(
+	page: Page,
+	selector: string,
+	opts?: { timeout?: number; sampleMs?: number },
+): Promise<void> {
+	const timeout = opts?.timeout ?? 10_000;
+	const sampleMs = opts?.sampleMs ?? 100;
+	await page.waitForFunction(
+		({ sel, interval }) => {
+			const el = document.querySelector(sel) as HTMLElement | null;
+			if (!el) return false;
+			const w = window as unknown as Record<string, { top: number; height: number; since: number } | undefined>;
+			const key = `__stableScroll:${sel}`;
+			const now = performance.now();
+			const rec = w[key];
+			if (!rec || rec.top !== el.scrollTop || rec.height !== el.scrollHeight) {
+				w[key] = { top: el.scrollTop, height: el.scrollHeight, since: now };
+				return false;
+			}
+			return now - rec.since >= interval;
+		},
+		{ sel: selector, interval: sampleMs },
+		{ timeout, polling: Math.min(sampleMs, 100) },
+	);
+	// Reset the sample marker so a later call re-samples from scratch instead
+	// of instantly succeeding on stale state.
+	await page.evaluate((sel) => {
+		delete (window as unknown as Record<string, unknown>)[`__stableScroll:${sel}`];
+	}, selector);
+}
+
+/**
+ * Wait for `frames` requestAnimationFrame ticks in the page.
+ *
+ * A frame boundary guarantees that pending scroll events and ResizeObserver
+ * callbacks scheduled by a preceding DOM mutation have been delivered (both
+ * run in the frame's update-the-rendering steps, before rAF callbacks of the
+ * following frame). Unlike a wall-clock sleep this stretches naturally with
+ * CPU contention.
+ */
+export async function waitForFrames(page: Page, frames = 2): Promise<void> {
+	await page.evaluate(
+		(n) =>
+			new Promise<void>((resolve) => {
+				const tick = (left: number): void => {
+					if (left <= 0) {
+						resolve();
+						return;
+					}
+					requestAnimationFrame(() => tick(left - 1));
+				};
+				tick(n);
+			}),
+		frames,
+	);
+}

--- a/tests2/browser/fixtures/agent-interface-scroll-hardening.spec.ts
+++ b/tests2/browser/fixtures/agent-interface-scroll-hardening.spec.ts
@@ -22,6 +22,7 @@
  */
 import { test, expect } from "@playwright/test";
 import path from "node:path";
+import { waitForFrames } from "../_helpers/stable-wait.js";
 
 const TEST_PAGE = `file://${path.resolve("tests/fixtures/agent-interface-scroll-hardening.html")}`;
 
@@ -80,12 +81,14 @@ test.describe("AgentInterface scroll hardening (post-redesign)", () => {
 	test("RO ticks on growth re-pin while sticking; viewport stays within sub-pixel tail", async ({ page }) => {
 		await page.evaluate(() => (window as any).__startAtBottom());
 		// Three staggered growths — async markdown / code-block layout.
+		// A frame boundary between ticks guarantees the async scroll events
+		// from each re-pin have been delivered before the next growth.
 		for (let i = 0; i < 3; i++) {
 			await page.evaluate(() => {
 				(window as any).__appendMessages(20);
 				(window as any).__fireResizeObserver();
 			});
-			await page.waitForTimeout(20);
+			await waitForFrames(page);
 		}
 		const after = await page.evaluate(() => (window as any).__getState());
 		const tail = after.scrollHeight - after.scrollTop - after.clientHeight;

--- a/tests2/browser/fixtures/bg-process-pills.spec.ts
+++ b/tests2/browser/fixtures/bg-process-pills.spec.ts
@@ -198,8 +198,9 @@ test.describe("Bg process pill animations", () => {
 		await lastPill.locator("[data-pill-toggle]").click();
 		await lastPill.locator("[data-remove]").click();
 
-		// Wait for animation to complete (150ms + buffer)
-		await page.waitForTimeout(300);
+		// The observable outcome of the 150ms dismiss animation completing is
+		// the pill leaving the DOM — toHaveCount polls until then.
+		await expect(page.locator("[data-pill-strip] bg-process-pill")).toHaveCount(2);
 		// Also wait for rAF re-render
 		await waitForMeasurement(page);
 
@@ -274,9 +275,13 @@ test.describe("Bg process pill animations", () => {
 		await lastPill.locator("[data-pill-toggle]").click();
 		await lastPill.locator("[data-remove]").click();
 
-		// Wait for the dismiss animation (150ms) + re-render
-		await page.waitForTimeout(400);
+		// The observable outcome of the dismiss animation (150ms) + re-render
+		// is the MutationObserver seeing the pill-promoted class — poll for it.
 		await waitForMeasurement(page);
+		await expect.poll(
+			async () => await page.evaluate(() => (window as any).__sawPromoted),
+			{ timeout: 5_000, message: "pill-promoted class was never observed after dismiss" },
+		).toBe(true);
 
 		// Check whether pill-promoted was observed
 		const sawPromoted = await page.evaluate(() => (window as any).__sawPromoted);

--- a/tests2/browser/fixtures/bg-process-popover.spec.ts
+++ b/tests2/browser/fixtures/bg-process-popover.spec.ts
@@ -50,8 +50,16 @@ test.describe("BgProcessPill inside More popover", () => {
 		// Click the dismiss (✕) button on a popover pill (hidden pill "old-1")
 		await page.locator("[data-pill-dismiss='old-1']").click();
 
-		// Wait for any async handling — animation would take 300ms if it played
-		await page.waitForTimeout(500);
+		// The observable outcome (post-fix) is the dismiss callback firing and
+		// _dismissingId being cleared — poll for that state instead of sleeping
+		// past a hypothetical 300ms animation.
+		await expect.poll(
+			async () => await page.evaluate(() =>
+				((window as any).__dismissCalls as string[]).includes("old-1")
+				&& (window as any).__dismissingId === null,
+			),
+			{ timeout: 5_000, message: "dismiss callback never fired / _dismissingId not cleared for popover pill" },
+		).toBe(true);
 
 		// BUG: The dismiss callback is never called because:
 		// 1. handlePillDismiss sets __dismissingId and expects animationend

--- a/tests2/browser/fixtures/collapse-scroll-bugs.spec.ts
+++ b/tests2/browser/fixtures/collapse-scroll-bugs.spec.ts
@@ -1,7 +1,10 @@
 import { test, expect } from "@playwright/test";
 import path from "node:path";
+import { waitForStableScroll } from "../_helpers/stable-wait.js";
 
 const TEST_PAGE = `file://${path.resolve("tests/fixtures/collapse-scroll-bugs.html")}`;
+
+const SCROLLER = "#scroll-container";
 
 test.describe("Collapse scroll bugs", () => {
 	test("phantom padding after collapse", async ({ page }) => {
@@ -12,20 +15,21 @@ test.describe("Collapse scroll bugs", () => {
 			const sc = document.getElementById("scroll-container")!;
 			(window as any).__scrollTo(sc.scrollHeight);
 		});
-		await page.waitForTimeout(200);
+		await waitForStableScroll(page, SCROLLER);
 
 		const state = await page.evaluate(() => (window as any).__getState());
 		expect(state.stickToBottom).toBe(true);
 
-		// Collapse all three 400px collapsible elements, calling handleResize after each
+		// Collapse all three 400px collapsible elements, calling handleResize after
+		// each and waiting for the async scroll clamp/adjustment to settle so each
+		// collapse is processed as a distinct resize (matching real usage).
 		for (const id of ["collapsible-1", "collapsible-2", "collapsible-3"]) {
 			await page.evaluate((elId) => {
 				(window as any).__collapseElement(elId);
 				(window as any).__handleResize();
 			}, id);
-			await page.waitForTimeout(50);
+			await waitForStableScroll(page, SCROLLER);
 		}
-		await page.waitForTimeout(200);
 
 		// Check the wrapper's paddingBottom — it should be "" or "0px" (no phantom padding)
 		const paddingBottom = await page.evaluate(() =>
@@ -47,7 +51,7 @@ test.describe("Collapse scroll bugs", () => {
 			const sc = document.getElementById("scroll-container")!;
 			(window as any).__scrollTo(sc.scrollHeight);
 		});
-		await page.waitForTimeout(200);
+		await waitForStableScroll(page, SCROLLER);
 
 		const state = await page.evaluate(() => (window as any).__getState());
 		expect(state.stickToBottom).toBe(true);
@@ -67,7 +71,8 @@ test.describe("Collapse scroll bugs", () => {
 			(window as any).__collapseElement("large-collapsible");
 			(window as any).__handleResize();
 		});
-		await page.waitForTimeout(200);
+		// Wait for the post-collapse clamp / async scroll events to settle
+		await waitForStableScroll(page, SCROLLER);
 
 		// The final message should still be visible within the scroll container viewport
 		const result = await page.evaluate(() => {

--- a/tests2/browser/fixtures/git-widget-portal.spec.ts
+++ b/tests2/browser/fixtures/git-widget-portal.spec.ts
@@ -13,8 +13,9 @@ test.describe("Git widget dropdown inside transformed ancestor", () => {
 		// Click the git status pill to expand the dropdown
 		await page.click("#git-pill");
 
-		// Wait a frame for positioning to apply
-		await page.waitForTimeout(100);
+		// The click handler creates and positions the dropdown synchronously —
+		// its visibility is the observable outcome to wait on.
+		await expect(page.locator("#git-status-dropdown")).toBeVisible();
 
 		// Verify the dropdown is toggled on
 		const isExpanded = await page.evaluate(() => (window as any).__isExpanded());

--- a/tests2/browser/fixtures/message-editor-attach.spec.ts
+++ b/tests2/browser/fixtures/message-editor-attach.spec.ts
@@ -415,7 +415,8 @@ test.describe("PI-08: Image paste edge cases", () => {
 			}));
 		});
 
-		// Small delay to ensure no async handler fires
+		// Deliberate fixed wait: asserting NO async paste handler fires for
+		// non-image content — there is no completion signal to await.
 		await page.waitForTimeout(200);
 		const count = await page.evaluate(() => (window as any).getAttachments().length);
 		expect(count).toBe(0);

--- a/tests2/browser/fixtures/mobile-review-annotation.spec.ts
+++ b/tests2/browser/fixtures/mobile-review-annotation.spec.ts
@@ -43,9 +43,8 @@ test.describe("Mobile review annotation — floating button", () => {
 		await setupMobile(page);
 		await selectText(page);
 
-		// Wait for debounce (300ms) + buffer
-		await page.waitForTimeout(400);
-
+		// The observable outcome of the 300ms debounce firing is the button
+		// becoming visible — toBeVisible() polls until then.
 		const btn = page.locator("#floating-btn");
 		await expect(btn).toBeVisible();
 		expect(await btn.textContent()).toContain("Comment");
@@ -55,6 +54,8 @@ test.describe("Mobile review annotation — floating button", () => {
 		await page.goto(TEST_PAGE);
 		// Do NOT call setupMobile — desktop mode
 		await selectText(page);
+		// Deliberate fixed wait: asserting the button NEVER appears — no mobile
+		// handler is registered, so there is no observable event to await.
 		await page.waitForTimeout(400);
 
 		const btn = page.locator("#floating-btn");
@@ -65,17 +66,16 @@ test.describe("Mobile review annotation — floating button", () => {
 		await page.goto(TEST_PAGE);
 		await setupMobile(page);
 		await selectText(page);
-		await page.waitForTimeout(400);
 
+		// Debounce fires → button appears (observable outcome, auto-waited)
 		await expect(page.locator("#floating-btn")).toBeVisible();
 
-		// Collapse selection
+		// Collapse selection — debounce fires → button hides (observable
+		// transition from visible to hidden, auto-waited)
 		await page.evaluate(() => {
 			window.getSelection()!.removeAllRanges();
 			document.dispatchEvent(new Event("selectionchange"));
 		});
-		await page.waitForTimeout(400);
-
 		await expect(page.locator("#floating-btn")).not.toBeVisible();
 	});
 
@@ -94,6 +94,8 @@ test.describe("Mobile review annotation — floating button", () => {
 			selection.addRange(range);
 			document.dispatchEvent(new Event("selectionchange"));
 		});
+		// Deliberate fixed wait: asserting the button NEVER appears after the
+		// 300ms debounce — the hide path is a no-op with no observable signal.
 		await page.waitForTimeout(400);
 
 		await expect(page.locator("#floating-btn")).not.toBeVisible();
@@ -128,8 +130,9 @@ test.describe("Mobile review annotation — bottom sheet", () => {
 		await page.goto(TEST_PAGE);
 		await setupMobile(page);
 		await selectText(page);
-		await page.waitForTimeout(400);
 
+		// Debounce fires → button appears (observable outcome, auto-waited)
+		await expect(page.locator("#floating-btn")).toBeVisible();
 		await page.locator("#floating-btn").click();
 
 		const sheet = page.locator("#sheet-popover");
@@ -162,7 +165,9 @@ test.describe("Mobile review annotation — bottom sheet", () => {
 		await page.goto(TEST_PAGE);
 		await setupMobile(page);
 		await selectText(page);
-		await page.waitForTimeout(400);
+
+		// Debounce fires → button appears (observable outcome, auto-waited)
+		await expect(page.locator("#floating-btn")).toBeVisible();
 
 		// Clear any existing annotations
 		await page.evaluate(() => sessionStorage.clear());
@@ -190,7 +195,9 @@ test.describe("Mobile review annotation — bottom sheet", () => {
 		await page.goto(TEST_PAGE);
 		await setupMobile(page);
 		await selectText(page);
-		await page.waitForTimeout(400);
+
+		// Debounce fires → button appears (observable outcome, auto-waited)
+		await expect(page.locator("#floating-btn")).toBeVisible();
 
 		await page.evaluate(() => sessionStorage.clear());
 
@@ -220,8 +227,8 @@ test.describe("Mobile review annotation — toast", () => {
 		await page.goto(TEST_PAGE);
 		await setupMobile(page);
 		await selectText(page);
-		await page.waitForTimeout(400);
 
+		// Debounce fires → button appears (observable outcome, auto-waited)
 		await expect(page.locator("#floating-btn")).toBeVisible();
 
 		// Clear selection before tapping Add Comment

--- a/tests2/browser/fixtures/mobile-scroll-keyboard.spec.ts
+++ b/tests2/browser/fixtures/mobile-scroll-keyboard.spec.ts
@@ -14,6 +14,25 @@ async function waitForStick(page: import("@playwright/test").Page, expected: boo
 	);
 }
 
+/** Append one message and observe its layout growth and completed bottom re-pin. */
+async function appendMessageAtBottom(page: import("@playwright/test").Page, text: string) {
+	const previousHeight = await page.evaluate(
+		() => document.getElementById("scroll-container")!.scrollHeight,
+	);
+	await page.evaluate((message) => (window as any).__addMessage(message), text);
+	await page.waitForFunction(
+		(priorHeight) => {
+			const el = document.getElementById("scroll-container")!;
+			return el.scrollHeight > priorHeight
+				&& el.scrollHeight - el.scrollTop - el.clientHeight < 5;
+		},
+		previousHeight,
+	);
+	// The stable sample also lets the resulting scroll event update the sticky
+	// flag before the next append, avoiding a later growth being misclassified.
+	await waitForStableScroll(page, SCROLLER);
+}
+
 test.describe("Stick-to-bottom scroll behavior", () => {
 	test.use({ viewport: { width: 375, height: 667 } }); // iPhone SE
 
@@ -29,11 +48,7 @@ test.describe("Stick-to-bottom scroll behavior", () => {
 		// outcome of each append: the ResizeObserver re-pin brings us back to
 		// the bottom before the next message lands.
 		for (let i = 0; i < 5; i++) {
-			await page.evaluate((n) => (window as any).__addMessage(`New ${n}`), i);
-			await page.waitForFunction(() => {
-				const el = document.getElementById("scroll-container")!;
-				return el.scrollHeight - el.scrollTop - el.clientHeight < 5;
-			});
+			await appendMessageAtBottom(page, `New ${i}`);
 		}
 
 		const state1 = await page.evaluate(() => (window as any).__getState());

--- a/tests2/browser/fixtures/mobile-scroll-keyboard.spec.ts
+++ b/tests2/browser/fixtures/mobile-scroll-keyboard.spec.ts
@@ -1,7 +1,18 @@
 import { test, expect } from "@playwright/test";
 import path from "node:path";
+import { waitForStableScroll, waitForFrames } from "../_helpers/stable-wait.js";
 
 const TEST_PAGE = `file://${path.resolve("tests/mobile-scroll-keyboard.html")}`;
+
+const SCROLLER = "#scroll-container";
+
+/** Wait until the stick-to-bottom flag reaches the expected value (scroll events are async). */
+async function waitForStick(page: import("@playwright/test").Page, expected: boolean) {
+	await page.waitForFunction(
+		(want) => (window as any).__getState().stickToBottom === want,
+		expected,
+	);
+}
 
 test.describe("Stick-to-bottom scroll behavior", () => {
 	test.use({ viewport: { width: 375, height: 667 } }); // iPhone SE
@@ -14,10 +25,15 @@ test.describe("Stick-to-bottom scroll behavior", () => {
 		expect(state0.stickToBottom).toBe(true);
 		expect(state0.distanceFromBottom).toBeLessThan(5);
 
-		// Add content — should auto-scroll to bottom
+		// Add content — should auto-scroll to bottom. Wait for the observable
+		// outcome of each append: the ResizeObserver re-pin brings us back to
+		// the bottom before the next message lands.
 		for (let i = 0; i < 5; i++) {
 			await page.evaluate((n) => (window as any).__addMessage(`New ${n}`), i);
-			await page.waitForTimeout(30);
+			await page.waitForFunction(() => {
+				const el = document.getElementById("scroll-container")!;
+				return el.scrollHeight - el.scrollTop - el.clientHeight < 5;
+			});
 		}
 
 		const state1 = await page.evaluate(() => (window as any).__getState());
@@ -29,22 +45,26 @@ test.describe("Stick-to-bottom scroll behavior", () => {
 		await page.goto(TEST_PAGE);
 		await page.waitForFunction(() => (window as any).__ready === true);
 
-		// Scroll up
+		// Scroll up — wait for the async scroll event to flip the flag
 		await page.evaluate(() => {
 			document.getElementById("scroll-container")!.scrollTop = 200;
 		});
-		await page.waitForTimeout(50);
+		await waitForStick(page, false);
 
 		const state = await page.evaluate(() => (window as any).__getState());
 		expect(state.stickToBottom).toBe(false);
 
 		const scrollBefore = state.scrollTop;
 
-		// New content arrives — should NOT scroll
+		// New content arrives — should NOT scroll. Frame waits guarantee the
+		// ResizeObserver callback for each append has been delivered (a buggy
+		// re-pin would have fired by then); the final stability wait catches
+		// any straggling scroll adjustment before we read the outcome.
 		for (let i = 0; i < 5; i++) {
 			await page.evaluate((n) => (window as any).__addMessage(`Stream ${n}`), i);
-			await page.waitForTimeout(30);
+			await waitForFrames(page);
 		}
+		await waitForStableScroll(page, SCROLLER);
 
 		const scrollAfter = await page.evaluate(
 			() => document.getElementById("scroll-container")!.scrollTop,
@@ -56,27 +76,30 @@ test.describe("Stick-to-bottom scroll behavior", () => {
 		await page.goto(TEST_PAGE);
 		await page.waitForFunction(() => (window as any).__ready === true);
 
-		// Scroll up
+		// Scroll up — wait for the async scroll event to flip the flag
 		await page.evaluate(() => {
 			document.getElementById("scroll-container")!.scrollTop = 200;
 		});
-		await page.waitForTimeout(50);
+		await waitForStick(page, false);
 		expect((await page.evaluate(() => (window as any).__getState())).stickToBottom).toBe(false);
 
-		// Scroll back to bottom
+		// Scroll back to bottom — wait for the flag to re-stick
 		await page.evaluate(() => {
 			const el = document.getElementById("scroll-container")!;
 			el.scrollTop = el.scrollHeight;
 		});
-		await page.waitForTimeout(50);
+		await waitForStick(page, true);
 		expect((await page.evaluate(() => (window as any).__getState())).stickToBottom).toBe(true);
 
-		// New content should auto-scroll
+		// New content should auto-scroll — wait for the observable scroll
 		const scrollBefore = await page.evaluate(
 			() => document.getElementById("scroll-container")!.scrollTop,
 		);
 		await page.evaluate(() => (window as any).__addMessage("Re-stuck content"));
-		await page.waitForTimeout(50);
+		await page.waitForFunction(
+			(prev) => document.getElementById("scroll-container")!.scrollTop > prev,
+			scrollBefore,
+		);
 		const scrollAfter = await page.evaluate(
 			() => document.getElementById("scroll-container")!.scrollTop,
 		);
@@ -90,9 +113,17 @@ test.describe("Stick-to-bottom scroll behavior", () => {
 		// At bottom, stuck
 		expect((await page.evaluate(() => (window as any).__getState())).stickToBottom).toBe(true);
 
-		// Open keyboard — shrinks container
+		// Open keyboard — shrinks container. Wait for the layout change to be
+		// observable, then for any resulting scroll adjustment to settle.
+		const heightBefore = await page.evaluate(
+			() => document.getElementById("scroll-container")!.clientHeight,
+		);
 		await page.evaluate(() => (window as any).__simulateKeyboardOpen(300));
-		await page.waitForTimeout(200);
+		await page.waitForFunction(
+			(h) => document.getElementById("scroll-container")!.clientHeight < h,
+			heightBefore,
+		);
+		await waitForStableScroll(page, SCROLLER);
 
 		// Container shrank, but we were at the bottom so still stuck
 		const state = await page.evaluate(() => (window as any).__getState());
@@ -105,26 +136,37 @@ test.describe("Stick-to-bottom scroll behavior", () => {
 		await page.goto(TEST_PAGE);
 		await page.waitForFunction(() => (window as any).__ready === true);
 
-		// Scroll to middle
+		// Scroll to middle — wait for the async scroll event to flip the flag
 		await page.evaluate(() => {
 			document.getElementById("scroll-container")!.scrollTop = 300;
 		});
-		await page.waitForTimeout(50);
+		await waitForStick(page, false);
 		expect((await page.evaluate(() => (window as any).__getState())).stickToBottom).toBe(false);
 
 		const scrollBefore = await page.evaluate(
 			() => document.getElementById("scroll-container")!.scrollTop,
 		);
 
-		// Open keyboard
+		// Open keyboard — wait for the layout shrink to be observable and
+		// any resulting scroll adjustment to settle
+		const heightBefore = await page.evaluate(
+			() => document.getElementById("scroll-container")!.clientHeight,
+		);
 		await page.evaluate(() => (window as any).__simulateKeyboardOpen(300));
-		await page.waitForTimeout(200);
+		await page.waitForFunction(
+			(h) => document.getElementById("scroll-container")!.clientHeight < h,
+			heightBefore,
+		);
+		await waitForStableScroll(page, SCROLLER);
 
-		// Add content
+		// Add content — frame waits guarantee each ResizeObserver tick has
+		// been delivered; the stability wait catches any straggling (buggy)
+		// scroll before we read the outcome.
 		for (let i = 0; i < 3; i++) {
 			await page.evaluate((n) => (window as any).__addMessage(`Msg ${n}`), i);
-			await page.waitForTimeout(30);
+			await waitForFrames(page);
 		}
+		await waitForStableScroll(page, SCROLLER);
 
 		const scrollAfter = await page.evaluate(
 			() => document.getElementById("scroll-container")!.scrollTop,
@@ -140,17 +182,20 @@ test.describe("Stick-to-bottom scroll behavior", () => {
 		await page.evaluate(() => {
 			document.getElementById("scroll-container")!.scrollTop = 400;
 		});
-		await page.waitForTimeout(50);
+		await waitForStableScroll(page, SCROLLER);
 
 		const scrollBefore = await page.evaluate(
 			() => document.getElementById("scroll-container")!.scrollTop,
 		);
 
-		// Repeated workflow bar updates
+		// Repeated workflow bar updates — a frame wait per update lets any
+		// (buggy) vertical scroll side-effect land; final stability wait
+		// ensures the smooth horizontal scroll has settled before we read.
 		for (let i = 0; i < 10; i++) {
 			await page.evaluate(() => (window as any).__simulateWorkflowBarUpdate());
-			await page.waitForTimeout(20);
+			await waitForFrames(page);
 		}
+		await waitForStableScroll(page, SCROLLER);
 
 		const scrollAfter = await page.evaluate(
 			() => document.getElementById("scroll-container")!.scrollTop,
@@ -162,22 +207,29 @@ test.describe("Stick-to-bottom scroll behavior", () => {
 		await page.goto(TEST_PAGE);
 		await page.waitForFunction(() => (window as any).__ready === true);
 
-		// Scroll to middle
+		// Scroll to middle — wait for scroll state to settle
 		await page.evaluate(() => {
 			document.getElementById("scroll-container")!.scrollTop = 400;
 		});
-		await page.waitForTimeout(50);
+		await waitForStableScroll(page, SCROLLER);
 
 		await page.locator("#chat-input").focus();
+		const heightBefore = await page.evaluate(
+			() => document.getElementById("scroll-container")!.clientHeight,
+		);
 		await page.evaluate(() => (window as any).__simulateKeyboardOpen(300));
-		await page.waitForTimeout(100);
+		await page.waitForFunction(
+			(h) => document.getElementById("scroll-container")!.clientHeight < h,
+			heightBefore,
+		);
+		await waitForStableScroll(page, SCROLLER);
 
 		const scrollBefore = await page.evaluate(
 			() => document.getElementById("scroll-container")!.scrollTop,
 		);
 
 		await page.locator("#chat-input").type("Hello world test", { delay: 20 });
-		await page.waitForTimeout(50);
+		await waitForStableScroll(page, SCROLLER);
 
 		const scrollAfter = await page.evaluate(
 			() => document.getElementById("scroll-container")!.scrollTop,

--- a/tests2/browser/fixtures/scroll-anchor-shrink.spec.ts
+++ b/tests2/browser/fixtures/scroll-anchor-shrink.spec.ts
@@ -1,7 +1,10 @@
 import { test, expect } from "@playwright/test";
 import path from "node:path";
+import { waitForStableScroll } from "../_helpers/stable-wait.js";
 
 const TEST_PAGE = `file://${path.resolve("tests/fixtures/scroll-anchor-shrink.html")}`;
+
+const SCROLLER = "#scroll-container";
 
 test.describe("Scroll anchor on shrink", () => {
 	test("does not jolt viewport when content shrinks while scrolled up (small collapse)", async ({ page }) => {
@@ -12,7 +15,7 @@ test.describe("Scroll anchor on shrink", () => {
 			const sc = document.getElementById("scroll-container")!;
 			sc.scrollTop = sc.scrollHeight;
 		});
-		await page.waitForTimeout(200);
+		await waitForStableScroll(page, SCROLLER);
 
 		// Scroll up ~300px from bottom so _stickToBottom becomes false
 		const initialState = await page.evaluate(() => {
@@ -21,7 +24,7 @@ test.describe("Scroll anchor on shrink", () => {
 			(window as any).__scrollTo(target);
 			return (window as any).__getState();
 		});
-		await page.waitForTimeout(200);
+		await waitForStableScroll(page, SCROLLER);
 
 		// Verify we're scrolled up (not stuck to bottom)
 		expect(initialState.stickToBottom).toBe(false);
@@ -32,7 +35,8 @@ test.describe("Scroll anchor on shrink", () => {
 			(window as any).__handleResize();
 		});
 
-		await page.waitForTimeout(100);
+		// Wait for the browser's async scroll clamp/adjustment to settle
+		await waitForStableScroll(page, SCROLLER);
 
 		// With the new post-collapse clamp, small collapses (< half viewport)
 		// let the browser naturally adjust scrollTop. The clamp only fires if
@@ -61,17 +65,17 @@ test.describe("Scroll anchor on shrink", () => {
 			const sc = document.getElementById("scroll-container")!;
 			(window as any).__scrollTo(sc.scrollHeight);
 		});
-		await page.waitForTimeout(200);
+		await waitForStableScroll(page, SCROLLER);
 
 		const state = await page.evaluate(() => (window as any).__getState());
 		expect(state.stickToBottom).toBe(true);
 
-		// Collapse and trigger resize
+		// Collapse and trigger resize, then wait for scroll to settle
 		await page.evaluate(() => {
 			(window as any).__collapseElement();
 			(window as any).__handleResize();
 		});
-		await page.waitForTimeout(100);
+		await waitForStableScroll(page, SCROLLER);
 
 		// Should remain at the bottom
 		const afterState = await page.evaluate(() => {
@@ -94,7 +98,7 @@ test.describe("Scroll anchor on shrink", () => {
 			const sc = document.getElementById("scroll-container")!;
 			(window as any).__scrollTo(sc.scrollHeight - sc.clientHeight - 300);
 		});
-		await page.waitForTimeout(200);
+		await waitForStableScroll(page, SCROLLER);
 
 		const scrollTopBefore = await page.evaluate(() =>
 			document.getElementById("scroll-container")!.scrollTop,
@@ -111,7 +115,8 @@ test.describe("Scroll anchor on shrink", () => {
 			}
 			(window as any).__handleResize();
 		});
-		await page.waitForTimeout(100);
+		// Wait for any (buggy) async scroll adjustment to settle before reading
+		await waitForStableScroll(page, SCROLLER);
 
 		const scrollTopAfter = await page.evaluate(() =>
 			document.getElementById("scroll-container")!.scrollTop,
@@ -129,17 +134,18 @@ test.describe("Scroll anchor on shrink", () => {
 			const sc = document.getElementById("scroll-container")!;
 			(window as any).__scrollTo(sc.scrollHeight);
 		});
-		await page.waitForTimeout(200);
+		await waitForStableScroll(page, SCROLLER);
 
 		const state = await page.evaluate(() => (window as any).__getState());
 		expect(state.stickToBottom).toBe(true);
 
-		// Collapse the element and trigger resize handler
+		// Collapse the element and trigger resize handler, then wait for the
+		// browser's async scroll clamp to settle
 		await page.evaluate(() => {
 			(window as any).__collapseElement();
 			(window as any).__handleResize();
 		});
-		await page.waitForTimeout(100);
+		await waitForStableScroll(page, SCROLLER);
 
 		// With the new post-collapse clamp, a 400px collapse while at bottom:
 		// browser clamps scrollTop naturally, content bottom = clientHeight (full viewport),

--- a/tests2/budgets.json
+++ b/tests2/budgets.json
@@ -13,7 +13,9 @@
       "label": "playwright-v2 browser (geometry adapters + smoke journeys)",
       "maxWallMs": 3600000,
       "maxCpuMs": 600000,
-      "note": "≤3600 s wall. Enforced by test:v2:browser via assert-budget browser --report. crash/restart + heavy fixtures live in the daily lane."
+      "perSpecMaxMs": 60000,
+      "perSpecGrandfather": {},
+      "note": "≤3600 s wall. Enforced by test:v2:browser via assert-budget browser --report. crash/restart + heavy fixtures live in the daily lane. perSpecMaxMs: each spec FILE's total wall (sum of test results incl. retries, from the Playwright JSON report) must stay under this cap; files listed in perSpecGrandfather (spec-file -> observed ms when grandfathered) warn instead of fail — do not add NEW entries, shrink the spec instead. WALL-only; CPU never gates."
     },
     "full": {
       "label": "npm run test:v2 (tier1 ∥ tier2, single isolated run)",

--- a/tests2/core/ensure-dist-build-key.test.ts
+++ b/tests2/core/ensure-dist-build-key.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Pins the content-addressed dist build cache (scripts/testing-v2/ensure-dist.mjs)
+ * used by test:e2e:v2 and tests2/browser-global-setup.ts: changed build inputs
+ * must change the key, and validation must fail closed on a missing/stale
+ * manifest or missing build artifacts so a stale dist can never be silently
+ * tested. Modeled on tests2/core/server-prebundle-cache.test.ts; uses a temp-dir
+ * fixture and the pure functions only — never runs a real build.
+ */
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { afterAll, beforeAll, describe, it } from "vitest";
+import { computeDistBuildKey, validateDistBuild } from "../../scripts/testing-v2/ensure-dist.mjs";
+
+const BASE_FILES: Record<string, string> = {
+	"src/server/cli.ts": "export const cli = 1;\n",
+	"src/shared/value.ts": "export const value = 1;\n",
+	"src/ui/app.ts": "export const app = 1;\n",
+	"defaults/roles/basic.yaml": "name: basic\n",
+	"market-packs/demo/pack.yaml": "name: demo\n",
+	"market-packs/demo/src/panel.ts": "export const panel = 1;\n",
+	"public/sw.js": "// sw\n",
+	"index.html": "<html></html>\n",
+	"package.json": '{"scripts":{"build":"noop"}}\n',
+	"package-lock.json": "{}\n",
+	"vite.config.ts": "export default {};\n",
+	"tsconfig.json": "{}\n",
+	"tsconfig.server.json": "{}\n",
+	"scripts/copy-defaults.mjs": "// copy defaults\n",
+	"scripts/copy-builtin-packs.mjs": "// copy builtin packs\n",
+	"scripts/build-market-packs.mjs": "// build packs\n",
+};
+
+function writeRepoFile(root: string, relativeFile: string, content: string): void {
+	const file = join(root, ...relativeFile.split("/"));
+	mkdirSync(dirname(file), { recursive: true });
+	writeFileSync(file, content);
+}
+
+function writeFakeRepo(root: string): void {
+	for (const [relativeFile, content] of Object.entries(BASE_FILES)) {
+		writeRepoFile(root, relativeFile, content);
+	}
+}
+
+function resetFakeRepo(root: string): void {
+	writeFakeRepo(root);
+}
+
+/** Well-formed dist fixture: artifacts + manifest matching `key`. */
+function writeDistFixture(root: string, key: string): void {
+	writeRepoFile(root, "dist/server/cli.js", "#!/usr/bin/env node\n// cli\n");
+	writeRepoFile(root, "dist/ui/index.html", "<html></html>\n");
+	writeRepoFile(root, "dist/.build-manifest.json", `${JSON.stringify({ schema: 1, key, createdAt: new Date().toISOString() }, null, 2)}\n`);
+}
+
+let workspace: string;
+let repoRoot: string;
+let key: string;
+
+beforeAll(() => {
+	workspace = mkdtempSync(join(tmpdir(), "bobbit-ensure-dist-"));
+	repoRoot = join(workspace, "repo");
+	writeFakeRepo(repoRoot);
+	key = computeDistBuildKey(repoRoot);
+});
+
+afterAll(() => {
+	rmSync(workspace, { recursive: true, force: true, maxRetries: 3, retryDelay: 25 });
+});
+
+describe.sequential("dist build cache key", () => {
+	it("is deterministic for identical inputs", () => {
+		assert.equal(computeDistBuildKey(repoRoot), key);
+	});
+
+	it("changes when any build input changes and ignores non-inputs", () => {
+		try {
+			const changedInputs: Array<[string, string]> = [
+				["src/server/cli.ts", "export const cli = 2;\n"],
+				["src/shared/value.ts", "export const value = 2;\n"],
+				["defaults/roles/basic.yaml", "name: changed\n"],
+				["market-packs/demo/src/panel.ts", "export const panel = 2;\n"],
+				["public/sw.js", "// sw v2\n"],
+				["index.html", "<html><body></body></html>\n"],
+				["vite.config.ts", "export default { build: {} };\n"],
+				["tsconfig.server.json", '{"compilerOptions":{}}\n'],
+				["package-lock.json", '{"lockfileVersion":3}\n'],
+				["scripts/copy-defaults.mjs", "// copy defaults v2\n"],
+			];
+			for (const [relativeFile, content] of changedInputs) {
+				writeRepoFile(repoRoot, relativeFile, content);
+				assert.notEqual(computeDistBuildKey(repoRoot), key, `${relativeFile} changes must change the key`);
+				writeRepoFile(repoRoot, relativeFile, BASE_FILES[relativeFile]);
+				assert.equal(computeDistBuildKey(repoRoot), key, `${relativeFile} restore must restore the key`);
+			}
+
+			// New files under input dirs are part of the key.
+			writeRepoFile(repoRoot, "src/server/new-module.ts", "export const added = 1;\n");
+			assert.notEqual(computeDistBuildKey(repoRoot), key, "added source files must change the key");
+			rmSync(join(repoRoot, "src", "server", "new-module.ts"));
+			assert.equal(computeDistBuildKey(repoRoot), key);
+
+			// Files outside the build input set must not affect the key.
+			writeRepoFile(repoRoot, "tests2/core/some.test.ts", "// not a build input\n");
+			writeRepoFile(repoRoot, "README.md", "# not a build input\n");
+			writeRepoFile(repoRoot, "src/node_modules/dep/index.js", "// skipped dir\n");
+			assert.equal(computeDistBuildKey(repoRoot), key, "non-inputs must not balloon the content key");
+		} finally {
+			resetFakeRepo(repoRoot);
+		}
+	});
+});
+
+describe.sequential("dist build validation (fail-closed)", () => {
+	it("fails on a missing manifest", () => {
+		assert.equal(validateDistBuild(repoRoot, key), false, "no dist/ at all must not validate");
+		writeRepoFile(repoRoot, "dist/server/cli.js", "// cli\n");
+		writeRepoFile(repoRoot, "dist/ui/index.html", "<html></html>\n");
+		assert.equal(validateDistBuild(repoRoot, key), false, "artifacts without a manifest must not validate");
+		rmSync(join(repoRoot, "dist"), { recursive: true, force: true });
+	});
+
+	it("passes on a well-formed fixture and pins schema + key matching", () => {
+		writeDistFixture(repoRoot, key);
+		assert.equal(validateDistBuild(repoRoot, key), true, "well-formed manifest + artifacts must validate");
+
+		assert.equal(validateDistBuild(repoRoot, "stale-key"), false, "wrong key must not validate");
+
+		writeRepoFile(repoRoot, "dist/.build-manifest.json", `${JSON.stringify({ schema: 999, key }, null, 2)}\n`);
+		assert.equal(validateDistBuild(repoRoot, key), false, "unknown schema must not validate");
+
+		writeRepoFile(repoRoot, "dist/.build-manifest.json", "not json{");
+		assert.equal(validateDistBuild(repoRoot, key), false, "corrupt manifest must fail closed");
+
+		rmSync(join(repoRoot, "dist"), { recursive: true, force: true });
+	});
+
+	it("fails when a build artifact is missing despite a matching manifest", () => {
+		writeDistFixture(repoRoot, key);
+		rmSync(join(repoRoot, "dist", "server", "cli.js"));
+		assert.equal(validateDistBuild(repoRoot, key), false, "missing dist/server/cli.js must not validate");
+
+		writeDistFixture(repoRoot, key);
+		rmSync(join(repoRoot, "dist", "ui", "index.html"));
+		assert.equal(validateDistBuild(repoRoot, key), false, "missing dist/ui/index.html must not validate");
+
+		rmSync(join(repoRoot, "dist"), { recursive: true, force: true });
+	});
+});

--- a/tests2/core/per-spec-budget.test.ts
+++ b/tests2/core/per-spec-budget.test.ts
@@ -1,0 +1,101 @@
+// Pins the tier-2 per-spec WALL budget classification (scripts/testing-v2/
+// assert-budget.mjs): a Playwright JSON report is folded into per-FILE total
+// duration (summing every test result, i.e. retries included, across nested
+// suites), and files over tiers.tier2.perSpecMaxMs are violations unless
+// grandfathered (then warn-only). Pure functions — no fs, no subprocesses.
+import { describe, expect, it } from "vitest";
+import { evaluatePerSpecBudget, perSpecWallFromReport } from "../../scripts/testing-v2/assert-budget.mjs";
+
+type SyntheticSuite = {
+	file?: string;
+	suites?: SyntheticSuite[];
+	specs?: Array<{ file?: string; tests?: Array<{ results?: Array<{ duration?: number }> }> }>;
+};
+
+function spec(file: string, ...durations: number[]) {
+	return { file, tests: [{ results: durations.map((duration) => ({ duration })) }] };
+}
+
+const report: { suites: SyntheticSuite[] } = {
+	suites: [
+		// Fast file, single result — well under budget.
+		{ file: "e2e/fast.spec.ts", specs: [spec("e2e/fast.spec.ts", 1_000)] },
+		// Over budget via RETRIES: two results on one test must be summed.
+		{ file: "e2e/retry-slow.spec.ts", specs: [spec("e2e/retry-slow.spec.ts", 40_000, 35_000)] },
+		// Over budget, grandfathered.
+		{ file: "e2e/grandfathered.spec.ts", specs: [spec("e2e/grandfathered.spec.ts", 90_000)] },
+		// Nested describe-suites: specs split across children of the same FILE
+		// must aggregate to one per-file total (30k + 35k = 65k > 60k cap).
+		{
+			file: "e2e/nested.spec.ts",
+			suites: [
+				{ specs: [spec("e2e/nested.spec.ts", 30_000)] },
+				{ suites: [{ specs: [{ tests: [{ results: [{ duration: 35_000 }] }] }] }] },
+			],
+		},
+		// Windows-style separators must normalise to forward slashes.
+		{ file: "e2e\\win.spec.ts", specs: [{ file: "e2e\\win.spec.ts", tests: [{ results: [{ duration: 70_000 }] }] }] },
+	],
+};
+
+const budget = {
+	perSpecMaxMs: 60_000,
+	perSpecGrandfather: { "e2e/grandfathered.spec.ts": 88_000 },
+};
+
+describe("perSpecWallFromReport", () => {
+	it("sums per-file durations including retries and nested suites, normalising separators", () => {
+		const perFileMs = perSpecWallFromReport(report);
+		expect(perFileMs["e2e/fast.spec.ts"]).toBe(1_000);
+		expect(perFileMs["e2e/retry-slow.spec.ts"]).toBe(75_000); // 40k + 35k retry
+		expect(perFileMs["e2e/nested.spec.ts"]).toBe(65_000); // 30k + 35k across nested suites
+		expect(perFileMs["e2e/win.spec.ts"]).toBe(70_000); // backslashes normalised
+		expect(Object.keys(perFileMs).sort()).toEqual([
+			"e2e/fast.spec.ts",
+			"e2e/grandfathered.spec.ts",
+			"e2e/nested.spec.ts",
+			"e2e/retry-slow.spec.ts",
+			"e2e/win.spec.ts",
+		]);
+	});
+
+	it("tolerates empty/absent report shapes", () => {
+		expect(perSpecWallFromReport({})).toEqual({});
+		expect(perSpecWallFromReport(null)).toEqual({});
+		expect(perSpecWallFromReport({ suites: [{ specs: [] }] })).toEqual({});
+	});
+});
+
+describe("evaluatePerSpecBudget", () => {
+	it("classifies under-budget as pass, grandfathered over-budget as warn, rest as violation", () => {
+		const { warns, violations } = evaluatePerSpecBudget(report, budget);
+		expect(warns).toEqual([{ file: "e2e/grandfathered.spec.ts", ms: 90_000, grandfatheredMs: 88_000 }]);
+		expect(violations.map((v: { file: string }) => v.file)).toEqual([
+			"e2e/retry-slow.spec.ts", // 75k, sorted desc
+			"e2e/win.spec.ts", // 70k
+			"e2e/nested.spec.ts", // 65k
+		]);
+	});
+
+	it("treats a file exactly at the cap as passing", () => {
+		const exact = { suites: [{ file: "e2e/exact.spec.ts", specs: [spec("e2e/exact.spec.ts", 60_000)] }] };
+		const { warns, violations } = evaluatePerSpecBudget(exact, budget);
+		expect(warns).toEqual([]);
+		expect(violations).toEqual([]);
+	});
+
+	it("matches grandfather keys written with backslashes", () => {
+		const { warns, violations } = evaluatePerSpecBudget(report, {
+			perSpecMaxMs: 60_000,
+			perSpecGrandfather: { "e2e\\grandfathered.spec.ts": 88_000 },
+		});
+		expect(warns.map((w: { file: string }) => w.file)).toEqual(["e2e/grandfathered.spec.ts"]);
+		expect(violations).toHaveLength(3);
+	});
+
+	it("disables the check when perSpecMaxMs is missing or invalid", () => {
+		expect(evaluatePerSpecBudget(report, {}).violations).toEqual([]);
+		expect(evaluatePerSpecBudget(report, { perSpecMaxMs: 0 }).violations).toEqual([]);
+		expect(evaluatePerSpecBudget(report, undefined).violations).toEqual([]);
+	});
+});

--- a/tests2/core/pwtest-cache-publish.test.ts
+++ b/tests2/core/pwtest-cache-publish.test.ts
@@ -1,0 +1,266 @@
+/**
+ * Pins the persistent Playwright transform-cache seed/publish helpers
+ * (scripts/testing-v2/pwtest-cache.ts) used by playwright-v2.config.ts and
+ * tests2/browser-global-teardown.ts:
+ *   - seed copies the `latest` snapshot into a run dir without clobbering
+ *     existing run-dir files, tolerates a missing `latest`, and fails open;
+ *   - publish atomically replaces `latest` from a non-empty run dir, skips
+ *     empty/missing run dirs, and a concurrent-publish loser cleans its tmp;
+ *   - the env-gated wrapper honours OWNED gating, the v2 namespace guard,
+ *     and KEEP=1 not suppressing publish (KEEP only affects deletion).
+ */
+import { mkdtempSync, mkdirSync, readFileSync, readdirSync, renameSync, rmSync, writeFileSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+	LATEST_SEGMENT,
+	V2_TRANSFORM_CACHE_SEGMENT,
+	latestTransformCacheDir,
+	publishTransformCache,
+	publishTransformCacheFromEnv,
+	seedTransformCache,
+	seedTransformCacheForRunDir,
+} from "../../scripts/testing-v2/pwtest-cache.js";
+
+const tempRoots: string[] = [];
+
+function makeBase(): { base: string; latest: string; run: string } {
+	const root = mkdtempSync(join(tmpdir(), "pwtest-cache-test-"));
+	tempRoots.push(root);
+	const base = join(root, V2_TRANSFORM_CACHE_SEGMENT);
+	const latest = join(base, LATEST_SEGMENT);
+	const run = join(base, "run-1");
+	mkdirSync(run, { recursive: true });
+	return { base, latest, run };
+}
+
+afterEach(() => {
+	for (const root of tempRoots.splice(0)) {
+		try { rmSync(root, { recursive: true, force: true }); } catch {}
+	}
+});
+
+describe("latestTransformCacheDir", () => {
+	it("is the `latest` sibling of the run dir", () => {
+		const { base, latest, run } = makeBase();
+		expect(latestTransformCacheDir(run)).toBe(latest);
+		expect(latestTransformCacheDir(join(base, "other-run"))).toBe(latest);
+	});
+});
+
+describe("seedTransformCache", () => {
+	it("copies latest contents (including subdirs) into the run dir", () => {
+		const { latest, run } = makeBase();
+		mkdirSync(join(latest, "sub"), { recursive: true });
+		writeFileSync(join(latest, "a.js"), "A");
+		writeFileSync(join(latest, "sub", "b.js"), "B");
+
+		expect(seedTransformCache(latest, run)).toBe(true);
+		expect(readFileSync(join(run, "a.js"), "utf8")).toBe("A");
+		expect(readFileSync(join(run, "sub", "b.js"), "utf8")).toBe("B");
+	});
+
+	it("never clobbers files already present in the run dir", () => {
+		const { latest, run } = makeBase();
+		mkdirSync(latest, { recursive: true });
+		writeFileSync(join(latest, "a.js"), "stale");
+		writeFileSync(join(run, "a.js"), "fresh");
+
+		seedTransformCache(latest, run);
+		expect(readFileSync(join(run, "a.js"), "utf8")).toBe("fresh");
+	});
+
+	it("tolerates a missing latest snapshot (cold start)", () => {
+		const { latest, run } = makeBase();
+		expect(existsSync(latest)).toBe(false);
+		expect(seedTransformCache(latest, run)).toBe(false);
+		expect(readdirSync(run)).toEqual([]);
+	});
+
+	it("refuses degenerate inputs (same dir, empty paths)", () => {
+		const { run } = makeBase();
+		expect(seedTransformCache(run, run)).toBe(false);
+		expect(seedTransformCache("", run)).toBe(false);
+		expect(seedTransformCache(run, "")).toBe(false);
+	});
+
+	it("seedTransformCacheForRunDir only seeds inside the v2 namespace and never `latest` itself", () => {
+		const { latest, run } = makeBase();
+		mkdirSync(latest, { recursive: true });
+		writeFileSync(join(latest, "a.js"), "A");
+
+		expect(seedTransformCacheForRunDir(run)).toBe(true);
+		expect(readFileSync(join(run, "a.js"), "utf8")).toBe("A");
+
+		// Outside the v2 namespace: no seed.
+		const outsideRoot = mkdtempSync(join(tmpdir(), "pwtest-cache-outside-"));
+		tempRoots.push(outsideRoot);
+		const outsideRun = join(outsideRoot, "some-cache", "run-1");
+		mkdirSync(outsideRun, { recursive: true });
+		expect(seedTransformCacheForRunDir(outsideRun)).toBe(false);
+
+		// Never seed `latest` from itself.
+		expect(seedTransformCacheForRunDir(latest)).toBe(false);
+	});
+});
+
+describe("publishTransformCache", () => {
+	it("creates latest from a non-empty run dir when latest is missing", () => {
+		const { latest, run } = makeBase();
+		writeFileSync(join(run, "a.js"), "A");
+
+		expect(publishTransformCache(run, latest)).toBe(true);
+		expect(readFileSync(join(latest, "a.js"), "utf8")).toBe("A");
+		// Run dir is left intact (deletion belongs to the legacy teardown).
+		expect(readFileSync(join(run, "a.js"), "utf8")).toBe("A");
+	});
+
+	it("replaces an existing latest atomically (no stale entries survive)", () => {
+		const { latest, run } = makeBase();
+		mkdirSync(latest, { recursive: true });
+		writeFileSync(join(latest, "old.js"), "OLD");
+		writeFileSync(join(run, "new.js"), "NEW");
+
+		expect(publishTransformCache(run, latest)).toBe(true);
+		expect(readdirSync(latest)).toEqual(["new.js"]);
+		expect(readFileSync(join(latest, "new.js"), "utf8")).toBe("NEW");
+	});
+
+	it("skips a missing run dir and an empty run dir", () => {
+		const { base, latest, run } = makeBase();
+		expect(publishTransformCache(join(base, "does-not-exist"), latest)).toBe(false);
+		expect(publishTransformCache(run, latest)).toBe(false); // exists but empty
+		expect(existsSync(latest)).toBe(false);
+	});
+
+	it("leaves no tmp dirs behind on success", () => {
+		const { base, latest, run } = makeBase();
+		writeFileSync(join(run, "a.js"), "A");
+		publishTransformCache(run, latest, "tag1");
+		const leftovers = readdirSync(base).filter((e) => e.includes("-tmp"));
+		expect(leftovers).toEqual([]);
+	});
+
+	it("concurrent-publish loser cleans up its tmp dir and keeps the winner's latest", () => {
+		const { base, latest, run } = makeBase();
+		writeFileSync(join(run, "loser.js"), "L");
+		const tag = "loser";
+		const tmpDir = `${latest}-${tag}-tmp`;
+
+		// Simulate a concurrent winner: between the loser's rmSync(latest) and
+		// its renameSync, the winner publishes `latest`. The injected renameSync
+		// re-creates the winner's snapshot at the destination and then performs
+		// the real rename, which fails (dir-over-existing-non-empty-dir fails on
+		// both Windows and POSIX).
+		const raceyRename: typeof renameSync = (from, to) => {
+			mkdirSync(latest, { recursive: true });
+			writeFileSync(join(latest, "winner.js"), "W");
+			renameSync(from, to);
+		};
+
+		expect(publishTransformCache(run, latest, tag, { renameSync: raceyRename })).toBe(false);
+		// Loser cleaned its tmp dir; no `-tmp` leftovers anywhere in the base.
+		expect(existsSync(tmpDir)).toBe(false);
+		expect(readdirSync(base).filter((e) => e.includes("-tmp"))).toEqual([]);
+		// Winner's snapshot untouched.
+		expect(readFileSync(join(latest, "winner.js"), "utf8")).toBe("W");
+	});
+
+	it("refuses degenerate inputs (same dir, empty paths)", () => {
+		const { run } = makeBase();
+		writeFileSync(join(run, "a.js"), "A");
+		expect(publishTransformCache(run, run)).toBe(false);
+		expect(publishTransformCache("", run)).toBe(false);
+		expect(publishTransformCache(run, "")).toBe(false);
+	});
+});
+
+describe("publishTransformCacheFromEnv", () => {
+	it("publishes when OWNED=1 and the run dir is in the v2 namespace", () => {
+		const { latest, run } = makeBase();
+		writeFileSync(join(run, "a.js"), "A");
+		const ok = publishTransformCacheFromEnv({
+			BOBBIT_E2E_PWTEST_CACHE_OWNED: "1",
+			BOBBIT_V2_PWTEST_RUN_CACHE_ROOT: run,
+		} as NodeJS.ProcessEnv);
+		expect(ok).toBe(true);
+		expect(readFileSync(join(latest, "a.js"), "utf8")).toBe("A");
+	});
+
+	it("does nothing when OWNED is unset or not '1'", () => {
+		const { latest, run } = makeBase();
+		writeFileSync(join(run, "a.js"), "A");
+		for (const owned of [undefined, "", "0", "true"]) {
+			const ok = publishTransformCacheFromEnv({
+				BOBBIT_E2E_PWTEST_CACHE_OWNED: owned,
+				BOBBIT_V2_PWTEST_RUN_CACHE_ROOT: run,
+			} as NodeJS.ProcessEnv);
+			expect(ok).toBe(false);
+		}
+		expect(existsSync(latest)).toBe(false);
+	});
+
+	it("KEEP=1 does not suppress publishing (KEEP only affects run-dir deletion)", () => {
+		const { latest, run } = makeBase();
+		writeFileSync(join(run, "a.js"), "A");
+		const ok = publishTransformCacheFromEnv({
+			BOBBIT_E2E_PWTEST_CACHE_OWNED: "1",
+			BOBBIT_KEEP_PWTEST_CACHE: "1",
+			BOBBIT_V2_PWTEST_RUN_CACHE_ROOT: run,
+		} as NodeJS.ProcessEnv);
+		expect(ok).toBe(true);
+		expect(readFileSync(join(latest, "a.js"), "utf8")).toBe("A");
+		// Run dir untouched by publish, honouring KEEP's inspection use case.
+		expect(readFileSync(join(run, "a.js"), "utf8")).toBe("A");
+	});
+
+	it("ignores run dirs outside the v2 namespace (legacy dirs untouched)", () => {
+		const root = mkdtempSync(join(tmpdir(), "pwtest-cache-legacy-"));
+		tempRoots.push(root);
+		const legacyRun = join(root, "pwtest-transform-cache", "run-1");
+		mkdirSync(legacyRun, { recursive: true });
+		writeFileSync(join(legacyRun, "a.js"), "A");
+		const ok = publishTransformCacheFromEnv({
+			BOBBIT_E2E_PWTEST_CACHE_OWNED: "1",
+			BOBBIT_V2_PWTEST_RUN_CACHE_ROOT: legacyRun,
+		} as NodeJS.ProcessEnv);
+		expect(ok).toBe(false);
+		expect(existsSync(join(root, "pwtest-transform-cache", "latest"))).toBe(false);
+	});
+
+	it("never publishes the `latest` dir onto itself and tolerates missing env", () => {
+		const { latest } = makeBase();
+		mkdirSync(latest, { recursive: true });
+		writeFileSync(join(latest, "a.js"), "A");
+		expect(publishTransformCacheFromEnv({
+			BOBBIT_E2E_PWTEST_CACHE_OWNED: "1",
+			BOBBIT_V2_PWTEST_RUN_CACHE_ROOT: latest,
+		} as NodeJS.ProcessEnv)).toBe(false);
+		expect(publishTransformCacheFromEnv({
+			BOBBIT_E2E_PWTEST_CACHE_OWNED: "1",
+		} as NodeJS.ProcessEnv)).toBe(false);
+	});
+
+	it("falls back to BOBBIT_E2E_PWTEST_CACHE_DIR when the v2 run-root var is absent", () => {
+		const { latest, run } = makeBase();
+		writeFileSync(join(run, "a.js"), "A");
+		const ok = publishTransformCacheFromEnv({
+			BOBBIT_E2E_PWTEST_CACHE_OWNED: "1",
+			BOBBIT_E2E_PWTEST_CACHE_DIR: run,
+		} as NodeJS.ProcessEnv);
+		expect(ok).toBe(true);
+		expect(readFileSync(join(latest, "a.js"), "utf8")).toBe("A");
+	});
+
+	it("round-trip: publish then seed warms a fresh run dir", () => {
+		const { base, latest, run } = makeBase();
+		writeFileSync(join(run, "a.js"), "A");
+		expect(publishTransformCache(run, latest)).toBe(true);
+
+		const nextRun = join(base, "run-2");
+		mkdirSync(nextRun, { recursive: true });
+		expect(seedTransformCacheForRunDir(nextRun)).toBe(true);
+		expect(readFileSync(join(nextRun, "a.js"), "utf8")).toBe("A");
+	});
+});

--- a/tests2/core/sandbox-wiring-goal-provisioned.test.ts
+++ b/tests2/core/sandbox-wiring-goal-provisioned.test.ts
@@ -32,7 +32,7 @@ enableTsWorkerResolver();
  *   4. restore/respawn (cwd already container-internal) does NOT re-dispatch.
  * No Docker required — the sandbox + stores are stubbed.
  */
-import { beforeAll, describe, it, vi } from "vitest";
+import { describe, it, vi } from "vitest";
 import assert from "node:assert/strict";
 import fs from "node:fs";
 import os from "node:os";
@@ -46,12 +46,6 @@ import type { PackContributionRegistry } from "../../src/server/extension-host/p
 import { makeTmpDir } from "../../tests/helpers/tmp.js";
 
 const CONTAINER_WORKTREE = "/workspace-wt/goal-g1-coder-x";
-
-// With pool:"forks" + isolate:false, another file's env guard can restore
-// NODE_OPTIONS after this module is collected but before its worker starts. Re-add
-// the .js→.ts resolver at run time so module-host-bootstrap.ts can resolve its
-// confinement-loader.js source import. This is test process isolation, not a wait.
-beforeAll(() => { enableTsWorkerResolver(); });
 
 // A valid admin token must be >= 64 chars (see src/server/auth/token.ts
 // readToken()). The previous fixture wrote a short "admin-token" that
@@ -268,6 +262,11 @@ describe("applySandboxWiring — goalProvisioned marker actually writes host-sid
 			});
 
 			const bridgeOptions: any = { env: {}, cwd: hostWorktree };
+			// Re-add the worker resolver immediately before the production invocation.
+			// Under pool:"forks" + isolate:false, a sibling file's env guard can restore
+			// NODE_OPTIONS after collection or a file-level beforeAll. Keeping this next
+			// to ModuleHost worker creation makes the test independent of file ordering.
+			enableTsWorkerResolver();
 			const ok = await sm.applySandboxWiring(bridgeOptions, "sess-fs", {
 				projectId: "proj-1",
 				goalId: "goal-g1",

--- a/tests2/tests-map.json
+++ b/tests2/tests-map.json
@@ -561,6 +561,33 @@
       }
     },
     {
+      "path": "tests2/core/ensure-dist-build-key.test.ts",
+      "reason": "Pins the content-addressed dist build cache used by test:e2e:v2 and browser-global-setup: changed build inputs must change the key, and validation must fail closed on missing/stale manifests or missing dist artifacts so a stale build is never silently tested.",
+      "execution": {
+        "runner": "vitest",
+        "tier": "unit",
+        "project": "core"
+      }
+    },
+    {
+      "path": "tests2/core/pwtest-cache-publish.test.ts",
+      "reason": "Pins the persistent Playwright transform-cache seed/publish helpers: seed copies the latest snapshot without clobbering run-dir files and tolerates a missing latest; publish atomically replaces latest from a non-empty run dir and a concurrent-publish loser cleans its tmp dir; the env-gated wrapper honours OWNED gating, the v2 namespace guard, and KEEP=1 not suppressing publish.",
+      "execution": {
+        "runner": "vitest",
+        "tier": "unit",
+        "project": "core"
+      }
+    },
+    {
+      "path": "tests2/core/per-spec-budget.test.ts",
+      "reason": "Pins per-spec tier-2 wall budget classification from Playwright JSON reports: grandfathered files warn, non-grandfathered files over budget fail, and retries count toward a file's total so budget regressions in the browser tier cannot creep in silently.",
+      "execution": {
+        "runner": "vitest",
+        "tier": "unit",
+        "project": "core"
+      }
+    },
+    {
       "path": "tests2/core/server-prebundle-cache.test.ts",
       "reason": "Pins content-addressed server-test prebundle cache invalidation and fail-closed artifact validation so changed source, stale keys, missing maps, or truncated bundles can never be silently reused.",
       "execution": {


### PR DESCRIPTION
## Summary

- add content-addressed dist reuse and persistent Playwright transform caching
- replace fixed browser sleeps with observable-state waits and stabilize mobile scroll timing
- migrate E2E fixtures to immutable template repositories and increase safe concurrency
- enforce per-spec browser budgets and broaden concurrent path-ownership auditing
- add pinning coverage for build keys, cache publication, and per-spec budgets

## Verification

- `npm run build`
- `npm run check`
- `npm run test:unit`
- `npm run test:browser`
- `npm run test:e2e`

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)