### PR TITLE
Remove manual publication git status

### DIFF
--- a/docs/design/git-status-widget-reliability.md
+++ b/docs/design/git-status-widget-reliability.md
@@ -442,9 +442,9 @@ turning any of them into a publication decision.
 
 In `GitStatusWidget`:
 - When `partial === true`: render the pill with a faint yellow dot (distinct from the blue refresh dot) next to the branch. Tooltip "Status scan timed out — showing partial data." Dropdown shows branch/ahead/behind fields but hides the file list with a "Re-scan" button that triggers an `?untracked=1` refetch.
-- For a non-primary work branch, show that remote publication is manual and keep the explicit **Push** control available. Missing upstream/base-ref state does not imply a failed or pending automatic publication.
+- For a non-primary work branch, omit remote-publication copy and controls from the status dropdown.
 
-Add `@property({ type: Boolean }) partial = false;` to `GitStatusWidget` and wire it from `AgentInterface.ts`. Publication copy is derived from the general local-only lifecycle, not from a status response field.
+Add `@property({ type: Boolean }) partial = false;` to `GitStatusWidget` and wire it from `AgentInterface.ts`.
 
 ---
 
@@ -461,7 +461,7 @@ Playwright file:// fixture rendering the widget.
 | Normal state | `loading=false`, `branch="foo"` | No dot, normal rendering |
 | Hidden when no data + not loading | `loading=false`, no branch | `render()` returns `nothing` |
 | Partial flag renders warning | `partial=true`, `branch="foo"` | Warning dot present, dropdown on open shows "Re-scan" button |
-| Manual publication hint | Non-primary `branch="foo"` with or without upstream | Dropdown explains remote publication is manual and offers explicit Push |
+| Hidden publication controls | Non-primary `branch="foo"` with or without upstream | Dropdown omits remote-publication copy and Push control |
 
 ### 8.2 Unit — `tests/git-status-refresh.spec.ts` (new)
 

--- a/src/ui/components/GitStatusWidget.ts
+++ b/src/ui/components/GitStatusWidget.ts
@@ -337,17 +337,8 @@ export class GitStatusWidget extends LitElement {
     }
 
     private _renderRemoteStatus() {
-        // Publishing a non-primary session branch is always an explicit action.
-        // Do not infer publication intent from upstream counters or base_ref:
-        // either may describe the comparison baseline rather than a matching
-        // remote work branch.
-        if (!this.isOnPrimary) {
-            if (!this.sessionId) return nothing;
-            return html`<div class="text-muted-foreground" data-testid="git-manual-publication">
-                Remote publication is manual.
-                ${this._renderPushButton()}
-            </div>`;
-        }
+        // Remote status and controls are only relevant on the primary branch.
+        if (!this.isOnPrimary) return nothing;
 
         // On primary branch only: show ahead/behind remote (edge case)
         if (this.ahead > 0 && this.behind > 0) {

--- a/tests2/dom/git-status-widget-states.test.ts
+++ b/tests2/dom/git-status-widget-states.test.ts
@@ -203,7 +203,7 @@ describe("GitStatusWidget render states", () => {
 		expect(p.textContent).not.toContain("-4");
 	});
 
-	it("offers manual publication for non-primary session branches", async () => {
+	it("hides remote publication controls for non-primary session branches", async () => {
 		const el = await mount({
 			loading: false,
 			branch: "session/manual-publish",
@@ -215,17 +215,13 @@ describe("GitStatusWidget render states", () => {
 			ahead: 3,
 			sessionId: "session-manual",
 		});
-		const pushEvents: Event[] = [];
-		el.addEventListener("git-push", (event) => pushEvents.push(event));
 
 		await openDropdown(el);
-		expect(dd()!.textContent).toContain("Remote publication is manual.");
-		expect(dd()!.textContent).not.toContain("published automatically");
-		btnByText(dd()!, "Push")!.click();
-		expect(pushEvents).toHaveLength(1);
+		expect(dd()!.textContent).not.toContain("Remote publication is manual.");
+		expect(btnByText(dd()!, "Push")).toBeUndefined();
 	});
 
-	it("does not infer automatic publication from missing upstream or base_ref", async () => {
+	it("hides remote publication controls without an upstream or base_ref", async () => {
 		const el = await mount({
 			loading: false,
 			branch: "goal/local-only",
@@ -240,8 +236,8 @@ describe("GitStatusWidget render states", () => {
 		});
 
 		await openDropdown(el);
-		expect(dd()!.querySelector('[data-testid="git-manual-publication"]')).toBeTruthy();
-		expect(btnByText(dd()!, "Push")).toBeTruthy();
+		expect(dd()!.textContent).not.toContain("Remote publication is manual.");
+		expect(btnByText(dd()!, "Push")).toBeUndefined();
 		expect(dd()!.querySelector('[data-testid="git-local-only-policy"]')).toBeFalsy();
 	});
 


### PR DESCRIPTION
## Summary
- remove the manual remote-publication message and Push control from non-primary git status dropdowns
- update widget tests and design documentation

## Tests
- `npx vitest run --config vitest.config.ts tests2/dom/git-status-widget-states.test.ts --silent=passed-only`

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)