### PR TITLE
Add CodeQL workflow (JS/TS + Actions scanning)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,41 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+  schedule:
+    - cron: '27 4 * * 1' # weekly, Monday 04:27 UTC
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write # upload code scanning results
+      contents: read
+      actions: read
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [javascript-typescript, actions]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          persist-credentials: false
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
+        with:
+          languages: ${{ matrix.language }}
+          queries: security-extended
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
Adds GitHub CodeQL static analysis for the repo.

- **Languages:** `javascript-typescript` (the app) and `actions` (scans the workflows themselves for issues like script injection).
- **Triggers:** push + PR to `master`, plus a weekly schedule.
- **Query suite:** `security-extended` for broader security coverage.
- Actions are SHA-pinned (codeql-action v4.37.1, checkout v5.0.1).

Results appear under the repo's Security tab and as PR annotations. This is the *vulnerability* SAST layer (complements Socket for malicious-dependency detection).