### PR TITLE
Move Start Review beside step name

### DIFF
--- a/src/ui/tools/renderers/GateInspectRenderer.ts
+++ b/src/ui/tools/renderers/GateInspectRenderer.ts
@@ -317,15 +317,17 @@ export class GateInspectRenderer implements ToolRenderer {
 									@click=${hasOutput ? toggleStep : null}
 								>
 									${stepStatusIcon(status)}
-									<span class="font-mono text-xs flex-1 min-w-0 truncate">${step.name}</span>
+									<div class="flex flex-1 min-w-0 items-center gap-2">
+										<span class="font-mono text-xs min-w-0 truncate">${step.name}</span>
+										${reviewTarget ? html`
+											<signoff-review-launcher class="shrink-0" .target=${reviewTarget}></signoff-review-launcher>
+										` : nothing}
+									</div>
 									<span class="px-1.5 py-0.5 rounded text-[10px] font-medium ${stepStatusClass(status)}">${statusLabel}</span>
 									<span class="px-1.5 py-0.5 rounded text-[10px] font-medium ${typeBadgeCls}">${step.type}</span>
 									${marker
 										? html`<span data-timeout-timing class="text-xs text-muted-foreground tabular-nums">${formatTimeoutTiming(marker)}</span>`
 										: shouldShowDuration(status, step.duration_ms) ? html`<span class="text-xs text-muted-foreground tabular-nums">${formatDuration(step.duration_ms)}</span>` : nothing}
-									${reviewTarget ? html`
-										<signoff-review-launcher .target=${reviewTarget}></signoff-review-launcher>
-									` : nothing}
 									${canChangeTimeout ? html`
 										<button
 											type="button"

--- a/src/ui/tools/renderers/GateVerificationLive.ts
+++ b/src/ui/tools/renderers/GateVerificationLive.ts
@@ -758,21 +758,23 @@ export class GateVerificationLive extends LitElement {
 					${step.status === "timeout"
 						? html`<span data-timeout-icon title="Timed out" class="text-warning">⏱</span>`
 						: html`<span class="${statusColor(dStatus)}">${statusIcon(dStatus)}</span>`}
-					<span class="font-mono text-xs flex-1 min-w-0 truncate">${step.name || "step"}</span>
+					<div class="flex flex-1 min-w-0 items-center gap-2">
+						<span class="font-mono text-xs min-w-0 truncate">${step.name || "step"}</span>
+						${canStartReview ? html`
+							<signoff-review-launcher class="shrink-0" .target=${{
+								goalId: this.goalId,
+								gateId: this.gateId,
+								signalId: this.signalId,
+								stepName: step.name,
+								stepLabel: step.humanLabel || step.name,
+							}}></signoff-review-launcher>
+						` : nothing}
+					</div>
 					<span class="px-1.5 py-0.5 rounded text-[10px] font-medium ${stepStatusBadgeClass(step.status)}">${statusLabel}</span>
 					<span class="px-1.5 py-0.5 rounded text-[10px] font-medium ${typeBadgeCls}">${step.type}</span>
 					${marker
 						? html`<span data-timeout-timing class="text-xs text-muted-foreground tabular-nums">${formatTimeoutTiming(marker)}</span>`
 						: shouldRenderDuration(step) ? renderDuration(entry) : nothing}
-					${canStartReview ? html`
-						<signoff-review-launcher .target=${{
-							goalId: this.goalId,
-							gateId: this.gateId,
-							signalId: this.signalId,
-							stepName: step.name,
-							stepLabel: step.humanLabel || step.name,
-						}}></signoff-review-launcher>
-					` : nothing}
 					${canChangeTimeout ? html`
 						<button
 							type="button"

--- a/tests2/dom/gate-inspect-renderer.test.ts
+++ b/tests2/dom/gate-inspect-renderer.test.ts
@@ -170,6 +170,7 @@ describe("GateInspectRenderer", () => {
 			stepName: "approved-review",
 			stepLabel: "Approve review",
 		});
+		expect(launchers[0].previousElementSibling?.textContent).toBe("approved-review");
 	});
 
 	it("does not mount an unusable review launcher without exact target identifiers", () => {

--- a/tests2/dom/gate-signal-renderer.test.ts
+++ b/tests2/dom/gate-signal-renderer.test.ts
@@ -153,6 +153,7 @@ describe("GateSignalRenderer", () => {
 			stepName: "actionable",
 			stepLabel: "Approve release",
 		});
+		expect(launchers[0].previousElementSibling?.textContent).toBe("actionable");
 		expect(launchers[0].querySelectorAll("button")).toHaveLength(1);
 		expect(launchers[0].querySelector("button")?.getAttribute("aria-label")).toBe("Start review: Approve release");
 	});


### PR DESCRIPTION
## Summary
- place the Start Review launcher immediately beside verification step names
- keep live verification and gate inspection layouts consistent
- add DOM assertions that pin launcher placement

## Testing
- `npm run check`
- `npm run test:unit` — 7,848 passed, 22 skipped
- `npm run test:browser` — 660 passed, 6 skipped, 1 flaky retry passed; budget passed
- `npm run test:e2e` — all four phases passed, including 144 Vitest E2E tests

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)