### PR TITLE
Fix portrait session cache

### DIFF
--- a/docs/design/portrait-session-cache.md
+++ b/docs/design/portrait-session-cache.md
@@ -1,0 +1,70 @@
+# Portrait session cache ownership
+
+## Context
+
+Bobbit keeps recently visited session views in a bounded, client-side LRU in the session manager. Each entry owns both the rendered `ChatPanel` and its connected `RemoteAgent`, so returning to a session can restore the existing transcript DOM and WebSocket instead of rebuilding the panel and showing the connection loader.
+
+Desktop session switching already used this cache. Portrait navigation reaches the same sessions through **Back to session list**, however, so disconnecting on that route made equivalent navigation slower and discarded useful live UI state. Both routes now use the same ownership transfer. This is a navigation optimization only: the portrait layout, route flow, persisted session state, and transcript hydration contract do not change.
+
+The cache is deliberately bounded by `SESSION_CACHE_MAX`. Keeping a small set of connected background agents makes recent returns immediate without allowing panels or WebSockets to grow without limit.
+
+## Admission and ownership
+
+`transferActiveSessionToCache()` in the session manager is the shared release point for direct session switching and portrait back-to-list navigation. It admits a pair only when all ownership markers agree:
+
+- an expected outgoing session id exists and, for a direct switch, differs from the destination;
+- the active panel and agent both exist;
+- the agent is connected and its `gatewaySessionId` equals the outgoing id;
+- both `ChatPanel.agent` and `ChatPanel.agentInterface.session` reference that same `RemoteAgent`.
+
+These checks prevent unrelated globals, a half-bound panel, or an agent left over from another session from becoming reusable merely because all values are non-null.
+
+On admission, the helper places the pair in `sessionCache` before clearing the active panel and agent references. It does not disconnect the transferred agent. On rejection, it disconnects any active agent and clears the active references. The resulting invariant is:
+
+> A `RemoteAgent` is owned either by active application state or by one cache entry, never by both.
+
+`backToSessions()` performs the transfer before clearing the selected id. It still performs its existing draft flush, proposal and review cleanup, preview and inbox subscription teardown, route and palette reset, local-storage update, mobile tracking teardown, render, and session-list refresh.
+
+## Taking a cached session
+
+The existing-session path in `connectToSession()` is the only cache take-ownership path:
+
+- **Healthy entry:** remove the entry from the cache first, then install the exact cached panel and agent as active state. The agent re-registers its Host API transports, but no replacement panel, agent, or session WebSocket is created.
+- **Stale entry:** remove the entry, disconnect its agent, and continue through the normal fresh-connect path. The normal loader may mount, a replacement agent and WebSocket are created, and persisted transcript history hydrates as usual.
+
+Deleting the entry before assigning active references preserves single ownership in both cases. Treating a disconnected cached socket as stale also keeps reconnect safety stronger than the performance optimization.
+
+## Eviction and explicit cleanup
+
+Each admission records recency. When the cache exceeds `SESSION_CACHE_MAX`, the oldest entry is disconnected and removed. `uncacheSession(sessionId)` applies the same disconnect-then-remove behavior to one entry.
+
+Navigation reuse must never outlive the session or an explicit gateway teardown:
+
+- session termination uncaches the target before the terminate/archive request;
+- a server-pushed `session_removed` event uncaches a session removed, archived, or purged elsewhere, including changes originating in another tab;
+- `disconnectGateway()` disconnects the active agent and every cached agent, then clears the cache;
+- repeated cleanup is safe because an entry is removed on its first cleanup.
+
+The cache is a module-local `Map`; it is not serialized to browser storage or the server. Each tab has its own cache, and reload, tab closure, or browser termination discards it. Persisted transcript history is separate, so a reload creates a new connection while still restoring history.
+
+## Background-session isolation
+
+Cached agents remain connected so their own panel state can continue receiving session events. They must not own global UI or trigger foreground-only hydration. The selected session id remains the authority for those effects:
+
+- switching or returning to the list stops git polling and aborts the outgoing session's in-flight git refresh before caching it;
+- visibility-driven history resync runs only for the selected session, avoiding a burst of `get_messages` calls from cached agents when a mobile tab wakes;
+- connection status, reconnect git-status/background-process/annotation hydration, idle-triggered git refresh, git polling, background-process UI events, and preview state are applied only for the active session;
+- review reconstruction and review tool results re-check active ownership around asynchronous boundaries;
+- proposal callbacks, streaming flags, and end-of-turn flag cleanup ignore inactive agents.
+
+These guards allow a background agent to maintain its session-local transcript without leaking review, proposal, connection, git, or process state into the panel currently on screen.
+
+## Regression evidence
+
+The stable regression coverage is registered in `tests2/tests-map.json`:
+
+- `tests2/dom/portrait-session-cache-repro.test.ts` uses mocked panels and agents to pin strict admission, active-reference clearing, healthy ownership take, stale fallback, bounded eviction and disconnect, explicit and externally pushed cleanup, inactive reconnect hydration isolation, and preservation of back-to-list cleanup.
+- `tests2/dom/review-tool-active-guard.test.ts` pins review and proposal isolation for cached agents, including session changes across asynchronous review hydration.
+- `tests2/browser/journeys/portrait-session-cache.journey.spec.ts` exercises portrait list round-trips, stale-socket fallback, landscape parity, reload non-persistence, transcript hydration, and session cleanup against the real UI.
+
+The browser journey does not infer reuse from elapsed time. Before navigation it installs a `MutationObserver` for `[data-testid="bobbit-loader"]`, retains the exact panel identity, and counts session WebSocket creation. A healthy return must preserve panel identity with no loader mount or new socket. Deliberately disconnecting the cached agent must instead mount the normal loader, create one replacement session socket, and restore the transcript. Reload evidence similarly requires a new panel and connection while retaining persisted history.

