### PR TITLE
Add CODEOWNERS (@SuuBro as accountable owner)

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# All changes require review from the accountable owner.
+*  @SuuBro


### PR DESCRIPTION
Adds a root `CODEOWNERS` making @SuuBro the sole code owner for the repository.

This is the first step of the branch-protection work. Once the `bobbit-require-human-review` ruleset is applied (`require_code_owner_review = true`), every PR will require @SuuBro's review — keeping review accountability with a single owner, while everyone else's contributions go through him. @SuuBro retains the ability to self-merge via a one-person bypass team.

No code changes.