### PR TITLE
Add PR gate workflow (build, type-check, unit)

### DIFF
--- a/.github/workflows/build-unit-gate.yml
+++ b/.github/workflows/build-unit-gate.yml
@@ -1,0 +1,43 @@
+name: Build & Unit Gate
+
+on:
+  pull_request:
+    branches: [master]
+  push:
+    branches: [master]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pr-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    name: Build, type-check, unit
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: '22.19.0'
+          cache: npm
+
+      - name: Install
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Type-check
+        run: npm run check
+
+      - name: Unit gate
+        run: npm run test:unit


### PR DESCRIPTION
Adds the first CI gate: `npm ci` → `build` → `check` → `test:unit` on every PR to `master`. Nothing currently builds or runs this code before merge.

## Validated on Linux (Node 22.19.0)

```
Install / Build / Type-check   pass
Unit gate    1 failed | 940 passed | 4 skipped (945)
Total        3m29s
```

## Excluded

- **`test:browser`** — 3600s wall budget, and its Playwright config reserves workers from `scripts/testing-v2/ledger.mjs`, which exists to share one dev box between concurrent sessions and is inert on a runner.
- **`test:e2e`** — needs Docker and real worktrees.

## The one failure

`tests2/core/file-mentions-resolve.test.ts:698` calls `execFileSync("mkfifo", ...)`, which this repo's own tier-1 spawn guard blocks. Introduced by #1030 and merged red because nothing ran it. Fixed separately so this PR stays reviewable on its own.

A clean macOS checkout fails 14 files, but 13 are local-environment artifacts (`TMPDIR` symlink resolution, and Node below the `engines` floor of 22.19 where native `.ts` loading landed). All 13 pass on Linux.

## Rollout

Keep non-required until it has been observed on a few PRs.