### PR TITLE
chore(release): v0.15.0

### DIFF
--- a/RELEASE_NOTES_v0.15.0.md
+++ b/RELEASE_NOTES_v0.15.0.md
@@ -1,0 +1,35 @@
+# Bobbit v0.15.0
+
+Upgrading from v0.14.2. This release makes it clearer who is speaking in a session, adds project-level notification control, refreshes the agent runtime, and improves responsiveness and recovery across sessions, previews, file mentions, and multi-repository teams.
+
+## ✨ New Features
+
+* 🪪 **Message author identity**: Bobbit now preserves whether prompts came from the user, another agent, or the system, with clear labels where a transcript would otherwise be ambiguous. Authorship survives reloads, search, compaction, delegation, and restart recovery.
+
+* 🔔 **Per-project completion sounds**: Each project can inherit the global agent-finish sound preference or override it, so noisy projects can be muted without losing unread indicators and favicon notifications.
+
+* 🤖 **Updated agent runtime & model metadata**: The Pi runtime has been refreshed with current provider and model metadata, including GPT-5.6 capabilities, while preserving Bobbit's existing Codex OAuth, sandbox, and provider-routing behavior.
+
+* 🧭 **Predictable standard sessions**: New ordinary sessions now start with the built-in General role, giving them a consistent default tool and behavior profile.
+
+## 🐛 Bug Fixes
+
+* ⚡ **Faster cold session loading**: Transcript rendering starts before slower workspace hydration, making large and revisited sessions appear sooner while preserving review tabs, restrictions, and proposal state.
+
+* 📎 **Reliable file mentions**: `@`-mentioned files now resolve safely under large, concurrent, code-heavy, and deeply nested prompts without misclassifying ordinary text or Markdown code.
+
+* 🖼️ **Consistent HTML preview themes**: Inline and mounted previews now receive the correct Bobbit theme tokens across source, packaged, reload, and standalone-tab paths.
+
+* 🧩 **Multi-repository team workers**: Team and delegated agents now inherit the correct coordinated repository heads and worktree layout across collisions, rollback, and cleanup.
+
+* 🧹 **Responsive background maintenance**: Preview, worktree, archive, mutation, and orphan cleanup now use bounded asynchronous I/O so large maintenance jobs do not stall unrelated gateway activity.
+
+* 🌐 **Network-filesystem startup**: Dependency checks no longer hang or corrupt runtime state on NFS and other slow or unusual filesystem layouts.
+
+* 🗂️ **Project proposal recovery**: A server-restored project proposal can no longer be erased when an empty local draft finishes loading later.
+
+* 🖥️ **Newer Node.js PTY support**: The bundled prebuilt terminal dependency has been updated for more reliable integrated terminal startup on current Node.js versions.
+
+---
+
+🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bobbit",
-  "version": "0.14.2",
+  "version": "0.15.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bobbit",
-      "version": "0.14.2",
+      "version": "0.15.0",
       "dependencies": {
         "@earendil-works/pi-agent-core": "0.81.1",
         "@earendil-works/pi-ai": "0.81.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bobbit",
-  "version": "0.14.2",
+  "version": "0.15.0",
   "type": "module",
   "engines": {
     "node": ">=22.19.0"

--- a/src/app/session-manager.ts
+++ b/src/app/session-manager.ts
@@ -891,12 +891,28 @@ const projectDraft = createDraftManager({
 	},
 	restore: (_sessionId, draft: any) => {
 		let dismissed = false;
+		let preservedCurrentProposal = false;
 		if (draft.activeProjectProposal) {
 			const p = draft.activeProjectProposal as any;
-			const fields = (p.fields ?? {}) as Record<string, unknown>;
+			const storedFields = (p.fields ?? {}) as Record<string, unknown>;
+			const storedRev = typeof p.rev === "number" && Number.isFinite(p.rev)
+				? Math.max(0, Math.trunc(p.rev))
+				: 1;
+			const existing = state.activeProposals.project?.sessionId === _sessionId
+				? state.activeProposals.project
+				: undefined;
+			const existingRev = typeof existing?.rev === "number" && Number.isFinite(existing.rev)
+				? Math.max(0, Math.trunc(existing.rev))
+				: 0;
+			const keepExisting = existing !== undefined && existingRev >= storedRev;
+			const fields = keepExisting ? existing!.fields : storedFields;
 			if (isProposalDismissedTyped(_sessionId, "project", fields)) {
 				delete state.activeProposals.project;
 				dismissed = true;
+			} else if (keepExisting) {
+				// proposal_update can land while a nonempty draft request is pending.
+				// The current-session slot is authoritative at an equal or newer rev.
+				preservedCurrentProposal = true;
 			} else {
 				// `projectId` was the legacy name for source provenance. It is read
 				// only during restoration and is never serialized again.
@@ -912,22 +928,26 @@ const projectDraft = createDraftManager({
 						? { createdProjectId: p.createdProjectId.trim() }
 						: {}),
 					streaming: typeof p.streaming === "boolean" ? p.streaming : false,
-					rev: typeof p.rev === "number" ? p.rev : 1,
+					rev: storedRev,
 				};
 			}
-		} else if (state.activeProposals.project?.sessionId !== _sessionId) {
+		} else if (state.activeProposals.project?.sessionId === _sessionId) {
 			// A server proposal may arrive while the client-draft request is in
 			// flight. An empty stored draft cannot erase that newer current-session
 			// slot; only discard a proposal left over from another session.
+			preservedCurrentProposal = true;
+		} else {
 			delete state.activeProposals.project;
 		}
 		const hasCurrentProposal = state.activeProposals.project?.sessionId === _sessionId;
 		state.assistantHasProposal = dismissed ? false : (hasCurrentProposal || (draft.hasReceivedProposal ?? false));
 		state.assistantTab = draft.assistantTab ?? "chat";
-		if (draft.accepted === true) {
-			state.projectProposalAcceptedBySessionId[_sessionId] = true;
-		} else {
-			delete state.projectProposalAcceptedBySessionId[_sessionId];
+		if (!preservedCurrentProposal) {
+			if (draft.accepted === true) {
+				state.projectProposalAcceptedBySessionId[_sessionId] = true;
+			} else {
+				delete state.projectProposalAcceptedBySessionId[_sessionId];
+			}
 		}
 	},
 });

--- a/src/app/session-manager.ts
+++ b/src/app/session-manager.ts
@@ -915,10 +915,14 @@ const projectDraft = createDraftManager({
 					rev: typeof p.rev === "number" ? p.rev : 1,
 				};
 			}
-		} else {
+		} else if (state.activeProposals.project?.sessionId !== _sessionId) {
+			// A server proposal may arrive while the client-draft request is in
+			// flight. An empty stored draft cannot erase that newer current-session
+			// slot; only discard a proposal left over from another session.
 			delete state.activeProposals.project;
 		}
-		state.assistantHasProposal = dismissed ? false : (draft.hasReceivedProposal ?? false);
+		const hasCurrentProposal = state.activeProposals.project?.sessionId === _sessionId;
+		state.assistantHasProposal = dismissed ? false : (hasCurrentProposal || (draft.hasReceivedProposal ?? false));
 		state.assistantTab = draft.assistantTab ?? "chat";
 		if (draft.accepted === true) {
 			state.projectProposalAcceptedBySessionId[_sessionId] = true;
@@ -2713,10 +2717,15 @@ export async function connectToSession(sessionId: string, isExisting: boolean, o
 			} else if (state.assistantType === "project" || state.assistantType === "project-scaffolding") {
 				const restored = await restoreProjectDraft(sessionId);
 				if (isStale()) return;
-				if (!restored) {
+				const liveProposal = liveProposalSlotForSession("project", sessionId);
+				if (!restored && !liveProposal) {
 					state.assistantTab = "chat";
 					delete state.activeProposals.project;
 					state.assistantHasProposal = false;
+				} else if (liveProposal) {
+					// proposal_update can land while the empty draft request is pending.
+					// Preserve the server-owned slot and its visible proposal state.
+					state.assistantHasProposal = true;
 				}
 			}
 		})();

--- a/tests2/browser/journeys/team-operations.journey.spec.ts
+++ b/tests2/browser/journeys/team-operations.journey.spec.ts
@@ -277,6 +277,16 @@ test.describe("Journey: Dashboard Fanout — behavioral assertions", () => {
 
 // Behavioral assertions ported from dashboard-mutation-pending.spec.ts
 test.describe("Journey: Dashboard Mutation Pending — behavioral assertions", () => {
+	test.beforeEach(async () => {
+		// The mutation card is Subgoals-gated. Pin the system preference instead
+		// of inheriting another journey's global toggle state within the worker.
+		const prefs = await apiFetch("/api/preferences", {
+			method: "PUT",
+			body: JSON.stringify({ subgoalsEnabled: true }),
+		});
+		expect(prefs.status, `enable subgoals for mutation dashboard: ${await prefs.clone().text()}`).toBe(200);
+	});
+
 	test("pending mutation card renders from route-mocked endpoint on load", async ({ page }) => {
 		const goal = await createGoal({ title: "v2-mutation-card-smoke", team: false });
 		const goalId = goal.id as string;

--- a/tests2/dom/cold-session-workspace-ordering-repro.test.ts
+++ b/tests2/dom/cold-session-workspace-ordering-repro.test.ts
@@ -78,6 +78,7 @@ const authoritativeWorkspaces = new Map<string, SidePanelWorkspace>();
 const workspaceDeleteOutcomes = new Map<string, WorkspaceDeleteOutcome[]>();
 const workspaceDeleteAttempts = new Map<string, WorkspaceDeleteAttempt[]>();
 const transcripts = new Map<string, any[]>();
+const projectDrafts = new Map<string, Record<string, unknown>>();
 let sessionListGate: DeferredGate | null = null;
 let sessionListFetchCount = 0;
 let sessionListResponseSessions: GatewaySession[] | null = null;
@@ -273,7 +274,14 @@ async function fetchFixture(input: RequestInfo | URL, init?: RequestInit): Promi
 		await gateFor(sessionId).promise;
 		return Response.json(cloneWorkspace(authoritativeWorkspace(sessionId)));
 	}
-	if (url.pathname.endsWith("/draft") && method === "GET") return new Response(null, { status: 204 });
+	if (url.pathname.endsWith("/draft") && method === "GET") {
+		const projectDraft = sessionId && url.searchParams.get("type") === "project"
+			? projectDrafts.get(sessionId)
+			: undefined;
+		return projectDraft
+			? Response.json({ data: projectDraft })
+			: new Response(null, { status: 204 });
+	}
 	if (url.pathname.endsWith("/git-status")) {
 		return Response.json({ branch: "master", status: [], clean: true });
 	}
@@ -486,6 +494,7 @@ beforeEach(() => {
 	authoritativeWorkspaces.clear();
 	workspaceDeleteOutcomes.clear();
 	workspaceDeleteAttempts.clear();
+	projectDrafts.clear();
 	sessionListGate = null;
 	sessionListFetchCount = 0;
 	sessionListResponseSessions = null;
@@ -695,6 +704,56 @@ describe("cold session transcript/workspace ordering", () => {
 				state.activeProposals.project,
 				"PROJECT_PROPOSAL_DRAFT_RESTORE_RACE: an empty client draft response erased the newer server proposal",
 			).toMatchObject({ sessionId: SESSION_A, fields, rev: 1 });
+			expect(state.assistantHasProposal).toBe(true);
+		} finally {
+			gateFor(SESSION_A).release();
+			await pendingConnect.catch(() => {});
+		}
+	});
+
+	it("preserves a newer server project proposal over a stale nonempty draft restore", async () => {
+		state.gatewaySessions = state.gatewaySessions.map((session) =>
+			session.id === SESSION_A ? { ...session, assistantType: "project" } : session);
+		const staleFields = {
+			name: "Stale draft project proposal",
+			root_path: "/fixture/stale-draft-project-proposal",
+		};
+		projectDrafts.set(SESSION_A, {
+			activeProjectProposal: {
+				sessionId: SESSION_A,
+				fields: staleFields,
+				streaming: false,
+				rev: 1,
+			},
+			hasReceivedProposal: true,
+			assistantTab: "preview",
+			accepted: true,
+		});
+		const pendingConnect = connectToSession(SESSION_A, true);
+
+		try {
+			await waitFor(
+				() => (workspaceFetchCount.get(SESSION_A) || 0) > 0
+					&& typeof state.remoteAgent?.onProposal === "function",
+				"PROJECT_PROPOSAL_DRAFT_RESTORE_RACE: project callback was not ready before a stale draft restore",
+			);
+			const fields = {
+				name: "Current server project proposal",
+				root_path: "/fixture/current-server-project-proposal",
+				test_command: "npm run test:unit",
+			};
+			state.remoteAgent?.onProposal?.("project", fields, false, 2, "rehydrate");
+			expect(state.activeProposals.project).toMatchObject({ sessionId: SESSION_A, fields, rev: 2 });
+
+			gateFor(SESSION_A).release();
+			await pendingConnect;
+
+			expect(
+				state.activeProposals.project,
+				"PROJECT_PROPOSAL_DRAFT_RESTORE_RACE: a stale nonempty draft overwrote the newer server proposal",
+			).toMatchObject({ sessionId: SESSION_A, fields, rev: 2 });
+			expect(state.activeProposals.project?.fields).not.toEqual(staleFields);
+			expect(state.projectProposalAcceptedBySessionId[SESSION_A]).toBeUndefined();
 			expect(state.assistantHasProposal).toBe(true);
 		} finally {
 			gateFor(SESSION_A).release();

--- a/tests2/dom/cold-session-workspace-ordering-repro.test.ts
+++ b/tests2/dom/cold-session-workspace-ordering-repro.test.ts
@@ -663,6 +663,45 @@ describe("cold session transcript/workspace ordering", () => {
 		expect(finalTranscriptRow(SESSION_A)?.textContent).toBe(`${SESSION_A} transcript row ${TRANSCRIPT_SIZE - 1}`);
 	});
 
+	it("preserves a server project proposal that arrives before an empty draft restore settles", async () => {
+		state.gatewaySessions = state.gatewaySessions.map((session) =>
+			session.id === SESSION_A ? { ...session, assistantType: "project" } : session);
+		const pendingConnect = connectToSession(SESSION_A, true);
+
+		try {
+			await waitFor(
+				() => (workspaceFetchCount.get(SESSION_A) || 0) > 0
+					&& typeof state.remoteAgent?.onProposal === "function",
+				"PROJECT_PROPOSAL_DRAFT_RESTORE_RACE: project callback was not ready while workspace hydration was pending",
+			);
+			expect(gateFor(SESSION_A).settled).toBe(false);
+
+			const fields = {
+				name: "Server project proposal",
+				root_path: "/fixture/server-project-proposal",
+				test_command: "npm test",
+			};
+			state.remoteAgent?.onProposal?.("project", fields, false, 1, "rehydrate");
+			expect(state.activeProposals.project).toMatchObject({
+				sessionId: SESSION_A,
+				fields,
+				rev: 1,
+			});
+
+			gateFor(SESSION_A).release();
+			await pendingConnect;
+
+			expect(
+				state.activeProposals.project,
+				"PROJECT_PROPOSAL_DRAFT_RESTORE_RACE: an empty client draft response erased the newer server proposal",
+			).toMatchObject({ sessionId: SESSION_A, fields, rev: 1 });
+			expect(state.assistantHasProposal).toBe(true);
+		} finally {
+			gateFor(SESSION_A).release();
+			await pendingConnect.catch(() => {});
+		}
+	});
+
 	it("keeps B foreground mirrors and transcript when A workspace completes after a rapid A to B switch", async () => {
 		const connectA = connectToSession(SESSION_A, true);
 		await waitFor(

--- a/tests2/tests-map.json
+++ b/tests2/tests-map.json
@@ -499,7 +499,7 @@
     },
     {
       "path": "tests2/dom/cold-session-workspace-ordering-repro.test.ts",
-      "reason": "Failing-first deterministic DOM regression around real connectToSession and RemoteAgent handshakes: a controlled WebSocket and delayed side-panel workspace fetch prove get_messages and a 321-row transcript do not wait for REST hydration, initial hydration has one owner, server project proposals survive an empty client-draft restore race, late abandoned-session workspace responses cannot replace foreground mirrors, reconnect hydration remains intact, and cached switch-back creates no new socket or workspace request. Failure tokens COLD_SESSION_LOAD_ORDERING_REGRESSION and PROJECT_PROPOSAL_DRAFT_RESTORE_RACE.",
+      "reason": "Failing-first deterministic DOM regression around real connectToSession and RemoteAgent handshakes: a controlled WebSocket and delayed side-panel workspace fetch prove get_messages and a 321-row transcript do not wait for REST hydration, initial hydration has one owner, server project proposals survive empty and stale nonempty client-draft restore races, late abandoned-session workspace responses cannot replace foreground mirrors, reconnect hydration remains intact, and cached switch-back creates no new socket or workspace request. Failure tokens COLD_SESSION_LOAD_ORDERING_REGRESSION and PROJECT_PROPOSAL_DRAFT_RESTORE_RACE.",
       "execution": {
         "runner": "vitest",
         "tier": "unit",

--- a/tests2/tests-map.json
+++ b/tests2/tests-map.json
@@ -499,7 +499,7 @@
     },
     {
       "path": "tests2/dom/cold-session-workspace-ordering-repro.test.ts",
-      "reason": "Failing-first deterministic DOM regression around real connectToSession and RemoteAgent handshakes: a controlled WebSocket and delayed side-panel workspace fetch prove get_messages and a 321-row transcript do not wait for REST hydration, initial hydration has one owner, late abandoned-session workspace responses cannot replace foreground mirrors, reconnect hydration remains intact, and cached switch-back creates no new socket or workspace request. Failure token COLD_SESSION_LOAD_ORDERING_REGRESSION.",
+      "reason": "Failing-first deterministic DOM regression around real connectToSession and RemoteAgent handshakes: a controlled WebSocket and delayed side-panel workspace fetch prove get_messages and a 321-row transcript do not wait for REST hydration, initial hydration has one owner, server project proposals survive an empty client-draft restore race, late abandoned-session workspace responses cannot replace foreground mirrors, reconnect hydration remains intact, and cached switch-back creates no new socket or workspace request. Failure tokens COLD_SESSION_LOAD_ORDERING_REGRESSION and PROJECT_PROPOSAL_DRAFT_RESTORE_RACE.",
       "execution": {
         "runner": "vitest",
         "tier": "unit",


### PR DESCRIPTION
## Summary

- preserve server-restored project proposals during cold-session hydration
- isolate the sub-goal mutation browser journey from persisted global preferences
- bump Bobbit to v0.15.0 and add approved release notes

## Validation

- `npm run build`
- `npm run check`
- `npm run test:unit` — 970 files, 8,463 tests passed
- `npm run test:browser` — 672 passed, 9 skipped, no retries
- `npm run test:e2e`
- `npm audit --omit=dev` — 0 vulnerabilities
- bundled binary versions unchanged; binary sub-packages do not require publication

## Packed-consumer audit exception

The packed-consumer audit is **not clean**. It reports inherited advisories under `@earendil-works/pi-coding-agent` that also affect published `bobbit@0.14.2` and are not introduced by this release:

- high: `brace-expansion<=5.0.7` (`GHSA-mh99-v99m-4gvg`)
- moderate: `protobufjs 7.5.0–7.6.4` (`GHSA-j3f2-48v5-ccww`)

The maintainer explicitly authorized proceeding with the release while retaining this disclosure.

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)