### PR TITLE
Reset dir singletons at file boundaries in isolate:false projects

### DIFF
--- a/tests2/harness/file-boundary-runner.ts
+++ b/tests2/harness/file-boundary-runner.ts
@@ -1,0 +1,17 @@
+import { VitestTestRunner } from "vitest/runners";
+import type { File } from "@vitest/runner";
+import { setProjectRoot } from "../../src/server/bobbit-dir.js";
+import { resetAgentDirStateForTests } from "../../src/server/agent-dir-config.js";
+
+const BASELINE_CWD = process.cwd();
+
+// isolate:false files share a fork's module graph, so the project-root and
+// agent-dir singletons leak between files. onCollectStart is the only hook that
+// runs per file before its module loads; env is left to the fork-scoped gateway.
+export default class FileBoundaryRunner extends VitestTestRunner {
+	onCollectStart(file: File): void {
+		setProjectRoot(BASELINE_CWD);
+		resetAgentDirStateForTests();
+		return super.onCollectStart(file);
+	}
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -50,6 +50,8 @@ const shared = {
 	},
 };
 const tier1SetupFiles = ["tests2/harness/tier1-spawn-guard.ts"];
+// Per-file reset of leaking dir singletons for the isolate:false projects.
+const fileBoundaryRunner = "tests2/harness/file-boundary-runner.ts";
 
 const coverage = {
 	provider: "v8" as const,
@@ -99,6 +101,7 @@ export default defineConfig({
 					...shared,
 					name: "v2-core",
 					environment: "node",
+					runner: fileBoundaryRunner,
 					setupFiles: tier1SetupFiles,
 					include: execution.core,
 				},
@@ -123,6 +126,7 @@ export default defineConfig({
 					...shared,
 					name: "v2-integration",
 					environment: "node",
+					runner: fileBoundaryRunner,
 					setupFiles: tier1SetupFiles,
 					include: execution.integration,
 					testTimeout: 60_000,


### PR DESCRIPTION
`mcp-meta-policy.test.ts` fails intermittently on CI with a real `mkdir` under `/memfs/...` (EACCES/ENOENT), while passing on the dev box.

Cause: under `isolate: false` (v2-core, v2-integration) files in a worker fork share one module graph, so bobbit-dir's project root and the agent-dir runtime state are shared. `docker-args.test.ts` sets the root to a memfs fixture path and never restores it, so a later file that relies on the default resolves `bobbitStateDir()` under the leaked root. Which file loses depends on worker sharding, so it moved between the dev box and CI, and `retry: 3` can't mask it — the retry reruns in the same fork.

Fix: a custom runner resets the project root and agent-dir state in `onCollectStart`, the one hook that runs per file before its module loads. `beforeAll` in a setup file fires once per worker, and `beforeEach` fires after the file's own `beforeAll`, so neither works. `process.env` is left alone — the fork-scoped gateway owns `BOBBIT_*`.

Deterministic repro (fails on master, passes here):

```
VITEST_MAX_WORKERS=1 vitest run --project v2-core \
  tests2/core/docker-args.test.ts tests2/core/mcp-meta-policy.test.ts
```

Full `test:unit` green at 2 and 3 workers (965 files); no test files or production code changed.