### PR TITLE
Relax unit file budget to 25 seconds

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,7 +39,7 @@ Orient here, then `rg` for the symbol.
 ## Testing (Test Suite v2)
 
 - **New tests land in `tests2/`** (or the guard fails). `*.test.ts`⇒Vitest (`core`/`dom`/`integration`, with explicit isolated exceptions); `*.spec.ts`⇒Playwright (`tests2/browser`). Register in `tests2/tests-map.json`. Three sequential gate phases: `test:unit` → `test:browser` → `test:e2e`; worktree/Docker/MCP/restart coverage belongs to E2E or `test:manual`.
-- **Unit gate** — one direct Vitest run, fixed three-worker cap, `retry: 3`, subprocess guard, and hard 15 s solo file budget. See [docs/testing-v2/unit-gate.md](docs/testing-v2/unit-gate.md).
+- **Unit gate** — one direct Vitest run, fixed three-worker cap, `retry: 3`, subprocess guard, and hard 25 s solo file budget. See [docs/testing-v2/unit-gate.md](docs/testing-v2/unit-gate.md).
 - Isolate only via the harness temp dir — never touch `.bobbit/`. **Never bg-server from bash** — use `bash_bg`. Run tests before committing.
 - Every user-facing feature needs a `tests2/browser` journey (nav, happy path, reload, cleanup). See [docs/testing-v2/](docs/testing-v2/).
 

--- a/docs/testing-strategy.md
+++ b/docs/testing-strategy.md
@@ -30,7 +30,7 @@ ownership, and lost declaration semantics.
 The unit phase uses one Vitest coordinator with a fixed three-worker cap and
 `retry: 3`. `VITEST_MAX_WORKERS` may lower the cap only. It has no lane runner,
 ledger reservation, cost sharding, lane logs, or gateway-boot lease. All four tier-1
-projects install the subprocess guard and enforce a hard 15-second solo file budget.
+projects install the subprocess guard and enforce a hard 25-second solo file budget.
 See [Unit gate operating model](testing-v2/unit-gate.md) for cache, proof-mode, E2E
 ownership, and audit details.
 
@@ -672,7 +672,7 @@ ledger capacity or gateway-boot leases. Its fixed cap of three workers is safe f
 three simultaneous suites on the acceptance host without dynamic allocation.
 
 **Solo enforcement.** `UnitFileBudgetReporter` measures each tier-1 module from start
-through hooks and retries. A file above 15 seconds fails an ordinary run, even when
+through hooks and retries. A file above 25 seconds fails an ordinary run, even when
 its tests pass. The unit-stage wall qualification also requires consecutive ordinary
 solo runs; see [`fast-gate-progress.md`](testing-v2/fast-gate-progress.md).
 
@@ -874,7 +874,7 @@ their transform-cache isolation and phase-specific worker/retry settings.
 
 - Do not raise the unit gate above three workers or route it through ledger, lane,
   cost-shard, or gateway-boot-lease orchestration.
-- Do not weaken the 15-second solo file budget or use concurrent-proof mode as solo
+- Do not weaken the 25-second solo file budget or use concurrent-proof mode as solo
   qualification evidence.
 - Do not add a third Vitest E2E owner; keep decision coverage in tier 1 when editing
   either approved real-fidelity suite.

--- a/docs/testing-v2/unit-gate.md
+++ b/docs/testing-v2/unit-gate.md
@@ -53,7 +53,7 @@ The inventory audit also rejects value imports or requires of `child_process` in
 
 ### File wall budget
 
-A tier-1 file has a hard 15-second wall budget from module start through hooks and retries. In an ordinary solo run, any overrun fails `test:unit` even when all assertions pass.
+A tier-1 file has a hard 25-second wall budget from module start through hooks and retries. In an ordinary solo run, any overrun fails `test:unit` even when all assertions pass.
 
 For the simultaneous load proof only, set:
 

