### PR TITLE
Update PTY Node Support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@earendil-works/pi-agent-core": "0.81.1",
         "@earendil-works/pi-ai": "0.81.1",
         "@earendil-works/pi-coding-agent": "0.81.1",
-        "@homebridge/node-pty-prebuilt-multiarch": "^0.13.1",
+        "@homebridge/node-pty-prebuilt-multiarch": "^0.14.1",
         "@lmstudio/sdk": "^1.5.0",
         "@mariozechner/mini-lit": "^0.2.0",
         "@recogito/text-annotator": "^3.4.9",
@@ -3026,17 +3026,17 @@
       }
     },
     "node_modules/@homebridge/node-pty-prebuilt-multiarch": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/@homebridge/node-pty-prebuilt-multiarch/-/node-pty-prebuilt-multiarch-0.13.1.tgz",
-      "integrity": "sha512-ccQ60nMcbEGrQh0U9E6x0ajW9qJNeazpcM/9CH6J8leyNtJgb+gu24WTBAfBUVeO486ZhscnaxLEITI2HXwhow==",
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/@homebridge/node-pty-prebuilt-multiarch/-/node-pty-prebuilt-multiarch-0.14.1.tgz",
+      "integrity": "sha512-JaaTsATWPkOhm/cM2t+IjA2lztDFkoWQYU5VS8ThTsa9VbKhHwp83Cww4t8X/BH0k4Q8cWqvOKmYoGrlwLVhbA==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "node-addon-api": "^7.1.0",
-        "prebuild-install": "^7.1.2"
+        "node-addon-api": "^8.9.0",
+        "prebuild-install": "^7.1.3"
       },
       "engines": {
-        "node": ">=18.0.0 <25.0.0"
+        "node": ">=20.0.0 <27.0.0"
       }
     },
     "node_modules/@istanbuljs/schema": {
@@ -8525,10 +8525,13 @@
       }
     },
     "node_modules/node-addon-api": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
-      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
-      "license": "MIT"
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.9.0.tgz",
+      "integrity": "sha512-ekZMeaaIzSQTSpr7X2X3iJM7lTzgnx8ahAG9pJfT/7+14mlEM8ZYQ9cgCDvSSRbReFK0oHli3WrZdCiRsgAT9Q==",
+      "license": "MIT",
+      "engines": {
+        "node": "^18 || ^20 || >= 21"
+      }
     },
     "node_modules/node-domexception": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "@earendil-works/pi-agent-core": "0.81.1",
     "@earendil-works/pi-ai": "0.81.1",
     "@earendil-works/pi-coding-agent": "0.81.1",
-    "@homebridge/node-pty-prebuilt-multiarch": "^0.13.1",
+    "@homebridge/node-pty-prebuilt-multiarch": "^0.14.1",
     "@lmstudio/sdk": "^1.5.0",
     "@mariozechner/mini-lit": "^0.2.0",
     "@recogito/text-annotator": "^3.4.9",


### PR DESCRIPTION
## Summary
- upgrade `@homebridge/node-pty-prebuilt-multiarch` from `^0.13.1` to `^0.14.1`
- regenerate the npm lockfile with PTY 0.14.1 native-addon support dependencies
- preserve Bobbit's Node engine floor and existing terminal integration

## Verification
- full workflow build, type-check, unit, browser, E2E, gap-analysis, code-quality, and bug-hunt checks passed
- focused PTY/terminal tests passed (13/13)
- native PTY spawn smoke passed
- clean packed-consumer install succeeded

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)