### PR TITLE
chore(release): v0.14.1

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -98,8 +98,8 @@ Run, in this order, and **stop on any failure**:
 ```bash
 npm ci                          # clean install, lockfile authoritative
 npm audit --omit=dev            # zero high/critical in runtime deps
-npm run check                   # type-check server + web
-npm run build                   # full build
+npm run build                   # full build; emits declarations used by test type-checks
+npm run check                   # type-check server + web + tests against fresh dist
 npm run test:unit               # fast unit suite
 npm run test:e2e                # API + browser E2E
 ```
@@ -107,6 +107,7 @@ npm run test:e2e                # API + browser E2E
 Rules:
 - **`npm audit` must show 0 vulnerabilities** (any severity, runtime deps). If it doesn't, stop and report what's flagged — do not release with known vulns. If a finding is genuinely a false positive (e.g. dev-only path), have the user explicitly acknowledge before continuing.
 - Don't skip E2E "because it's slow" — releases are the one place flakes bite users.
+- Build must precede `check`: `tsconfig.tests2.json` follows intentional imports of emitted `dist/server/*.js` declarations, so a clean checkout cannot type-check the test graph before the build.
 - If any test fails, the failure is the bug. Fix it or abort the release; do not retry hoping it's flaky.
 
 Long-running steps (`build`, `test:e2e`) should use `bash_bg` so output stays inspectable.

