### PR TITLE
Use neutral Headquarters accent

### DIFF
--- a/docs/design/headquarters-ux.md
+++ b/docs/design/headquarters-ux.md
@@ -53,7 +53,7 @@ Match existing icon sizing exactly:
 | Project picker popover | accent dot/folder surrogate | `TowerControl`, `sm` or same row height |
 | Settings/config scope pill | color dot | `TowerControl`, `xs` |
 
-Do not render the normal project color dot for Headquarters. Let the icon carry the identity. Use the same color treatment as the project label in that surface, normally `var(--primary)` when active and `var(--muted-foreground)` or inherited text color when inactive.
+Do not render the normal project color dot for Headquarters. Let the icon carry the identity. Its accent is a theme-aware mix weighted toward the primary text colour — `color-mix(in oklch, var(--foreground) 75%, var(--muted-foreground))` — so it stays neutral and prominent without the full contrast of pure foreground.
 
 ## Sidebar behavior
 

--- a/src/app/config-scope.ts
+++ b/src/app/config-scope.ts
@@ -6,7 +6,7 @@ import { icon } from "@mariozechner/mini-lit";
 import { html, type TemplateResult } from "lit";
 import { state } from "./state.js";
 import { gatewayFetch } from "./api.js";
-import { HEADQUARTERS_HELPER_TEXT, HEADQUARTERS_PROJECT_ID, HEADQUARTERS_PROJECT_NAME, isHeadquartersProject, projectIconComponent, projectIconKind, projectIconTestId } from "./headquarters.js";
+import { HEADQUARTERS_ACCENT_COLOR, HEADQUARTERS_HELPER_TEXT, HEADQUARTERS_PROJECT_ID, HEADQUARTERS_PROJECT_NAME, isHeadquartersProject, projectIconComponent, projectIconKind, projectIconTestId } from "./headquarters.js";
 
 export type ConfigOrigin = "builtin" | "server" | "user" | "project";
 
