### PR TITLE
Clarify explicit sign-off action

### DIFF
--- a/docs/review-pane-signoff.md
+++ b/docs/review-pane-signoff.md
@@ -2,6 +2,8 @@
 
 The review pane is Bobbit's shared human decision surface for markdown reviews and gate sign-offs. It lets reviewers read the submitted content at full pane size, add inline annotations, add a final decision note, and then approve or reject from one consistent action bar.
 
+Opening a pending sign-off review does not resolve the gate; the reviewer must explicitly select **Approve** or **Reject**.
+
 This keeps compact surfaces, including the goal status widget and gate tool cards, focused on alerting and handoff instead of duplicating submitted-content rendering or decision validation.
 
 ## Launch sources


### PR DESCRIPTION
## Summary

- document that opening a pending sign-off review does not resolve its gate
- clarify that reviewers must explicitly select Approve or Reject
- keep the change limited to one existing Markdown file

## Validation

- `git diff --check master...HEAD`
- implementation gate quick check and review passed

Human Approval passed before implementation began.

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)