--- a/tests2/core/async-background-cleanup-static.test.ts
+++ b/tests2/core/async-background-cleanup-static.test.ts
@@ -610,7 +610,7 @@ function createScopedProgram(): ts.Program {
 	// Root production source explicitly and disable dependency expansion. This
 	// retains one cross-file TypeChecker for aliases, destructuring, methods and
 	// wrappers while avoiding the cost of loading/checking every third-party
-	// declaration pulled in by server.ts. The static guard must fit the 15 s solo
+	// declaration pulled in by server.ts. The static guard must fit the 25 s solo
 	// unit-file budget on Windows as well as Linux.
 	const rootNames = productionTypeScriptFiles(path.resolve("src/server"));
 	const sharedRoot = path.resolve("src/shared");

--- a/tests2/core/file-mentions-resource-limits.test.ts
+++ b/tests2/core/file-mentions-resource-limits.test.ts
@@ -38,10 +38,9 @@ const FileMentionBudgetError = Reflect.get(resolverModule, "FileMentionBudgetErr
 const EXPECTED_RAW_CANDIDATE_LIMIT = 8_192;
 const EXPECTED_UNIQUE_PROBE_LIMIT = 4_096;
 const EXPECTED_AUTHENTICATED_PROMPT_TEXT_LIMIT_BYTES = 8 * 1024 * 1024;
-// The exact 8 MiB form takes longer than this tier's hard 15 s file wall on
-// the vulnerable object-per-CRLF map. This bounded form still forces 65k+
-// normalization discontinuities without destabilizing later cases; the WS
-// integration suite separately pins the exact authenticated byte ceiling.
+// Keep the exact 8 MiB form in the WS integration suite that pins the
+// authenticated byte ceiling. This bounded tier-1 form still forces 65k+
+// normalization discontinuities without destabilizing later cases.
 const BOUNDED_CRLF_MAP_STRESS_BYTES = 192 * 1024;
 const FILE_MENTION_RESOLUTION_CONCURRENCY = (
 	Reflect.get(resolverModule, "FILE_MENTION_RESOLUTION_CONCURRENCY")

--- a/tests2/core/unit-file-budget-reporter.test.ts
+++ b/tests2/core/unit-file-budget-reporter.test.ts
@@ -35,7 +35,7 @@ function timedReporter(options: {
 }
 
 describe("UnitFileBudgetReporter", () => {
-	test("allows every tier-1 project at the exact 15 second boundary", () => {
+	test("allows every tier-1 project at the exact 25 second boundary", () => {
 		const { reporter, elapse } = timedReporter();
 		for (const project of ["v2-core", "v2-dom", "v2-integration", "v2-isolated"]) {
 			elapse(moduleFor(`/repo/tests2/${project}.test.ts`, project), UNIT_FILE_WALL_BUDGET_MS);
@@ -46,17 +46,17 @@ describe("UnitFileBudgetReporter", () => {
 
 	test("hard-fails by default after measuring the whole module wall and aggregating retries", () => {
 		const { reporter, elapse } = timedReporter();
-		elapse(moduleFor("C:\\repo\\tests2\\core\\retry.test.ts?first", "v2-core"), 7_500);
-		elapse(moduleFor("file:///C:/repo/tests2/core/retry.test.ts?retry", "v2-core"), 7_501);
+		elapse(moduleFor("C:\\repo\\tests2\\core\\retry.test.ts?first", "v2-core"), 12_500);
+		elapse(moduleFor("file:///C:/repo/tests2/core/retry.test.ts?retry", "v2-core"), 12_501);
 
 		assert.throws(
 			() => reporter.onTestRunEnd(),
 			(error: unknown) => {
 				assert.ok(error instanceof Error);
-				assert.match(error.message, /budget=15000ms/);
+				assert.match(error.message, /budget=25000ms/);
 				assert.match(error.message, /path=C:\/repo\/tests2\/core\/retry\.test\.ts/);
 				assert.match(error.message, /project=v2-core/);
-				assert.match(error.message, /duration=15001ms/);
+				assert.match(error.message, /duration=25001ms/);
 				return true;
 			},
 		);
@@ -64,15 +64,15 @@ describe("UnitFileBudgetReporter", () => {
 
 	test("reports all over-budget files with path, project, and duration", () => {
 		const { reporter, elapse } = timedReporter();
-		elapse(moduleFor("/repo/tests2/dom/slow.test.ts", "v2-dom"), 15_250.2);
-		elapse(moduleFor("/repo/tests2/integration/slower.test.ts", "v2-integration"), 18_000);
+		elapse(moduleFor("/repo/tests2/dom/slow.test.ts", "v2-dom"), 25_250.2);
+		elapse(moduleFor("/repo/tests2/integration/slower.test.ts", "v2-integration"), 28_000);
 
 		assert.throws(
 			() => reporter.onTestRunEnd(),
 			(error: unknown) => {
 				assert.ok(error instanceof Error);
-				assert.match(error.message, /path=\/repo\/tests2\/integration\/slower\.test\.ts project=v2-integration duration=18000ms/);
-				assert.match(error.message, /path=\/repo\/tests2\/dom\/slow\.test\.ts project=v2-dom duration=15251ms/);
+				assert.match(error.message, /path=\/repo\/tests2\/integration\/slower\.test\.ts project=v2-integration duration=28000ms/);
+				assert.match(error.message, /path=\/repo\/tests2\/dom\/slow\.test\.ts project=v2-dom duration=25251ms/);
 				return true;
 			},
 		);
@@ -85,16 +85,16 @@ describe("UnitFileBudgetReporter", () => {
 			output: message => output.push(message),
 		});
 		reporter.onTestRunStart();
-		elapse(moduleFor("/repo/tests2/dom/slow.test.ts", "v2-dom"), 15_250.2);
-		elapse(moduleFor("/repo/tests2/integration/slower.test.ts", "v2-integration"), 18_000);
+		elapse(moduleFor("/repo/tests2/dom/slow.test.ts", "v2-dom"), 25_250.2);
+		elapse(moduleFor("/repo/tests2/integration/slower.test.ts", "v2-integration"), 28_000);
 
 		assert.doesNotThrow(() => reporter.onTestRunEnd());
 		assert.equal(output[0], UNIT_CONCURRENT_PROOF_BANNER);
 		assert.equal(output.length, 2);
 		assert.match(output[1], /CONCURRENT PROOF MODE/);
 		assert.match(output[1], /do not qualify as solo unit-stage evidence/);
-		assert.match(output[1], /path=\/repo\/tests2\/integration\/slower\.test\.ts project=v2-integration duration=18000ms/);
-		assert.match(output[1], /path=\/repo\/tests2\/dom\/slow\.test\.ts project=v2-dom duration=15251ms/);
+		assert.match(output[1], /path=\/repo\/tests2\/integration\/slower\.test\.ts project=v2-integration duration=28000ms/);
+		assert.match(output[1], /path=\/repo\/tests2\/dom\/slow\.test\.ts project=v2-dom duration=25251ms/);
 		assert.match(output[1], /suite and test failures remain authoritative/);
 	});
 
@@ -102,18 +102,18 @@ describe("UnitFileBudgetReporter", () => {
 		const { reporter, elapse } = timedReporter({
 			env: { [UNIT_CONCURRENT_PROOF_ENV]: "true" },
 		});
-		elapse(moduleFor("/repo/tests2/core/slow.test.ts", "v2-core"), 15_001);
+		elapse(moduleFor("/repo/tests2/core/slow.test.ts", "v2-core"), 25_001);
 
-		assert.throws(() => reporter.onTestRunEnd(), /duration=15001ms/);
+		assert.throws(() => reporter.onTestRunEnd(), /duration=25001ms/);
 	});
 
 	test("does not create exemptions for additional unit projects", () => {
 		const { reporter, elapse } = timedReporter();
-		elapse(moduleFor("/repo/tests2/core/future.test.ts", "v2-future-unit"), 15_001);
+		elapse(moduleFor("/repo/tests2/core/future.test.ts", "v2-future-unit"), 25_001);
 
 		assert.throws(
 			() => reporter.onTestRunEnd(),
-			/project=v2-future-unit duration=15001ms/,
+			/project=v2-future-unit duration=25001ms/,
 		);
 	});
 
@@ -126,7 +126,7 @@ describe("UnitFileBudgetReporter", () => {
 
 	test("resets completed timing aggregates at the start of each run", () => {
 		const { reporter, elapse } = timedReporter();
-		elapse(moduleFor("/repo/tests2/core/slow.test.ts", "v2-core"), 16_000);
+		elapse(moduleFor("/repo/tests2/core/slow.test.ts", "v2-core"), 26_000);
 		reporter.onTestRunStart();
 
 		assert.doesNotThrow(() => reporter.onTestRunEnd());

--- a/tests2/harness/unit-file-budget-reporter.ts
+++ b/tests2/harness/unit-file-budget-reporter.ts
@@ -3,7 +3,7 @@ import type { Reporter } from "vitest/reporters";
 
 type TestModule = Parameters<NonNullable<Reporter["onTestModuleStart"]>>[0];
 
-export const UNIT_FILE_WALL_BUDGET_MS = 15_000;
+export const UNIT_FILE_WALL_BUDGET_MS = 25_000;
 export const UNIT_CONCURRENT_PROOF_ENV = "BOBBIT_UNIT_CONCURRENT_PROOF";
 export const UNIT_CONCURRENT_PROOF_BANNER =
 	"[unit-file-budget] CONCURRENT PROOF MODE — wall-budget overruns are report-only and do not qualify as solo unit-stage evidence.";

--- a/tests2/tests-map.json
+++ b/tests2/tests-map.json
@@ -1021,7 +1021,7 @@
     },
     {
       "path": "tests2/core/unit-file-budget-reporter.test.ts",
-      "reason": "Pins the 15-second tier-1 file budget reporter boundary, aggregation, retry accounting, E2E exclusion, and Windows path rendering.",
+      "reason": "Pins the 25-second tier-1 file budget reporter boundary, aggregation, retry accounting, E2E exclusion, and Windows path rendering.",
       "execution": {
         "runner": "vitest",
         "tier": "unit",


### PR DESCRIPTION
## Summary
- raise the tier-1 per-file wall budget from 15 seconds to 25 seconds
- update reporter boundary coverage and test inventory metadata
- align unit-gate documentation and source comments with the new limit

## Testing
- `npx vitest run --config vitest.config.ts --silent=passed-only tests2/core/unit-file-budget-reporter.test.ts`
- `git diff --check`

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)