### PR TITLE
Improve desktop working directory footer

### DIFF
--- a/src/app/api.ts
+++ b/src/app/api.ts
@@ -83,9 +83,9 @@ export function goalDeepLink(goalId: string): string {
 }
 
 /** Copy text via the async Clipboard API, falling back to a legacy
- *  execCommand("copy") path so links are still copied in insecure contexts
+ *  execCommand("copy") path so text is still copied in insecure contexts
  *  (e.g. plain http:// over NordLynx) where the Clipboard API is blocked. */
-async function copyTextToClipboard(text: string): Promise<boolean> {
+export async function copyTextToClipboard(text: string): Promise<boolean> {
 	try {
 		if (typeof navigator !== "undefined" && navigator.clipboard?.writeText) {
 			await navigator.clipboard.writeText(text);

--- a/src/ui/components/AgentInterface.ts
+++ b/src/ui/components/AgentInterface.ts
@@ -6,7 +6,7 @@ import { Select, type SelectOption } from "@mariozechner/mini-lit/dist/Select.js
 import type { ToolResultMessage, Usage } from "@earendil-works/pi-ai";
 import { html, LitElement, nothing } from "lit";
 import { customElement, property, query, state } from "lit/decorators.js";
-import { AlertTriangle, ArrowDown, ArrowUp, Brain, ChevronsDown, Image as ImageIcon, Sparkles } from "lucide";
+import { AlertTriangle, ArrowDown, ArrowUp, Brain, Check, ChevronsDown, Copy, Image as ImageIcon, Sparkles } from "lucide";
 import type { ModelSelector } from "../dialogs/ModelSelector.js";
 import type { ImageModelSelector } from "../dialogs/ImageModelSelector.js";
 
@@ -45,7 +45,7 @@ import { getAppStorage } from "../storage/app-storage.js";
 import "./StreamingMessageContainer.js";
 import "./BellToggle.js";
 import { state as appState, renderApp, type GatewaySession } from "../../app/state.js";
-import { gatewayFetch } from "../../app/api.js";
+import { copyTextToClipboard, gatewayFetch } from "../../app/api.js";
 import { selectProposalWorkspaceTab } from "../../app/preview-panel.js";
 import { setHashRoute } from "../../app/routing.js";
 import { canContinueArchivedSession, continueArchivedSession } from "../../app/session-actions.js";
@@ -397,6 +397,8 @@ export class AgentInterface extends LitElement {
 		? !window.matchMedia("(min-width: 640px)").matches
 		: false;
 	private _narrowResizeObserver?: ResizeObserver;
+	@state() private _cwdCopied = false;
+	private _cwdCopyResetTimer?: ReturnType<typeof setTimeout>;
 	private _updateNarrow = (width: number) => {
 		const next = width > 0 && width < 640;
 		if (next !== this._isNarrow) {
@@ -404,6 +406,18 @@ export class AgentInterface extends LitElement {
 			this.requestUpdate();
 		}
 	};
+
+	private async _copyCwd(event: Event): Promise<void> {
+		event.preventDefault();
+		event.stopPropagation();
+		if (!this.cwd || !await copyTextToClipboard(this.cwd)) return;
+		this._cwdCopied = true;
+		if (this._cwdCopyResetTimer) clearTimeout(this._cwdCopyResetTimer);
+		this._cwdCopyResetTimer = setTimeout(() => {
+			this._cwdCopied = false;
+			this._cwdCopyResetTimer = undefined;
+		}, 1500);
+	}
 
 	/**
 	 * Window-level Escape handler. Aborts the streaming agent regardless of
@@ -969,6 +983,10 @@ export class AgentInterface extends LitElement {
 		if (this._scrollDeferTimer) {
 			clearTimeout(this._scrollDeferTimer);
 			this._scrollDeferTimer = null;
+		}
+		if (this._cwdCopyResetTimer) {
+			clearTimeout(this._cwdCopyResetTimer);
+			this._cwdCopyResetTimer = undefined;
 		}
 
 		if (this._pillResizeObserver) {
@@ -2096,11 +2114,21 @@ export class AgentInterface extends LitElement {
 			})
 			: "";
 
-		const cwdHtml = this.cwd ? (() => {
-			const parts = this.cwd!.split(/[/\\]/).filter(Boolean);
-			const short = parts.length <= 2 ? parts.join("/") : "…/" + parts.slice(-2).join("/");
-			return html`<span class="font-mono opacity-60 flex items-center gap-1 truncate" style="max-width:280px;" title="${this.cwd}">${short}</span>`;
-		})() : "";
+		const cwdHtml = this.cwd ? html`
+			<span
+				class="font-mono opacity-60 truncate"
+				data-testid="footer-cwd-path"
+				title=${this.cwd}
+			>${this.cwd}</span>
+			<button
+				type="button"
+				class="shrink-0 rounded p-1 opacity-60 hover:bg-accent hover:text-foreground hover:opacity-100 transition-colors"
+				data-testid="footer-cwd-copy"
+				aria-label=${this._cwdCopied ? "Working directory copied" : "Copy working directory"}
+				title=${this._cwdCopied ? "Copied" : "Copy working directory"}
+				@click=${(event: Event) => void this._copyCwd(event)}
+			>${icon(this._cwdCopied ? Check : Copy, "xs")}</button>
+		` : nothing;
 
 		// Build context popover content
 		const popoverContent = this._contextPopoverOpen ? (() => {
@@ -2200,15 +2228,15 @@ export class AgentInterface extends LitElement {
 		};
 
 		return html`
-			<div class="text-xs text-muted-foreground flex justify-between items-center mt-0.5 pl-2 pr-2 sm:pl-0 sm:pr-0">
-				<div class="flex items-center">
+			<div class="text-xs text-muted-foreground flex items-center mt-0.5 pl-2 pr-2 sm:pl-0 sm:pr-0">
+				<div class="flex shrink-0 items-center">
 					${this.showThemeToggle ? html`<bell-toggle></bell-toggle><theme-toggle></theme-toggle>` : html``}
 					${thinkingSelect}
 					${modelButton}
 					${imageModelButton}
 				</div>
-				${cwdHtml && !this._isNarrow ? html`<div class="flex items-center pl-4">${cwdHtml}</div>` : ""}
-				<div class="flex ml-auto items-center gap-3 relative" style="position:relative">
+				${this.cwd && !this._isNarrow ? html`<div class="flex min-w-0 flex-1 items-center gap-1 pl-4 pr-3">${cwdHtml}</div>` : ""}
+				<div class="flex shrink-0 ml-auto items-center gap-3 relative" style="position:relative">
 					${popoverContent}
 					<span class="cursor-pointer hover:text-foreground transition-colors"
 						@click=${(e: Event) => { e.stopPropagation(); togglePopover(); }}>

--- a/tests2/browser/journeys/misc.journey.spec.ts
+++ b/tests2/browser/journeys/misc.journey.spec.ts
@@ -312,6 +312,38 @@ test.describe("Journey: Compaction", () => {
 	});
 });
 
+test.describe("Journey: Footer Working Directory", () => {
+	test.use({ permissions: ["clipboard-read", "clipboard-write"] });
+
+	test("desktop footer shows the full path and copies it", async ({ page }) => {
+		await page.setViewportSize({ width: 1440, height: 900 });
+		const project = await defaultProject();
+		const sessionId = await createSession({ cwd: project.rootPath, projectId: project.id });
+		await waitForSessionStatus(sessionId, "idle");
+		try {
+			await openApp(page);
+			await navigateToHash(page, `#/session/${sessionId}`);
+			await expect(page.locator("message-editor textarea").first()).toBeVisible({ timeout: 15_000 });
+
+			const cwdPath = page.getByTestId("footer-cwd-path");
+			await expect(cwdPath).toBeVisible({ timeout: 15_000 });
+			await expect(cwdPath).toHaveText(project.rootPath);
+			await expect(cwdPath).toHaveAttribute("title", project.rootPath);
+
+			const copyButton = page.getByTestId("footer-cwd-copy");
+			await copyButton.click();
+			await expect(copyButton).toHaveAttribute("aria-label", "Working directory copied");
+			await expect.poll(() => page.evaluate(() => navigator.clipboard.readText()), { timeout: 15_000 }).toBe(project.rootPath);
+
+			await page.reload();
+			await expect(page.getByTestId("footer-cwd-path")).toHaveText(project.rootPath, { timeout: 20_000 });
+			await expect(page.getByTestId("footer-cwd-copy")).toBeVisible();
+		} finally {
+			await deleteSession(sessionId).catch(() => {});
+		}
+	});
+});
+
 // Ported from prompt-stats-e2e.spec.ts (audit: misc GAP / BR51): after an agent
 // response, the stats bar must show the model name, a context-usage tooltip
 // prefixed "Context:" with a percentage, and a "$" cost. The journey previously


### PR DESCRIPTION
## Summary
- show the full working directory in the desktop footer when space permits
- add a copy-path button with success feedback and clipboard fallback
- cover display, clipboard, and reload behavior in the browser journey

## Tests
- npm run check
- npx playwright test tests2/browser/journeys/misc.journey.spec.ts --config=playwright-v2.config.ts --project=browser-v2 --grep="Footer Working Directory"

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)