### PR TITLE
Show build version in settings header

### DIFF
--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -77,6 +77,7 @@ A small set of UI probe endpoints accept `optional=1` to represent expected abse
 | Method | Path | Description |
 |---|---|---|
 | `GET` | `/api/health` | Health check + session count |
+| `GET` | `/api/app-info` | Running Bobbit package version and build provenance: `{ version, buildType: "installed" | "source", commitSha? }` |
 | `GET` | `/api/connection-info` | List network interface addresses for multi-device access |
 | `GET` | `/api/ca-cert` | Download the Bobbit CA certificate for device trust |
 

--- a/src/app/api.ts
+++ b/src/app/api.ts
@@ -2977,8 +2977,30 @@ export async function dismissSetup(): Promise<void> {
 }
 
 // ============================================================================
-// HARNESS STATUS API
+// APP INFO + HARNESS STATUS API
 // ============================================================================
+
+export interface AppInfo {
+	version: string;
+	buildType: "installed" | "source";
+	commitSha?: string;
+}
+
+export async function fetchAppInfo(): Promise<AppInfo | null> {
+	try {
+		const res = await gatewayFetch("/api/app-info");
+		if (!res.ok) return null;
+		const data = await res.json().catch(() => null);
+		if (typeof data?.version !== "string" || (data?.buildType !== "installed" && data?.buildType !== "source")) return null;
+		return {
+			version: data.version,
+			buildType: data.buildType,
+			...(typeof data.commitSha === "string" ? { commitSha: data.commitSha } : {}),
+		};
+	} catch {
+		return null;
+	}
+}
 
 export interface HarnessStatus {
 	restartAvailable: boolean;

--- a/src/app/render.ts
+++ b/src/app/render.ts
@@ -21,7 +21,7 @@ import {
 	type GatewaySession,
 	type Project,
 } from "./state.js";
-import { fetchProjects, gatewayFetch, retryLoadSessions, resumeGoalWithDialog, isGoalPauseResumeActionPending } from "./api.js";
+import { fetchAppInfo, fetchProjects, gatewayFetch, retryLoadSessions, resumeGoalWithDialog, isGoalPauseResumeActionPending, type AppInfo } from "./api.js";
 import { headerToast, showHeaderToast } from "./header-toast.js";
 export { showHeaderToast } from "./header-toast.js";
 import { clearAllAnnotations, getDocumentAnnotationCount, markReviewSubmitted, flushPendingWrites } from "../ui/components/review/AnnotationStore.js";
@@ -111,6 +111,35 @@ import {
 } from "./side-panel-workspace.js";
 
 const bobbitIcon = html`<img src="/favicon.svg" alt="" style="width:20px;height:18px;image-rendering:pixelated;" />`;
+
+let settingsAppInfo: AppInfo | null = null;
+let settingsAppInfoLoadStarted = false;
+
+function loadSettingsAppInfo(): void {
+	if (settingsAppInfoLoadStarted) return;
+	settingsAppInfoLoadStarted = true;
+	fetchAppInfo().then(info => {
+		settingsAppInfo = info;
+		renderApp();
+	});
+}
+
+function settingsAppVersionLabel(info: AppInfo): string {
+	return `Bobbit v${info.version}${info.buildType === "source" ? ` [${info.commitSha || "source"}]` : ""}`;
+}
+
+function renderSettingsAppVersionHeaderSlot() {
+	if (!settingsAppInfo) return html``;
+	return html`
+		<div class="flex items-center px-3" data-testid="settings-version-header-slot">
+			<span
+				class="text-xs text-muted-foreground whitespace-nowrap"
+				data-testid="settings-app-version"
+				title=${settingsAppInfo.buildType === "source" ? "Running from source" : "Running from an installed build"}
+			>${settingsAppVersionLabel(settingsAppInfo)}</span>
+		</div>
+	`;
+}
 
 // ──────────────────────────────────────────────────────────────────────
 // Splash-screen new-session gating
@@ -2120,6 +2149,7 @@ export function doRenderApp(): void {
 
 	// Session action buttons (shared between headerLeft mobile and headerRight desktop)
 	const route = getRouteFromHash();
+	if (route.view === "settings") loadSettingsAppInfo();
 	const routeSessionId = route.view === "session" ? route.sessionId : undefined;
 	const routeCachedSession = routeSessionId
 		? state.gatewaySessions.find(s => s.id === routeSessionId) ?? state.archivedSessions.find(s => s.id === routeSessionId)
@@ -2239,8 +2269,10 @@ export function doRenderApp(): void {
 
 	const headerRight = () => {
 		if (desktop) {
+			if (route.view === "settings" && settingsAppInfo) return renderSettingsAppVersionHeaderSlot();
 			return hasHeaderSessionActions ? html`<div class="flex items-center gap-1 px-2">${headerSessionActions}</div>` : html``;
 		}
+		if (route.view === "settings" && settingsAppInfo) return renderSettingsAppVersionHeaderSlot();
 		const settingsBtn = Button({
 			variant: "ghost",
 			size: "sm",
@@ -3069,7 +3101,7 @@ export function doRenderApp(): void {
 				${headerToast()}
 				${extRouteUnavailable()}
 				${renderClientDebugButton()}
-				<div class="flex items-center border-b border-border shrink-0 header-shadow">
+				<div class="flex items-center border-b border-border shrink-0 header-shadow" data-testid="app-header-row">
 					${state.sidebarCollapsed ? html`
 					<div class="w-14 shrink-0 flex items-center justify-center self-stretch" style="background: var(--sidebar);">
 						${bobbitIcon}
@@ -3126,7 +3158,7 @@ export function doRenderApp(): void {
 				${renderClientDebugButton()}
 				<div id="app-header"
 					class="fixed top-0 left-0 right-0 z-50 bg-background flex flex-col">
-					<div class="flex items-center justify-between border-b border-border">
+					<div class="flex items-center justify-between border-b border-border" data-testid="app-header-row">
 						${headerLeft()}
 						${headerRight()}
 					</div>
@@ -3149,7 +3181,7 @@ export function doRenderApp(): void {
 			<div class="w-full app-shell flex flex-col bg-background text-foreground overflow-hidden relative">
 				${headerToast()}
 				${extRouteUnavailable()}
-				<div class="flex items-center justify-between border-b border-border shrink-0 header-shadow">
+				<div class="flex items-center justify-between border-b border-border shrink-0 header-shadow" data-testid="app-header-row">
 					${headerLeft()}
 					${headerRight()}
 				</div>

--- a/src/app/render.ts
+++ b/src/app/render.ts
@@ -120,6 +120,13 @@ function loadSettingsAppInfo(): void {
 	settingsAppInfoLoadStarted = true;
 	fetchAppInfo().then(info => {
 		settingsAppInfo = info;
+		if (!info) {
+			// Allow a later render (including navigating away and back or a gateway
+			// reconnect) to retry. Do not render here: a persistent failure would
+			// otherwise create an immediate fetch/render retry loop.
+			settingsAppInfoLoadStarted = false;
+			return;
+		}
 		renderApp();
 	});
 }

--- a/src/server/app-info.ts
+++ b/src/server/app-info.ts
@@ -1,0 +1,101 @@
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+export type BobbitBuildType = "installed" | "source";
+
+export interface BobbitAppInfo {
+	version: string;
+	buildType: BobbitBuildType;
+	commitSha?: string;
+}
+
+const BOBBIT_PACKAGE_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+
+function readPackageVersion(packageRoot: string): string {
+	const packagePath = path.join(packageRoot, "package.json");
+	try {
+		const parsed = JSON.parse(fs.readFileSync(packagePath, "utf-8")) as { version?: unknown };
+		if (typeof parsed.version === "string" && parsed.version.trim()) return parsed.version.trim();
+		throw new Error("missing string version field");
+	} catch (err) {
+		throw new Error(`Failed to read Bobbit version from ${packagePath}: ${err instanceof Error ? err.message : String(err)}`);
+	}
+}
+
+function readLooseGitCommitSha(packageRoot: string): string | undefined {
+	const markerPath = path.join(packageRoot, ".git");
+	try {
+		const marker = fs.statSync(markerPath).isDirectory()
+			? undefined
+			: fs.readFileSync(markerPath, "utf-8").trim();
+		const gitDir = marker?.startsWith("gitdir:")
+			? path.resolve(packageRoot, marker.slice("gitdir:".length).trim())
+			: markerPath;
+		const head = fs.readFileSync(path.join(gitDir, "HEAD"), "utf-8").trim();
+		if (/^[0-9a-f]{40}$/i.test(head)) return head;
+		if (!head.startsWith("ref:")) return undefined;
+
+		const ref = head.slice("ref:".length).trim();
+		const commonDirPath = path.join(gitDir, "commondir");
+		const commonDir = fs.existsSync(commonDirPath)
+			? path.resolve(gitDir, fs.readFileSync(commonDirPath, "utf-8").trim())
+			: gitDir;
+		for (const root of new Set([gitDir, commonDir])) {
+			const looseRefPath = path.join(root, ...ref.split("/"));
+			if (fs.existsSync(looseRefPath)) return fs.readFileSync(looseRefPath, "utf-8").trim();
+			const packedRefsPath = path.join(root, "packed-refs");
+			if (!fs.existsSync(packedRefsPath)) continue;
+			const packedRef = fs.readFileSync(packedRefsPath, "utf-8")
+				.split(/\r?\n/)
+				.find(line => line.endsWith(` ${ref}`));
+			if (packedRef) return packedRef.split(" ", 1)[0];
+		}
+	} catch {
+		return undefined;
+	}
+	return undefined;
+}
+
+function readGitCommitSha(packageRoot: string): string | undefined {
+	const looseSha = readLooseGitCommitSha(packageRoot);
+	if (looseSha) return looseSha;
+	try {
+		return execFileSync("git", ["rev-parse", "--short=7", "HEAD"], {
+			cwd: packageRoot,
+			encoding: "utf-8",
+			stdio: ["ignore", "pipe", "ignore"],
+		}).trim();
+	} catch {
+		return undefined;
+	}
+}
+
+/**
+ * Resolve the running Bobbit package's version and provenance. A `.git` marker
+ * at the package root distinguishes a source checkout (including worktrees)
+ * from an npm-installed package without accidentally reading the host
+ * project's commit from a parent repository.
+ */
+export function resolveBobbitAppInfo(
+	packageRoot = BOBBIT_PACKAGE_ROOT,
+	resolveCommitSha: (root: string) => string | undefined = readGitCommitSha,
+): BobbitAppInfo {
+	const version = readPackageVersion(packageRoot);
+	if (!fs.existsSync(path.join(packageRoot, ".git"))) {
+		return { version, buildType: "installed" };
+	}
+
+	const rawCommitSha = resolveCommitSha(packageRoot)?.trim();
+	const commitSha = rawCommitSha && /^[0-9a-f]{7,40}$/i.test(rawCommitSha)
+		? rawCommitSha.slice(0, 7).toLowerCase()
+		: undefined;
+	return {
+		version,
+		buildType: "source",
+		...(commitSha ? { commitSha } : {}),
+	};
+}
+
+export const BOBBIT_APP_INFO: Readonly<BobbitAppInfo> = Object.freeze(resolveBobbitAppInfo());

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -34,6 +34,7 @@ import {
 import { recordBootTiming, readBootTimings, BOOT_TIMING_FILE } from "./dev-boot-timing.js";
 import { bootLog, bootMark, makePhaseTimer, SLOW_PHASE_MS } from "./boot-profile.js";
 import { touchGatewayRestartSentinel } from "./harness-signal.js";
+import { BOBBIT_APP_INFO } from "./app-info.js";
 import { isSetupComplete } from "./setup-status.js";
 export { isSetupComplete };
 import { WebSocketServer, type WebSocket } from "ws";
@@ -4316,6 +4317,13 @@ async function handleApiRoute(
 		if (sandboxScope.goalIds.has(task.goalId)) return true;
 		json({ error: "Forbidden: task is outside the sandbox scope", code: "SANDBOX_SCOPE_VIOLATION" }, 403);
 		return false;
+	}
+
+	// GET /api/app-info — report the running package version and whether this is
+	// an installed package or a source checkout (with its short commit SHA).
+	if (url.pathname === "/api/app-info" && req.method === "GET") {
+		json(BOBBIT_APP_INFO);
+		return;
 	}
 
 	// GET /api/harness-status — report whether the dev restart harness is active

--- a/tests2/browser/journeys/project-settings.journey.spec.ts
+++ b/tests2/browser/journeys/project-settings.journey.spec.ts
@@ -240,6 +240,30 @@ test.describe("Journey: Settings App Version", () => {
 		expect(restartBox).not.toBeNull();
 		expect(headerBox!.y + headerBox!.height).toBeLessThanOrEqual(restartBox!.y);
 	});
+
+	test("retries app info after a transient failure", async ({ page }) => {
+		let appInfoAvailable = false;
+		let attempts = 0;
+		await page.route("**/api/app-info", route => {
+			attempts++;
+			return appInfoAvailable
+				? route.fulfill({ json: { version: "0.14.1", buildType: "installed" } })
+				: route.fulfill({ status: 503, json: { error: "temporarily unavailable" } });
+		});
+		await openApp(page);
+		await navigateToHash(page, "#/settings/system/general");
+
+		await expect.poll(() => attempts).toBeGreaterThan(0);
+		await expect(page.getByTestId("settings-app-version")).toHaveCount(0);
+
+		await navigateToHash(page, "#/");
+		appInfoAvailable = true;
+		await navigateToHash(page, "#/settings/system/general");
+
+		await expect(page.getByTestId("app-header-row").getByTestId("settings-app-version"))
+			.toHaveText("Bobbit v0.14.1");
+		expect(attempts).toBeGreaterThan(1);
+	});
 });
 
 // Ported from settings-restart-button.spec.ts (audit: project-settings GAP,

--- a/tests2/browser/journeys/project-settings.journey.spec.ts
+++ b/tests2/browser/journeys/project-settings.journey.spec.ts
@@ -205,6 +205,43 @@ test.describe("Journey: Project Assistant", () => {
 	});
 });
 
+test.describe("Journey: Settings App Version", () => {
+	test("installed builds show the package version", async ({ page }) => {
+		await page.route("**/api/app-info", route => route.fulfill({
+			json: { version: "0.14.1", buildType: "installed" },
+		}));
+		await openApp(page);
+		await navigateToHash(page, "#/settings/system/general");
+
+		const appHeader = page.getByTestId("app-header-row");
+		const version = appHeader.getByTestId("settings-app-version");
+		await expect(version).toHaveText("Bobbit v0.14.1");
+		await expect(version).toHaveAttribute("title", "Running from an installed build");
+	});
+
+	test("source builds show the commit in the app header row", async ({ page }) => {
+		await page.route("**/api/app-info", route => route.fulfill({
+			json: { version: "0.14.1", buildType: "source", commitSha: "e3563ba" },
+		}));
+		await page.route("**/api/harness-status", route => route.fulfill({
+			json: { restartAvailable: true },
+		}));
+		await openApp(page);
+		await navigateToHash(page, "#/settings/system/general");
+
+		const appHeader = page.getByTestId("app-header-row");
+		const version = appHeader.getByTestId("settings-app-version");
+		const restart = page.getByRole("button", { name: "Restart Server" });
+		await expect(version).toHaveText("Bobbit v0.14.1 [e3563ba]");
+		await expect(version).toHaveAttribute("title", "Running from source");
+		await expect(restart).toBeVisible();
+		const [headerBox, restartBox] = await Promise.all([appHeader.boundingBox(), restart.boundingBox()]);
+		expect(headerBox).not.toBeNull();
+		expect(restartBox).not.toBeNull();
+		expect(headerBox!.y + headerBox!.height).toBeLessThanOrEqual(restartBox!.y);
+	});
+});
+
 // Ported from settings-restart-button.spec.ts (audit: project-settings GAP,
 // mutant BR63): without the dev harness the Restart Server control must be
 // absent — and stay absent across reload + navigation.

--- a/tests2/core/app-info.test.ts
+++ b/tests2/core/app-info.test.ts
@@ -1,0 +1,56 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { resolveBobbitAppInfo } from "../../src/server/app-info.js";
+
+const tempRoots: string[] = [];
+
+function packageRoot(version = "0.14.1"): string {
+	const root = mkdtempSync(path.join(tmpdir(), "bobbit-app-info-"));
+	tempRoots.push(root);
+	writeFileSync(path.join(root, "package.json"), JSON.stringify({ name: "bobbit", version }), "utf-8");
+	return root;
+}
+
+afterEach(() => {
+	for (const root of tempRoots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+describe("Bobbit app info", () => {
+	it("reports an installed package with only its package version", () => {
+		const root = packageRoot();
+		let commitRead = false;
+
+		expect(resolveBobbitAppInfo(root, () => {
+			commitRead = true;
+			return "e3563ba";
+		})).toEqual({ version: "0.14.1", buildType: "installed" });
+		expect(commitRead).toBe(false);
+	});
+
+	it("reports a source checkout with a normalized short commit SHA", () => {
+		const root = packageRoot();
+		mkdirSync(path.join(root, ".git"));
+
+		expect(resolveBobbitAppInfo(root, () => "E3563BA91A2")).toEqual({
+			version: "0.14.1",
+			buildType: "source",
+			commitSha: "e3563ba",
+		});
+	});
+
+	it("reads the source commit directly from Git metadata", () => {
+		const root = packageRoot();
+		const gitDir = path.join(root, ".git");
+		mkdirSync(path.join(gitDir, "refs", "heads"), { recursive: true });
+		writeFileSync(path.join(gitDir, "HEAD"), "ref: refs/heads/master\n", "utf-8");
+		writeFileSync(path.join(gitDir, "refs", "heads", "master"), "e3563ba91a234567890123456789012345678901\n", "utf-8");
+
+		expect(resolveBobbitAppInfo(root)).toEqual({
+			version: "0.14.1",
+			buildType: "source",
+			commitSha: "e3563ba",
+		});
+	});
+});

--- a/tests2/integration/app-info-api.test.ts
+++ b/tests2/integration/app-info-api.test.ts
@@ -1,0 +1,18 @@
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { test, expect } from "./_e2e/in-process-harness.js";
+import { apiFetch } from "./_e2e/e2e-setup.js";
+
+test.describe("app info API", () => {
+	test("reports the running Bobbit package version and build provenance", async () => {
+		const resp = await apiFetch("/api/app-info");
+		expect(resp.status).toBe(200);
+		const info = await resp.json();
+		const packageVersion = JSON.parse(readFileSync(path.join(process.cwd(), "package.json"), "utf-8")).version;
+		const expectedBuildType = existsSync(path.join(process.cwd(), ".git")) ? "source" : "installed";
+
+		expect(info).toMatchObject({ version: packageVersion, buildType: expectedBuildType });
+		if (expectedBuildType === "source") expect(info.commitSha).toMatch(/^[0-9a-f]{7}$/);
+		else expect(info).not.toHaveProperty("commitSha");
+	});
+});

--- a/tests2/tests-map.json
+++ b/tests2/tests-map.json
@@ -75,6 +75,24 @@
       }
     },
     {
+      "path": "tests2/core/app-info.test.ts",
+      "reason": "Pins installed-versus-source build detection and short commit SHA normalization for the Settings version label.",
+      "execution": {
+        "runner": "vitest",
+        "tier": "unit",
+        "project": "core"
+      }
+    },
+    {
+      "path": "tests2/integration/app-info-api.test.ts",
+      "reason": "Exercises the running package version and build provenance endpoint against a real in-process gateway.",
+      "execution": {
+        "runner": "vitest",
+        "tier": "unit",
+        "project": "integration"
+      }
+    },
+    {
       "path": "tests2/core/unit-inventory-git.test.ts",
       "reason": "Pins the unit inventory audit's optional historical migration source policy with an injected Git reader: the exact absent-path-at-revision error returns empty text while unrelated Git failures remain fatal, without spawning a subprocess.",
       "execution": {


### PR DESCRIPTION
## Summary
- expose the running Bobbit package version and installed/source provenance
- show the version in the Settings route's top app-header action slot
- include the short commit SHA for source checkouts
- cover installed and source formats with unit, API, and browser tests

## Testing
- `npm run check`
- `npx vitest run --config vitest.config.ts tests2/core/app-info.test.ts --silent=passed-only`
- `npx vitest run --config vitest.config.ts tests2/integration/app-info-api.test.ts --silent=passed-only`
- `npx playwright test tests2/browser/journeys/project-settings.journey.spec.ts --config playwright-v2.config.ts --project=browser-v2 --grep "Settings App Version"`

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)