--- a/RELEASE_NOTES_v0.14.1.md
+++ b/RELEASE_NOTES_v0.14.1.md
@@ -1,0 +1,27 @@
+# Bobbit v0.14.1
+
+Upgrading from v0.14.0. This release makes Bobbit safer around Git publication, expands project-aware proposals and AI Gateway routing, and strengthens recovery when interrupted tool history would previously leave a session unusable.
+
+## ✨ New Features
+
+* 🌐 **AI Gateway discovery & routing**: Bobbit can discover compatible models, metadata, and pricing from an AI Gateway well-known endpoint, persist the resolved configuration safely, and route sandboxed sessions through the configured gateway.
+
+* 🗂️ **Cross-project proposals**: Agents can propose goals, projects, roles, tools, and staff into a different registered project. Proposal panels clearly show the target project and acceptance now routes changes to the correct project and workflow.
+
+* 🛡️ **Local-first Git lifecycle**: Worktree creation, child-goal merges, and session status checks no longer push branches implicitly. Non-primary branch status stays focused on local working state and no longer presents remote-publication copy or Push controls.
+
+* 📦 **More compact gateway tools**: Bobbit read, orchestration, and administration tools now return bounded compact responses by default, with explicit verbose views for deeper inspection. Context-heavy transcript reads are guarded to prevent accidental prompt bloat.
+
+## 🐛 Bug Fixes
+
+* 🧵 **Interrupted session recovery**: Orphaned tool results and poisoned transcript branches are repaired in place across restart, role assignment, sandbox rehydration, and queued-prompt recovery, preventing damaged history from stranding otherwise recoverable sessions.
+
+* ✅ **Project proposal acceptance**: New, provisional, existing, and cross-project proposals now take the correct create, promote, or edit path, including after proposal revisions change the target.
+
+* 🧩 **Skill discovery consistency**: The Skills page and composer now share the active project scope, discover nested plugin skills and configured custom directories consistently, and recover the correct scope after refresh.
+
+* 🎨 **Workspace polish**: Headquarters uses a neutral accent, and the desktop working-directory footer is clearer and easier to inspect.
+
+---
+
+🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bobbit",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bobbit",
-      "version": "0.14.0",
+      "version": "0.14.1",
       "dependencies": {
         "@earendil-works/pi-agent-core": "0.80.6",
         "@earendil-works/pi-ai": "0.80.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bobbit",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "type": "module",
   "engines": {
     "node": ">=22.19.0"

--- a/tests2/core/release-skill-preflight-order.test.ts
+++ b/tests2/core/release-skill-preflight-order.test.ts
@@ -1,0 +1,24 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, it } from "vitest";
+
+const skill = readFileSync(resolve(process.cwd(), ".claude/skills/release/SKILL.md"), "utf8");
+const preflight = skill.match(/## 2\. Pre-flight quality gates[\s\S]*?```bash\n([\s\S]*?)\n```/)?.[1];
+
+function position(command: string): number {
+	assert.ok(preflight, "release skill must contain a fenced pre-flight command block");
+	const index = preflight.indexOf(command);
+	assert.notEqual(index, -1, `pre-flight command is missing: ${command}`);
+	return index;
+}
+
+describe("release skill pre-flight order", () => {
+	it("builds declarations before type-checking the test graph", () => {
+		assert.ok(position("npm ci") < position("npm audit --omit=dev"));
+		assert.ok(position("npm audit --omit=dev") < position("npm run build"));
+		assert.ok(position("npm run build") < position("npm run check"));
+		assert.ok(position("npm run check") < position("npm run test:unit"));
+		assert.ok(position("npm run test:unit") < position("npm run test:e2e"));
+	});
+});

--- a/tests2/core/tier1-spawn-guard-policy.test.ts
+++ b/tests2/core/tier1-spawn-guard-policy.test.ts
@@ -27,6 +27,11 @@ function messageFrom(call: () => unknown): string {
 }
 
 describe("tier-1 spawn guard policy", () => {
+	it("pins non-interactive verification flags before test modules boot", () => {
+		expect(process.env.BOBBIT_LLM_REVIEW_SKIP).toBe("1");
+		expect(process.env.BOBBIT_HUMAN_SIGNOFF_SKIP).toBe("1");
+	});
+
 	it("blocks every sync and async process API with migration guidance", () => {
 		const target = fakeTarget();
 		const guard = createTier1SpawnGuardController(target);

--- a/tests2/harness/tier1-spawn-guard.ts
+++ b/tests2/harness/tier1-spawn-guard.ts
@@ -8,6 +8,12 @@ import {
 } from "../../src/server/agent/tool-extension-preflight.js";
 import { prepareGitTemplate } from "./git-template.js";
 
+// Tier-1 never launches real review agents. Setup files execute before the test
+// module graph, so pin these boot-frozen flags here rather than in an imported
+// compatibility shim whose ESM dependencies may boot the gateway first.
+process.env.BOBBIT_LLM_REVIEW_SKIP = "1";
+process.env.BOBBIT_HUMAN_SIGNOFF_SKIP = "1";
+
 const DISABLE_ENV = "BOBBIT_TIER1_SPAWN_GUARD_DISABLE";
 const STATE_KEY = Symbol.for("bobbit.tests2.tier1-spawn-guard-state");
 const GUARDED_APIS = ["spawn", "spawnSync", "exec", "execSync", "execFile", "execFileSync", "fork"] as const;

--- a/tests2/integration/_e2e/in-process-harness.ts
+++ b/tests2/integration/_e2e/in-process-harness.ts
@@ -14,14 +14,9 @@
  *
  * This keeps the shared fork clean (R2 mitigation) without editing spec bodies.
  */
-// The fork gateway freezes `skipLlmReview` at boot from process.env (server.ts
-// reads resolveLegacyTestRuntimeFlags() directly). Set it before the singleton
-// boot so llm-review / agent-qa / human-signoff verification steps auto-pass in
-// tier-1 (they have no reviewer sub-agent). NOTE: for full determinism the
-// gateway fixture itself should set this before boot — see the escalation note
-// in the migration report; this import-time set is a transitional belt.
-process.env.BOBBIT_LLM_REVIEW_SKIP ??= "1";
-process.env.BOBBIT_HUMAN_SIGNOFF_SKIP ??= "1";
+// The tier-1 setup file pins non-interactive verification flags before this
+// module graph loads. Do not move them back here: ESM dependencies evaluate
+// before module-body assignments and can boot the fork gateway first.
 
 import { mkdirSync, renameSync, writeFileSync } from "node:fs";
 import { join } from "node:path";

--- a/tests2/tests-map.json
+++ b/tests2/tests-map.json
@@ -633,6 +633,15 @@
       }
     },
     {
+      "path": "tests2/core/release-skill-preflight-order.test.ts",
+      "reason": "Pins the clean-release pre-flight order so the build emits dist/server declarations before tsconfig.tests2 follows intentional runtime imports of those artifacts.",
+      "execution": {
+        "runner": "vitest",
+        "tier": "unit",
+        "project": "core"
+      }
+    },
+    {
       "path": "tests2/core/pwtest-cache-publish.test.ts",
       "reason": "Pins the persistent Playwright transform-cache seed/publish helpers: seed copies the latest snapshot without clobbering run-dir files and tolerates a missing latest; publish atomically replaces latest from a non-empty run dir and a concurrent-publish loser cleans its tmp dir; the env-gated wrapper honours OWNED gating, the v2 namespace guard, and KEEP=1 not suppressing publish.",
       "execution": {


### PR DESCRIPTION
## Summary

- fixes clean release preflight ordering
- pins tier-1 review skips before gateway boot
- bumps Bobbit to v0.14.1 and adds approved release notes

## Verification

- npm audit --omit=dev (0 vulnerabilities)
- npm run build
- npm run check
- npm run test:unit (7,778 passed)
- npm run test:e2e (all four phases passed)
- bobbit@0.14.1 published to npm without provenance

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)