@@ -93,7 +93,7 @@ export function renderConfigScopeRow(currentScope: string, onScopeChange: (scope
 					: "text-muted-foreground hover:text-foreground hover:bg-secondary/50"}"
 				@click=${() => onScopeChange("system")}
 			>
-				<span data-testid="headquarters-icon" data-project-icon="headquarters" class="inline-flex items-center">${icon(projectIconComponent("headquarters"), "xs")}</span>
+				<span data-testid="headquarters-icon" data-project-icon="headquarters" class="inline-flex items-center" style="color:${HEADQUARTERS_ACCENT_COLOR};">${icon(projectIconComponent("headquarters"), "xs")}</span>
 				<span class="inline-flex flex-col items-start leading-tight">
 					<span>${HEADQUARTERS_PROJECT_NAME}</span>
 					<span class="text-[11px] text-muted-foreground">${HEADQUARTERS_HELPER_TEXT}</span>
@@ -104,7 +104,7 @@ export function renderConfigScopeRow(currentScope: string, onScopeChange: (scope
 				const isDark = document.documentElement.classList.contains("dark");
 				const headquarters = isHeadquartersProject(project);
 				const color = headquarters
-					? "var(--primary)"
+					? HEADQUARTERS_ACCENT_COLOR
 					: isDark
 						? (project.colorDark || project.color || "var(--muted-foreground)")
 						: (project.colorLight || project.color || "var(--muted-foreground)");

--- a/src/app/headquarters.ts
+++ b/src/app/headquarters.ts
@@ -4,6 +4,8 @@ export const HEADQUARTERS_PROJECT_ID = "headquarters";
 export const HEADQUARTERS_PROJECT_NAME = "Headquarters";
 export const HEADQUARTERS_PROJECT_KIND = "headquarters";
 export const HEADQUARTERS_HELPER_TEXT = "Server workspace";
+/** Theme-aware Headquarters accent: primarily foreground, softened slightly to avoid excessive contrast. */
+export const HEADQUARTERS_ACCENT_COLOR = "color-mix(in oklch, var(--foreground) 75%, var(--muted-foreground))";
 export const SHOW_HEADQUARTERS_IN_PROJECT_LISTS_PREF = "showHeadquartersInProjectLists";
 
 export type ProjectKind = "normal" | "headquarters" | "system";

--- a/src/app/render-helpers.ts
+++ b/src/app/render-helpers.ts
@@ -18,7 +18,7 @@ import {
 import { statusBobbit } from "./session-colors.js";
 import { connectToSession, createAndConnectSession, startReattempt } from "./session-manager.js";
 import { setHashRoute } from "./routing.js";
-import { isHeadquartersProject } from "./headquarters.js";
+import { HEADQUARTERS_ACCENT_COLOR, isHeadquartersProject } from "./headquarters.js";
 import { startTeam, deleteGoal, gatewayFetch, copySidebarLink, fetchGoalGithubLink, getCachedGoalGithubLink, goalDeepLink, type GoalGithubLinkResponse } from "./api.js";
 import { buildArchivedSessionActions, buildSessionActions, openSessionInNewWindow, resetSessionForkNewWorktree, type SessionActionDescriptor, type SessionActionTrailingToggle } from "./session-actions.js";
 import { getActiveNavId } from "./sidebar-nav.js";
@@ -217,7 +217,7 @@ export function filterArchivedSessionsByQuery(
 
 /** Get the appropriate project accent color for the current theme mode. */
 export function getProjectAccentColor(project: Project): string {
-	if (isHeadquartersProject(project)) return "var(--primary)";
+	if (isHeadquartersProject(project)) return HEADQUARTERS_ACCENT_COLOR;
 	const isDark = document.documentElement.classList.contains("dark");
 	return isDark
 		? (project.colorDark || project.color || "var(--muted-foreground)")

--- a/src/app/render.ts
+++ b/src/app/render.ts
@@ -45,7 +45,7 @@ export { setSelectedWorkflowId } from "./proposal-panels-lazy.js";
 // chunk is shared across all UI surfaces that open dialogs.
 import { openGatewayDialog, showQrCodeDialog, showSupportDialog, showGoalDialog, showProjectDialog } from "./dialogs-lazy.js";
 import { startNewGoalFlow } from "./goal-entry.js";
-import { HEADQUARTERS_HELPER_TEXT, HEADQUARTERS_PROJECT_ID, defaultCwdForProjectSession, isHeadquartersProject, projectIconComponent, projectIconKind, projectIconTestId } from "./headquarters.js";
+import { HEADQUARTERS_ACCENT_COLOR, HEADQUARTERS_HELPER_TEXT, HEADQUARTERS_PROJECT_ID, defaultCwdForProjectSession, isHeadquartersProject, projectIconComponent, projectIconKind, projectIconTestId } from "./headquarters.js";
 import { renderSidebar, toggleRolePicker, renderRolePickerDropdown, filterStaffByQuery, renderStaffSidebarSection, isProjectReordering, projectOrderForRender, renderProjectReorderHandle, renderProjectReorderLiveRegion, handleSidebarSearchInput, handleSidebarSearchClear, renderArchivedSearchControls, filterSidebarTreeModelGoalsForSearch, collectSidebarSearchSessionRetention } from "./sidebar.js";
 import { buildSidebarTree, type GoalContext, type SidebarProjectTree, type SidebarTreeNode } from "./sidebar-tree-builder.js";
 import { loadSidebarTreeLayoutPreference, sidebarTreeBaseIndentStyle, sidebarTreeHalfIndentStyle, sidebarTreeNodeIndentStyle } from "./sidebar-tree-layout.js";
@@ -237,7 +237,7 @@ function _splashProjectPicker() {
 			${projects.map(p => {
 				const isDark = document.documentElement.classList.contains("dark");
 				const color = isHeadquartersProject(p)
-					? "var(--primary)"
+					? HEADQUARTERS_ACCENT_COLOR
 					: isDark
 						? (p.colorDark || p.color || "var(--muted-foreground)")
 						: (p.colorLight || p.color || "var(--muted-foreground)");

--- a/src/ui/components/ProjectPickerPopover.ts
+++ b/src/ui/components/ProjectPickerPopover.ts
@@ -12,7 +12,7 @@
 import { icon } from "@mariozechner/mini-lit";
 import { html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
-import { HEADQUARTERS_HELPER_TEXT, isHeadquartersProject, projectIconComponent, projectIconKind, projectIconTestId, projectSearchText } from "../../app/headquarters.js";
+import { HEADQUARTERS_ACCENT_COLOR, HEADQUARTERS_HELPER_TEXT, isHeadquartersProject, projectIconComponent, projectIconKind, projectIconTestId, projectSearchText } from "../../app/headquarters.js";
 
 /**
  * Project info exposed to the picker. Callers pass the subset of their
@@ -190,7 +190,7 @@ export class ProjectPickerPopover extends LitElement {
 	}
 
 	private _accent(p: ProjectPickerItem): string {
-		if (isHeadquartersProject(p)) return "var(--primary)";
+		if (isHeadquartersProject(p)) return HEADQUARTERS_ACCENT_COLOR;
 		const isDark = document.documentElement.classList.contains("dark");
 		return (isDark ? (p.colorDark || p.colorLight) : (p.colorLight || p.colorDark)) || p.color || "var(--muted-foreground)";
 	}

--- a/tests2/browser/journeys/stories-registry.journey.spec.ts
+++ b/tests2/browser/journeys/stories-registry.journey.spec.ts
@@ -46,6 +46,38 @@ test.describe("Journey: Headquarters", () => {
 		await page.waitForFunction(() => window.location.hash.includes("settings"), null, { timeout: 20_000 });
 		await expect(page.locator(".sidebar-edge").first()).toBeVisible({ timeout: 15_000 });
 	});
+
+	test("Headquarters accent stays neutral and foreground-weighted in light and dark modes", async ({ page }) => {
+		await apiFetch("/api/preferences", {
+			method: "PUT",
+			body: JSON.stringify({ showHeadquartersInProjectLists: true }),
+		});
+		await openApp(page);
+		const icon = page.locator('[data-testid="project-header"][data-project-id="headquarters"] [data-testid="headquarters-icon"]').first();
+		await expect(icon).toBeVisible({ timeout: 15_000 });
+
+		const colors = async (dark: boolean) => page.evaluate(({ dark }) => {
+			document.documentElement.classList.toggle("dark", dark);
+			const target = document.querySelector('[data-testid="project-header"][data-project-id="headquarters"] [data-testid="headquarters-icon"]');
+			if (!target) return null;
+			const probe = document.createElement("span");
+			probe.style.color = "color-mix(in oklch, var(--foreground) 75%, var(--muted-foreground))";
+			document.body.appendChild(probe);
+			const result = { actual: getComputedStyle(target).color, expected: getComputedStyle(probe).color };
+			probe.remove();
+			return result;
+		}, { dark });
+
+		const light = await colors(false);
+		expect(light).not.toBeNull();
+		expect(light?.actual).toBe(light?.expected);
+		const dark = await colors(true);
+		expect(dark).not.toBeNull();
+		expect(dark?.actual).toBe(dark?.expected);
+
+		await page.reload();
+		await expect(page.locator('[data-testid="project-header"][data-project-id="headquarters"] [data-testid="headquarters-icon"]').first()).toBeVisible({ timeout: 20_000 });
+	});
 });
 
 // ═══════════════════════════════════════════════════════════════

--- a/tests2/dom/render-highlighted-text.test.ts
+++ b/tests2/dom/render-highlighted-text.test.ts
@@ -21,7 +21,7 @@ describe("getProjectAccentColor", () => {
 		document.documentElement.classList.remove("dark");
 		expect(getProjectAccentColor(headquarters)).toBe(HEADQUARTERS_ACCENT_COLOR);
 		document.documentElement.classList.add("dark");
-		expect(getProjectAccentColor(headquarters)).toBe("color-mix(in oklch, var(--foreground) 75%, var(--muted-foreground))");
+		expect(getProjectAccentColor(headquarters)).toBe(HEADQUARTERS_ACCENT_COLOR);
 		document.documentElement.classList.remove("dark");
 	});
 });

--- a/tests2/dom/render-highlighted-text.test.ts
+++ b/tests2/dom/render-highlighted-text.test.ts
@@ -11,7 +11,20 @@ import {
 	splitByQuery,
 	filterArchivedGoalsByQuery,
 	filterArchivedSessionsByQuery,
+	getProjectAccentColor,
 } from "../../src/app/render-helpers.js";
+import { HEADQUARTERS_ACCENT_COLOR } from "../../src/app/headquarters.js";
+
+describe("getProjectAccentColor", () => {
+	it("keeps the Headquarters accent neutral and foreground-weighted in light and dark modes", () => {
+		const headquarters = { id: "headquarters", kind: "headquarters", color: "#ff00ff", colorLight: "#ff0000", colorDark: "#00ff00" } as any;
+		document.documentElement.classList.remove("dark");
+		expect(getProjectAccentColor(headquarters)).toBe(HEADQUARTERS_ACCENT_COLOR);
+		document.documentElement.classList.add("dark");
+		expect(getProjectAccentColor(headquarters)).toBe("color-mix(in oklch, var(--foreground) 75%, var(--muted-foreground))");
+		document.documentElement.classList.remove("dark");
+	});
+});
 
 describe("splitByQuery", () => {
 	it("empty query returns the text as a single unmatched segment", () => {


### PR DESCRIPTION
## Summary
- centralize the Headquarters accent as a neutral, foreground-weighted theme color
- apply it consistently across sidebars, project pickers, config scopes, and proposal chrome
- document and test light/dark behavior, including reload coverage

## Tests
- npm run check
- npx vitest run --config vitest.config.ts tests2/dom/render-highlighted-text.test.ts --silent=passed-only
- npx playwright test tests2/browser/journeys/stories-registry.journey.spec.ts --config=playwright-v2.config.ts --project=browser-v2 --grep="Headquarters accent"

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)