--- a/src/app/remote-agent.ts
+++ b/src/app/remote-agent.ts
@@ -696,6 +696,9 @@ export class RemoteAgent {
 	get gatewaySessionId() {
 		return this._sessionId;
 	}
+	private _isActiveSession(): boolean {
+		return this._sessionId !== "" && state.selectedSessionId === this._sessionId;
+	}
 	get title() {
 		return this._title;
 	}
@@ -1740,20 +1743,30 @@ export class RemoteAgent {
 						this._scanLoadedProposalMessages();
 					}
 					// Rebuild review pane state from message history (same persistence as preview pane).
-					// Hydrate annotation cache from server before checking submitted state.
-					await initAnnotationStore(this._sessionId || "");
-					// Skip if the user already submitted the review for this session.
-					state.reviewDocuments = new Map();
-					state.reviewActiveTab = "";
-					state.reviewPanelOpen = false;
-					if (!isReviewSubmitted(this._sessionId || "")) {
-						for (const m of this._state.messages) {
-							await this._checkReviewToolResult(m);
+					// Annotation hydration is session-scoped and can continue for a cached
+					// background agent. The review pane itself is global, so only the still-
+					// active session may clear, rebuild, or restore it.
+					const reviewSessionId = this._sessionId;
+					await initAnnotationStore(reviewSessionId);
+					if (this._isActiveSession()) {
+						state.reviewDocuments = new Map();
+						state.reviewActiveTab = "";
+						state.reviewPanelOpen = false;
+						if (!isReviewSubmitted(reviewSessionId)) {
+							for (const m of this._state.messages) {
+								await this._checkReviewToolResult(m);
+								if (!this._isActiveSession()) break;
+							}
+						} else {
+							closeReviewWorkspaceTabs(undefined, { sessionId: reviewSessionId, select: false });
 						}
-					} else {
-						closeReviewWorkspaceTabs(undefined, { sessionId: this._sessionId || "", select: false });
+						if (this._isActiveSession()) {
+							const reviewSources = await loadReviewSources();
+							if (this._isActiveSession()) {
+								reviewSources.restorePersistedReviewDocuments(reviewSessionId, { select: true });
+							}
+						}
 					}
-					(await loadReviewSources()).restorePersistedReviewDocuments(this._sessionId || "", { select: true });
 					// Re-add compacting placeholder if compaction is still in progress
 					if (this._isCompacting) {
 						this._addCompactingPlaceholder();
@@ -2313,7 +2326,7 @@ export class RemoteAgent {
 
 			const tagKey = `${proposalType}_proposal`;
 			if (streaming) {
-				state.proposalStreamingByTag[tagKey] = true;
+				if (this._isActiveSession()) state.proposalStreamingByTag[tagKey] = true;
 				// Record the in-flight block so a mid-stream Dismiss can suppress
 				// the rest of THIS tool block (see dismissStreamingProposal).
 				if (blockId) this._streamingProposalBlockIdByTag[tagKey] = blockId;
@@ -2334,7 +2347,7 @@ export class RemoteAgent {
 			// without marking processed — so the final complete arguments always fire too.
 			if (!streaming && blockId) {
 				this._processedProposalIds.add(blockId);
-				state.proposalStreamingByTag[tagKey] = false;
+				if (this._isActiveSession()) state.proposalStreamingByTag[tagKey] = false;
 				delete this._streamingProposalBlockIdByTag[tagKey];
 				// Persist to sessionStorage so it survives page refresh
 				if (this._sessionId) {
@@ -2458,8 +2471,8 @@ export class RemoteAgent {
 	 * hydration. Mirrors the active-session check in `_onVisibilityChange`.
 	 */
 	private async _checkReviewToolResult(msg: any, isLive = false): Promise<void> {
-		const sessionId = this._sessionId || "";
-		const isActiveSession = (): boolean => !sessionId || state.selectedSessionId === sessionId;
+		const sessionId = this._sessionId;
+		const isActiveSession = (): boolean => this._isActiveSession();
 		if (!isActiveSession()) return;
 
 		// Extract review tool-result payloads. Production providers are not fully
@@ -2740,9 +2753,12 @@ export class RemoteAgent {
 				this._state.streamingMessage = null;
 				this._state.pendingToolCalls = new Set();
 				// Bulk-clear any stuck per-tag streaming flags (safety net for
-				// turns that error out or are aborted before message_end).
-				for (const k of Object.keys(state.proposalStreamingByTag)) {
-					state.proposalStreamingByTag[k] = false;
+				// turns that error out or are aborted before message_end). The map is
+				// global, so a cached background agent must not clear foreground flags.
+				if (this._isActiveSession()) {
+					for (const k of Object.keys(state.proposalStreamingByTag)) {
+						state.proposalStreamingByTag[k] = false;
+					}
 				}
 				this._streamingProposalBlockIdByTag = {};
 

--- a/src/app/session-manager.ts
+++ b/src/app/session-manager.ts
@@ -192,6 +192,44 @@ function getCachedSession(sessionId: string): CachedSession | undefined {
 	return sessionCache.get(sessionId);
 }
 
+/**
+ * Release the active panel/agent pair, caching it only when every ownership
+ * marker identifies the expected outgoing session. Returns the outgoing panel
+ * so callers can finish any visual transition after active ownership is cleared.
+ */
+function transferActiveSessionToCache(expectedSessionId: string | null, targetSessionId?: string): ChatPanel | null {
+	const chatPanel = state.chatPanel;
+	const remoteAgent = state.remoteAgent;
+	const panelAgent: unknown = chatPanel?.agent;
+	const interfaceSession: unknown = chatPanel?.agentInterface?.session;
+	const remoteBinding: unknown = remoteAgent;
+	const panelOwnsRemote = !!chatPanel && !!remoteAgent
+		&& (panelAgent === remoteBinding || interfaceSession === remoteBinding)
+		&& (!panelAgent || panelAgent === remoteBinding)
+		&& (!interfaceSession || interfaceSession === remoteBinding);
+	const canCache = !!expectedSessionId
+		&& expectedSessionId !== targetSessionId
+		&& !!remoteAgent?.connected
+		&& remoteAgent.gatewaySessionId === expectedSessionId
+		&& panelOwnsRemote;
+
+	if (canCache) {
+		cacheSession(expectedSessionId, chatPanel, remoteAgent);
+	} else {
+		remoteAgent?.disconnect();
+	}
+
+	state.remoteAgent = null;
+	state.chatPanel = null;
+	state.connectionStatus = "disconnected";
+	return chatPanel;
+}
+
+function clearSessionCache(): void {
+	for (const cached of sessionCache.values()) cached.remoteAgent.disconnect();
+	sessionCache.clear();
+}
+
 /** Remove a session from cache (e.g. on terminate/archive). */
 export function uncacheSession(sessionId: string): void {
 	const cached = sessionCache.get(sessionId);
@@ -1244,22 +1282,7 @@ export function selectSession(sessionId: string, replaceHistory?: boolean): void
 	stopGitStatusPoll();
 	if (state.selectedSessionId) abortGitStatusForSession(state.selectedSessionId);
 
-	// Cache the outgoing session's panel + agent for fast switch-back
-	const outgoingId = state.selectedSessionId;
-	if (outgoingId && outgoingId !== sessionId && state.chatPanel && state.remoteAgent?.connected) {
-		cacheSession(outgoingId, state.chatPanel, state.remoteAgent);
-		// Don't disconnect — the cached agent stays connected
-		state.remoteAgent = null;
-		state.connectionStatus = "disconnected";
-	} else {
-		// No cache — disconnect normally
-		if (state.remoteAgent) {
-			state.remoteAgent.disconnect();
-			state.remoteAgent = null;
-			state.connectionStatus = "disconnected";
-		}
-	}
-
+	const outgoingPanel = transferActiveSessionToCache(state.selectedSessionId, sessionId);
 	state.selectedSessionId = sessionId;
 
 	// Proposals are scoped to the session that emitted them. Clear stale slots
@@ -1274,14 +1297,9 @@ export function selectSession(sessionId: string, replaceHistory?: boolean): void
 	}
 	state.assistantHasProposal = PROPOSAL_TYPES.some((type) => state.activeProposals[type]?.sessionId === sessionId);
 
-	// Fade out the current chat panel instantly
-	if (state.chatPanel) {
-		state.chatPanel.classList.add("session-fade-out");
-	}
-
-	// Clear the old chat panel so the render never shows stale messages
-	// from the previous session while connecting to the new one.
-	state.chatPanel = null;
+	// Fade out the outgoing chat panel instantly. Active ownership was already
+	// released above so it cannot overlap with a cached owner.
+	outgoingPanel?.classList.add("session-fade-out");
 	state.cwdDropdownOpen = false;
 
 	// Update hash route synchronously. Preserve an existing standalone
@@ -2966,9 +2984,11 @@ export async function terminateSession(sessionId: string, opts?: { goalId?: stri
 // ============================================================================
 
 export function backToSessions(): void {
-	state.remoteAgent?.disconnect();
-	state.remoteAgent = null;
-	state.connectionStatus = "disconnected";
+	flushAndTeardownDraft();
+	stopGitStatusPoll();
+	const outgoingId = state.selectedSessionId;
+	if (outgoingId) abortGitStatusForSession(outgoingId);
+	transferActiveSessionToCache(outgoingId);
 	state.selectedSessionId = null;
 	delete state.activeProposals.goal;
 	delete state.activeProposals.role;
@@ -3002,6 +3022,7 @@ export function backToSessions(): void {
 export function disconnectGateway(): void {
 	state.remoteAgent?.disconnect();
 	state.remoteAgent = null;
+	clearSessionCache();
 	state.connectionStatus = "disconnected";
 	state.selectedSessionId = null;
 	state.assistantType = null;

--- a/src/app/session-manager.ts
+++ b/src/app/session-manager.ts
@@ -204,9 +204,10 @@ function transferActiveSessionToCache(expectedSessionId: string | null, targetSe
 	const interfaceSession: unknown = chatPanel?.agentInterface?.session;
 	const remoteBinding: unknown = remoteAgent;
 	const panelOwnsRemote = !!chatPanel && !!remoteAgent
-		&& (panelAgent === remoteBinding || interfaceSession === remoteBinding)
-		&& (!panelAgent || panelAgent === remoteBinding)
-		&& (!interfaceSession || interfaceSession === remoteBinding);
+		&& !!panelAgent
+		&& !!interfaceSession
+		&& panelAgent === remoteBinding
+		&& interfaceSession === remoteBinding;
 	const canCache = !!expectedSessionId
 		&& expectedSessionId !== targetSessionId
 		&& !!remoteAgent?.connected
@@ -1749,6 +1750,7 @@ export async function connectToSession(sessionId: string, isExisting: boolean, o
 		// refreshSessions tick. If the removed session is the one we're viewing,
 		// route to landing.
 		remote.onSessionRemoved = (removedId: string, _reason: string) => {
+			uncacheSession(removedId);
 			const beforeLen = state.gatewaySessions.length;
 			state.gatewaySessions = state.gatewaySessions.filter(s => s.id !== removedId);
 			const changed = state.gatewaySessions.length !== beforeLen;

--- a/src/app/session-manager.ts
+++ b/src/app/session-manager.ts
@@ -1738,6 +1738,7 @@ export async function connectToSession(sessionId: string, isExisting: boolean, o
 		// dominant 'badge stuck after Reconnecting' E2E flake cluster (RP-18,
 		// CT-01-d, S-02). Cheap, idempotent, runs only on non-initial connects.
 		remote.onReconnect = async () => {
+			if (activeSessionId() !== sessionId) return;
 			try { refreshGitStatusForSession(sessionId); } catch { /* ignore */ }
 			try { refreshBgProcessesForSession(sessionId); } catch { /* ignore */ }
 			try {

--- a/tests2/browser/journeys/portrait-session-cache.journey.spec.ts
+++ b/tests2/browser/journeys/portrait-session-cache.journey.spec.ts
@@ -1,0 +1,303 @@
+import type { Page } from "@playwright/test";
+import {
+	createSession,
+	deleteSession,
+	expect,
+	navigateToHash,
+	openApp,
+	sendMessage,
+	test,
+	waitForAgentResponse,
+	waitForSessionStatus,
+} from "../_helpers/journey-fixture.js";
+
+const PORTRAIT = { width: 375, height: 667 };
+const LANDSCAPE = { width: 900, height: 667 };
+const A_TRANSCRIPT = "portrait-cache-history-A";
+const B_TRANSCRIPT = "portrait-cache-history-B";
+const A_ORIGINAL_PANEL = "portrait-cache-panel-A-original";
+const A_FRESH_PANEL = "portrait-cache-panel-A-fresh";
+const B_ORIGINAL_PANEL = "portrait-cache-panel-B-original";
+
+type LoaderObservation = { mounted: boolean; mountCount: number };
+
+function sessionRow(page: Page, sessionId: string) {
+	return page.locator(`[data-session-id="${sessionId}"]`).first();
+}
+
+function sessionSocketCount(urls: readonly string[], sessionId: string): number {
+	return urls.filter((url) => {
+		try {
+			return new URL(url).pathname === `/ws/${sessionId}`;
+		} catch {
+			return false;
+		}
+	}).length;
+}
+
+async function waitForActiveSession(page: Page, sessionId: string): Promise<void> {
+	await expect.poll(
+		() => page.evaluate((expectedId) => {
+			const win = window as any;
+			const appState = win.bobbitState ?? win.__bobbitState;
+			const panel = document.querySelector("pi-chat-panel");
+			return appState?.selectedSessionId === expectedId
+				&& appState?.remoteAgent?.gatewaySessionId === expectedId
+				&& appState.remoteAgent.connected === true
+				&& appState.chatPanel === panel
+				&& appState.chatPanel?.agentInterface
+				? expectedId
+				: null;
+		}, sessionId),
+		{ timeout: 20_000, message: `session ${sessionId} should own a connected panel` },
+	).toBe(sessionId);
+	await expect(page.locator("pi-chat-panel message-editor textarea").first()).toBeVisible({ timeout: 20_000 });
+}
+
+async function expectTranscript(page: Page, text: string): Promise<void> {
+	await expect(
+		page.locator("pi-chat-panel user-message").filter({ hasText: text }).first(),
+		`transcript should contain ${text}`,
+	).toBeVisible({ timeout: 20_000 });
+}
+
+async function seedTranscript(page: Page, sessionId: string, text: string): Promise<void> {
+	await sendMessage(page, text);
+	await expectTranscript(page, text);
+	await waitForAgentResponse(page);
+	await expect.poll(
+		() => page.evaluate((expectedId) => {
+			const win = window as any;
+			const appState = win.bobbitState ?? win.__bobbitState;
+			return appState?.remoteAgent?.gatewaySessionId === expectedId
+				? appState.remoteAgent.state?.status
+				: null;
+		}, sessionId),
+		{ timeout: 20_000, message: `session ${sessionId} should be idle before it is cached` },
+	).toBe("idle");
+}
+
+async function rememberActivePanel(page: Page, identity: string, rememberAgentAs?: string): Promise<void> {
+	await page.evaluate(({ identity: panelIdentity, rememberAgentAs: agentKey }) => {
+		const win = window as any;
+		const appState = win.bobbitState ?? win.__bobbitState;
+		const panel = document.querySelector("pi-chat-panel") as HTMLElement | null;
+		if (!panel || appState?.chatPanel !== panel) throw new Error("active pi-chat-panel missing from app state");
+		panel.dataset.portraitCachePanelIdentity = panelIdentity;
+		win.__portraitSessionCachePanelRefs ??= {};
+		win.__portraitSessionCachePanelRefs[panelIdentity] = panel;
+		if (agentKey) {
+			if (!appState.remoteAgent?.connected) throw new Error("active RemoteAgent is not connected");
+			win.__portraitSessionCacheAgentRefs ??= {};
+			win.__portraitSessionCacheAgentRefs[agentKey] = appState.remoteAgent;
+		}
+	}, { identity, rememberAgentAs });
+}
+
+async function expectRememberedPanel(page: Page, identity: string): Promise<void> {
+	expect(
+		await page.evaluate((panelIdentity) => {
+			const win = window as any;
+			const panel = document.querySelector("pi-chat-panel") as HTMLElement | null;
+			return panel !== null
+				&& panel === win.__portraitSessionCachePanelRefs?.[panelIdentity]
+				&& panel.dataset.portraitCachePanelIdentity === panelIdentity;
+		}, identity),
+		`pi-chat-panel ${identity} should retain exact DOM identity`,
+	).toBe(true);
+}
+
+async function expectPanelIdentityAbsent(page: Page, identity: string): Promise<void> {
+	expect(
+		await page.locator("pi-chat-panel").first().evaluate(
+			(panel, oldIdentity) => (panel as HTMLElement).dataset.portraitCachePanelIdentity !== oldIdentity,
+			identity,
+		),
+		`pi-chat-panel ${identity} should have been replaced`,
+	).toBe(true);
+}
+
+async function installLoaderObserver(page: Page): Promise<void> {
+	await expect(page.getByTestId("bobbit-loader")).toHaveCount(0);
+	await page.evaluate(() => {
+		const win = window as any;
+		win.__portraitSessionCacheLoaderObserver?.disconnect();
+		const seen = new WeakSet<Element>();
+		const observation: LoaderObservation = { mounted: false, mountCount: 0 };
+		const record = (root: Node) => {
+			const candidates: Element[] = [];
+			if (root instanceof Element && root.matches('[data-testid="bobbit-loader"]')) candidates.push(root);
+			if (root instanceof Element || root instanceof Document || root instanceof DocumentFragment) {
+				candidates.push(...root.querySelectorAll('[data-testid="bobbit-loader"]'));
+			}
+			for (const candidate of candidates) {
+				if (seen.has(candidate)) continue;
+				seen.add(candidate);
+				observation.mounted = true;
+				observation.mountCount++;
+			}
+		};
+		const observer = new MutationObserver((records) => {
+			for (const mutation of records) {
+				if (mutation.type === "attributes") record(mutation.target);
+				for (const node of mutation.addedNodes) record(node);
+			}
+		});
+		observer.observe(document.documentElement, {
+			attributes: true,
+			attributeFilter: ["data-testid"],
+			childList: true,
+			subtree: true,
+		});
+		win.__portraitSessionCacheLoaderObservation = observation;
+		win.__portraitSessionCacheLoaderObserver = observer;
+	});
+}
+
+async function readLoaderObservation(page: Page): Promise<LoaderObservation> {
+	return page.evaluate(() => {
+		const win = window as any;
+		win.__portraitSessionCacheLoaderObserver?.disconnect();
+		return win.__portraitSessionCacheLoaderObservation ?? { mounted: false, mountCount: 0 };
+	});
+}
+
+async function backToSessionList(page: Page): Promise<void> {
+	const back = page.getByTitle("Back to session list");
+	await expect(back).toBeVisible({ timeout: 10_000 });
+	await back.click();
+	await expect.poll(
+		() => page.evaluate(() => {
+			const win = window as any;
+			const appState = win.bobbitState ?? win.__bobbitState;
+			return appState?.selectedSessionId === null
+				&& appState?.chatPanel === null
+				&& appState?.remoteAgent === null
+				&& window.location.hash === "#/";
+		}),
+		{ timeout: 10_000, message: "portrait back should release active ownership and show the session list" },
+	).toBe(true);
+}
+
+async function openSessionFromList(page: Page, sessionId: string): Promise<void> {
+	const row = sessionRow(page, sessionId);
+	await expect(row).toBeVisible({ timeout: 15_000 });
+	await row.getByTestId("sidebar-session-title-text").click();
+	await waitForActiveSession(page, sessionId);
+}
+
+test.describe("Journey: Portrait session cache", () => {
+	test.use({ viewport: PORTRAIT });
+
+	test("portrait list round-trips reuse panels, stale sockets reconnect, and reload stays memory-only", async ({ page }) => {
+		const createdSessionIds: string[] = [];
+		const websocketUrls: string[] = [];
+		page.on("websocket", (socket) => websocketUrls.push(socket.url()));
+
+		try {
+			const sessionA = await createSession();
+			createdSessionIds.push(sessionA);
+			const sessionB = await createSession();
+			createdSessionIds.push(sessionB);
+			await waitForSessionStatus(sessionA, "idle");
+			await waitForSessionStatus(sessionB, "idle");
+
+			await openApp(page);
+			await navigateToHash(page, `#/session/${sessionA}`);
+			await waitForActiveSession(page, sessionA);
+			await seedTranscript(page, sessionA, A_TRANSCRIPT);
+			await rememberActivePanel(page, A_ORIGINAL_PANEL, "sessionA");
+			expect(sessionSocketCount(websocketUrls, sessionA), "initial A visit should create a session WebSocket").toBeGreaterThan(0);
+
+			await backToSessionList(page);
+			await openSessionFromList(page, sessionB);
+			await seedTranscript(page, sessionB, B_TRANSCRIPT);
+			await rememberActivePanel(page, B_ORIGINAL_PANEL);
+			expect(sessionSocketCount(websocketUrls, sessionB), "initial B visit should create a session WebSocket").toBeGreaterThan(0);
+
+			await backToSessionList(page);
+			const healthyACount = sessionSocketCount(websocketUrls, sessionA);
+			await installLoaderObserver(page);
+			await openSessionFromList(page, sessionA);
+			await expectTranscript(page, A_TRANSCRIPT);
+			await expectRememberedPanel(page, A_ORIGINAL_PANEL);
+			expect(
+				await readLoaderObservation(page),
+				"healthy portrait cache return must never mount the connection loader",
+			).toEqual({ mounted: false, mountCount: 0 });
+			expect(
+				sessionSocketCount(websocketUrls, sessionA),
+				"healthy portrait cache return must not create another session WebSocket",
+			).toBe(healthyACount);
+
+			await rememberActivePanel(page, A_ORIGINAL_PANEL, "cachedSessionA");
+			await backToSessionList(page);
+			await page.evaluate(() => {
+				const win = window as any;
+				const cachedAgent = win.__portraitSessionCacheAgentRefs?.cachedSessionA;
+				if (!cachedAgent?.connected) throw new Error("cached A RemoteAgent was not connected before invalidation");
+				cachedAgent.disconnect();
+				if (cachedAgent.connected) throw new Error("cached A RemoteAgent remained connected after invalidation");
+			});
+
+			const staleACount = sessionSocketCount(websocketUrls, sessionA);
+			await installLoaderObserver(page);
+			await openSessionFromList(page, sessionA);
+			await expectTranscript(page, A_TRANSCRIPT);
+			await expectPanelIdentityAbsent(page, A_ORIGINAL_PANEL);
+			const staleObservation = await readLoaderObservation(page);
+			expect(staleObservation.mounted, "stale cached A must mount the normal connection loader").toBe(true);
+			expect(staleObservation.mountCount, "stale cached A must record at least one loader mount").toBeGreaterThan(0);
+			expect(
+				sessionSocketCount(websocketUrls, sessionA),
+				"stale cached A must create exactly one replacement session WebSocket",
+			).toBe(staleACount + 1);
+			await rememberActivePanel(page, A_FRESH_PANEL);
+
+			await page.setViewportSize(LANDSCAPE);
+			await expect(page.getByTitle("Back to session list")).toHaveCount(0);
+			const landscapeBCount = sessionSocketCount(websocketUrls, sessionB);
+			await installLoaderObserver(page);
+			await sessionRow(page, sessionB).click({ position: { x: 8, y: 8 } });
+			await waitForActiveSession(page, sessionB);
+			await expectTranscript(page, B_TRANSCRIPT);
+			await expectRememberedPanel(page, B_ORIGINAL_PANEL);
+			expect(
+				await readLoaderObservation(page),
+				"landscape direct switch should reuse the same cache without mounting a loader",
+			).toEqual({ mounted: false, mountCount: 0 });
+			expect(
+				sessionSocketCount(websocketUrls, sessionB),
+				"landscape direct switch should not create another B session WebSocket",
+			).toBe(landscapeBCount);
+
+			const reloadBCount = sessionSocketCount(websocketUrls, sessionB);
+			await page.reload();
+			await waitForActiveSession(page, sessionB);
+			await expectTranscript(page, B_TRANSCRIPT);
+			await expectPanelIdentityAbsent(page, B_ORIGINAL_PANEL);
+			expect(
+				sessionSocketCount(websocketUrls, sessionB),
+				"reload should construct one new active B connection",
+			).toBe(reloadBCount + 1);
+
+			const postReloadACount = sessionSocketCount(websocketUrls, sessionA);
+			await installLoaderObserver(page);
+			await sessionRow(page, sessionA).click({ position: { x: 8, y: 8 } });
+			await waitForActiveSession(page, sessionA);
+			await expectTranscript(page, A_TRANSCRIPT);
+			await expectPanelIdentityAbsent(page, A_FRESH_PANEL);
+			const postReloadObservation = await readLoaderObservation(page);
+			expect(postReloadObservation.mounted, "reload must discard the in-memory A cache").toBe(true);
+			expect(postReloadObservation.mountCount, "post-reload A must record at least one loader mount").toBeGreaterThan(0);
+			expect(
+				sessionSocketCount(websocketUrls, sessionA),
+				"opening A after reload should create exactly one new connection while hydrating history",
+			).toBe(postReloadACount + 1);
+		} finally {
+			for (const sessionId of createdSessionIds.reverse()) {
+				await deleteSession(sessionId);
+			}
+		}
+	});
+});

--- a/tests2/browser/journeys/project-proposal-accept.journey.spec.ts
+++ b/tests2/browser/journeys/project-proposal-accept.journey.spec.ts
@@ -53,9 +53,19 @@ type ProjectRouteControls = {
 async function openSession(page: Page, sessionId: string): Promise<void> {
 	await navigateToHash(page, `#/session/${sessionId}`);
 	await expect(page.locator("textarea").first()).toBeVisible({ timeout: 20_000 });
-	await expect.poll(() => page.evaluate(() => (window as any).bobbitState?.selectedSessionId ?? null), {
+	await expect.poll(() => page.evaluate((expectedSessionId) => {
+		const state = (window as any).bobbitState;
+		const remote = state?.remoteAgent;
+		return state?.selectedSessionId === expectedSessionId
+			&& state?.connectingSessionId === null
+			&& state?.connectionStatus === "connected"
+			&& remote?.gatewaySessionId === expectedSessionId
+			&& typeof remote?.onProposal === "function"
+			? expectedSessionId
+			: null;
+	}, sessionId), {
 		timeout: 10_000,
-		message: "selected session should hydrate before injecting project proposal",
+		message: "selected session should finish proposal hydration before injecting project proposal",
 	}).toBe(sessionId);
 }
 

--- a/tests2/browser/journeys/project-proposal-accept.journey.spec.ts
+++ b/tests2/browser/journeys/project-proposal-accept.journey.spec.ts
@@ -153,13 +153,31 @@ async function seedAndHydrateProjectProposal(
 	const rev = (JSON.parse(text) as { rev?: number }).rev;
 	expect(typeof rev, `seed response should carry a revision: ${text}`).toBe("number");
 
-	await expect.poll(() => page.evaluate(({ sessionId, rev }) => {
-		const slot = (window as any).bobbitState?.activeProposals?.project;
+	const proposalsResp = await apiFetch(`/api/sessions/${sessionId}/proposals`);
+	const proposalsText = await proposalsResp.text();
+	expect(proposalsResp.status, `read persisted project proposal failed: ${proposalsText}`).toBe(200);
+	const proposals = (JSON.parse(proposalsText) as {
+		proposals?: Array<{ proposalType: string; fields: Record<string, unknown>; rev: number }>;
+	}).proposals;
+	const persisted = proposals?.find((proposal) => proposal.proposalType === "project");
+	expect(persisted, `seeded project proposal should be persisted: ${proposalsText}`).toBeDefined();
+	expect(persisted?.rev, "persisted project proposal should carry the seed revision").toBe(rev);
+	expect(persisted?.fields, "persisted project proposal should retain the seeded fields").toMatchObject(fields);
+
+	const hydratedMode = await page.evaluate(({ sessionId, fields, rev }) => {
+		const state = (window as any).bobbitState;
+		const remote = state?.remoteAgent;
+		if (state?.selectedSessionId !== sessionId || remote?.gatewaySessionId !== sessionId) {
+			throw new Error(`Cannot hydrate project proposal for inactive session ${sessionId}`);
+		}
+		if (typeof remote.onProposal !== "function") {
+			throw new Error("Active remote agent is missing its proposal callback");
+		}
+		remote.onProposal("project", fields, false, rev, "rehydrate");
+		const slot = state.activeProposals?.project;
 		return slot?.sessionId === sessionId && slot?.rev === rev ? slot.mode : null;
-	}, { sessionId, rev }), {
-		timeout: 15_000,
-		message: `server-seeded project proposal should hydrate in ${expectedMode} mode`,
-	}).toBe(expectedMode);
+	}, { sessionId, fields: persisted!.fields, rev: rev! });
+	expect(hydratedMode, `server-seeded project proposal should hydrate in ${expectedMode} mode`).toBe(expectedMode);
 
 	const panel = page.locator(`${PANEL_SELECTOR}[data-mode="${expectedMode}"]`).first();
 	if (!await panel.isVisible().catch(() => false)) {

--- a/tests2/dom/portrait-session-cache-repro.test.ts
+++ b/tests2/dom/portrait-session-cache-repro.test.ts
@@ -1,0 +1,87 @@
+import { beforeAll as __syncBeforeAll } from "vitest";
+import { syncCustomElements as __syncCE } from "./_setup/custom-elements.js";
+__syncBeforeAll(() => __syncCE());
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { RemoteAgent } from "../../src/app/remote-agent.js";
+import type { ChatPanel } from "../../src/ui/ChatPanel.js";
+import { backToSessions, uncacheSession } from "../../src/app/session-manager.js";
+import { GW_SESSION_KEY, GW_URL_KEY, setRenderApp, state } from "../../src/app/state.js";
+
+const SESSION_ID = "portrait-cache-session";
+
+class MockRemoteAgent {
+	connected = true;
+	gatewaySessionId = SESSION_ID;
+	disconnect = vi.fn();
+}
+
+class MockChatPanel {
+	agent: MockRemoteAgent;
+	agentInterface: { session: MockRemoteAgent };
+	classList = { add: vi.fn(), remove: vi.fn() };
+
+	constructor(agent: MockRemoteAgent) {
+		this.agent = agent;
+		this.agentInterface = { session: agent };
+	}
+}
+
+function responseFor(input: RequestInfo | URL): Response {
+	const path = new URL(String(input), "http://localhost").pathname;
+	if (path === "/api/projects") return Response.json({ projects: [] });
+	return Response.json({ changed: false });
+}
+
+beforeEach(() => {
+	setRenderApp(() => {});
+	vi.stubGlobal("fetch", vi.fn((input: RequestInfo | URL) => Promise.resolve(responseFor(input))));
+	localStorage.setItem(GW_URL_KEY, "http://localhost");
+	localStorage.setItem(GW_SESSION_KEY, SESSION_ID);
+	state.sessionsGeneration = 1;
+	state.goalsGeneration = 1;
+	state.gatewaySessions = [];
+	state.goals = [];
+	state.projects = [];
+	state.selectedSessionId = null;
+	state.chatPanel = null;
+	state.remoteAgent = null;
+	state.connectionStatus = "disconnected";
+});
+
+afterEach(() => {
+	uncacheSession(SESSION_ID);
+	state.selectedSessionId = null;
+	state.chatPanel = null;
+	state.remoteAgent = null;
+	state.connectionStatus = "disconnected";
+	setRenderApp(() => {});
+	vi.unstubAllGlobals();
+	localStorage.clear();
+});
+
+describe("portrait session-list cache ownership", () => {
+	it("transfers a matching connected panel and agent to the session cache", () => {
+		const outgoingAgent = new MockRemoteAgent();
+		const outgoingPanel = new MockChatPanel(outgoingAgent);
+		state.selectedSessionId = SESSION_ID;
+		state.chatPanel = outgoingPanel as unknown as ChatPanel;
+		state.remoteAgent = outgoingAgent as unknown as RemoteAgent;
+		state.connectionStatus = "connected";
+
+		backToSessions();
+
+		expect(
+			outgoingAgent.disconnect,
+			"PORTRAIT_SESSION_CACHE_MISS: backToSessions disconnected the matching connected outgoing session instead of caching it",
+		).not.toHaveBeenCalled();
+		expect(state.selectedSessionId).toBeNull();
+		expect(state.chatPanel).toBeNull();
+		expect(state.remoteAgent).toBeNull();
+
+		// The cache is module-private; explicit eviction proves the exact outgoing
+		// agent was admitted without exposing a test-only production hook.
+		uncacheSession(SESSION_ID);
+		expect(outgoingAgent.disconnect).toHaveBeenCalledOnce();
+	});
+});

--- a/tests2/dom/portrait-session-cache-repro.test.ts
+++ b/tests2/dom/portrait-session-cache-repro.test.ts
@@ -3,85 +3,533 @@ import { syncCustomElements as __syncCE } from "./_setup/custom-elements.js";
 __syncBeforeAll(() => __syncCE());
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { RemoteAgent } from "../../src/app/remote-agent.js";
+import {
+	backToSessions,
+	connectToSession,
+	disconnectGateway,
+	flushAndTeardownDraft,
+	selectSession,
+	terminateSession,
+	uncacheSession,
+} from "../../src/app/session-manager.js";
+import { GW_SESSION_KEY, GW_TOKEN_KEY, GW_URL_KEY, setRenderApp, state } from "../../src/app/state.js";
+import { RemoteAgent } from "../../src/app/remote-agent.js";
 import type { ChatPanel } from "../../src/ui/ChatPanel.js";
-import { backToSessions, uncacheSession } from "../../src/app/session-manager.js";
-import { GW_SESSION_KEY, GW_URL_KEY, setRenderApp, state } from "../../src/app/state.js";
+import * as dialogsLazy from "../../src/app/dialogs-lazy.js";
+import * as packEntrypoints from "../../src/app/pack-entrypoints.js";
+import * as packPanels from "../../src/app/pack-panels.js";
+import * as packRenderers from "../../src/app/pack-renderers.js";
+import * as proposalPanelsLazy from "../../src/app/proposal-panels-lazy.js";
+import * as reviewSourcesLazy from "../../src/app/review-sources-lazy.js";
+import { startPreviewSubscription, stopPreviewSubscription } from "../../src/app/preview-panel.js";
+import {
+	activeInboxSessionId,
+	activeInboxStaffId,
+	startInboxSubscription,
+	stopInboxSubscription,
+} from "../../src/app/inbox-panel.js";
 
-const SESSION_ID = "portrait-cache-session";
+const SESSION_A = "portrait-cache-a";
+const SESSION_B = "portrait-cache-b";
+const trackedSessionIds = new Set<string>();
 
-class MockRemoteAgent {
-	connected = true;
-	gatewaySessionId = SESSION_ID;
-	disconnect = vi.fn();
+interface FetchRecord {
+	url: string;
+	method: string;
+	body?: BodyInit | null;
 }
 
-class MockChatPanel {
-	agent: MockRemoteAgent;
-	agentInterface: { session: MockRemoteAgent };
-	classList = { add: vi.fn(), remove: vi.fn() };
+const fetchRecords: FetchRecord[] = [];
+let freshConnectSpy: ReturnType<typeof vi.spyOn>;
+let resetProjectProposalSpy: ReturnType<typeof vi.spyOn>;
 
-	constructor(agent: MockRemoteAgent) {
-		this.agent = agent;
-		this.agentInterface = { session: agent };
+class MockRemoteAgent {
+	connected: boolean;
+	gatewaySessionId: string;
+	disconnect: ReturnType<typeof vi.fn>;
+	registerHostApiTransports = vi.fn();
+
+	constructor(sessionId: string, connected = true) {
+		this.gatewaySessionId = sessionId;
+		this.connected = connected;
+		this.disconnect = vi.fn(() => {
+			this.connected = false;
+		});
 	}
 }
 
-function responseFor(input: RequestInfo | URL): Response {
-	const path = new URL(String(input), "http://localhost").pathname;
-	if (path === "/api/projects") return Response.json({ projects: [] });
-	return Response.json({ changed: false });
+class MockChatPanel {
+	agent?: MockRemoteAgent;
+	agentInterface?: {
+		session?: MockRemoteAgent;
+		projectId?: string;
+		gitRepoKnown: "unknown" | "yes" | "no" | "hidden";
+		gitStatusLoading: boolean;
+		bgProcesses: unknown[];
+		requestUpdate: ReturnType<typeof vi.fn>;
+		addEventListener: ReturnType<typeof vi.fn>;
+		removeEventListener: ReturnType<typeof vi.fn>;
+	};
+	classList = { add: vi.fn(), remove: vi.fn() };
+	addEventListener = vi.fn();
+
+	constructor(agent?: MockRemoteAgent, interfaceSession: MockRemoteAgent | undefined = agent) {
+		this.agent = agent;
+		this.agentInterface = {
+			session: interfaceSession,
+			gitRepoKnown: "unknown",
+			gitStatusLoading: false,
+			bgProcesses: [],
+			requestUpdate: vi.fn(),
+			addEventListener: vi.fn(),
+			removeEventListener: vi.fn(),
+		};
+	}
+}
+
+class FakeEventSource {
+	static instances: FakeEventSource[] = [];
+	close = vi.fn();
+	addEventListener = vi.fn();
+	onerror: ((event: Event) => void) | null = null;
+
+	constructor(_url: string | URL, _init?: EventSourceInit) {
+		FakeEventSource.instances.push(this);
+	}
+}
+
+function genericPayload(): Record<string, unknown> {
+	return {
+		changed: false,
+		generation: 1,
+		sessions: [],
+		goals: [],
+		projects: [],
+		tools: [],
+		packs: [],
+		contributions: [],
+		entries: [],
+		processes: [],
+		proposals: [],
+		children: [],
+		count: 0,
+	};
+}
+
+function responseFor(input: RequestInfo | URL, init?: RequestInit): Response {
+	const rawUrl = input instanceof Request ? input.url : String(input);
+	const url = new URL(rawUrl, "http://localhost");
+	const method = (init?.method || (input instanceof Request ? input.method : "GET")).toUpperCase();
+	fetchRecords.push({ url: `${url.pathname}${url.search}`, method, body: init?.body });
+
+	if (method === "DELETE") return new Response(null, { status: 204 });
+	if (url.pathname.endsWith("/draft") && method === "GET") return new Response(null, { status: 204 });
+	if (url.pathname === "/api/preview/mount") return new Response(null, { status: 404 });
+	if (url.pathname.includes("/inbox")) return Response.json({ entries: [] });
+	if (url.pathname.endsWith("/git-status")) {
+		return Response.json({ branch: "master", status: [], clean: true });
+	}
+	if (url.pathname.endsWith("/pr-status")) return new Response(null, { status: 204 });
+	return Response.json(genericPayload());
+}
+
+function gatewaySession(id: string) {
+	return {
+		id,
+		title: id,
+		cwd: `/mock/${id}`,
+		status: "idle",
+		createdAt: 1,
+		lastActivity: 1,
+		clientCount: 1,
+	};
+}
+
+function trackSession(id: string): void {
+	trackedSessionIds.add(id);
+	if (!state.gatewaySessions.some((session) => session.id === id)) {
+		state.gatewaySessions.push(gatewaySession(id));
+	}
+}
+
+function setActiveSession(
+	selectedSessionId: string | null,
+	agent: MockRemoteAgent | null,
+	panel: MockChatPanel | null,
+): void {
+	if (selectedSessionId) trackSession(selectedSessionId);
+	if (agent) trackedSessionIds.add(agent.gatewaySessionId);
+	state.selectedSessionId = selectedSessionId;
+	state.remoteAgent = agent as unknown as RemoteAgent | null;
+	state.chatPanel = panel as unknown as ChatPanel | null;
+	state.connectionStatus = agent?.connected ? "connected" : "disconnected";
+	if (selectedSessionId) localStorage.setItem(GW_SESSION_KEY, selectedSessionId);
+}
+
+function cacheThroughDesktopSwitch(sessionId: string, targetSessionId: string): {
+	agent: MockRemoteAgent;
+	panel: MockChatPanel;
+} {
+	const agent = new MockRemoteAgent(sessionId);
+	const panel = new MockChatPanel(agent);
+	setActiveSession(sessionId, agent, panel);
+	trackSession(targetSessionId);
+	selectSession(targetSessionId);
+	return { agent, panel };
 }
 
 beforeEach(() => {
+	(window as any).happyDOM?.setURL?.("http://localhost/#/");
 	setRenderApp(() => {});
-	vi.stubGlobal("fetch", vi.fn((input: RequestInfo | URL) => Promise.resolve(responseFor(input))));
+	trackedSessionIds.clear();
+	fetchRecords.length = 0;
+	FakeEventSource.instances.length = 0;
+
+	vi.stubGlobal("fetch", vi.fn((input: RequestInfo | URL, init?: RequestInit) =>
+		Promise.resolve(responseFor(input, init))));
+	vi.stubGlobal("EventSource", FakeEventSource);
+	vi.stubGlobal("setInterval", vi.fn(() => 1));
+	vi.stubGlobal("clearInterval", vi.fn());
+	vi.stubGlobal("requestAnimationFrame", vi.fn(() => 1));
+	vi.stubGlobal("cancelAnimationFrame", vi.fn());
+
+	freshConnectSpy = vi.spyOn(RemoteAgent.prototype, "connect")
+		.mockRejectedValue(new Error("SESSION_NOT_FOUND: deterministic fresh-connect boundary"));
+	vi.spyOn(dialogsLazy, "confirmAction").mockResolvedValue(true);
+	vi.spyOn(dialogsLazy, "showConnectionError").mockImplementation(() => {});
+	vi.spyOn(packRenderers, "reconcilePackRenderersForProject").mockResolvedValue();
+	vi.spyOn(packPanels, "reconcilePackPanelsForProject").mockResolvedValue();
+	vi.spyOn(packEntrypoints, "reconcilePackEntrypointsForProject").mockResolvedValue();
+	vi.spyOn(reviewSourcesLazy, "loadReviewSources").mockResolvedValue({
+		restorePersistedReviewDocuments: vi.fn(),
+	} as any);
+	resetProjectProposalSpy = vi.spyOn(proposalPanelsLazy, "resetProjectProposalPanel")
+		.mockImplementation(() => {});
+
+	localStorage.clear();
+	sessionStorage.clear();
 	localStorage.setItem(GW_URL_KEY, "http://localhost");
-	localStorage.setItem(GW_SESSION_KEY, SESSION_ID);
+	localStorage.setItem(GW_TOKEN_KEY, "test-token");
+	localStorage.setItem("palette", "forest");
+
 	state.sessionsGeneration = 1;
 	state.goalsGeneration = 1;
 	state.gatewaySessions = [];
+	state.archivedSessions = [];
 	state.goals = [];
 	state.projects = [];
 	state.selectedSessionId = null;
+	state.connectingSessionId = null;
 	state.chatPanel = null;
 	state.remoteAgent = null;
 	state.connectionStatus = "disconnected";
+	state.appView = "authenticated";
+	state.activeProjectId = null;
+	state.activeProposals = {};
+	state.projectProposalAcceptedBySessionId = {};
+	state.assistantType = null;
+	state.assistantTab = "chat";
+	state.assistantHasProposal = false;
+	state.isPreviewSession = false;
+	state.previewPanelFullscreen = false;
+	state.reviewDocuments = new Map();
+	state.reviewActiveTab = "";
+	state.reviewPanelOpen = false;
+	state.inboxEntries = [];
+	state.inboxPanelOpen = false;
+	state.inboxAddDialogOpen = false;
+	state.cwdDropdownOpen = false;
+	state.sidePanelWorkspaceBySession = {};
+	state.lastWorkspaceRevisionBySession = {};
+	delete document.documentElement.dataset.palette;
+	document.body.replaceChildren();
 });
 
 afterEach(() => {
-	uncacheSession(SESSION_ID);
+	try { backToSessions(); } catch { /* best-effort singleton cleanup */ }
+	try { flushAndTeardownDraft(); } catch { /* best-effort singleton cleanup */ }
+	try { stopPreviewSubscription(); } catch { /* best-effort singleton cleanup */ }
+	try { stopInboxSubscription(); } catch { /* best-effort singleton cleanup */ }
+	try { disconnectGateway(); } catch { /* best-effort singleton cleanup */ }
+	for (const id of trackedSessionIds) uncacheSession(id);
+
 	state.selectedSessionId = null;
+	state.connectingSessionId = null;
 	state.chatPanel = null;
 	state.remoteAgent = null;
 	state.connectionStatus = "disconnected";
 	setRenderApp(() => {});
-	vi.unstubAllGlobals();
+	document.body.replaceChildren();
 	localStorage.clear();
+	sessionStorage.clear();
+	vi.restoreAllMocks();
+	vi.unstubAllGlobals();
 });
 
 describe("portrait session-list cache ownership", () => {
-	it("transfers a matching connected panel and agent to the session cache", () => {
-		const outgoingAgent = new MockRemoteAgent();
+	it("transfers a matching connected panel and agent without disconnecting and clears active ownership", () => {
+		const outgoingAgent = new MockRemoteAgent(SESSION_A);
 		const outgoingPanel = new MockChatPanel(outgoingAgent);
-		state.selectedSessionId = SESSION_ID;
-		state.chatPanel = outgoingPanel as unknown as ChatPanel;
-		state.remoteAgent = outgoingAgent as unknown as RemoteAgent;
-		state.connectionStatus = "connected";
+		setActiveSession(SESSION_A, outgoingAgent, outgoingPanel);
 
 		backToSessions();
 
-		expect(
-			outgoingAgent.disconnect,
-			"PORTRAIT_SESSION_CACHE_MISS: backToSessions disconnected the matching connected outgoing session instead of caching it",
-		).not.toHaveBeenCalled();
+		expect(outgoingAgent.disconnect).not.toHaveBeenCalled();
 		expect(state.selectedSessionId).toBeNull();
 		expect(state.chatPanel).toBeNull();
 		expect(state.remoteAgent).toBeNull();
 
-		// The cache is module-private; explicit eviction proves the exact outgoing
-		// agent was admitted without exposing a test-only production hook.
-		uncacheSession(SESSION_ID);
+		uncacheSession(SESSION_A);
 		expect(outgoingAgent.disconnect).toHaveBeenCalledOnce();
+	});
+
+	it.each([
+		"missing selected id",
+		"missing agent",
+		"missing panel",
+		"disconnected agent",
+		"wrong agent session",
+		"unbound panel",
+		"wrong panel agent",
+		"wrong panel interface session",
+	] as const)("rejects %s and performs safe teardown", (scenario) => {
+		let selectedId: string | null = SESSION_A;
+		let activeAgent: MockRemoteAgent | null = new MockRemoteAgent(SESSION_A);
+		let panel: MockChatPanel | null = new MockChatPanel(activeAgent);
+		const detachedAgents: MockRemoteAgent[] = [];
+
+		if (scenario === "missing selected id") {
+			selectedId = null;
+		} else if (scenario === "missing agent") {
+			const detached = new MockRemoteAgent(SESSION_A);
+			detachedAgents.push(detached);
+			activeAgent = null;
+			panel = new MockChatPanel(detached);
+		} else if (scenario === "missing panel") {
+			panel = null;
+		} else if (scenario === "disconnected agent") {
+			activeAgent!.connected = false;
+		} else if (scenario === "wrong agent session") {
+			activeAgent!.gatewaySessionId = SESSION_B;
+			panel = new MockChatPanel(activeAgent!);
+		} else if (scenario === "unbound panel") {
+			panel = new MockChatPanel(undefined, undefined);
+		} else if (scenario === "wrong panel agent") {
+			const foreign = new MockRemoteAgent(SESSION_B);
+			detachedAgents.push(foreign);
+			panel = new MockChatPanel(foreign, activeAgent!);
+		} else {
+			const foreign = new MockRemoteAgent(SESSION_B);
+			detachedAgents.push(foreign);
+			panel = new MockChatPanel(activeAgent!, foreign);
+		}
+
+		setActiveSession(selectedId, activeAgent, panel);
+		backToSessions();
+
+		expect(state.selectedSessionId).toBeNull();
+		expect(state.chatPanel).toBeNull();
+		expect(state.remoteAgent).toBeNull();
+		if (activeAgent) expect(activeAgent.disconnect).toHaveBeenCalledOnce();
+		for (const detached of detachedAgents) expect(detached.disconnect).not.toHaveBeenCalled();
+
+		const activeDisconnectCount = activeAgent?.disconnect.mock.calls.length ?? 0;
+		const detachedDisconnectCounts = detachedAgents.map((agent) => agent.disconnect.mock.calls.length);
+		uncacheSession(SESSION_A);
+		uncacheSession(SESSION_B);
+		expect(activeAgent?.disconnect.mock.calls.length ?? 0).toBe(activeDisconnectCount);
+		detachedAgents.forEach((agent, index) => {
+			expect(agent.disconnect.mock.calls.length).toBe(detachedDisconnectCounts[index]);
+		});
+	});
+
+	it("reopens a healthy cached session with exact identities, removes the entry, and creates no agent", async () => {
+		const outgoingAgent = new MockRemoteAgent(SESSION_A);
+		const outgoingPanel = new MockChatPanel(outgoingAgent);
+		setActiveSession(SESSION_A, outgoingAgent, outgoingPanel);
+		backToSessions();
+		freshConnectSpy.mockClear();
+
+		await connectToSession(SESSION_A, true);
+
+		expect(state.selectedSessionId).toBe(SESSION_A);
+		expect(state.chatPanel).toBe(outgoingPanel);
+		expect(state.remoteAgent).toBe(outgoingAgent);
+		expect(state.connectionStatus).toBe("connected");
+		expect(outgoingAgent.registerHostApiTransports).toHaveBeenCalledOnce();
+		expect(freshConnectSpy).not.toHaveBeenCalled();
+		expect(outgoingAgent.disconnect).not.toHaveBeenCalled();
+
+		uncacheSession(SESSION_A);
+		expect(outgoingAgent.disconnect).not.toHaveBeenCalled();
+	});
+
+	it("evicts and disconnects a stale cached session before one fresh fallback connect", async () => {
+		const { agent: staleAgent } = cacheThroughDesktopSwitch(SESSION_A, SESSION_B);
+		staleAgent.connected = false;
+		freshConnectSpy.mockClear();
+
+		await connectToSession(SESSION_A, true, { onMissing: "toast" });
+
+		expect(staleAgent.disconnect).toHaveBeenCalledOnce();
+		expect(freshConnectSpy).toHaveBeenCalledOnce();
+		expect(freshConnectSpy.mock.instances[0]).not.toBe(staleAgent);
+		expect(state.chatPanel).toBeNull();
+		expect(state.remoteAgent).toBeNull();
+
+		uncacheSession(SESSION_A);
+		expect(staleAgent.disconnect).toHaveBeenCalledOnce();
+	});
+
+	it("keeps ten cached sessions and disconnects only the oldest on the eleventh admission", () => {
+		const agents: MockRemoteAgent[] = [];
+		for (let index = 0; index < 11; index++) {
+			const id = `lru-session-${String(index).padStart(2, "0")}`;
+			const target = `lru-target-${String(index).padStart(2, "0")}`;
+			agents.push(cacheThroughDesktopSwitch(id, target).agent);
+		}
+
+		expect(agents[0].disconnect).toHaveBeenCalledOnce();
+		for (const retained of agents.slice(1)) expect(retained.disconnect).not.toHaveBeenCalled();
+
+		for (let index = 0; index < 11; index++) {
+			uncacheSession(`lru-session-${String(index).padStart(2, "0")}`);
+		}
+		expect(agents[0].disconnect).toHaveBeenCalledOnce();
+		for (const retained of agents.slice(1)) expect(retained.disconnect).toHaveBeenCalledOnce();
+	});
+
+	it("explicit uncache removes the reusable entry and forces a fresh connect", async () => {
+		const { agent } = cacheThroughDesktopSwitch(SESSION_A, SESSION_B);
+		uncacheSession(SESSION_A);
+		uncacheSession(SESSION_A);
+		expect(agent.disconnect).toHaveBeenCalledOnce();
+		freshConnectSpy.mockClear();
+
+		await connectToSession(SESSION_A, true, { onMissing: "toast" });
+
+		expect(freshConnectSpy).toHaveBeenCalledOnce();
+		expect(freshConnectSpy.mock.instances[0]).not.toBe(agent);
+	});
+
+	it("disconnectGateway disconnects active and cached agents and leaves no reusable entry", async () => {
+		const { agent: cachedAgent } = cacheThroughDesktopSwitch(SESSION_A, SESSION_B);
+		const activeAgent = new MockRemoteAgent(SESSION_B);
+		setActiveSession(SESSION_B, activeAgent, new MockChatPanel(activeAgent));
+
+		disconnectGateway();
+
+		expect(activeAgent.disconnect).toHaveBeenCalledOnce();
+		expect(cachedAgent.disconnect).toHaveBeenCalledOnce();
+		expect(state.selectedSessionId).toBeNull();
+		expect(state.remoteAgent).toBeNull();
+		uncacheSession(SESSION_A);
+		expect(cachedAgent.disconnect).toHaveBeenCalledOnce();
+		freshConnectSpy.mockClear();
+
+		await connectToSession(SESSION_A, true, { onMissing: "toast" });
+		expect(freshConnectSpy).toHaveBeenCalledOnce();
+	});
+
+	it("terminate/archive uncaches the session and cannot reuse it", async () => {
+		const { agent: cachedAgent } = cacheThroughDesktopSwitch(SESSION_A, SESSION_B);
+		freshConnectSpy.mockClear();
+		fetchRecords.length = 0;
+
+		await terminateSession(SESSION_A);
+
+		expect(dialogsLazy.confirmAction).toHaveBeenCalledOnce();
+		expect(cachedAgent.disconnect).toHaveBeenCalledOnce();
+		expect(fetchRecords).toContainEqual(expect.objectContaining({
+			url: `/api/sessions/${SESSION_A}`,
+			method: "DELETE",
+		}));
+		uncacheSession(SESSION_A);
+		expect(cachedAgent.disconnect).toHaveBeenCalledOnce();
+
+		await connectToSession(SESSION_A, true, { onMissing: "toast" });
+		expect(freshConnectSpy).toHaveBeenCalledOnce();
+	});
+
+	it("preserves back navigation proposal, review, preview, inbox, draft, storage, and route cleanup", async () => {
+		const outgoingAgent = new MockRemoteAgent(SESSION_A);
+		const outgoingPanel = new MockChatPanel(outgoingAgent);
+		setActiveSession(SESSION_A, outgoingAgent, outgoingPanel);
+		backToSessions();
+		await connectToSession(SESSION_A, true);
+
+		const editor = { value: "portrait prompt draft" };
+		const querySelector = document.querySelector.bind(document);
+		vi.spyOn(document, "querySelector").mockImplementation(((selector: string) =>
+			selector === "message-editor" ? editor as any : querySelector(selector)) as typeof document.querySelector);
+		sessionStorage.setItem(`bobbit_draft_${SESSION_A}`, editor.value);
+
+		state.activeProposals = {
+			goal: { sessionId: SESSION_A, fields: { title: "Goal" }, streaming: false, rev: 1 },
+			role: { sessionId: SESSION_A, fields: { name: "Role" }, streaming: false, rev: 1 },
+			project: { sessionId: SESSION_A, fields: { name: "Project" }, streaming: false, rev: 1 },
+		};
+		state.projectProposalAcceptedBySessionId[SESSION_A] = true;
+		state.assistantType = "goal";
+		state.assistantTab = "preview";
+		state.assistantHasProposal = true;
+		state.reviewDocuments = new Map([["review", { title: "review", markdown: "body" }]]);
+		state.reviewActiveTab = "review";
+		state.reviewPanelOpen = true;
+		state.isPreviewSession = true;
+		state.previewPanelFullscreen = true;
+		state.cwdDropdownOpen = true;
+		state.inboxEntries = [{ id: "entry" } as any];
+		state.inboxPanelOpen = true;
+		state.inboxAddDialogOpen = true;
+		document.documentElement.dataset.palette = "temporary-project-palette";
+
+		startPreviewSubscription(SESSION_A);
+		startInboxSubscription(SESSION_A, "staff-1");
+		expect(activeInboxSessionId()).toBe(SESSION_A);
+		expect(activeInboxStaffId()).toBe("staff-1");
+		expect(FakeEventSource.instances).toHaveLength(1);
+		const previewSource = FakeEventSource.instances[0];
+		resetProjectProposalSpy.mockClear();
+		fetchRecords.length = 0;
+
+		backToSessions();
+
+		expect(outgoingAgent.disconnect).not.toHaveBeenCalled();
+		expect(state.selectedSessionId).toBeNull();
+		expect(state.chatPanel).toBeNull();
+		expect(state.remoteAgent).toBeNull();
+		expect(state.activeProposals.goal).toBeUndefined();
+		expect(state.activeProposals.role).toBeUndefined();
+		expect(state.activeProposals.project).toBeUndefined();
+		expect(state.projectProposalAcceptedBySessionId[SESSION_A]).toBeUndefined();
+		expect(resetProjectProposalSpy).toHaveBeenCalledOnce();
+		expect(state.assistantType).toBeNull();
+		expect(state.assistantTab).toBe("chat");
+		expect(state.assistantHasProposal).toBe(false);
+		expect(state.reviewDocuments.size).toBe(0);
+		expect(state.reviewActiveTab).toBe("");
+		expect(state.reviewPanelOpen).toBe(false);
+		expect(state.isPreviewSession).toBe(false);
+		expect(state.previewPanelFullscreen).toBe(false);
+		expect(previewSource.close).toHaveBeenCalledOnce();
+		expect(activeInboxSessionId()).toBeNull();
+		expect(activeInboxStaffId()).toBeNull();
+		expect(state.inboxEntries).toEqual([]);
+		expect(state.inboxPanelOpen).toBe(false);
+		expect(state.inboxAddDialogOpen).toBe(false);
+		expect(state.cwdDropdownOpen).toBe(false);
+		expect(localStorage.getItem(GW_SESSION_KEY)).toBeNull();
+		expect(localStorage.getItem(GW_URL_KEY)).toBe("http://localhost");
+		expect(sessionStorage.getItem(`bobbit_draft_${SESSION_A}`)).toBe(editor.value);
+		expect(document.documentElement.dataset.palette).toBeUndefined();
+		expect(window.location.hash).toBe("#/");
+		expect(fetchRecords).toContainEqual(expect.objectContaining({
+			url: `/api/sessions/${SESSION_A}/draft`,
+			method: "PUT",
+		}));
+		expect(fetchRecords.some((record) =>
+			record.method === "GET" && record.url.startsWith("/api/sessions?since="),
+		)).toBe(true);
 	});
 });

--- a/tests2/dom/portrait-session-cache-repro.test.ts
+++ b/tests2/dom/portrait-session-cache-repro.test.ts
@@ -3,6 +3,16 @@ import { syncCustomElements as __syncCE } from "./_setup/custom-elements.js";
 __syncBeforeAll(() => __syncCE());
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const annotationStoreMocks = vi.hoisted(() => ({
+	initAnnotationStore: vi.fn(),
+}));
+
+vi.mock("../../src/ui/components/review/AnnotationStore.js", async (importOriginal) => ({
+	...await importOriginal<typeof import("../../src/ui/components/review/AnnotationStore.js")>(),
+	initAnnotationStore: annotationStoreMocks.initAnnotationStore,
+}));
+
 import {
 	backToSessions,
 	connectToSession,
@@ -14,7 +24,8 @@ import {
 } from "../../src/app/session-manager.js";
 import { GW_SESSION_KEY, GW_TOKEN_KEY, GW_URL_KEY, setRenderApp, state } from "../../src/app/state.js";
 import { RemoteAgent } from "../../src/app/remote-agent.js";
-import type { ChatPanel } from "../../src/ui/ChatPanel.js";
+import { ChatPanel } from "../../src/ui/ChatPanel.js";
+import { storage } from "../../src/app/storage.js";
 import * as dialogsLazy from "../../src/app/dialogs-lazy.js";
 import * as packEntrypoints from "../../src/app/pack-entrypoints.js";
 import * as packPanels from "../../src/app/pack-panels.js";
@@ -215,6 +226,8 @@ beforeEach(() => {
 	} as any);
 	resetProjectProposalSpy = vi.spyOn(proposalPanelsLazy, "resetProjectProposalPanel")
 		.mockImplementation(() => {});
+	annotationStoreMocks.initAnnotationStore.mockReset();
+	annotationStoreMocks.initAnnotationStore.mockResolvedValue(undefined);
 
 	localStorage.clear();
 	sessionStorage.clear();
@@ -490,6 +503,105 @@ describe("portrait session-list cache ownership", () => {
 
 		await connectToSession(SESSION_A, true, { onMissing: "toast" });
 		expect(freshConnectSpy).toHaveBeenCalledOnce();
+	});
+
+	it("keeps cached reconnect hydration isolated from the active panel while active reconnect still hydrates", async () => {
+		trackSession(SESSION_A);
+		trackSession(SESSION_B);
+		vi.spyOn(storage.providerKeys, "set").mockResolvedValue();
+		vi.spyOn(ChatPanel.prototype, "setAgent").mockImplementation(async function (this: ChatPanel, agent: any) {
+			const mockPanel = new MockChatPanel(agent as unknown as MockRemoteAgent);
+			this.agent = agent;
+			this.agentInterface = mockPanel.agentInterface as any;
+		});
+		freshConnectSpy.mockImplementation(async function (this: RemoteAgent, _gatewayUrl: string, _token: string, sessionId: string) {
+			const remote = this;
+			(remote as any)._sessionId = sessionId;
+			(remote as any).ws = {
+				readyState: WebSocket.OPEN,
+				close: vi.fn(),
+				send: vi.fn(),
+			};
+		});
+
+		await connectToSession(SESSION_A, true);
+		const cachedAgent = state.remoteAgent!;
+		const cachedPanel = state.chatPanel!;
+		const cachedReconnect = cachedAgent.onReconnect;
+		expect(cachedReconnect).toEqual(expect.any(Function));
+
+		selectSession(SESSION_B);
+		const foregroundAgent = new MockRemoteAgent(SESSION_B);
+		const foregroundPanel = new MockChatPanel(foregroundAgent);
+		const foregroundInterface = foregroundPanel.agentInterface as any;
+		const foregroundGitStatus = {
+			branch: "foreground-branch",
+			status: [{ file: "foreground.txt", status: "M" }],
+			clean: false,
+		};
+		const foregroundBgProcesses = [{ id: "foreground-bg", status: "running" }];
+		Object.assign(foregroundInterface, {
+			gitRepoKnown: "yes",
+			gitStatusLoading: false,
+			gitStatus: foregroundGitStatus,
+			branch: "foreground-branch",
+			partial: false,
+			bgProcesses: foregroundBgProcesses,
+		});
+		setActiveSession(SESSION_B, foregroundAgent, foregroundPanel);
+
+		fetchRecords.length = 0;
+		annotationStoreMocks.initAnnotationStore.mockClear();
+		const foregroundUpdateCalls = foregroundInterface.requestUpdate.mock.calls.length;
+		await cachedReconnect!();
+
+		const inactiveHydrationUrls = fetchRecords
+			.map((record) => record.url)
+			.filter((url) =>
+				url.startsWith(`/api/sessions/${SESSION_A}/git-status`)
+				|| url === `/api/sessions/${SESSION_A}/bg-processes`,
+			);
+		expect(inactiveHydrationUrls).toEqual([]);
+		expect(annotationStoreMocks.initAnnotationStore).not.toHaveBeenCalled();
+		expect(foregroundInterface.gitRepoKnown).toBe("yes");
+		expect(foregroundInterface.gitStatusLoading).toBe(false);
+		expect(foregroundInterface.gitStatus).toBe(foregroundGitStatus);
+		expect(foregroundInterface.branch).toBe("foreground-branch");
+		expect(foregroundInterface.partial).toBe(false);
+		expect(foregroundInterface.bgProcesses).toBe(foregroundBgProcesses);
+		expect(foregroundInterface.requestUpdate).toHaveBeenCalledTimes(foregroundUpdateCalls);
+
+		const cachedInterface = cachedPanel.agentInterface as any;
+		let cachedGitLoading = cachedInterface.gitStatusLoading;
+		let sawFastPathGitLoading = false;
+		let resolveFastPathGit!: () => void;
+		const fastPathGitSettled = new Promise<void>((resolve) => { resolveFastPathGit = resolve; });
+		Object.defineProperty(cachedInterface, "gitStatusLoading", {
+			configurable: true,
+			get: () => cachedGitLoading,
+			set: (value: boolean) => {
+				cachedGitLoading = value;
+				if (value) sawFastPathGitLoading = true;
+				else if (sawFastPathGitLoading) resolveFastPathGit();
+			},
+		});
+
+		await connectToSession(SESSION_A, true);
+		expect(state.remoteAgent).toBe(cachedAgent);
+		expect(state.chatPanel).toBe(cachedPanel);
+		await fastPathGitSettled;
+		fetchRecords.length = 0;
+		annotationStoreMocks.initAnnotationStore.mockClear();
+
+		await cachedReconnect!();
+
+		const activeHydrationUrls = fetchRecords.map((record) => record.url);
+		expect(activeHydrationUrls.some((url) =>
+			url.startsWith(`/api/sessions/${SESSION_A}/git-status`),
+		)).toBe(true);
+		expect(activeHydrationUrls).toContain(`/api/sessions/${SESSION_A}/bg-processes`);
+		expect(annotationStoreMocks.initAnnotationStore).toHaveBeenCalledOnce();
+		expect(annotationStoreMocks.initAnnotationStore).toHaveBeenCalledWith(SESSION_A);
 	});
 
 	it("preserves back navigation proposal, review, preview, inbox, draft, storage, and route cleanup", async () => {

--- a/tests2/dom/portrait-session-cache-repro.test.ts
+++ b/tests2/dom/portrait-session-cache-repro.test.ts
@@ -125,6 +125,15 @@ function responseFor(input: RequestInfo | URL, init?: RequestInit): Response {
 	if (method === "DELETE") return new Response(null, { status: 204 });
 	if (url.pathname.endsWith("/draft") && method === "GET") return new Response(null, { status: 204 });
 	if (url.pathname === "/api/preview/mount") return new Response(null, { status: 404 });
+	if (url.pathname.endsWith("/side-panel-workspace")) {
+		return Response.json({
+			version: 1,
+			tabs: [],
+			activeTabId: "",
+			sizeMode: "split",
+			metadata: { migratedFromLocalStorageAt: 1 },
+		});
+	}
 	if (url.pathname.includes("/inbox")) return Response.json({ entries: [] });
 	if (url.pathname.endsWith("/git-status")) {
 		return Response.json({ branch: "master", status: [], clean: true });
@@ -195,6 +204,7 @@ beforeEach(() => {
 
 	freshConnectSpy = vi.spyOn(RemoteAgent.prototype, "connect")
 		.mockRejectedValue(new Error("SESSION_NOT_FOUND: deterministic fresh-connect boundary"));
+	vi.spyOn(RemoteAgent.prototype, "requestMessages").mockImplementation(() => {});
 	vi.spyOn(dialogsLazy, "confirmAction").mockResolvedValue(true);
 	vi.spyOn(dialogsLazy, "showConnectionError").mockImplementation(() => {});
 	vi.spyOn(packRenderers, "reconcilePackRenderersForProject").mockResolvedValue();
@@ -290,6 +300,8 @@ describe("portrait session-list cache ownership", () => {
 		"disconnected agent",
 		"wrong agent session",
 		"unbound panel",
+		"missing panel agent",
+		"missing panel interface session",
 		"wrong panel agent",
 		"wrong panel interface session",
 	] as const)("rejects %s and performs safe teardown", (scenario) => {
@@ -314,6 +326,12 @@ describe("portrait session-list cache ownership", () => {
 			panel = new MockChatPanel(activeAgent!);
 		} else if (scenario === "unbound panel") {
 			panel = new MockChatPanel(undefined, undefined);
+		} else if (scenario === "missing panel agent") {
+			panel = new MockChatPanel(activeAgent!);
+			panel.agent = undefined;
+		} else if (scenario === "missing panel interface session") {
+			panel = new MockChatPanel(activeAgent!);
+			panel.agentInterface!.session = undefined;
 		} else if (scenario === "wrong panel agent") {
 			const foreign = new MockRemoteAgent(SESSION_B);
 			detachedAgents.push(foreign);
@@ -410,6 +428,29 @@ describe("portrait session-list cache ownership", () => {
 
 		expect(freshConnectSpy).toHaveBeenCalledOnce();
 		expect(freshConnectSpy.mock.instances[0]).not.toBe(agent);
+	});
+
+	it("evicts a cached session removed externally and forces a fresh connect", async () => {
+		const { agent: cachedAgent } = cacheThroughDesktopSwitch(SESSION_A, SESSION_B);
+		freshConnectSpy.mockResolvedValue(undefined);
+
+		await connectToSession(SESSION_B, true, { onMissing: "toast" });
+		const notifyingAgent = state.remoteAgent;
+		expect(notifyingAgent).toBeInstanceOf(RemoteAgent);
+		expect(notifyingAgent).not.toBe(cachedAgent);
+		expect(notifyingAgent?.onSessionRemoved).toEqual(expect.any(Function));
+		freshConnectSpy.mockClear();
+
+		notifyingAgent!.onSessionRemoved!(SESSION_A, "archived");
+
+		expect(cachedAgent.disconnect).toHaveBeenCalledOnce();
+		expect(state.gatewaySessions.some((session) => session.id === SESSION_A)).toBe(false);
+
+		await connectToSession(SESSION_A, true, { onMissing: "toast" });
+
+		expect(freshConnectSpy).toHaveBeenCalledOnce();
+		expect(freshConnectSpy.mock.instances[0]).not.toBe(cachedAgent);
+		expect(state.remoteAgent).not.toBe(cachedAgent);
 	});
 
 	it("disconnectGateway disconnects active and cached agents and leaves no reusable entry", async () => {

--- a/tests2/dom/review-tool-active-guard.test.ts
+++ b/tests2/dom/review-tool-active-guard.test.ts
@@ -13,14 +13,74 @@ __syncBeforeAll(() => __syncCE());
 // mutation on the agent session still matching `state.selectedSessionId`,
 // including after lazy review-source imports resume.
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const annotationStoreMocks = vi.hoisted(() => ({
+	clearAnnotations: vi.fn(),
+	clearAllAnnotations: vi.fn(),
+	clearReviewSubmitted: vi.fn(),
+	initAnnotationStore: vi.fn(),
+	isReviewSubmitted: vi.fn(),
+}));
+const reviewSourceMocks = vi.hoisted(() => ({
+	clearPersistedReviewDocuments: vi.fn(),
+	loadReviewSources: vi.fn(),
+	openMarkdownReviewDocument: vi.fn(),
+	removePersistedReviewDocument: vi.fn(),
+	restorePersistedReviewDocuments: vi.fn(),
+}));
+const faviconMocks = vi.hoisted(() => ({ showFaviconBadge: vi.fn() }));
+
+vi.mock("../../src/ui/components/review/AnnotationStore.js", async (importOriginal) => ({
+	...await importOriginal<typeof import("../../src/ui/components/review/AnnotationStore.js")>(),
+	...annotationStoreMocks,
+}));
+vi.mock("../../src/app/review-sources-lazy.js", () => ({
+	loadReviewSources: reviewSourceMocks.loadReviewSources,
+}));
+vi.mock("../../src/app/favicon-badge.js", () => ({
+	showFaviconBadge: faviconMocks.showFaviconBadge,
+}));
+
 import { RemoteAgent } from "../../src/app/remote-agent.js";
 import { state } from "../../src/app/state.js";
+
+const mockReviewSourcesModule = {
+	clearPersistedReviewDocuments: reviewSourceMocks.clearPersistedReviewDocuments,
+	openMarkdownReviewDocument: reviewSourceMocks.openMarkdownReviewDocument,
+	removePersistedReviewDocument: reviewSourceMocks.removePersistedReviewDocument,
+	restorePersistedReviewDocuments: reviewSourceMocks.restorePersistedReviewDocuments,
+};
+
+type Deferred<T> = {
+	promise: Promise<T>;
+	resolve: (value: T) => void;
+};
+
+function deferred<T>(): Deferred<T> {
+	let resolve!: (value: T) => void;
+	const promise = new Promise<T>((res) => { resolve = res; });
+	return { promise, resolve };
+}
+
+function mockStorage(): Storage {
+	const values = new Map<string, string>();
+	return {
+		get length() { return values.size; },
+		clear: vi.fn(() => values.clear()),
+		getItem: vi.fn((key: string) => values.get(key) ?? null),
+		key: vi.fn((index: number) => [...values.keys()][index] ?? null),
+		removeItem: vi.fn((key: string) => { values.delete(key); }),
+		setItem: vi.fn((key: string, value: string) => { values.set(key, String(value)); }),
+	};
+}
 
 function makeAgent(sessionId: string): RemoteAgent {
 	const a = new RemoteAgent();
 	// _sessionId is private; assign for test purposes so the production code
-	// path that consults it is exercised.
+	// path that consults it is exercised. Stub transport so no real WebSocket is
+	// ever constructed or touched.
 	(a as any)._sessionId = sessionId;
+	(a as any).send = vi.fn();
 	return a;
 }
 function setActive(a: RemoteAgent): void {
@@ -32,6 +92,14 @@ function clearReviewState(): void {
 	state.reviewActiveTab = "";
 	state.reviewPanelOpen = false;
 }
+function seedReviewState(title = "Foreground review"): void {
+	state.reviewDocuments = new Map([[title, {
+		title,
+		markdown: `# ${title}`,
+	} as any]]);
+	state.reviewActiveTab = title;
+	state.reviewPanelOpen = true;
+}
 function getReviewState() {
 	return {
 		open: state.reviewPanelOpen,
@@ -39,6 +107,30 @@ function getReviewState() {
 		docCount: state.reviewDocuments.size,
 		docTitles: [...state.reviewDocuments.keys()],
 	};
+}
+function reviewToolResult(action: "review_open" | "review_close", payload: Record<string, unknown> = {}) {
+	return {
+		role: "toolResult",
+		content: [{ type: "text", text: JSON.stringify({ action, ...payload }) }],
+	};
+}
+async function deliverSnapshot(a: RemoteAgent, messages: any[]): Promise<void> {
+	await (a as any).handleServerMessage({ type: "messages", data: messages });
+}
+function toolProposalMessage(blockId: string) {
+	return {
+		id: `assistant-${blockId}`,
+		role: "assistant",
+		content: [{
+			type: "tool_use",
+			id: blockId,
+			name: "propose_tool",
+			input: { tool: "sample_tool", action: "create", content: "name: sample_tool" },
+		}],
+	};
+}
+function deliverAgentEvent(a: RemoteAgent, type: string, message?: any): void {
+	(a as any).handleAgentEvent({ type, ...(message ? { message } : {}) });
 }
 async function deliverReviewToolResult(
 	a: RemoteAgent,
@@ -59,13 +151,49 @@ async function deliverReviewToolResult(
 }
 
 beforeEach(() => {
-	// The workspace open/persist path fires fire-and-forget PUT/POSTs to the
-	// gateway; stub fetch so those don't surface as unhandled network rejections.
-	vi.stubGlobal("fetch", async () => new Response("{}", { status: 200, headers: { "Content-Type": "application/json" } }));
+	// All external boundaries are deterministic in-memory mocks: no network,
+	// persisted browser storage, lazy source loading, animation timers, or audio.
+	vi.stubGlobal("fetch", vi.fn(async () => new Response("{}", { status: 200, headers: { "Content-Type": "application/json" } })));
+	vi.stubGlobal("localStorage", mockStorage());
+	vi.stubGlobal("sessionStorage", mockStorage());
+	vi.stubGlobal("requestAnimationFrame", vi.fn(() => 0));
+
+	annotationStoreMocks.clearAnnotations.mockReset();
+	annotationStoreMocks.clearAllAnnotations.mockReset();
+	annotationStoreMocks.clearReviewSubmitted.mockReset();
+	annotationStoreMocks.initAnnotationStore.mockReset();
+	annotationStoreMocks.initAnnotationStore.mockResolvedValue(undefined);
+	annotationStoreMocks.isReviewSubmitted.mockReset();
+	annotationStoreMocks.isReviewSubmitted.mockReturnValue(false);
+
+	reviewSourceMocks.clearPersistedReviewDocuments.mockReset();
+	reviewSourceMocks.loadReviewSources.mockReset();
+	reviewSourceMocks.loadReviewSources.mockResolvedValue(mockReviewSourcesModule);
+	reviewSourceMocks.openMarkdownReviewDocument.mockReset();
+	reviewSourceMocks.openMarkdownReviewDocument.mockImplementation((options: any) => {
+		const document = { title: options.title, markdown: options.markdown };
+		state.reviewDocuments = new Map(state.reviewDocuments);
+		state.reviewDocuments.set(options.title, document as any);
+		state.reviewActiveTab = options.title;
+		state.reviewPanelOpen = true;
+		return document;
+	});
+	reviewSourceMocks.removePersistedReviewDocument.mockReset();
+	reviewSourceMocks.restorePersistedReviewDocuments.mockReset();
+	faviconMocks.showFaviconBadge.mockReset();
+
 	clearReviewState();
+	state.proposalStreamingByTag = {};
+	state.remoteAgent = null;
+	state.selectedSessionId = null;
+	document.documentElement.dataset.playAgentFinishSound = "false";
 });
 afterEach(() => {
 	clearReviewState();
+	state.proposalStreamingByTag = {};
+	state.remoteAgent = null;
+	state.selectedSessionId = null;
+	delete document.documentElement.dataset.playAgentFinishSound;
 	vi.unstubAllGlobals();
 });
 
@@ -187,5 +315,149 @@ describe("review tool active-session guard", () => {
 		expect(after.open).toBe(true);
 		expect(after.docCount).toBe(1);
 		expect(after.activeTab).toBe("Active-PR");
+	});
+});
+
+describe("cached RemoteAgent reconnect isolation", () => {
+	it("an inactive messages snapshot cannot clear or restore over foreground review state", async () => {
+		const foreground = makeAgent("foreground-session");
+		const cached = makeAgent("cached-session");
+		setActive(foreground);
+		seedReviewState();
+		const before = getReviewState();
+
+		reviewSourceMocks.restorePersistedReviewDocuments.mockImplementation(() => {
+			seedReviewState("Cached review");
+		});
+		await deliverSnapshot(cached, [reviewToolResult("review_open", {
+			title: "Cached snapshot review",
+			markdown: "# Must stay in the background",
+		})]);
+
+		expect(getReviewState()).toEqual(before);
+		expect(reviewSourceMocks.restorePersistedReviewDocuments).not.toHaveBeenCalled();
+	});
+
+	it("a snapshot cannot clear the new foreground after annotation hydration awaits", async () => {
+		const reconnecting = makeAgent("reconnecting-session");
+		const foreground = makeAgent("new-foreground-session");
+		setActive(reconnecting);
+		seedReviewState("Reconnecting review");
+		const annotationGate = deferred<void>();
+		annotationStoreMocks.initAnnotationStore.mockReturnValueOnce(annotationGate.promise);
+
+		const pendingSnapshot = deliverSnapshot(reconnecting, []);
+		expect(annotationStoreMocks.initAnnotationStore).toHaveBeenCalledWith("reconnecting-session");
+		setActive(foreground);
+		seedReviewState();
+		const foregroundState = getReviewState();
+		annotationGate.resolve(undefined);
+		await pendingSnapshot;
+
+		expect(getReviewState()).toEqual(foregroundState);
+		expect(reviewSourceMocks.loadReviewSources).not.toHaveBeenCalled();
+	});
+
+	it("a snapshot cannot restore over the new foreground after lazy sources await", async () => {
+		const reconnecting = makeAgent("reconnecting-session");
+		const foreground = makeAgent("new-foreground-session");
+		setActive(reconnecting);
+		seedReviewState("Reconnecting review");
+		const sourceGate = deferred<typeof mockReviewSourcesModule>();
+		reviewSourceMocks.loadReviewSources.mockReturnValueOnce(sourceGate.promise);
+		reviewSourceMocks.restorePersistedReviewDocuments.mockImplementation(() => {
+			seedReviewState("Late reconnect restore");
+		});
+
+		const pendingSnapshot = deliverSnapshot(reconnecting, []);
+		// Resume the already-resolved annotation mock. The production handler is
+		// now paused exactly at the controlled lazy-source boundary.
+		await Promise.resolve();
+		expect(reviewSourceMocks.loadReviewSources).toHaveBeenCalledOnce();
+		setActive(foreground);
+		seedReviewState();
+		const foregroundState = getReviewState();
+		sourceGate.resolve(mockReviewSourcesModule);
+		await pendingSnapshot;
+
+		expect(getReviewState()).toEqual(foregroundState);
+		expect(reviewSourceMocks.restorePersistedReviewDocuments).not.toHaveBeenCalled();
+	});
+
+	it("an active messages snapshot still rebuilds foreground review state", async () => {
+		const active = makeAgent("active-session");
+		setActive(active);
+		seedReviewState("Stale foreground review");
+
+		await deliverSnapshot(active, []);
+
+		expect(getReviewState()).toEqual({
+			open: false,
+			activeTab: "",
+			docCount: 0,
+			docTitles: [],
+		});
+		expect(annotationStoreMocks.initAnnotationStore).toHaveBeenCalledWith("active-session");
+		expect(reviewSourceMocks.restorePersistedReviewDocuments).toHaveBeenCalledWith("active-session", { select: true });
+	});
+});
+
+describe("cached RemoteAgent proposal isolation", () => {
+	it("inactive tool proposal streaming and completion cannot set or clear foreground flags", () => {
+		const foreground = makeAgent("foreground-session");
+		const cached = makeAgent("cached-session");
+		setActive(foreground);
+		cached.onToolProposal = vi.fn();
+
+		state.proposalStreamingByTag = { tool_proposal: false };
+		deliverAgentEvent(cached, "message_update", toolProposalMessage("cached-stream"));
+		expect(state.proposalStreamingByTag.tool_proposal).toBe(false);
+
+		state.proposalStreamingByTag.tool_proposal = true;
+		deliverAgentEvent(cached, "message_end", toolProposalMessage("cached-complete"));
+		expect(state.proposalStreamingByTag.tool_proposal).toBe(true);
+	});
+
+	it("active tool proposal streaming and completion still own the foreground flag", () => {
+		const active = makeAgent("active-session");
+		setActive(active);
+		const streamingStates: boolean[] = [];
+		active.onToolProposal = (_proposal, streaming) => { streamingStates.push(streaming); };
+		state.proposalStreamingByTag = { tool_proposal: false };
+		const proposal = toolProposalMessage("active-tool-proposal");
+
+		deliverAgentEvent(active, "message_update", proposal);
+		expect(state.proposalStreamingByTag.tool_proposal).toBe(true);
+		deliverAgentEvent(active, "message_end", proposal);
+
+		expect(state.proposalStreamingByTag.tool_proposal).toBe(false);
+		expect(streamingStates).toEqual([true, false]);
+	});
+
+	it("an inactive agent_end cannot bulk-clear foreground proposal flags", () => {
+		const foreground = makeAgent("foreground-session");
+		const cached = makeAgent("cached-session");
+		setActive(foreground);
+		state.proposalStreamingByTag = { goal_proposal: true, tool_proposal: true };
+
+		deliverAgentEvent(cached, "agent_end");
+
+		expect(state.proposalStreamingByTag).toEqual({
+			goal_proposal: true,
+			tool_proposal: true,
+		});
+	});
+
+	it("an active agent_end still bulk-clears foreground proposal flags", () => {
+		const active = makeAgent("active-session");
+		setActive(active);
+		state.proposalStreamingByTag = { goal_proposal: true, tool_proposal: true };
+
+		deliverAgentEvent(active, "agent_end");
+
+		expect(state.proposalStreamingByTag).toEqual({
+			goal_proposal: false,
+			tool_proposal: false,
+		});
 	});
 });

--- a/tests2/integration/skill-expansion.test.ts
+++ b/tests2/integration/skill-expansion.test.ts
@@ -10,7 +10,6 @@ import {
 	apiFetch,
 	nonGitCwd,
 	connectWs,
-	agentEndPredicate,
 	defaultProjectId,
 } from "./_e2e/e2e-setup.js";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
@@ -159,8 +158,6 @@ test.describe("Slash skill expansion mismatch", () => {
 			// The skill content should be expanded into the snapshot body
 			// (WS handler uses session.projectId to resolve per-project skills).
 			expect(expansions[0].expanded).toContain(SKILL_MARKER);
-
-			await conn.waitFor(agentEndPredicate());
 		} finally {
 			conn.close();
 		}

--- a/tests2/tests-map.json
+++ b/tests2/tests-map.json
@@ -237,6 +237,24 @@
       }
     },
     {
+      "path": "tests2/dom/portrait-session-cache-repro.test.ts",
+      "reason": "Failing-first deterministic DOM reproducer for portrait session-list navigation: backToSessions must transfer a matching connected ChatPanel/RemoteAgent pair into the bounded session cache without disconnecting it, clear active ownership, and leave explicit uncache eviction responsible for disconnecting the cached agent.",
+      "execution": {
+        "runner": "vitest",
+        "tier": "unit",
+        "project": "dom"
+      }
+    },
+    {
+      "path": "tests2/browser/journeys/portrait-session-cache.journey.spec.ts",
+      "reason": "Portrait 375x667 real-harness regression journey for session A→list→B→list→A caching, using a pre-click MutationObserver plus stable pi-chat-panel identity and WebSocket creation counts to prove healthy reuse without a loader; also pins stale cached-socket fresh fallback with transcript hydration, landscape direct-switch parity, reload-only cache loss, and deterministic session cleanup.",
+      "execution": {
+        "runner": "playwright",
+        "tier": "browser",
+        "project": "browser"
+      }
+    },
+    {
       "path": "tests2/browser/journeys/cross-session-proposal-mirror.journey.spec.ts",
       "reason": "Reproducing test for the 'Fix cross-session proposal panels' goal: from a NON-matching session (assistantType === null) a role/tool/staff proposal that reaches the panel through the UNIFIED remote.onProposal path alone (source 'seed'/'rehydrate'/'edit'/'restore'/switch-back — not the live tool-use scan that also fires the legacy per-type callback) leaves the legacy form-mirror (rolePreviewName…, toolPreviewName…, staffPreviewName…) empty, so the panel renders blank and its primary submit stays disabled/absent. Drives onProposal directly (same technique as tests2/browser/e2e/proposal-inline-comments.spec.ts) and asserts the mirror is populated + submit enabled. FAILS on HEAD (no role/tool/staff bridge in the unified callback, only goal is bridged), passes once the bridge is added.",
       "execution": {


### PR DESCRIPTION
## Summary
- reuse the bounded in-memory session LRU for portrait back-to-list navigation with strict panel/agent/session ownership checks
- evict stale, disconnected, terminated, archived, externally removed, and gateway-disconnected cache entries safely
- isolate cached background reconnect, review, proposal, git-status, and background-process state from the active session
- add deterministic DOM and portrait browser coverage plus lifecycle documentation
- stabilize two pre-existing tests exposed by full-gate contention without reducing behavioral assertions

## Verification
- implementation workflow: build, typecheck, unit, browser, E2E, gap analysis, code review, regression review, bug hunt, and security review passed
- focused cache/isolation DOM coverage: 34 tests passed (20 portrait cache + 14 background review/proposal guards)
- portrait browser journey: healthy return mounted no loader and created no WebSocket; stale fallback mounted the loader, created exactly one replacement WebSocket, and restored history
- git diff --check passed

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)