### PR TITLE
ci: trigger workflows on main instead of master

### DIFF
--- a/.github/workflows/build-unit-gate.yml
+++ b/.github/workflows/build-unit-gate.yml
@@ -2,9 +2,9 @@ name: Build & Unit Gate
 
 on:
   pull_request:
-    branches: [master]
+    branches: [main]
   push:
-    branches: [master]
+    branches: [main]
 
 permissions:
   contents: read

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,9 +2,9 @@ name: CodeQL
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
-    branches: [master]
+    branches: [main]
   schedule:
     - cron: '27 4 * * 1' # weekly, Monday 04:27 UTC
 


### PR DESCRIPTION
The default branch was renamed `master` → `main`, but the workflow triggers still referenced `master`, so **CodeQL** and **Build & Unit Gate** stopped running on pushes/PRs to `main`.

This updates the `branches:` filters in both workflows to `main`, restoring CI on the default branch.

- `build-unit-gate.yml`: push + pull_request → `main`
- `codeql.yml`: push + pull_request → `main` (weekly cron unchanged)

`release-publish.yml` is tag-triggered (`v*`) and needs no change.