### PR TITLE
Fix polyrepo Git status widgets

### DIFF
--- a/.bobbit/config/project.yaml
+++ b/.bobbit/config/project.yaml
@@ -1,6 +1,6 @@
 sandbox: docker
 sandbox_image: bobbit-agent
-base_ref: origin/master
+base_ref: origin/main
 components:
   - name: bobbit
     repo: .
@@ -282,7 +282,7 @@ workflows:
             type: command
             run: git push origin {{branch}}:refs/heads/{{branch}} && git ls-remote --heads
               origin {{branch}} | grep -q .
-          - name: Master merged into branch
+          - name: Base ref merged into branch
             type: command
             run: git fetch origin {{baseBranch}} && git merge-base --is-ancestor
               origin/{{baseBranch}} {{branch}}
@@ -553,7 +553,7 @@ workflows:
             type: command
             run: git push origin {{branch}}:refs/heads/{{branch}} && git ls-remote --heads
               origin {{branch}} | grep -q .
-          - name: Master merged into branch
+          - name: Base ref merged into branch
             type: command
             run: git fetch origin {{baseBranch}} && git merge-base --is-ancestor
               origin/{{baseBranch}} {{branch}}
@@ -715,7 +715,7 @@ workflows:
             type: command
             run: git push origin {{branch}}:refs/heads/{{branch}} && git ls-remote --heads
               origin {{branch}} | grep -q .
-          - name: Master merged into branch
+          - name: Base ref merged into branch
             type: command
             run: git fetch origin {{baseBranch}} && git merge-base --is-ancestor
               origin/{{baseBranch}} {{branch}}
@@ -799,7 +799,7 @@ workflows:
             type: command
             run: git push origin {{branch}}:refs/heads/{{branch}} && git ls-remote --heads
               origin {{branch}} | grep -q .
-          - name: Master merged into branch
+          - name: Base ref merged into branch
             type: command
             run: git fetch origin {{baseBranch}} && git merge-base --is-ancestor
               origin/{{baseBranch}} {{branch}}

--- a/docs/design/multi-repo-components.md
+++ b/docs/design/multi-repo-components.md
@@ -501,6 +501,20 @@ A `.` entry whose source *is* a git repo root (a genuine single-repo / container
 
 **Net effect.** Staff creation in a poly-repo now produces one worktree per git sub-repo under the branch container — byte-for-byte the same shape a regular session produces for the same project. Projects with no worktree-able git repo fall back to no-worktree instead of throwing.
 
+### 4.6 Team leads borrow the goal-owned set
+
+A non-sandboxed polyrepo team lead runs in the goal's existing branch container. Team startup passes the goal's `worktreePath`, `repoPath`, `branch`, and `repoWorktrees` into session creation and the subsequent metadata update. It does **not** claim a pool entry, call `createWorktreeSet`, or provision a parallel lead worktree. This keeps the lead and goal on the same component HEADs and avoids duplicate branches for what is conceptually one goal workspace.
+
+The coordinate shapes differ by lifecycle layer:
+
+- `PersistedGoal.repoWorktrees` and `PersistedSession.repoWorktrees` are `Record<string, string>` maps from repository key to worktree path. This compact form is the durable source across gateway restarts.
+- A live session expands the map to `Array<{ repo, repoPath, worktreePath }>` so callers have both the component worktree and its primary checkout. `repoPath` is derived from the persisted container `repoPath` and repository key.
+- `worktreePath`, `repoPath`, `branch`, and `repoWorktrees` are recovery-critical session fields, so metadata updates flush synchronously. Session restoration rebuilds the live array from the persisted record before Git-status and diff routes use it.
+
+Borrowing coordinates does not transfer cleanup ownership. The goal remains the owner of the directories, Git worktree registrations, and shared branch. Archiving a non-sandboxed polyrepo lead keeps its coordinates for restoration and history but excludes the borrowed set from archived-session cleanup. Purging the lead removes its record without deleting those worktrees. The normal reference guards still protect worktrees used by live goals, sessions, teams, or staff.
+
+If a team-store entry survives but its lead session record is missing, orphan recovery reconstructs the lead from the goal and copies the same component map for a non-sandboxed goal. That makes the recovered session status-capable without inventing new worktrees. Sandboxed leads retain sandbox-owned restoration instead, and Headquarters retains its no-worktree contract. These ownership boundaries matter because recovery metadata must make a workspace discoverable, not make it deletable by a second owner.
+
 ---
 
 ## 5. Worktree pool fixes
@@ -661,13 +675,17 @@ export function readHandoff(task: PersistedTask, repo: string):
 
 ### 6.2 Aggregated git status / diff
 
-`server.ts`:
+Goal and session Git-status routes normalize their different metadata shapes into the same ordered `{ repo, worktreePath }` targets, then use one collector and aggregation policy. Root and component probes run independently, so a non-Git branch container cannot prevent component status from being collected.
 
-- `GET /api/goals/:id/git-status` → returns `{ aggregate: GitStatus, repos: Record<string, GitStatus> }` for multi-repo; single-repo returns `{ aggregate, repos: { ".": aggregate } }` (back-compat — existing UI handles flat shape).
-- `GET /api/goals/:id/git-diff?repo=<name>` → diff scoped to a repo. Without `?repo=`, returns concatenated diff with per-repo headers.
-- `batchGitStatus()` (existing) is reused per-repo and aggregated.
+Both routes return a flat-compatible envelope:
 
-The matching **session-context** endpoints (`GET /api/sessions/:id/git-status` and `git-diff`) reached parity in a follow-up — see §13 for the session envelope, the synthesized aggregate for non-git branch containers, per-repo diff routing, and the container-diff security hardening.
+```typescript
+{ ...aggregate, aggregate: GitStatusResult, repos: Record<string, GitStatusResult> }
+```
+
+Configured component results are authoritative whenever at least one succeeds; the root is only a fallback when no component succeeds. This prevents a Git root or an offset `cwd` from duplicating or overriding component counts. A sole `"."` repository retains the flat single-repo shape, while a sole named component remains a component envelope. See §13 for synthesis, failure classification, fetch/cache behaviour, and UI semantics.
+
+Diff routing remains explicit and unchanged: `?repo=<name>` selects that component worktree for both goal and session routes. A missing or unknown repository parameter retains the route's root/container fallback. Widget file links from named sections always include the repository key, so a component file is diffed in the repository that reported it.
 
 ### 6.3 PR-per-repo
 
@@ -799,7 +817,7 @@ Plus:
 
 ### 8.4 Git status widget
 
-`src/ui/components/GitStatusWidget.ts`: when `repos` map has more than one entry, render a collapsible per-repo section with aggregated counts in the header:
+`GitStatusWidget` treats an envelope as component-oriented when `repos` has multiple entries **or any sole key other than `"."`**. Only `{ ".": result }` uses the flat single-repo rendering. This distinction matters for a polyrepo with one available named component: the repository section must remain visible rather than collapsing into an anonymous flat list.
 
 ```
 [Git status]  3 changed across 2 repos    ▾
@@ -808,7 +826,7 @@ Plus:
   shared   clean
 ```
 
-API contract change: existing flat shape continues for single-repo. Multi-repo returns the new envelope; widget detects and renders accordingly.
+The pill derives dirty counts and primary-comparison segments from `repos`; the dropdown renders one named collapsible section per returned component. Dirty sections open by default and clean sections remain collapsed. Both the session surface and goal dashboard accept the same successful envelope and reconstruct the sections after reload. The client treats only an exact 400 `Not a git repository` response as terminal; retryable failures do not hide the widget permanently, and a later successful envelope restores it.
 
 ### 8.5 `propose_project` tool
 
@@ -844,7 +862,9 @@ Acceptance side (`session-manager.ts::acceptProjectProposal`): writes `component
 
 ---
 
-## 9. Testing plan (mapped to acceptance criteria)
+## 9. Testing plan and regression ownership
+
+Sections 9.1–9.4 preserve the original feature acceptance plan. The current Test Suite v2 regression owners for the corrected Git-status lifecycle are listed in §9.5; those entries supersede older path and coverage claims for this follow-up.
 
 ### 9.1 Unit / file-fixture tests (`tests/*.spec.ts`)
 
@@ -879,6 +899,17 @@ Acceptance side (`session-manager.ts::acceptProjectProposal`): writes `component
 | AC | Test |
 |----|------|
 | 23 | `multi-repo-docker.test.ts` — real Docker, real git, two real repos in container; create goal; per-component setup runs inside container; one llm-review and one agent-qa gate execute end-to-end; teardown succeeds. |
+
+### 9.5 Current Git-status regression owners
+
+These tests are registered in `tests2/tests-map.json`:
+
+- `tests2/integration/team-spawn-multi-repo-real-git.test.ts` creates real component repositories beneath a non-Git root. It pins goal-owned coordinates, live and persisted lead metadata, session restoration, goal/session envelopes with real summed line counts, and archive/purge safety for the borrowed set.
+- `tests2/core/git-status-envelope.test.ts` pins component-authoritative synthesis, all required aggregate fields, root fallback, partial sibling survival, sole-named and sole-root shapes, missing-path classification, and deduplicated target side effects.
+- `tests2/core/git-status-native-classification.test.ts` pins host and container probe classification, including definitive outside-repository diagnostics, spawn/timeout/permission failures, and partial results from optional probe failures.
+- `tests2/integration/git-status-polyrepo-fetch-policy.test.ts` warms separate root and component cache variants, then proves both endpoint families fetch and invalidate every target even when the non-Git root fetch fails.
+- `tests2/core/git-status-local-only-policy.test.ts` and `tests2/integration/git-status-local-only-policy.test.ts` pin the read-only status policy and keep publication behind explicit Git-action routes.
+- `tests2/dom/git-status-widget-multi-repo.test.ts` pins aggregate pill and section behaviour, including a sole named component. `tests2/browser/journeys/polyrepo-git-status.journey.spec.ts` exercises the session and goal-dashboard surfaces, explicit refresh, multiple named components, the sole-named case, and reload.
 
 ---
 
@@ -947,59 +978,101 @@ Acceptance side (`session-manager.ts::acceptProjectProposal`): writes `component
 
 ---
 
-## 13. Session git-status / git-diff parity (addendum, 2026-06)
+## 13. Shared Git-status lifecycle and aggregation contract
 
-§6.2 described the **goal** dashboard's aggregated git status/diff. This section documents the matching **session-context** work: the per-session pill + popover above the composer now show the same multi-repo aggregate that the goal dashboard does. Goal and single-repo behaviour are byte-for-byte unchanged; only the session code path gained multi-repo awareness.
+Goal dashboards and session widgets now use the same Git-status collector. This is necessary because a true polyrepo's branch container is intentionally not a Git repository: treating the container probe as a prerequisite hides valid component worktrees and can poison the client's negative-repository cache.
 
-**Why this was needed.** A polyrepo session's worktrees live one level under a non-git *branch container* (see §4.2). The session widget previously statused only the container `cwd` and rendered a flat single-repo result — so a true polyrepo session showed just a branch name with no per-repo breakdown and no aggregated dirty/ahead/behind/diff counts. The goal path already solved this; sessions were the remaining gap.
+### 13.1 Target collection
 
-### 13.1 Envelope shape (`GET /api/sessions/:id/git-status`)
+The two routes normalize durable metadata before collection:
 
-The handler in `src/server/server.ts` (the `/api/sessions/:id/git-status` branch) mirrors the goal handler's envelope:
+- A goal supplies its persisted `Record<string, string>` directly as ordered `{ repo, worktreePath }` component targets.
+- A live session supplies the same target shape from its `Array<{ repo, repoPath, worktreePath }>` representation. Restored team leads have this array because §4.6 rebuilds it from the persisted record.
 
-- **Single-repo / no `repoWorktrees`** → unchanged flat shape plus back-compat keys: `{ ...result, aggregate: result, repos: { ".": result } }`. The existing 400 `{ error: "Not a git repository" }` and 500 paths are preserved. Status is read-only for every session; legacy publication metadata does not change that contract.
-- **Multi-repo** (`session.repoWorktrees.length > 1`) → `{ ...aggregate, aggregate, repos }`, where `repos` is keyed by **repo name** and each entry is a full `GitStatusResult`.
+The collector builds a root-plus-components target set, deduplicated by worktree path. It probes the root and every configured component independently; root failure never short-circuits component work. The same policy therefore covers a normal Git root, a non-Git polyrepo container, an offset `cwd`, and a sole named component without separate goal/session implementations.
 
-**Shape note.** In-memory `session.repoWorktrees` is an **array** `Array<{ repo, repoPath, worktreePath }>` (see `session-manager.ts`), unlike the goal's `Record<string, string>` (`goal.repoWorktrees`). The session handler iterates the array and statuses each entry's `worktreePath` (sandboxed sessions route through the container via the `containerId` argument, exactly as the flat path does). Per-repo failures are swallowed (`try/catch`, skip the entry) so one broken sub-repo cannot 500 the whole status. Each per-repo `batchGitStatus` call honours the project `base_ref` config (`configuredBaseRef`), matching the goal handler and `docs/design/base-ref.md` §5.
+Host targets are existence-checked before Git runs. Container targets are classified by the container probe because their paths are not meaningful to the host. Missing configured host paths are failures rather than silently skipped components, so an incomplete worktree set is observable.
 
-### 13.2 Synthesized aggregate for non-git containers
+### 13.2 Flat-compatible envelope and synthesis
 
-The root container status comes from `batchGitStatus(cwd, …)`. In a **true polyrepo** the container `cwd` is *not* itself a git repo (§4.2), so this returns `null` / throws. That is **non-fatal in multi-repo mode** — the per-repo worktrees are the source of truth. The aggregate is resolved as:
+Every successful response has the same shape:
 
-1. **Root `result` exists** (the container is itself a git repo — e.g. a `repo: "."` component, or a single-repo collapse) → use it as the aggregate, for back-compat with the flat shape.
-2. **Root `result` is null** (genuine non-git container) → **synthesize** an aggregate from the per-repo results. All sub-repos share the same session branch, so `branch` / `primaryBranch` / `primaryRef` / `isOnPrimary` / `hasUpstream` / `mergedIntoPrimary` are taken from the **first** repo, while the numeric counters (`ahead`, `behind`, `aheadOfPrimary`, `behindPrimary`, `insertionsVsPrimary`, `deletionsVsPrimary`) are **summed** across repos. `clean` is the **AND** across repos (clean only if every repo is clean), `unpushed` is the **OR**, `status` is `[]` (the flat file list is suppressed — the per-repo popover sections are authoritative), and `summary` is `"<N> repos"`.
+```typescript
+interface GitStatusEnvelope extends GitStatusResult {
+  aggregate: GitStatusResult;
+  repos: Record<string, GitStatusResult>;
+}
+```
 
-If neither a root `result` nor any per-repo result is available, the handler returns the same 400 `{ error: "Not a git repository" }` as the flat path.
+The top level spreads `aggregate` for callers that still read flat fields. Each `GitStatusResult` includes the required identity, file, remote, primary-comparison, line-count, and state fields:
 
-**Why synthesize rather than 400.** Without the synthesized aggregate, a polyrepo session whose container is non-git would have no top-level status object at all, so the pill would fall back to rendering only the branch name — the exact gap this work closes. Synthesizing lets the pill show real aggregated stats even though the directory the agent's `cwd` points at is not a git repo.
+```typescript
+{
+  branch, primaryBranch, primaryRef, isOnPrimary,
+  status, hasUpstream, ahead, behind,
+  aheadOfPrimary, behindPrimary, mergedIntoPrimary,
+  insertionsVsPrimary, deletionsVsPrimary,
+  clean, summary, unpushed,
+  partial?, untrackedIncluded?
+}
+```
 
-**Status is read-only.** A non-git-container polyrepo has no root repository, so the handler synthesizes its aggregate from per-repo results. Neither the root nor per-repo status path publishes branches. Persistent per-repo worktrees are the collaboration and durability mechanism; explicit user/agent push and workflow commands remain separate.
+Aggregation follows these rules:
 
-### 13.3 Per-repo diff routing (`GET /api/sessions/:id/git-diff`)
+1. **Successful configured components are authoritative.** If any configured component succeeds, `repos` contains the successful components and the root result is not counted. This avoids duplicate or contradictory data when the root is Git or `cwd` is inside a component.
+2. **Identity is deterministic.** The first successful component in configured order supplies `branch`, `primaryBranch`, `primaryRef`, `isOnPrimary`, `hasUpstream`, and `mergedIntoPrimary`.
+3. **Counters are additive.** `ahead`, `behind`, `aheadOfPrimary`, `behindPrimary`, `insertionsVsPrimary`, and `deletionsVsPrimary` are summed across successful components.
+4. **State is collective.** `clean` is true only when every successful component is clean; `unpushed` is true when any is unpushed. The synthesized `status` is empty because per-repository file lists are authoritative, and `summary` is `"<N> repo(s)"`.
+5. **Incomplete data stays visible.** A failed component is omitted from `repos`, successful siblings remain, and `partial` becomes true. A component's own partial result also propagates. `untrackedIncluded` is true only when every configured component succeeded with complete untracked data.
+6. **Root is fallback, not winner.** The root result is used only when no configured component succeeds. If configured components were attempted, the root fallback is marked partial and untracked-incomplete. With no component targets, the root result remains byte-compatible with the flat single-repo response.
 
-Clicking a file inside a per-repo popover section opens that repo's diff. The widget's `_openDiffModal(file, repo?)` (`src/ui/components/GitStatusWidget.ts`) appends `?repo=<name>` to the diff URL when the file came from a multi-repo section. The session `git-diff` handler resolves `?repo=` against `session.repoWorktrees` (find the array entry whose `repo` matches) and diffs that entry's `worktreePath`; an absent or `.` repo param (or an unknown name) falls back to the container `cwd`. This mirrors the goal `git-diff` handler's `?repo=` resolution.
+A sole `"."` component keeps `{ ...result, aggregate: result, repos: { ".": result } }`. A sole named component uses the component-authoritative synthesis, including `status: []`, and retains its name in `repos`. This distinction lets the widget show the repository section even when only one named component is available.
 
-### 13.4 Container-path security: argument-vector exec
+### 13.3 Definitive non-repository versus retryable failure
 
-`getGitDiff`'s container branch previously built a `/bin/sh -c "git diff … -- <file>"` string with the user-supplied `file` interpolated in, a command-injection vector. It now uses **argument-vector execution** via `execGitArgsSafe` → `execGitArgs`, which runs `docker exec -w <cwd> <containerId> git <args…>` with `file` passed as a distinct argv element — never parsed by a shell. (Path-traversal / absolute / drive-letter `file` values are still rejected up front with `INVALID_PATH`.)
+The shared status path uses classified probes rather than collapsing every non-zero command to `null`. Native host/container probes produce these outcomes, and the collector adds path-validation failures:
 
-**Why argv instead of a shell string.** Passing `file` through `/bin/sh -c` meant any shell metacharacters in the filename were interpreted by the container's shell. Argv execution removes the shell entirely, so the diff target is always treated as literal data regardless of its contents — closing the injection vector without changing behaviour for legitimate paths.
+- `success` carries a `GitStatusResult`.
+- `not-repository` is reserved for the mandatory branch probe when Git itself exits with its known outside-repository diagnostic.
+- `error` covers timeouts, killed processes, spawn failures such as `ENOENT` or `EACCES`, missing Git or Docker, Docker execution failure, permission or dubious-ownership diagnostics, unknown non-zero exits, missing configured paths, and unexpected exceptions.
 
-### 13.5 Widget rendering
+On the host, process code, signal, killed/timeout state, stderr, and stdout are retained so terminal-looking text from a failed spawn cannot be mistaken for a definitive Git answer. In a container, the batch script emits separate machine-readable sentinels for the known non-repository case and other mandatory-probe failures; a Docker rejection occurs outside the script and is always an error. Optional porcelain, upstream, count, or shortstat failures may still return success, but mark the result `partial` and clear untracked completeness where applicable.
 
-`src/ui/components/GitStatusWidget.ts` already rendered per-repo sections and a multi-repo pill label; this work completed the aggregation:
+HTTP classification is based on all attempted targets:
 
-- **Pill** — in multi-repo mode (`repos` has >1 entry) the pill shows `"<N> changed across <M> repos"` (dirty-file count summed across repos, `M` = count of dirty repos) **plus** full aggregated primary-comparison segments. `_aggregatePrimaryStats()` sums `aheadOfPrimary` / `behindPrimary` / `insertionsVsPrimary` / `deletionsVsPrimary` across the `repos` envelope entries, and `_segmentSpans()` renders the shared coloured `↓behind ↑ahead +ins -del` markup (the same helper the flat `_pillSegments()` uses, so styling never diverges).
-- **Clean collapse** — multi-repo clean state (every repo clean *and* all summed primary stats zero, with no PR) collapses to the single green "clean" indicator. This is derived from the **aggregate**, **independent of `isOnPrimary`** — a clean `session/…` branch must still collapse to "clean" even though it is not on the primary branch. Flat/single-repo collapse logic is unchanged (it still considers `isOnPrimary` / `mergedIntoPrimary`).
-- **Popover** — `_renderMultiRepoSections()` renders one collapsible section per repo with per-repo counts; dirty repos auto-expand, clean ones stay collapsed.
+- Return 200 when the root or any component succeeds.
+- Return 400 `{ error: "Not a git repository" }` only when every attempted target is definitively `not-repository`.
+- Return a retryable 500 when nothing succeeds and any target is `error`. In particular, an all-missing component set is not a terminal non-repository result.
 
-The per-repo envelope entries already carried `aheadOfPrimary` / `behindPrimary` / `insertionsVsPrimary` / `deletionsVsPrimary` (added by the line-counts work in `docs/design/git-status-widget-reliability.md` §13), so the pill aggregation reuses those fields directly rather than recomputing anything server-side.
+The existing missing-sole-root precondition may still return 404 before collection when there are no component targets. Headquarters and goal no-worktree checks retain their existing unavailable responses; an ordinary session still statuses its configured `cwd`. On the client, only the exact 400 payload becomes `not-a-repo`; other failures remain retry-eligible, and a later successful envelope restores the widget.
 
-### 13.6 Tests
+### 13.4 Per-target fetch and cache policy
 
-- **Widget unit / file-fixture** — the `git-status-widget-multi-repo` bundle (`tests/fixtures/build-bundle.ts`) covers the full-aggregate pill (summed dirty + ahead/behind/+/−) and the clean-collapse case.
-- **API E2E** — `GET /api/sessions/:id/git-status` returns `{ repos, aggregate }` for a multi-repo session and the unchanged flat + `repos: { ".": result }` shape for single-repo.
-- **Browser E2E** (`tests/e2e/ui/`) — a polyrepo session shows aggregated pill stats; the popover shows one section per repo with correct counts; a clean repo renders collapsed; clicking a file opens that repo's diff; state persists across reload.
+`?fetch=true` operates on the same deduplicated root-plus-components set used for status:
+
+1. Best-effort fetch every applicable target independently. A non-Git root or one failed component does not stop sibling fetches.
+2. In a `finally` path, invalidate every requested target even when fetch fails or a host path is absent.
+3. Invalidation clears both the summary and untracked cache variants for that path and container scope before status is collected.
+
+Status caching is also per target and separates summary from untracked requests. In-flight calls are coalesced, successful and definitive non-repository probes use the short cache window, and retryable errors are evicted immediately. This prevents stale component entries from surviving an explicit refresh merely because the container root failed first.
+
+Fetch and status remain read-only. They do not push, pull, merge, rename branches, set upstreams, or publish a session branch. Explicit Git-action routes and workflow commands retain ownership of those mutations.
+
+### 13.5 Widget and reload behaviour
+
+Both the session header and goal dashboard consume the top-level aggregate while forwarding `repos` to `GitStatusWidget`. A component-only response still has a top-level branch, so the normal reveal logic keeps the widget visible when the root container is non-Git.
+
+The widget uses per-repository mode for multiple entries or a sole named key; only a sole `"."` key stays flat. It shows summed dirty and primary-comparison segments in the pill, renders one collapsible section per successful repository, opens dirty sections by default, and leaves clean sections collapsed. A partially failed sibling therefore does not hide valid sections. Opening the widget requests explicit fetch and full untracked status, and navigation reload refetches the envelope, so both multiple-component and sole-named sections reappear after reload.
+
+### 13.6 Per-repository diff routing
+
+Clicking a file in a named section appends `?repo=<name>` to the goal or session diff URL. Each route resolves the key against its own `repoWorktrees` shape and runs the diff in that component worktree. An absent or unknown key retains the historical root/container fallback; component links always carry the key, which is essential when that fallback is a non-Git directory.
+
+Container diff execution passes the file as an argument-vector element rather than interpolating it into a shell command. Existing path validation still rejects traversal, absolute, and drive-letter paths. This preserves diff behaviour while ensuring a repository filename cannot become shell syntax.
+
+### 13.7 Regression boundaries
+
+The canonical regression owners are listed in §9.5. Together they pin the real-Git team-lead lifecycle and cleanup boundary, shared aggregation and native failure policy, per-target fetch/cache invalidation, read-only status behaviour, DOM rendering, and browser reload journeys. Single-repo envelopes, Headquarters/no-worktree handling, sandbox probing, diff routing, and explicit Git actions remain separate compatibility boundaries rather than special cases inside the polyrepo collector.
 
 ---
 

--- a/docs/design/multi-repo-components.md
+++ b/docs/design/multi-repo-components.md
@@ -1020,9 +1020,9 @@ The top level spreads `aggregate` for callers that still read flat fields. Each 
 Aggregation follows these rules:
 
 1. **Successful configured components are authoritative.** If any configured component succeeds, `repos` contains the successful components and the root result is not counted. This avoids duplicate or contradictory data when the root is Git or `cwd` is inside a component.
-2. **Identity is deterministic.** The first successful component in configured order supplies `branch`, `primaryBranch`, `primaryRef`, `isOnPrimary`, `hasUpstream`, and `mergedIntoPrimary`.
+2. **Identity is deterministic.** The first successful component in configured order supplies `branch`, `primaryBranch`, `primaryRef`, `isOnPrimary`, and `hasUpstream`.
 3. **Counters are additive.** `ahead`, `behind`, `aheadOfPrimary`, `behindPrimary`, `insertionsVsPrimary`, and `deletionsVsPrimary` are summed across successful components.
-4. **State is collective.** `clean` is true only when every successful component is clean; `unpushed` is true when any is unpushed. The synthesized `status` is empty because per-repository file lists are authoritative, and `summary` is `"<N> repo(s)"`.
+4. **State is collective.** `clean` is true only when every successful component is clean; `unpushed` is true when any is unpushed. `mergedIntoPrimary` is true only when the aggregate is complete and every successful component reports merged; a partial aggregate always reports false so missing or incomplete comparisons cannot imply that the whole polyrepo is merged. The synthesized `status` is empty because per-repository file lists are authoritative, and `summary` is `"<N> repo(s)"`.
 5. **Incomplete data stays visible.** A failed component is omitted from `repos`, successful siblings remain, and `partial` becomes true. A component's own partial result also propagates. `untrackedIncluded` is true only when every configured component succeeded with complete untracked data.
 6. **Root is fallback, not winner.** The root result is used only when no configured component succeeds. If configured components were attempted, the root fallback is marked partial and untracked-incomplete. With no component targets, the root result remains byte-compatible with the flat single-repo response.
 
@@ -1063,6 +1063,8 @@ Fetch and status remain read-only. They do not push, pull, merge, rename branche
 Both the session header and goal dashboard consume the top-level aggregate while forwarding `repos` to `GitStatusWidget`. A component-only response still has a top-level branch, so the normal reveal logic keeps the widget visible when the root container is non-Git.
 
 The widget uses per-repository mode for multiple entries or a sole named key; only a sole `"."` key stays flat. It shows summed dirty and primary-comparison segments in the pill, renders one collapsible section per successful repository, opens dirty sections by default, and leaves clean sections collapsed. A partially failed sibling therefore does not hide valid sections. Opening the widget requests explicit fetch and full untracked status, and navigation reload refetches the envelope, so both multiple-component and sole-named sections reappear after reload.
+
+A named-component envelope is aggregate status, not an action target. Pull, Push, rebase on primary, squash-push, and commit-history controls are therefore hidden until their APIs accept an explicit repository identity; otherwise they would ambiguously target the non-Git container or an arbitrary component. A sole `"."` repository retains these single-repo controls. PR display and merge remain available because their existing PR identity is independent of the aggregate Git-action target.
 
 ### 13.6 Per-repository diff routing
 

--- a/scripts/testing-v2/unit-declaration-semantic-map.json
+++ b/scripts/testing-v2/unit-declaration-semantic-map.json
@@ -1829,5 +1829,16 @@
       }
     ],
     "rationale": "The removed synchronous scanner twin is now owned by the async SessionStore-snapshot suite, which retains this traversal, filtering, cap, or missing-root semantic."
+  },
+  {
+    "baseFile": "tests2/dom/git-status-widget-multi-repo.test.ts",
+    "baseName": "single-repo (one entry) does NOT trigger multi-repo rendering",
+    "current": [
+      {
+        "file": "tests2/dom/git-status-widget-multi-repo.test.ts",
+        "name": "sole root entry stays flat for single-repo compatibility"
+      }
+    ],
+    "rationale": "The renamed test retains the sole `.` repository entry's flat-render compatibility invariant, while named-component multi-repository rendering behavior is covered separately."
   }
 ]

--- a/src/app/api.ts
+++ b/src/app/api.ts
@@ -1522,7 +1522,7 @@ export async function refreshPrStatusCache(skipRender = false): Promise<boolean>
 // GIT STATUS
 // ============================================================================
 
-export interface GitStatusData {
+export interface GitStatusEntry {
 	branch: string;
 	primaryBranch: string;
 	/**
@@ -1546,6 +1546,19 @@ export interface GitStatusData {
 	deletionsVsPrimary: number;
 	unpushed: boolean;
 	status: Array<{ file: string; status: string }>;
+	partial?: boolean;
+	untrackedIncluded?: boolean;
+}
+
+export type GitStatusRepoEntry = Partial<GitStatusEntry> & {
+	/** Client-normalized alias used by the widget and untracked-file merge path. */
+	statusFiles?: Array<{ file: string; status: string }>;
+};
+
+/** Flat-compatible git status response with its canonical per-repository envelope. */
+export interface GitStatusData extends GitStatusEntry {
+	aggregate?: GitStatusEntry;
+	repos?: Record<string, GitStatusRepoEntry>;
 }
 
 /**
@@ -1554,7 +1567,7 @@ export interface GitStatusData {
  * transient failure (retry-eligible) and from success.
  */
 export type GitStatusResult =
-	| { kind: 'ok'; data: GitStatusData & { partial?: boolean; untrackedIncluded?: boolean } }
+	| { kind: 'ok'; data: GitStatusData }
 	| { kind: 'not-a-repo' }
 	| { kind: 'error'; status?: number; message: string };
 

--- a/src/server/agent/session-manager.ts
+++ b/src/server/agent/session-manager.ts
@@ -371,6 +371,15 @@ interface ArchivedWorktreeGuardRef {
 	repoWorktrees?: Record<string, string>;
 }
 
+/** Non-sandboxed polyrepo team leads borrow, but never own, the goal worktree set. */
+function hasGoalOwnedTeamLeadWorktrees(ps: Pick<PersistedSession, "role" | "goalId" | "teamGoalId" | "sandboxed" | "repoWorktrees">): boolean {
+	return ps.role === "team-lead"
+		&& !!(ps.teamGoalId ?? ps.goalId)
+		&& !ps.sandboxed
+		&& !!ps.repoWorktrees
+		&& Object.keys(ps.repoWorktrees).length > 0;
+}
+
 interface ArchivedWorktreeScanContext {
 	candidateContexts: ProjectContext[];
 	sessionPathRecords: WorktreeReferenceRecord[];
@@ -10859,6 +10868,9 @@ export class SessionManager {
 	}
 
 	private async archivedSessionWorktreeItems(ps: PersistedSession, ctx: ArchivedWorktreeScanContext, projectName?: string): Promise<ArchivedSessionWorktreeItem[]> {
+		// Borrowed goal worktrees remain goal-owned after the lead is archived;
+		// do not expose them as archived-session cleanup candidates.
+		if (hasGoalOwnedTeamLeadWorktrees(ps)) return [];
 		const specs: Array<{ repo: string; repoPath?: string; worktreePath?: string; branch?: string; source: "repoWorktrees" | "sessionWorktree" }> = [];
 		if (ps.repoWorktrees && Object.keys(ps.repoWorktrees).length > 0) {
 			for (const [repo, wt] of Object.entries(ps.repoWorktrees)) {
@@ -11246,8 +11258,9 @@ export class SessionManager {
 		// Clean up host worktree.  Sandboxed session worktrees also create a host-side
 		// worktree for server bookkeeping, so we clean those up too.  Skip paths that
 		// are container-internal (start with /workspace) — those have no host counterpart.
-		// Skip delegates — they share the parent's worktree and must never remove it.
-		if (ps.worktreePath && ps.repoPath && !ps.worktreePath.startsWith("/workspace") && !ps.delegateOf) {
+		// Skip delegates and non-sandboxed polyrepo leads — both borrow worktrees owned elsewhere.
+		const goalOwnsTeamLeadWorktrees = hasGoalOwnedTeamLeadWorktrees(ps);
+		if (ps.worktreePath && ps.repoPath && !ps.worktreePath.startsWith("/workspace") && !ps.delegateOf && !goalOwnsTeamLeadWorktrees) {
 			try {
 				const { cleanupWorktree, removeEmptyWorktreeSetContainer } = await import("../skills/git.js");
 				const allPersisted = this.getAllPersistedSessionsForWorktreeGuard();
@@ -11283,6 +11296,8 @@ export class SessionManager {
 			} catch (err) {
 				console.error(`[session-manager] Failed to cleanup worktree for ${ps.id}:`, err);
 			}
+		} else if (goalOwnsTeamLeadWorktrees) {
+			console.log(`[session-manager] Skipping goal-owned component worktree cleanup for purged team lead ${ps.id}.`);
 		}
 
 		// Remove color

--- a/src/server/agent/team-manager.ts
+++ b/src/server/agent/team-manager.ts
@@ -737,6 +737,7 @@ export class TeamManager {
 										worktreePath: goal.worktreePath,
 										repoPath: goal.repoPath,
 										branch: goal.branch,
+										repoWorktrees: goal.repoWorktrees,
 										sandboxed: goal.sandboxed,
 										archived: goal.archived,
 									},
@@ -838,6 +839,7 @@ export class TeamManager {
 								worktreePath: goal.worktreePath,
 								repoPath: goal.repoPath,
 								branch: goal.branch,
+								repoWorktrees: goal.repoWorktrees,
 								sandboxed: goal.sandboxed,
 								archived: goal.archived,
 							},
@@ -1902,6 +1904,17 @@ export class TeamManager {
 		// The extension registers first-class tools (team_spawn, task_create, etc.) in the agent.
 		// When sandboxed, create a worktree inside the per-project container for the goal branch.
 		const sandboxed = goal.sandboxed ?? this.sessionManager.isSandboxEnabled;
+		const goalOwnedWorktreeMeta = !sandboxed
+			&& !headquartersGoal
+			&& goal.repoWorktrees
+			&& Object.keys(goal.repoWorktrees).length > 0
+			? {
+				worktreePath: goal.worktreePath,
+				repoPath: goal.repoPath,
+				branch: goal.branch,
+				repoWorktrees: goal.repoWorktrees,
+			}
+			: undefined;
 
 		// Resolve team-lead extension via cascade (ToolManager) or fall back to deprecated TOOLS_DIR
 		let teamLeadExtPath: string;
@@ -1928,6 +1941,9 @@ export class TeamManager {
 				// Empty string falls through to undefined → system default.
 				initialModel: storedRole.model || undefined,
 				initialThinkingLevel: storedRole.thinkingLevel || undefined,
+				// A non-sandboxed polyrepo lead borrows the goal-owned component set;
+				// passing coordinates here persists them without provisioning another worktree.
+				...goalOwnedWorktreeMeta,
 			},
 		);
 
@@ -1941,6 +1957,7 @@ export class TeamManager {
 			role: "team-lead",
 			teamGoalId: goalId,
 			worktreePath: headquartersGoal ? undefined : goal.worktreePath,
+			...goalOwnedWorktreeMeta,
 			accessory: teamLeadAccessory,
 		});
 

--- a/src/server/agent/team-store-consistency.ts
+++ b/src/server/agent/team-store-consistency.ts
@@ -154,6 +154,7 @@ export interface OrphanTeamRecoveryInput {
 		worktreePath?: string;
 		repoPath?: string;
 		branch?: string;
+		repoWorktrees?: Record<string, string>;
 		sandboxed?: boolean;
 		archived?: boolean;
 	};
@@ -182,6 +183,7 @@ export interface ReconstructedTeamLeadRecord {
 	worktreePath?: string;
 	repoPath?: string;
 	branch?: string;
+	repoWorktrees?: Record<string, string>;
 	agentSessionFile: string;
 	sandboxed?: boolean;
 	accessory: "crown";
@@ -214,6 +216,11 @@ export function reconstructTeamLeadSessionRecord(input: OrphanTeamRecoveryInput)
 		worktreePath: goal.worktreePath,
 		repoPath: goal.repoPath,
 		branch: goal.branch,
+		// Host polyrepo leads borrow the goal-owned component set. Sandboxed leads
+		// retain their container-owned restoration path and never borrow host paths.
+		...(!goal.sandboxed && goal.repoWorktrees && Object.keys(goal.repoWorktrees).length > 0
+			? { repoWorktrees: goal.repoWorktrees }
+			: {}),
 		agentSessionFile: chosenJsonl.jsonlPath,
 		sandboxed: !!goal.sandboxed,
 		accessory: "crown",

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -492,7 +492,14 @@ function viewerSubscribedToGoal(ws: any, goalId: string): boolean {
 	return goalIds instanceof Set && goalIds.has(goalId);
 }
 
-import { runBatchGitStatusNative } from "./skills/git-status-native.js";
+import { probeBatchGitStatusNative } from "./skills/git-status-native.js";
+import {
+	collectGitStatusEnvelope,
+	type GitStatusProbe,
+	type GitStatusResult,
+	type GitStatusTarget,
+} from "./skills/git-status-envelope.js";
+export type { GitStatusResult } from "./skills/git-status-envelope.js";
 import { VerificationHarness, goalBranchContainer } from "./agent/verification-harness.js";
 import { validateAnswers, crossValidate, type UserQuestion } from "./agent/ask-user-choices-validation.js";
 import { buildAskResponseEnvelope, findAskResponseAnswers } from "../shared/ask-envelope.js";
@@ -1323,28 +1330,6 @@ async function publishCurrentBranchToOrigin(
 	return output;
 }
 
-/** Git status result shape (+ optional partial/untrackedIncluded flags). */
-export interface GitStatusResult {
-	branch: string; primaryBranch: string; isOnPrimary: boolean;
-	/**
-	 * Actual ref used for `aheadOfPrimary`/`behindPrimary` calculations.
-	 * Equals `origin/<primaryBranch>` when the remote ref exists, else the
-	 * bare local branch name `<primaryBranch>`. Surfaced separately from
-	 * `primaryBranch` so the UI can render the truthful target (a configured
-	 * `base_ref` of `MyUpstream` is a LOCAL branch — "Merged into
-	 * origin/MyUpstream" is misleading when origin has no such ref).
-	 */
-	primaryRef: string;
-	status: { file: string; status: string }[];
-	hasUpstream: boolean; ahead: number; behind: number;
-	aheadOfPrimary: number; behindPrimary: number; mergedIntoPrimary: boolean;
-	insertionsVsPrimary: number; deletionsVsPrimary: number;
-	clean: boolean; summary: string; unpushed: boolean;
-	/** true if porcelain (Phase B) was skipped or timed-out */
-	partial?: boolean;
-	/** true only when ?untracked=1 was passed (-uall); false on default -uno */
-	untrackedIncluded?: boolean;
-}
 
 // ── Git status cache + single-flight ──
 // Short TTL (2000ms) to coalesce the storm of event-driven refreshes (reconnect,
@@ -1357,9 +1342,9 @@ export interface GitStatusResult {
 // responses never cross-contaminate each other.
 const GIT_STATUS_TTL_MS = 2000;
 interface GitStatusCacheEntry {
-	promise: Promise<GitStatusResult | null>;
+	promise: Promise<GitStatusProbe>;
 	resolvedAt: number; // 0 while in flight
-	result: GitStatusResult | null | undefined; // undefined while in flight
+	result: GitStatusProbe | undefined; // undefined while in flight
 }
 const gitStatusCache = new Map<string, GitStatusCacheEntry>();
 
@@ -1373,7 +1358,8 @@ export function __resetGitStatusInvocationCount(): void { _runBatchGitStatusCoun
  *  exercise the TTL/single-flight/coalesce logic deterministically without
  *  spawning Git Bash under CI load (which fails unpredictably). Production
  *  code never sets this. */
-let _gitStatusFake: ((cwd: string, containerId?: string, opts?: { untracked?: boolean; configuredBaseRef?: string }) => Promise<GitStatusResult | null>) | undefined;
+type GitStatusFakeValue = GitStatusResult | GitStatusProbe | null;
+let _gitStatusFake: ((cwd: string, containerId?: string, opts?: { untracked?: boolean; configuredBaseRef?: string }) => Promise<GitStatusFakeValue>) | undefined;
 export function __setGitStatusFake(fn: typeof _gitStatusFake): void { _gitStatusFake = fn; }
 export function __clearGitStatusFake(): void { _gitStatusFake = undefined; }
 
@@ -1421,7 +1407,7 @@ async function batchGitStatus(
 	cwd: string,
 	containerId?: string,
 	opts?: { untracked?: boolean; configuredBaseRef?: string },
-): Promise<GitStatusResult | null> {
+): Promise<GitStatusProbe> {
 	const key = gitStatusCacheKey(cwd, containerId, opts?.untracked);
 	const now = Date.now();
 	evictExpired(now);
@@ -1436,13 +1422,17 @@ async function batchGitStatus(
 		(result) => {
 			const entry = gitStatusCache.get(key);
 			if (entry && entry.promise === promise) {
-				entry.result = result;
-				entry.resolvedAt = Date.now();
+				if (result.kind === "error") {
+					// Transient failures must never poison the cache.
+					gitStatusCache.delete(key);
+				} else {
+					entry.result = result;
+					entry.resolvedAt = Date.now();
+				}
 			}
 			return result;
 		},
 		(err) => {
-			// Do NOT cache errors — next caller will retry fresh.
 			const entry = gitStatusCache.get(key);
 			if (entry && entry.promise === promise) gitStatusCache.delete(key);
 			throw err;
@@ -1452,19 +1442,20 @@ async function batchGitStatus(
 	return promise;
 }
 
-/** Batched git status — host path uses native parallel execFile (no shell);
- *  container path keeps the legacy `docker exec sh -c <batch>` round-trip.
- *  Implementation lives in `./skills/git-status-native.ts`. Returns null if
- *  not a git repository. `partial` is reserved for a future degraded-mode
- *  flag and is currently always `false` on success. */
+/** Classified native status producer behind the cache/single-flight layer. */
 async function runBatchGitStatus(
 	cwd: string,
 	containerId?: string,
 	opts?: { untracked?: boolean; configuredBaseRef?: string },
-): Promise<GitStatusResult | null> {
+): Promise<GitStatusProbe> {
 	_runBatchGitStatusCount++;
-	if (_gitStatusFake) return _gitStatusFake(cwd, containerId, opts);
-	return runBatchGitStatusNative(cwd, { ...opts, containerId });
+	if (_gitStatusFake) {
+		const result = await _gitStatusFake(cwd, containerId, opts);
+		if (result === null) return { kind: "not-repository" };
+		if ("kind" in result) return result;
+		return { kind: "success", result };
+	}
+	return probeBatchGitStatusNative(cwd, { ...opts, containerId });
 }
 
 // ── Git diff / commit helpers (shared between session and goal endpoints) ──
@@ -11987,35 +11978,30 @@ async function handleApiRoute(
 			}
 		} catch { /* container/config unavailable — fall through */ }
 
-		if (!cid && !fs.existsSync(cwd)) { json({ error: "Working directory not found" }, 404); return; }
+		const repoWorktrees = (goal as { repoWorktrees?: Record<string, string> }).repoWorktrees;
+		const components: GitStatusTarget[] = Object.entries(repoWorktrees ?? {}).map(([repo, worktreePath]) => ({ repo, worktreePath }));
+		if (!cid && components.length === 0 && !fs.existsSync(cwd)) { json({ error: "Working directory not found" }, 404); return; }
 		const goalUntracked = url.searchParams.get('untracked') === '1';
-		if (url.searchParams.get('fetch') === 'true') {
-			try { await execGit('git fetch --quiet', cwd, 15000, cid); } catch { /* best-effort */ }
-			invalidateGitStatusCache(cwd, cid);
-		}
+		const shouldFetch = url.searchParams.get('fetch') === 'true';
 		try {
-			const result = await batchGitStatus(cwd, cid, { untracked: goalUntracked, configuredBaseRef: goalBaseRef });
-			if (!result) { json({ error: "Not a git repository" }, 400); return; }
-
-			// Multi-repo aware envelope: include `repos` map + `aggregate` for back-compat.
-			const repoWorktrees = (goal as { repoWorktrees?: Record<string, string> }).repoWorktrees;
-			if (repoWorktrees && Object.keys(repoWorktrees).length > 0) {
-				const repos: Record<string, typeof result> = {};
-				for (const [repoName, repoPath] of Object.entries(repoWorktrees)) {
-					try {
-						if (cid || fs.existsSync(repoPath)) {
-							const r = await batchGitStatus(repoPath, cid, { untracked: goalUntracked, configuredBaseRef: goalBaseRef });
-							if (r) repos[repoName] = r;
-						}
-					} catch { /* per-repo failure non-fatal */ }
-				}
-				json({ ...result, aggregate: result, repos });
+			const collected = await collectGitStatusEnvelope({
+				rootPath: cwd,
+				components,
+				probe: worktreePath => batchGitStatus(worktreePath, cid, { untracked: goalUntracked, configuredBaseRef: goalBaseRef }),
+				pathExists: cid ? undefined : fs.existsSync,
+				fetchTarget: shouldFetch ? worktreePath => execGit('git fetch --quiet', worktreePath, 15000, cid) : undefined,
+				invalidateTarget: shouldFetch ? worktreePath => invalidateGitStatusCache(worktreePath, cid) : undefined,
+			});
+			if (collected.kind === "success") {
+				json(collected.envelope);
+			} else if (collected.kind === "not-repository") {
+				json({ error: "Not a git repository" }, 400);
 			} else {
-				// Single-repo: include `repos: { ".": result }, aggregate: result` for back-compat.
-				json({ ...result, aggregate: result, repos: { ".": result } });
+				console.error("[git-status handler] error for goal", goalId, "cwd=", cwd, "message=", collected.diagnostic);
+				json({ error: collected.diagnostic || "git status failed" }, 500);
 			}
 		} catch (err: any) {
-			jsonError(500, err, { error: err.stderr?.trim() || err.message || "git status failed" });
+			jsonError(500, err, { error: err?.stderr?.trim() || err?.message || "git status failed" });
 		}
 		return;
 	}
@@ -14038,8 +14024,6 @@ async function handleApiRoute(
 		const cwd = session.cwd;
 		const cid = session.sandboxed ? session.containerId : undefined;
 
-		if (!cid && !fs.existsSync(cwd)) { json({ error: "Working directory not found" }, 404); return; }
-
 		// Resolve project `base_ref` config for the `aheadOfPrimary`/`behindPrimary`
 		// counter — see `docs/design/base-ref.md` §5.
 		let sessionBaseRef: string | undefined;
@@ -14048,98 +14032,32 @@ async function handleApiRoute(
 			if (sessCtx) sessionBaseRef = sessCtx.projectConfigStore.get("base_ref") || undefined;
 		} catch { /* config unavailable — fall through */ }
 
-		// Optional: run git fetch first when ?fetch=true is passed
+		// Session metadata uses an array while goal metadata uses a record. Both
+		// normalize into the same collector policy, including a sole named repo.
+		const components: GitStatusTarget[] = (session.repoWorktrees ?? []).map(({ repo, worktreePath }) => ({ repo, worktreePath }));
+		if (!cid && components.length === 0 && !fs.existsSync(cwd)) { json({ error: "Working directory not found" }, 404); return; }
 		const sessUntracked = url.searchParams.get('untracked') === '1';
-		if (url.searchParams.get('fetch') === 'true') {
-			try { await execGit('git fetch --quiet', cwd, 15000, cid); } catch { /* best-effort */ }
-			invalidateGitStatusCache(cwd, cid);
-		}
-
-		// Single attempt — native parallel execFile is fast (50–150 ms p50 on
-		// Windows) and errors are not cached, so the client retry loop in
-		// `git-status-refresh.ts` (4 attempts × 0/500/2000/5000 ms backoff) is
-		// the resilience layer for transient failures.
-		// `session.repoWorktrees` is an ARRAY `Array<{repo, repoPath, worktreePath}>`
-		// (session-manager.ts), unlike the goal's `Record<string,string>`.
-		const sessRepoWorktrees = session.repoWorktrees;
-		const isMultiRepo = !!(sessRepoWorktrees && sessRepoWorktrees.length > 1);
-
-		// Root container status. In a TRUE polyrepo (no `repo: "."` git-root
-		// component) the container `cwd` is NOT itself a git repo, so this is
-		// null/throws — that is non-fatal in multi-repo mode (the per-repo
-		// worktrees below are the source of truth). For single-repo it must
-		// keep the existing 400/500 behavior.
-		let result: Awaited<ReturnType<typeof batchGitStatus>> | undefined;
+		const shouldFetch = url.searchParams.get('fetch') === 'true';
 		try {
-			result = await batchGitStatus(cwd, cid, { untracked: sessUntracked, configuredBaseRef: sessionBaseRef });
-		} catch (err: any) {
-			if (!isMultiRepo) {
-				console.error("[git-status handler] error for session", id, "cwd=", cwd, "code=", err?.code, "signal=", err?.signal, "killed=", err?.killed, "stderr=", err?.stderr, "message=", err?.message);
-				jsonError(500, err, { error: err?.stderr?.trim() || err?.message || "git status failed" });
-				return;
+			const collected = await collectGitStatusEnvelope({
+				rootPath: cwd,
+				components,
+				probe: worktreePath => batchGitStatus(worktreePath, cid, { untracked: sessUntracked, configuredBaseRef: sessionBaseRef }),
+				pathExists: cid ? undefined : fs.existsSync,
+				fetchTarget: shouldFetch ? worktreePath => execGit('git fetch --quiet', worktreePath, 15000, cid) : undefined,
+				invalidateTarget: shouldFetch ? worktreePath => invalidateGitStatusCache(worktreePath, cid) : undefined,
+			});
+			if (collected.kind === "success") {
+				json(collected.envelope);
+			} else if (collected.kind === "not-repository") {
+				json({ error: "Not a git repository" }, 400);
+			} else {
+				console.error("[git-status handler] error for session", id, "cwd=", cwd, "message=", collected.diagnostic);
+				json({ error: collected.diagnostic || "git status failed" }, 500);
 			}
-			// Multi-repo: container-cwd failure is expected/non-fatal.
-			result = undefined;
+		} catch (err: any) {
+			jsonError(500, err, { error: err?.stderr?.trim() || err?.message || "git status failed" });
 		}
-
-		if (!isMultiRepo) {
-			// Single-repo / no repoWorktrees: keep back-compat flat shape plus
-			// `repos: { ".": result }, aggregate: result`.
-			if (!result) { json({ error: "Not a git repository" }, 400); return; }
-			json({ ...result, aggregate: result, repos: { ".": result } });
-			return;
-		}
-
-		// Multi-repo aware envelope (parity with the goal git-status handler):
-		// emit a `repos` map keyed by repo name + an `aggregate`.
-		const repos: Record<string, GitStatusResult> = {};
-		for (const { repo, worktreePath } of sessRepoWorktrees!) {
-			try {
-				if (cid || fs.existsSync(worktreePath)) {
-					const r = await batchGitStatus(worktreePath, cid, { untracked: sessUntracked, configuredBaseRef: sessionBaseRef });
-					if (r) repos[repo] = r;
-				}
-			} catch { /* per-repo failure non-fatal */ }
-		}
-
-		const repoResults = Object.values(repos);
-		// Aggregate: prefer the root container status when it IS a git repo
-		// (e.g. a `repo: "."` component) for back-compat; otherwise synthesize
-		// one from the per-repo results. All sub-repos share the same session
-		// branch, so branch/primary fields come from the first repo while the
-		// numeric counters are summed and `clean` is the AND across repos.
-		let aggregate: GitStatusResult | undefined = result ?? undefined;
-		if (!aggregate) {
-			if (repoResults.length === 0) { json({ error: "Not a git repository" }, 400); return; }
-			const base = repoResults[0];
-			const sum = (pick: (r: GitStatusResult) => number) =>
-				repoResults.reduce((acc, r) => acc + (typeof pick(r) === "number" ? pick(r) : 0), 0);
-			const ahead = sum(r => r.ahead);
-			const behind = sum(r => r.behind);
-			const insertionsVsPrimary = sum(r => r.insertionsVsPrimary);
-			const deletionsVsPrimary = sum(r => r.deletionsVsPrimary);
-			aggregate = {
-				branch: base.branch,
-				primaryBranch: base.primaryBranch,
-				primaryRef: base.primaryRef,
-				isOnPrimary: base.isOnPrimary,
-				hasUpstream: base.hasUpstream,
-				mergedIntoPrimary: base.mergedIntoPrimary,
-				status: [], // multi-repo mode suppresses the flat list; per-repo sections are authoritative
-				ahead,
-				behind,
-				aheadOfPrimary: sum(r => r.aheadOfPrimary),
-				behindPrimary: sum(r => r.behindPrimary),
-				insertionsVsPrimary,
-				deletionsVsPrimary,
-				clean: repoResults.every(r => r.clean),
-				unpushed: repoResults.some(r => r.unpushed),
-				summary: `${repoResults.length} repos`,
-				untrackedIncluded: sessUntracked,
-			};
-		}
-
-		json({ ...aggregate, aggregate, repos });
 		return;
 	}
 	// GET /api/sessions/:id/tool-content/:messageIndex/:blockIndex — lazy-load full tool input content

--- a/src/server/skills/git-status-envelope.ts
+++ b/src/server/skills/git-status-envelope.ts
@@ -95,13 +95,15 @@ export function aggregateGitStatusProbes(
 
 		const results = successfulComponents.map(({ probe }) => probe.result);
 		const base = results[0];
+		const partial = components.some(({ probe }) => probe.kind !== "success")
+			|| results.some((result) => result.partial === true);
 		const aggregate: GitStatusResult = {
 			branch: base.branch,
 			primaryBranch: base.primaryBranch,
 			primaryRef: base.primaryRef,
 			isOnPrimary: base.isOnPrimary,
 			hasUpstream: base.hasUpstream,
-			mergedIntoPrimary: base.mergedIntoPrimary,
+			mergedIntoPrimary: !partial && results.every((result) => result.mergedIntoPrimary),
 			status: [],
 			ahead: sum(results, (result) => result.ahead),
 			behind: sum(results, (result) => result.behind),
@@ -112,7 +114,7 @@ export function aggregateGitStatusProbes(
 			clean: results.every((result) => result.clean),
 			unpushed: results.some((result) => result.unpushed),
 			summary: `${results.length} ${results.length === 1 ? "repo" : "repos"}`,
-			partial: components.some(({ probe }) => probe.kind !== "success") || results.some((result) => result.partial === true),
+			partial,
 			untrackedIncluded: components.every(({ probe }) => probe.kind === "success")
 				&& results.every((result) => result.untrackedIncluded === true),
 		};

--- a/src/server/skills/git-status-envelope.ts
+++ b/src/server/skills/git-status-envelope.ts
@@ -1,0 +1,190 @@
+export interface GitStatusResult {
+	branch: string;
+	primaryBranch: string;
+	isOnPrimary: boolean;
+	primaryRef: string;
+	status: { file: string; status: string }[];
+	hasUpstream: boolean;
+	ahead: number;
+	behind: number;
+	aheadOfPrimary: number;
+	behindPrimary: number;
+	mergedIntoPrimary: boolean;
+	insertionsVsPrimary: number;
+	deletionsVsPrimary: number;
+	clean: boolean;
+	summary: string;
+	unpushed: boolean;
+	partial?: boolean;
+	untrackedIncluded?: boolean;
+}
+
+export type GitStatusProbe =
+	| { kind: "success"; result: GitStatusResult }
+	| { kind: "not-repository"; diagnostic?: string }
+	| { kind: "error"; error: Error; diagnostic: string };
+
+export interface GitStatusTarget {
+	repo: string;
+	worktreePath: string;
+}
+
+export interface GitStatusEnvelope extends GitStatusResult {
+	aggregate: GitStatusResult;
+	repos: Record<string, GitStatusResult>;
+}
+
+export type GitStatusCollection =
+	| { kind: "success"; envelope: GitStatusEnvelope }
+	| { kind: "not-repository"; diagnostic?: string }
+	| { kind: "error"; error: Error; diagnostic: string };
+
+export interface CollectGitStatusOptions {
+	rootPath: string;
+	components?: readonly GitStatusTarget[];
+	probe(path: string): Promise<GitStatusProbe>;
+	/** Host-only existence check. Omit for container paths. */
+	pathExists?: (path: string) => boolean;
+	/** Best-effort pre-probe operation used by `?fetch=true`. */
+	fetchTarget?: (path: string) => Promise<unknown>;
+	/** Called after every requested fetch, including failed/skipped fetches. */
+	invalidateTarget?: (path: string) => void;
+}
+
+function probeError(message: string, cause?: unknown): GitStatusProbe {
+	const error = cause instanceof Error ? cause : new Error(message);
+	return { kind: "error", error, diagnostic: message || error.message };
+}
+
+/** Root plus configured components, deduplicated by worktree path for side effects. */
+export function collectGitStatusTargets(rootPath: string, components: readonly GitStatusTarget[] = []): string[] {
+	const targets: string[] = [];
+	const seen = new Set<string>();
+	for (const worktreePath of [rootPath, ...components.map((component) => component.worktreePath)]) {
+		if (typeof worktreePath !== "string" || seen.has(worktreePath)) continue;
+		seen.add(worktreePath);
+		targets.push(worktreePath);
+	}
+	return targets;
+}
+
+function sum(results: readonly GitStatusResult[], pick: (result: GitStatusResult) => number): number {
+	return results.reduce((total, result) => total + (Number.isFinite(pick(result)) ? pick(result) : 0), 0);
+}
+
+/**
+ * Synthesize the shared goal/session response policy from already-classified
+ * probes. Configured components are authoritative whenever any succeeds; the
+ * root is only a fallback. A sole `.` component retains the flat single-repo
+ * response shape.
+ */
+export function aggregateGitStatusProbes(
+	root: GitStatusProbe,
+	components: readonly { target: GitStatusTarget; probe: GitStatusProbe }[] = [],
+): GitStatusCollection {
+	const successfulComponents = components.filter(
+		(entry): entry is { target: GitStatusTarget; probe: Extract<GitStatusProbe, { kind: "success" }> } => entry.probe.kind === "success",
+	);
+
+	if (successfulComponents.length > 0) {
+		const repos = Object.fromEntries(successfulComponents.map(({ target, probe }) => [target.repo, probe.result]));
+		if (components.length === 1 && successfulComponents[0].target.repo === ".") {
+			const result = successfulComponents[0].probe.result;
+			return { kind: "success", envelope: { ...result, aggregate: result, repos } };
+		}
+
+		const results = successfulComponents.map(({ probe }) => probe.result);
+		const base = results[0];
+		const aggregate: GitStatusResult = {
+			branch: base.branch,
+			primaryBranch: base.primaryBranch,
+			primaryRef: base.primaryRef,
+			isOnPrimary: base.isOnPrimary,
+			hasUpstream: base.hasUpstream,
+			mergedIntoPrimary: base.mergedIntoPrimary,
+			status: [],
+			ahead: sum(results, (result) => result.ahead),
+			behind: sum(results, (result) => result.behind),
+			aheadOfPrimary: sum(results, (result) => result.aheadOfPrimary),
+			behindPrimary: sum(results, (result) => result.behindPrimary),
+			insertionsVsPrimary: sum(results, (result) => result.insertionsVsPrimary),
+			deletionsVsPrimary: sum(results, (result) => result.deletionsVsPrimary),
+			clean: results.every((result) => result.clean),
+			unpushed: results.some((result) => result.unpushed),
+			summary: `${results.length} ${results.length === 1 ? "repo" : "repos"}`,
+			partial: components.some(({ probe }) => probe.kind !== "success") || results.some((result) => result.partial === true),
+			untrackedIncluded: components.every(({ probe }) => probe.kind === "success")
+				&& results.every((result) => result.untrackedIncluded === true),
+		};
+		return { kind: "success", envelope: { ...aggregate, aggregate, repos } };
+	}
+
+	if (root.kind === "success") {
+		const result = components.length === 0
+			? root.result
+			: { ...root.result, partial: true, untrackedIncluded: false };
+		return {
+			kind: "success",
+			envelope: { ...result, aggregate: result, repos: { ".": root.result } },
+		};
+	}
+
+	const attempted = [root, ...components.map(({ probe }) => probe)];
+	if (attempted.length > 0 && attempted.every((probe) => probe.kind === "not-repository")) {
+		return {
+			kind: "not-repository",
+			diagnostic: attempted.find((probe) => probe.kind === "not-repository" && probe.diagnostic)?.diagnostic,
+		};
+	}
+
+	const failure = attempted.find((probe): probe is Extract<GitStatusProbe, { kind: "error" }> => probe.kind === "error");
+	return failure
+		? { kind: "error", error: failure.error, diagnostic: failure.diagnostic }
+		: { kind: "error", error: new Error("git status failed"), diagnostic: "git status failed" };
+}
+
+/** Collect, classify, and aggregate one root plus zero or more components. */
+export async function collectGitStatusEnvelope(options: CollectGitStatusOptions): Promise<GitStatusCollection> {
+	const components = options.components ?? [];
+	const paths = collectGitStatusTargets(options.rootPath, components);
+
+	if (options.fetchTarget) {
+		await Promise.all(paths.map(async (worktreePath) => {
+			try {
+				if (!options.pathExists || options.pathExists(worktreePath)) {
+					await options.fetchTarget!(worktreePath);
+				}
+			} catch {
+				// Fetch is deliberately best-effort; status classification follows.
+			} finally {
+				options.invalidateTarget?.(worktreePath);
+			}
+		}));
+	}
+
+	const probes = new Map<string, Promise<GitStatusProbe>>();
+	const probePath = (worktreePath: string): Promise<GitStatusProbe> => {
+		const existing = probes.get(worktreePath);
+		if (existing) return existing;
+		const pending = (async () => {
+			if (!worktreePath) return probeError("Configured Git worktree path is missing");
+			try {
+				if (options.pathExists && !options.pathExists(worktreePath)) {
+					return probeError(`Git worktree path not found: ${worktreePath}`);
+				}
+				return await options.probe(worktreePath);
+			} catch (cause) {
+				const message = cause instanceof Error ? cause.message : String(cause);
+				return probeError(message || "git status failed", cause);
+			}
+		})();
+		probes.set(worktreePath, pending);
+		return pending;
+	};
+
+	const [root, componentProbes] = await Promise.all([
+		probePath(options.rootPath),
+		Promise.all(components.map(async (target) => ({ target, probe: await probePath(target.worktreePath) }))),
+	]);
+	return aggregateGitStatusProbes(root, componentProbes);
+}

--- a/src/server/skills/git-status-native.ts
+++ b/src/server/skills/git-status-native.ts
@@ -19,13 +19,8 @@
 import { performance } from "node:perf_hooks";
 import { cpuDiagnosticsEnabled, getCpuDiagnostics } from "../agent/cpu-diagnostics.js";
 import { realCommandRunner, type CommandRunner } from "../gateway-deps.js";
-import type { GitStatusResult } from "../server.js";
+import type { GitStatusProbe, GitStatusResult } from "./git-status-envelope.js";
 import { parseBaseRef } from "./git.js";
-
-function childErrorCode(err: unknown): string {
-	const code = (err as { code?: unknown } | null)?.code;
-	return typeof code === "string" || typeof code === "number" ? String(code) : "error";
-}
 
 function statusGitOperation(args: readonly string[]): string {
 	const [cmd, sub] = args;
@@ -57,14 +52,65 @@ export interface BatchGitStatusOpts {
 
 const PER_CALL_TIMEOUT_MS = 3000;
 const CONTAINER_BATCH_TIMEOUT_MS = 15000;
+const NOT_REPOSITORY_RE = /not a git repository(?:\s|\(|$)/i;
+const CONTAINER_NOT_REPOSITORY = "__BOBBIT_GIT_STATUS__:NOT_REPOSITORY";
+const CONTAINER_PROBE_ERROR = "__BOBBIT_GIT_STATUS__:PROBE_ERROR:";
+const CONTAINER_OPTIONAL_ERROR = "__BOBBIT_GIT_STATUS__:OPTIONAL_ERROR";
 
-/** Spawn `git` (or `docker exec ... git`) and capture stdout. Never throws —
- * returns `{ ok: false, stdout: "" }` on any failure (non-zero exit, timeout,
- * spawn error). Argv array — never goes through a shell.
- *
- * `trim` defaults to true (strip surrounding whitespace, mirroring the legacy
- * bash script's behavior for single-line metadata). Pass `trim: false` for
- * porcelain output where leading spaces in status codes are significant. */
+interface GitCommandFailure {
+	error: Error;
+	diagnostic: string;
+	code?: string;
+	signal?: string;
+	killed?: boolean;
+	timedOut: boolean;
+}
+
+interface GitCommandResult {
+	stdout: string;
+	stderr: string;
+	ok: boolean;
+	failure?: GitCommandFailure;
+}
+
+function errorText(value: unknown): string {
+	return typeof value === "string" || Buffer.isBuffer(value) ? value.toString().trim() : "";
+}
+
+function commandFailure(err: unknown): GitCommandFailure {
+	const candidate = err as { stderr?: unknown; stdout?: unknown; message?: unknown; code?: unknown; signal?: unknown; killed?: unknown } | null;
+	const error = err instanceof Error ? err : new Error(typeof candidate?.message === "string" ? candidate.message : String(err));
+	const code = typeof candidate?.code === "string" || typeof candidate?.code === "number" ? String(candidate.code) : undefined;
+	const signal = typeof candidate?.signal === "string" ? candidate.signal : undefined;
+	const killed = candidate?.killed === true;
+	const diagnostic = errorText(candidate?.stderr) || errorText(candidate?.stdout) || error.message || "git command failed";
+	return {
+		error,
+		diagnostic,
+		code,
+		signal,
+		killed,
+		timedOut: killed || code === "ETIMEDOUT" || /timed?\s*out/i.test(error.message),
+	};
+}
+
+/** Only Git's explicit outside-repository diagnostic is terminal. */
+export function classifyMandatoryGitFailure(failure: GitCommandFailure): Exclude<GitStatusProbe, { kind: "success" }> {
+	// A numeric exit code means Git itself ran. Spawn-layer string codes,
+	// signals, and timeouts are always transient even if their text happens to
+	// contain Git's outside-repository diagnostic.
+	const processFailed = failure.timedOut
+		|| !!failure.signal
+		|| !failure.code
+		|| !/^\d+$/.test(failure.code);
+	if (!processFailed && NOT_REPOSITORY_RE.test(failure.diagnostic)) {
+		return { kind: "not-repository", diagnostic: failure.diagnostic };
+	}
+	return { kind: "error", error: failure.error, diagnostic: failure.diagnostic };
+}
+
+/** Spawn `git` and retain enough failure metadata to distinguish a definitive
+ * outside-repository result from spawn, timeout, permission, and unknown errors. */
 async function runGit(
 	args: string[],
 	cwd: string,
@@ -72,13 +118,14 @@ async function runGit(
 	timeoutMs = PER_CALL_TIMEOUT_MS,
 	trim = true,
 	commandRunner: CommandRunner = realCommandRunner,
-): Promise<{ stdout: string; ok: boolean }> {
+): Promise<GitCommandResult> {
 	const diagEnabled = cpuDiagnosticsEnabled();
 	const diagStart = diagEnabled ? performance.now() : 0;
 	let success = 0;
 	let errorCode = "none";
 	try {
 		let stdout: string;
+		let stderr: string;
 		if (containerId) {
 			const r = await commandRunner.execFile(
 				"docker",
@@ -86,6 +133,7 @@ async function runGit(
 				{ encoding: "utf-8", timeout: timeoutMs, windowsHide: true },
 			);
 			stdout = r.stdout.toString();
+			stderr = r.stderr.toString();
 		} else {
 			const r = await commandRunner.execFile("git", args, {
 				cwd,
@@ -94,12 +142,14 @@ async function runGit(
 				windowsHide: true,
 			});
 			stdout = r.stdout.toString();
+			stderr = r.stderr.toString();
 		}
 		success = 1;
-		return { stdout: trim ? stdout.trim() : stdout.replace(/\r?\n$/, ""), ok: true };
+		return { stdout: trim ? stdout.trim() : stdout.replace(/\r?\n$/, ""), stderr, ok: true };
 	} catch (err) {
-		errorCode = childErrorCode(err);
-		return { stdout: "", ok: false };
+		const failure = commandFailure(err);
+		errorCode = failure.code ?? "error";
+		return { stdout: "", stderr: "", ok: false, failure };
 	} finally {
 		if (diagEnabled) {
 			getCpuDiagnostics().recordChildProcess(containerId ? "docker exec git status" : "git status", performance.now() - diagStart, {
@@ -160,7 +210,7 @@ function parsePorcelain(raw: string): { status: { file: string; status: string }
 }
 
 /** Host path: parallel native execFile per design §2 (Phase A then Phase B). */
-async function runHost(cwd: string, untracked: boolean, configuredBaseRef: string | undefined, commandRunner: CommandRunner): Promise<GitStatusResult | null> {
+async function runHost(cwd: string, untracked: boolean, configuredBaseRef: string | undefined, commandRunner: CommandRunner): Promise<GitStatusProbe> {
 	const runGitStatus = (args: string[], timeoutMs = PER_CALL_TIMEOUT_MS, trim = true) => runGit(args, cwd, undefined, timeoutMs, trim, commandRunner);
 
 	const porcelainArgs = [
@@ -181,8 +231,13 @@ async function runHost(cwd: string, untracked: boolean, configuredBaseRef: strin
 		runGitStatus(["rev-parse", "--abbrev-ref", "@{u}"]),
 	]);
 
-	// A1 mandatory.
-	if (!a1.ok || !a1.stdout) return null;
+	// A1 is the mandatory repository probe. Only Git's known outside-repo
+	// diagnostic is terminal; every other failure remains retryable.
+	if (!a1.ok) return classifyMandatoryGitFailure(a1.failure ?? commandFailure(new Error("git repository probe failed")));
+	if (!a1.stdout) {
+		const error = new Error("git repository probe returned an empty branch");
+		return { kind: "error", error, diagnostic: error.message };
+	}
 	const branch = a1.stdout;
 
 	// primaryBranch resolution — honour configured `base_ref` when set, else
@@ -247,34 +302,40 @@ async function runHost(cwd: string, untracked: boolean, configuredBaseRef: strin
 	}
 
 	return {
-		branch,
-		primaryBranch,
-		primaryRef: pref,
-		isOnPrimary,
-		status,
-		hasUpstream,
-		ahead,
-		behind,
-		aheadOfPrimary,
-		behindPrimary,
-		mergedIntoPrimary,
-		insertionsVsPrimary,
-		deletionsVsPrimary,
-		clean,
-		summary,
-		unpushed: hasUpstream ? ahead > 0 : !mergedIntoPrimary,
-		partial: false,
-		untrackedIncluded: untracked,
+		kind: "success",
+		result: {
+			branch,
+			primaryBranch,
+			primaryRef: pref,
+			isOnPrimary,
+			status,
+			hasUpstream,
+			ahead,
+			behind,
+			aheadOfPrimary,
+			behindPrimary,
+			mergedIntoPrimary,
+			insertionsVsPrimary,
+			deletionsVsPrimary,
+			clean,
+			summary,
+			unpushed: hasUpstream ? ahead > 0 : !mergedIntoPrimary,
+			partial: !a5.ok
+				|| (hasUpstream && (!b1.ok || !b2.ok))
+				|| (!isOnPrimary && (!b3.ok || !b4.ok || !b5.ok || !b6.ok)),
+			untrackedIncluded: untracked && a5.ok,
+		},
 	};
 }
 
 /** Container path: preserve the legacy single-spawn batched script. The
  * Windows tax is host-side only; inside Linux containers `git` is fast and
  * one `docker exec sh -c` round-trip beats 11 parallel `docker exec` calls. */
-async function runContainer(cwd: string, containerId: string, untracked: boolean, configuredBaseRef: string | undefined, commandRunner: CommandRunner): Promise<GitStatusResult | null> {
-	const porcelainLine = untracked
-		? "git -c core.filemode=false status --porcelain=v1 -uall 2>/dev/null"
-		: "git -c core.filemode=false status --porcelain=v1 -uno 2>/dev/null";
+async function runContainer(cwd: string, containerId: string, untracked: boolean, configuredBaseRef: string | undefined, commandRunner: CommandRunner): Promise<GitStatusProbe> {
+	const porcelainCommand = untracked
+		? "git -c core.filemode=false status --porcelain=v1 -uall"
+		: "git -c core.filemode=false status --porcelain=v1 -uno";
+	const porcelainLine = `PORCELAIN=$(${porcelainCommand} 2>/dev/null); PORCELAIN_CODE=$?; if [ "$PORCELAIN_CODE" -eq 0 ]; then printf "%s" "$PORCELAIN"; else printf "${CONTAINER_OPTIONAL_ERROR}"; fi`;
 
 	// When `base_ref` is configured, substitute the resolved branch name
 	// directly into the script (saves a `symbolic-ref` round-trip and honours
@@ -289,7 +350,9 @@ async function runContainer(cwd: string, containerId: string, untracked: boolean
 			].join("\n");
 
 	const batchScript = [
-		"git rev-parse --abbrev-ref HEAD 2>/dev/null || echo __FAIL__",
+		'PROBE_OUTPUT=$(git rev-parse --abbrev-ref HEAD 2>&1)',
+		'PROBE_CODE=$?',
+		'if [ "$PROBE_CODE" -eq 0 ]; then printf "%s" "$PROBE_OUTPUT"; else case "$PROBE_OUTPUT" in *"not a git repository"*) printf "__BOBBIT_GIT_STATUS__:NOT_REPOSITORY" ;; *) PROBE_DIAG=$(printf "%s" "$PROBE_OUTPUT" | tr "\\r\\n" "  " | cut -c 1-400); printf "__BOBBIT_GIT_STATUS__:PROBE_ERROR:%s:%s" "$PROBE_CODE" "$PROBE_DIAG" ;; esac; fi',
 		'printf "\\0"',
 		"git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null || echo __FAIL__",
 		'printf "\\0"',
@@ -302,19 +365,19 @@ async function runContainer(cwd: string, containerId: string, untracked: boolean
 		"BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)",
 		'git rev-parse --abbrev-ref "$BRANCH@{u}" 2>/dev/null || echo __FAIL__',
 		'printf "\\0"',
-		"git rev-list --count @{u}..HEAD 2>/dev/null || echo 0",
+		`git rev-list --count @{u}..HEAD 2>/dev/null || echo ${CONTAINER_OPTIONAL_ERROR}`,
 		'printf "\\0"',
-		"git rev-list --count HEAD..@{u} 2>/dev/null || echo 0",
+		`git rev-list --count HEAD..@{u} 2>/dev/null || echo ${CONTAINER_OPTIONAL_ERROR}`,
 		'printf "\\0"',
 		primaryResolutionScript,
 		'if git rev-parse --verify "origin/$PRIMARY" >/dev/null 2>&1; then PREF="origin/$PRIMARY"; else PREF="$PRIMARY"; fi',
-		'git rev-list --count "$PREF..HEAD" 2>/dev/null || echo 0',
+		`git rev-list --count "$PREF..HEAD" 2>/dev/null || echo ${CONTAINER_OPTIONAL_ERROR}`,
 		'printf "\\0"',
-		'git rev-list --count "HEAD..$PREF" 2>/dev/null || echo 0',
+		`git rev-list --count "HEAD..$PREF" 2>/dev/null || echo ${CONTAINER_OPTIONAL_ERROR}`,
 		'printf "\\0"',
-		'git diff --shortstat "$PREF...HEAD" 2>/dev/null || true',
+		`git diff --shortstat "$PREF...HEAD" 2>/dev/null || printf "${CONTAINER_OPTIONAL_ERROR}"`,
 		'printf "\\0"',
-		'git diff --shortstat HEAD 2>/dev/null || true',
+		`git diff --shortstat HEAD 2>/dev/null || printf "${CONTAINER_OPTIONAL_ERROR}"`,
 		'printf "\\0"',
 		// Echo the resolved PREF so the host can report which ref was actually
 		// used (`origin/<primary>` if it exists, else the bare local branch).
@@ -340,8 +403,9 @@ async function runContainer(cwd: string, containerId: string, untracked: boolean
 		success = 1;
 		stdout = result.stdout.toString();
 	} catch (err) {
-		errorCode = childErrorCode(err);
-		throw err;
+		const failure = commandFailure(err);
+		errorCode = failure.code ?? "error";
+		return { kind: "error", error: failure.error, diagnostic: failure.diagnostic };
 	} finally {
 		if (diagEnabled) {
 			getCpuDiagnostics().recordChildProcess("docker exec git status", performance.now() - diagStart, {
@@ -356,7 +420,17 @@ async function runContainer(cwd: string, containerId: string, untracked: boolean
 
 	const sections = stdout.split("\0").map((s) => s.replace(/\s+$/, ""));
 	const branchRaw = sections[0] || "";
-	if (branchRaw === "__FAIL__" || !branchRaw) return null;
+	if (branchRaw === CONTAINER_NOT_REPOSITORY) {
+		return { kind: "not-repository", diagnostic: "Not a git repository" };
+	}
+	if (branchRaw.startsWith(CONTAINER_PROBE_ERROR)) {
+		const diagnostic = branchRaw.slice(CONTAINER_PROBE_ERROR.length).replace(/^\d+:/, "") || "container git repository probe failed";
+		return { kind: "error", error: new Error(diagnostic), diagnostic };
+	}
+	if (!branchRaw) {
+		const diagnostic = "container git repository probe returned an empty branch";
+		return { kind: "error", error: new Error(diagnostic), diagnostic };
+	}
 	const branch = branchRaw;
 
 	let primaryBranch = "master";
@@ -397,7 +471,8 @@ async function runContainer(cwd: string, containerId: string, untracked: boolean
 		deletionsVsPrimary = c.deletions + w.deletions;
 	}
 
-	const { status, clean, summary } = parsePorcelain(sections[4] || "");
+	const porcelainFailed = sections[4] === CONTAINER_OPTIONAL_ERROR;
+	const { status, clean, summary } = parsePorcelain(porcelainFailed ? "" : (sections[4] || ""));
 
 	// Section 12: the resolved PREF echoed by the batch script (see above).
 	// Fall back to the host-side mirror of the same `origin/<primary>` vs bare
@@ -405,40 +480,59 @@ async function runContainer(cwd: string, containerId: string, untracked: boolean
 	const primaryRef = sections[12] && sections[12] !== "" ? sections[12] : primaryBranch;
 
 	return {
-		branch,
-		primaryBranch,
-		primaryRef,
-		isOnPrimary,
-		status,
-		hasUpstream,
-		ahead,
-		behind,
-		aheadOfPrimary,
-		behindPrimary,
-		mergedIntoPrimary,
-		insertionsVsPrimary,
-		deletionsVsPrimary,
-		clean,
-		summary,
-		unpushed: hasUpstream ? ahead > 0 : !mergedIntoPrimary,
-		partial: false,
-		untrackedIncluded: untracked,
+		kind: "success",
+		result: {
+			branch,
+			primaryBranch,
+			primaryRef,
+			isOnPrimary,
+			status,
+			hasUpstream,
+			ahead,
+			behind,
+			aheadOfPrimary,
+			behindPrimary,
+			mergedIntoPrimary,
+			insertionsVsPrimary,
+			deletionsVsPrimary,
+			clean,
+			summary,
+			unpushed: hasUpstream ? ahead > 0 : !mergedIntoPrimary,
+			partial: porcelainFailed
+				|| (hasUpstream && (sections[6] === CONTAINER_OPTIONAL_ERROR || sections[7] === CONTAINER_OPTIONAL_ERROR))
+				|| (!isOnPrimary && sections.slice(8, 12).some((section) => section === CONTAINER_OPTIONAL_ERROR)),
+			untrackedIncluded: untracked && !porcelainFailed,
+		},
 	};
 }
 
-/** Top-level entry — dispatches to host (parallel native) or container
- * (batched docker exec). Never retries internally; caller (single-flight
- * cache + client) handles transient failure. */
-export async function runBatchGitStatusNative(
+/** Classified top-level probe used by the HTTP collector. Never retries. */
+export async function probeBatchGitStatusNative(
 	cwd: string,
 	opts?: BatchGitStatusOpts,
-): Promise<GitStatusResult | null> {
+): Promise<GitStatusProbe> {
 	const untracked = opts?.untracked === true;
 	const commandRunner = opts?.commandRunner ?? realCommandRunner;
 	if (opts?.containerId) {
 		return runContainer(cwd, opts.containerId, untracked, opts?.configuredBaseRef, commandRunner);
 	}
 	return runHost(cwd, untracked, opts?.configuredBaseRef, commandRunner);
+}
+
+/**
+ * Compatibility wrapper for callers that predate classified probes. Host
+ * failures retain the old nullable result; container execution errors retain
+ * the old rejection behaviour. New route code must use
+ * `probeBatchGitStatusNative` so transient failures cannot become terminal.
+ */
+export async function runBatchGitStatusNative(
+	cwd: string,
+	opts?: BatchGitStatusOpts,
+): Promise<GitStatusResult | null> {
+	const probe = await probeBatchGitStatusNative(cwd, opts);
+	if (probe.kind === "success") return probe.result;
+	if (probe.kind === "error" && opts?.containerId) throw probe.error;
+	return null;
 }
 
 /** Single-quote a string for safe inclusion in an `sh -c` shell script.

--- a/src/ui/components/GitStatusWidget.ts
+++ b/src/ui/components/GitStatusWidget.ts
@@ -137,6 +137,15 @@ export class GitStatusWidget extends LitElement {
         return Object.keys(this.repos).length;
     }
 
+    /**
+     * Aggregate component status has no unambiguous repository action target.
+     * Only the flat shape (including a sole `"."` envelope) may invoke the
+     * historical root Git actions and commit-history endpoints.
+     */
+    private _canTargetRootGitActions(): boolean {
+        return !this._isMultiRepo();
+    }
+
     @state() private expanded = false;
     @state() private merging = false;
     @state() private mergeError = '';
@@ -336,27 +345,64 @@ export class GitStatusWidget extends LitElement {
         return segments;
     }
 
+    private _renderHistoryCount(
+        count: number,
+        label: string,
+        direction: 'ahead' | 'behind',
+        className: string,
+        vs?: 'primary',
+    ) {
+        if (!this._canTargetRootGitActions()) {
+            return html`<span
+                class=${className}
+                data-testid="git-aggregate-status-count"
+                data-direction=${direction}
+                data-comparison=${vs ?? 'remote'}
+            >${count} ${label}</span>`;
+        }
+        const openHistory = (e: Event) => {
+            e.stopPropagation();
+            this._fetchCommits(direction, vs);
+        };
+        return html`<span
+            class=${className}
+            style="cursor:pointer;text-decoration:underline;text-decoration-style:dotted"
+            role="button"
+            tabindex="0"
+            data-testid="git-commit-history-trigger"
+            data-direction=${direction}
+            data-comparison=${vs ?? 'remote'}
+            @click=${openHistory}
+            @keydown=${(e: KeyboardEvent) => {
+                if (e.key !== 'Enter' && e.key !== ' ') return;
+                e.preventDefault();
+                openHistory(e);
+            }}
+        >${count} ${label}</span>`;
+    }
+
     private _renderRemoteStatus() {
         // Remote status and controls are only relevant on the primary branch.
         if (!this.isOnPrimary) return nothing;
 
-        // On primary branch only: show ahead/behind remote (edge case)
+        // On primary branch only: show ahead/behind remote (edge case).
+        // Component aggregates remain readable, but cannot target root actions.
         if (this.ahead > 0 && this.behind > 0) {
             return html`<div class="text-muted-foreground">
-                Remote: <span class="text-amber-600 dark:text-amber-400" style="cursor:pointer;text-decoration:underline;text-decoration-style:dotted" @click=${(e: MouseEvent) => { e.stopPropagation(); this._fetchCommits('ahead'); }}>${this.ahead} ahead</span>,
-                <span class="text-amber-600 dark:text-amber-400" style="cursor:pointer;text-decoration:underline;text-decoration-style:dotted" @click=${(e: MouseEvent) => { e.stopPropagation(); this._fetchCommits('behind'); }}>${this.behind} behind</span>
+                Remote: ${this._renderHistoryCount(this.ahead, 'ahead', 'ahead', 'text-amber-600 dark:text-amber-400')},
+                ${this._renderHistoryCount(this.behind, 'behind', 'behind', 'text-amber-600 dark:text-amber-400')}
                 ${this._renderPullButton()}
             </div>`;
         }
         if (this.ahead > 0) {
             return html`<div class="text-muted-foreground">
-                <span class="text-amber-600 dark:text-amber-400" style="cursor:pointer;text-decoration:underline;text-decoration-style:dotted" @click=${(e: MouseEvent) => { e.stopPropagation(); this._fetchCommits('ahead'); }}>${this.ahead} unpushed</span> to remote
+                ${this._renderHistoryCount(this.ahead, 'unpushed', 'ahead', 'text-amber-600 dark:text-amber-400')} to remote
                 ${this._renderPushButton()}
             </div>`;
         }
         if (this.behind > 0) {
             return html`<div class="text-muted-foreground">
-                <span class="text-amber-600 dark:text-amber-400" style="cursor:pointer;text-decoration:underline;text-decoration-style:dotted" @click=${(e: MouseEvent) => { e.stopPropagation(); this._fetchCommits('behind'); }}>${this.behind} behind</span> remote
+                ${this._renderHistoryCount(this.behind, 'behind', 'behind', 'text-amber-600 dark:text-amber-400')} remote
                 ${this._renderPullButton()}
             </div>`;
         }
@@ -375,15 +421,15 @@ export class GitStatusWidget extends LitElement {
         }
         if (this.aheadOfPrimary > 0 && this.behindPrimary > 0) {
             return html`<div class="text-muted-foreground">
-                <span class="text-blue-600 dark:text-blue-400" style="cursor:pointer;text-decoration:underline;text-decoration-style:dotted" @click=${(e: MouseEvent) => { e.stopPropagation(); this._fetchCommits('ahead', 'primary'); }}>${this.aheadOfPrimary} ahead</span>,
-                <span class="text-red-600 dark:text-red-400" style="cursor:pointer;text-decoration:underline;text-decoration-style:dotted" @click=${(e: MouseEvent) => { e.stopPropagation(); this._fetchCommits('behind', 'primary'); }}>${this.behindPrimary} behind</span>
+                ${this._renderHistoryCount(this.aheadOfPrimary, 'ahead', 'ahead', 'text-blue-600 dark:text-blue-400', 'primary')},
+                ${this._renderHistoryCount(this.behindPrimary, 'behind', 'behind', 'text-red-600 dark:text-red-400', 'primary')}
                 ${this.primaryRef}
                 ${this._renderMergePrimaryButton()}
             </div>`;
         }
         if (this.aheadOfPrimary > 0) {
             return html`<div class="text-muted-foreground">
-                <span class="text-blue-600 dark:text-blue-400" style="cursor:pointer;text-decoration:underline;text-decoration-style:dotted" @click=${(e: MouseEvent) => { e.stopPropagation(); this._fetchCommits('ahead', 'primary'); }}>${this.aheadOfPrimary} ahead</span>
+                ${this._renderHistoryCount(this.aheadOfPrimary, 'ahead', 'ahead', 'text-blue-600 dark:text-blue-400', 'primary')}
                 of ${this.primaryRef}
                 ${!this.prState ? this._renderAskPrButton() : nothing}
                 ${!this.prState && this.viewerIsAdmin ? this._renderSquashPushButton() : nothing}
@@ -391,7 +437,7 @@ export class GitStatusWidget extends LitElement {
         }
         if (this.behindPrimary > 0) {
             return html`<div class="text-muted-foreground">
-                <span class="text-red-600 dark:text-red-400" style="cursor:pointer;text-decoration:underline;text-decoration-style:dotted" @click=${(e: MouseEvent) => { e.stopPropagation(); this._fetchCommits('behind', 'primary'); }}>${this.behindPrimary} behind</span>
+                ${this._renderHistoryCount(this.behindPrimary, 'behind', 'behind', 'text-red-600 dark:text-red-400', 'primary')}
                 ${this.primaryRef}
                 ${this._renderMergePrimaryButton()}
             </div>`;
@@ -512,11 +558,14 @@ export class GitStatusWidget extends LitElement {
     }
 
     private _renderMergePrimaryButton() {
+        if (!this._canTargetRootGitActions()) return nothing;
         // Label uses the bare branch name to stay compact ("Rebase on dev");
         // tooltip carries the full resolved ref (`origin/dev` or local `dev`)
         // so the user can see exactly what the rebase will target.
         return html`<button
             style="font-size:12px;padding:1px 8px;border-radius:4px;border:1px solid var(--border);background:oklch(0.55 0.12 250 / 0.12);color:oklch(0.55 0.12 250);cursor:pointer;font-weight:500;margin-left:4px"
+            data-testid="git-root-action"
+            data-git-action="rebase-primary"
             ?disabled=${this.mergingPrimary}
             @click=${(e: MouseEvent) => { e.stopPropagation(); this._handleMergePrimary(); }}
             title="Rebase this branch on top of ${this.primaryRef}"
@@ -524,6 +573,7 @@ export class GitStatusWidget extends LitElement {
     }
 
     private _handleMergePrimary() {
+        if (!this._canTargetRootGitActions()) return;
         this.mergingPrimary = true;
         this.mergePrimaryError = '';
         this.dispatchEvent(new CustomEvent('git-merge-primary', {
@@ -555,8 +605,11 @@ export class GitStatusWidget extends LitElement {
     @state() private squashPushError = '';
 
     private _renderSquashPushButton() {
+        if (!this._canTargetRootGitActions()) return nothing;
         return html`<button
             style="font-size:12px;padding:1px 8px;border-radius:4px;border:1px solid var(--border);background:oklch(0.55 0.12 145 / 0.12);color:oklch(0.55 0.12 145);cursor:pointer;font-weight:500;margin-left:4px"
+            data-testid="git-root-action"
+            data-git-action="squash-push"
             ?disabled=${this.squashPushing}
             @click=${(e: MouseEvent) => { e.stopPropagation(); this._handleSquashPush(); }}
             title="Squash all branch commits into one and push directly to ${this.primaryBranch}"
@@ -564,6 +617,7 @@ export class GitStatusWidget extends LitElement {
     }
 
     private _handleSquashPush() {
+        if (!this._canTargetRootGitActions()) return;
         this.squashPushing = true;
         this.squashPushError = '';
         this.dispatchEvent(new CustomEvent('git-squash-push', {
@@ -578,14 +632,18 @@ export class GitStatusWidget extends LitElement {
     }
 
     private _renderPullButton() {
+        if (!this._canTargetRootGitActions()) return nothing;
         return html`<button
             style="font-size:12px;padding:1px 8px;border-radius:4px;border:1px solid var(--border);background:oklch(0.55 0.12 250 / 0.12);color:oklch(0.55 0.12 250);cursor:pointer;font-weight:500;margin-left:4px"
+            data-testid="git-root-action"
+            data-git-action="pull"
             ?disabled=${this.pulling}
             @click=${() => this._handlePull()}
         >${this.pulling ? 'Pulling\u2026' : 'Pull'}</button>${this.pullError ? html`<span style="font-size:11px;color:var(--destructive);margin-left:4px">${this.pullError}</span>` : nothing}`;
     }
 
     private _handlePull() {
+        if (!this._canTargetRootGitActions()) return;
         this.pulling = true;
         this.pullError = '';
         this.dispatchEvent(new CustomEvent('git-pull', {
@@ -601,14 +659,18 @@ export class GitStatusWidget extends LitElement {
     }
 
     private _renderPushButton() {
+        if (!this._canTargetRootGitActions()) return nothing;
         return html`<button
             style="font-size:12px;padding:1px 8px;border-radius:4px;border:1px solid var(--border);background:oklch(0.55 0.12 145 / 0.12);color:oklch(0.55 0.12 145);cursor:pointer;font-weight:500;margin-left:4px"
+            data-testid="git-root-action"
+            data-git-action="push"
             ?disabled=${this.pushing}
             @click=${() => this._handlePush()}
         >${this.pushing ? 'Pushing\u2026' : 'Push'}</button>${this.pushError ? html`<span style="font-size:11px;color:var(--destructive);margin-left:4px">${this.pushError}</span>` : nothing}`;
     }
 
     private _handlePush() {
+        if (!this._canTargetRootGitActions()) return;
         this.pushing = true;
         this.pushError = '';
         this.dispatchEvent(new CustomEvent('git-push', {
@@ -777,6 +839,7 @@ export class GitStatusWidget extends LitElement {
     }
 
     private async _fetchCommits(direction: 'ahead' | 'behind' = 'ahead', vs?: 'primary') {
+        if (!this._canTargetRootGitActions()) return;
         this._commitsLoading = true;
         this._commits = [];
         this._expandedCommits = new Set();

--- a/src/ui/components/GitStatusWidget.ts
+++ b/src/ui/components/GitStatusWidget.ts
@@ -89,10 +89,10 @@ export class GitStatusWidget extends LitElement {
     };
 
     /**
-     * Multi-repo aware envelope. When set with >1 entry, the widget renders
-     * per-repo collapsible sections inside the dropdown and shows an aggregate
-     * count in the pill (e.g. "3 changed across 2 repos"). Single-key
-     * (`"."`) cases use the flat render and the pill stays simple.
+     * Multi-repo aware envelope. Multiple entries or a sole named component
+     * render per-repo collapsible sections inside the dropdown and show an
+     * aggregate count in the pill (e.g. "3 changed across 2 repos"). Only a
+     * sole root (`"."`) entry uses the flat render and keeps the pill simple.
      *
      * Per-repo entries accept the canonical server envelope from
      * `GET /api/goals/:id/git-status`: each value carries either `statusFiles`
@@ -124,11 +124,11 @@ export class GitStatusWidget extends LitElement {
         return n;
     }
 
-    /** True if this widget is rendering multi-repo data (>1 entry, ignoring "." alone). */
+    /** True for multiple repos or any sole named component; only "." stays flat. */
     private _isMultiRepo(): boolean {
         if (!this.repos) return false;
         const keys = Object.keys(this.repos);
-        return keys.length > 1;
+        return keys.length > 1 || (keys.length === 1 && keys[0] !== '.');
     }
 
     /** Helper: how many distinct repos this widget has data for. */
@@ -993,7 +993,7 @@ export class GitStatusWidget extends LitElement {
         const totalDirty = this._aggregateDirtyCount();
         const headerText = totalDirty > 0
             ? `${totalDirty} changed across ${dirtyRepoCount || entries.length} repo${(dirtyRepoCount || entries.length) === 1 ? '' : 's'}`
-            : `${entries.length} repos clean`;
+            : `${entries.length} repo${entries.length === 1 ? '' : 's'} clean`;
         return html`
             <div class="border-t border-border pt-2 mt-2 flex flex-col gap-1.5" data-testid="multi-repo-sections">
                 <div class="text-[12px] text-muted-foreground uppercase tracking-wider font-medium flex items-center justify-between" data-testid="multi-repo-header">
@@ -1047,7 +1047,7 @@ export class GitStatusWidget extends LitElement {
             <div class="flex items-center gap-1.5 mb-2 text-foreground font-medium text-sm">
                 <span>⎇</span>
                 <span class="break-all">${this.branch}</span>
-                ${multiRepoSections ? html`<span class="ml-auto text-[11px] text-muted-foreground" data-testid="multi-repo-badge">${Object.keys(this.repos!).length} repos</span>` : ''}
+                ${multiRepoSections ? html`<span class="ml-auto text-[11px] text-muted-foreground" data-testid="multi-repo-badge">${Object.keys(this.repos!).length} repo${Object.keys(this.repos!).length === 1 ? '' : 's'}</span>` : ''}
             </div>
 
             <div class="flex flex-col gap-1 mb-2">
@@ -1121,8 +1121,8 @@ export class GitStatusWidget extends LitElement {
         if (!this.branch) return nothing;
 
         const segments = this._pillSegments();
-        // Multi-repo aggregate: when we have a per-repo envelope with >1
-        // entries, override the dirty-file count in the pill to reflect
+        // Multi-repo aggregate: when we have multiple entries or a sole named
+        // component, override the dirty-file count in the pill to reflect
         // the sum across repos (the flat `statusFiles` only covers the
         // goal worktree's own repo). Match the design's mock: e.g.
         // "3 changed across 2 repos".

--- a/tests/e2e/pi-packed-consumer.spec.ts
+++ b/tests/e2e/pi-packed-consumer.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect, type TestInfo } from "@playwright/test";
-import { existsSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
@@ -13,6 +13,8 @@ import {
 } from "./test-utils/pi-packed-consumer-command.js";
 
 const PROJECT_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const PACKAGE_NAME = (JSON.parse(readFileSync(join(PROJECT_ROOT, "package.json"), "utf8")) as { name: string }).name;
+const PACKAGE_INSTALL_SEGMENTS = PACKAGE_NAME.split("/");
 const PI_PACKAGES = [
 	"@earendil-works/pi-agent-core",
 	"@earendil-works/pi-ai",
@@ -164,7 +166,7 @@ test.describe("published Bobbit package dependency security", () => {
 			expect(Array.isArray(packJson), "npm pack must report one-element JSON array").toBe(true);
 			expect(packJson).toHaveLength(1);
 			const packEntry = asRecord((packJson as unknown[])[0], "npm pack entry");
-			expect(packEntry.name).toBe("bobbit");
+			expect(packEntry.name).toBe(PACKAGE_NAME);
 			expect(typeof packEntry.filename).toBe("string");
 			const tarballPath = resolve(packDir, packEntry.filename as string);
 			expect(existsSync(tarballPath), `npm pack did not create ${tarballPath}`).toBe(true);
@@ -189,7 +191,7 @@ test.describe("published Bobbit package dependency security", () => {
 			).toBe(true);
 
 			const installedManifest = JSON.parse(await readFile(
-				join(consumerDir, "node_modules", "bobbit", "package.json"),
+				join(consumerDir, "node_modules", ...PACKAGE_INSTALL_SEGMENTS, "package.json"),
 				"utf8",
 			)) as { dependencies?: Record<string, string> };
 			const piPins = PI_PACKAGES.map(name => installedManifest.dependencies?.[name]);
@@ -220,7 +222,7 @@ test.describe("published Bobbit package dependency security", () => {
 					`${piPackage} must not have mixed or stale versions`,
 				).toEqual([selectedPiVersion]);
 				expect(
-					piOccurrences.every(entry => entry.path.includes("bobbit")),
+					piOccurrences.every(entry => entry.path.includes(PACKAGE_NAME)),
 					`${piPackage} must resolve through the installed Bobbit package`,
 				).toBe(true);
 			}
@@ -250,7 +252,14 @@ test.describe("published Bobbit package dependency security", () => {
 				).toBe(true);
 			}
 
-			const binariesModulePath = join(consumerDir, "node_modules", "bobbit", "dist", "server", "binaries.js");
+			const binariesModulePath = join(
+				consumerDir,
+				"node_modules",
+				...PACKAGE_INSTALL_SEGMENTS,
+				"dist",
+				"server",
+				"binaries.js",
+			);
 			const binaries = await import(pathToFileURL(binariesModulePath).href) as {
 				expectedBinaryPackage(): string | null;
 				getFdResolution(): { source: string; path: string | null; expectedPackage: string };

--- a/tests2/browser/e2e/packaged-inline-html-theme.spec.ts
+++ b/tests2/browser/e2e/packaged-inline-html-theme.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect, type Page, type TestInfo } from "@playwright/test";
-import { existsSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { mkdir, mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join, relative, resolve } from "node:path";
@@ -20,6 +20,8 @@ import {
 } from "./packaged-runtime-helpers.js";
 
 const REPO_ROOT = resolve(import.meta.dirname, "..", "..", "..");
+const PACKAGE_NAME = (JSON.parse(readFileSync(join(REPO_ROOT, "package.json"), "utf8")) as { name: string }).name;
+const PACKAGE_INSTALL_SEGMENTS = PACKAGE_NAME.split("/");
 const CANONICAL_BRIDGE_SIGNATURE = "data-bobbit-inline-theme-bridge";
 const SOURCE_BRIDGE_PATH = "src/shared/preview-bridge-scripts.ts";
 const THEME_TOKENS = ["--background", "--foreground", "--card", "--positive", "--chart-1"] as const;
@@ -213,7 +215,7 @@ test.describe("packed Bobbit inline HTML runtime", () => {
 			report.commands.push(packed);
 			expect(packed.code, commandFailure(packed)).toBe(0);
 			const pack = parsePackResult(packed.stdout);
-			expect(pack.name).toBe("bobbit");
+			expect(pack.name).toBe(PACKAGE_NAME);
 			expect(typeof pack.filename).toBe("string");
 			report.packFiles = normalizedPackagePaths(pack);
 			expect(report.packFiles).toContain("dist/server/cli.js");
@@ -237,7 +239,7 @@ test.describe("packed Bobbit inline HTML runtime", () => {
 			report.commands.push(install);
 			expect(install.code, commandFailure(install)).toBe(0);
 
-			const installedRoot = join(consumerDir, "node_modules", "bobbit");
+			const installedRoot = join(consumerDir, "node_modules", ...PACKAGE_INSTALL_SEGMENTS);
 			const installedManifest = JSON.parse(await readFile(join(installedRoot, "package.json"), "utf8")) as {
 				bin?: Record<string, string>;
 			};

--- a/tests2/browser/journeys/polyrepo-git-status.journey.spec.ts
+++ b/tests2/browser/journeys/polyrepo-git-status.journey.spec.ts
@@ -1,0 +1,266 @@
+import type { Locator, Page, Route } from "@playwright/test";
+import {
+  createGoal,
+  createSession,
+  deleteGoal,
+  deleteSession,
+  expect,
+  navigateToHash,
+  openApp,
+  test,
+  waitForSessionStatus,
+} from "../_helpers/journey-fixture.js";
+
+type StatusFile = { file: string; status: string };
+type RepoStatus = ReturnType<typeof repoStatus>;
+
+function repoStatus(
+  status: StatusFile[],
+  overrides: Partial<{
+    ahead: number;
+    behind: number;
+    aheadOfPrimary: number;
+    behindPrimary: number;
+    insertionsVsPrimary: number;
+    deletionsVsPrimary: number;
+  }> = {},
+) {
+  return {
+    branch: "goal/polyrepo-widget",
+    primaryBranch: "master",
+    primaryRef: "origin/master",
+    isOnPrimary: false,
+    clean: status.length === 0,
+    hasUpstream: true,
+    ahead: 0,
+    behind: 0,
+    aheadOfPrimary: 0,
+    behindPrimary: 0,
+    insertionsVsPrimary: 0,
+    deletionsVsPrimary: 0,
+    mergedIntoPrimary: false,
+    unpushed: false,
+    partial: false,
+    status,
+    summary: status.length > 0 ? `${status.length} changed` : "",
+    ...overrides,
+  };
+}
+
+/** Successful component-only shape returned when the container root is not Git. */
+function componentEnvelope(repos: Record<string, RepoStatus>) {
+  const entries = Object.values(repos);
+  if (entries.length === 0)
+    throw new Error("component envelope needs at least one repository");
+  const identity = entries[0];
+  const status = entries.flatMap((repo) => repo.status);
+  const aggregate = {
+    ...identity,
+    clean: entries.every((repo) => repo.clean),
+    ahead: entries.reduce((sum, repo) => sum + repo.ahead, 0),
+    behind: entries.reduce((sum, repo) => sum + repo.behind, 0),
+    aheadOfPrimary: entries.reduce((sum, repo) => sum + repo.aheadOfPrimary, 0),
+    behindPrimary: entries.reduce((sum, repo) => sum + repo.behindPrimary, 0),
+    insertionsVsPrimary: entries.reduce(
+      (sum, repo) => sum + repo.insertionsVsPrimary,
+      0,
+    ),
+    deletionsVsPrimary: entries.reduce(
+      (sum, repo) => sum + repo.deletionsVsPrimary,
+      0,
+    ),
+    unpushed: entries.some((repo) => repo.unpushed),
+    partial: entries.some((repo) => repo.partial),
+    status,
+    summary:
+      status.length > 0 ? `${status.length} changed across components` : "",
+  };
+  return { ...aggregate, aggregate, repos };
+}
+
+async function installGitStatusRoute(
+  page: Page,
+  apiPath: string,
+  body: ReturnType<typeof componentEnvelope>,
+): Promise<string[]> {
+  const requests: string[] = [];
+  await page.route(
+    new RegExp(`${apiPath}(?:\\?.*)?$`),
+    async (route: Route) => {
+      if (route.request().method() !== "GET") return route.fallback();
+      requests.push(route.request().url());
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(body),
+      });
+    },
+  );
+  return requests;
+}
+
+async function expectNamedRepoSections(
+  page: Page,
+  widget: Locator,
+  expectedNames: string[],
+): Promise<void> {
+  await expect(widget, "Git status widget should remain visible").toBeVisible({
+    timeout: 20_000,
+  });
+  const pill = widget.locator("button[data-state='ready']").first();
+  await expect(pill).toBeVisible({ timeout: 20_000 });
+  await pill.click();
+
+  const dropdown = page.locator("#git-status-dropdown");
+  await expect(dropdown).toBeVisible({ timeout: 5_000 });
+  const sections = dropdown.locator('[data-testid="multi-repo-entry"]');
+  await expect(sections).toHaveCount(expectedNames.length);
+  await expect(sections.locator('[data-testid="repo-name"]')).toHaveText(
+    expectedNames,
+  );
+  for (const name of expectedNames) {
+    await expect(dropdown.locator(`[data-repo-name="${name}"]`)).toBeVisible();
+  }
+}
+
+async function expectExplicitFetch(
+  requests: string[],
+  surface: string,
+): Promise<void> {
+  await expect
+    .poll(
+      () =>
+        requests.some(
+          (request) => new URL(request).searchParams.get("fetch") === "true",
+        ),
+      {
+        timeout: 5_000,
+        message: `${surface} Git widget should explicitly request fetch=true`,
+      },
+    )
+    .toBe(true);
+}
+
+test.describe("Journey: Polyrepo Git status widgets", () => {
+  test("session widget keeps multiple named component sections through reload", async ({
+    page,
+  }) => {
+    test.setTimeout(60_000);
+    const sessionId = await createSession();
+    await waitForSessionStatus(sessionId, "idle");
+    const repos = {
+      "number-lib": repoStatus([{ file: "src/add.ts", status: "M" }], {
+        ahead: 1,
+        aheadOfPrimary: 1,
+        insertionsVsPrimary: 8,
+      }),
+      "string-lib": repoStatus([]),
+      "hello-cli": repoStatus([{ file: "src/index.ts", status: "A" }], {
+        ahead: 2,
+        aheadOfPrimary: 2,
+        insertionsVsPrimary: 12,
+      }),
+    };
+    const requests = await installGitStatusRoute(
+      page,
+      `/api/sessions/${sessionId}/git-status`,
+      componentEnvelope(repos),
+    );
+    const names = Object.keys(repos);
+
+    try {
+      await openApp(page);
+      await navigateToHash(page, `#/session/${sessionId}`);
+      await expect(page.locator("message-editor textarea").first()).toBeVisible(
+        { timeout: 20_000 },
+      );
+
+      const sessionWidget = page
+        .locator("pi-chat-panel git-status-widget")
+        .first();
+      await expectNamedRepoSections(page, sessionWidget, names);
+      await expectExplicitFetch(requests, "session");
+
+      const requestCountBeforeReload = requests.length;
+      await page.reload();
+      await expect(page.locator("message-editor textarea").first()).toBeVisible(
+        { timeout: 20_000 },
+      );
+      await expect
+        .poll(() => requests.length, {
+          timeout: 20_000,
+          message: "session reload should refetch component Git status",
+        })
+        .toBeGreaterThan(requestCountBeforeReload);
+      await expectNamedRepoSections(
+        page,
+        page.locator("pi-chat-panel git-status-widget").first(),
+        names,
+      );
+    } finally {
+      await deleteSession(sessionId);
+    }
+  });
+
+  test("goal dashboard treats a sole named component as a repository section after reload", async ({
+    page,
+  }) => {
+    test.setTimeout(60_000);
+    const goal = await createGoal({
+      title: `polyrepo-one-component-widget-${Date.now()}`,
+      team: false,
+      worktree: false,
+    });
+    const goalId = goal.id as string;
+    const repos = {
+      "number-lib": repoStatus([{ file: "src/multiply.ts", status: "M" }], {
+        ahead: 1,
+        aheadOfPrimary: 1,
+        insertionsVsPrimary: 5,
+        deletionsVsPrimary: 1,
+      }),
+    };
+    const requests = await installGitStatusRoute(
+      page,
+      `/api/goals/${goalId}/git-status`,
+      componentEnvelope(repos),
+    );
+
+    try {
+      await openApp(page);
+      await navigateToHash(page, `#/goal/${goalId}`);
+      await expect(
+        page
+          .locator(".dashboard-container, .goal-dashboard, goal-dashboard")
+          .first(),
+      ).toBeVisible({ timeout: 20_000 });
+
+      const dashboardWidget = page
+        .locator(".dashboard-git-row git-status-widget")
+        .first();
+      await expectNamedRepoSections(page, dashboardWidget, ["number-lib"]);
+      await expectExplicitFetch(requests, "goal dashboard");
+
+      const requestCountBeforeReload = requests.length;
+      await page.reload();
+      await expect(
+        page
+          .locator(".dashboard-container, .goal-dashboard, goal-dashboard")
+          .first(),
+      ).toBeVisible({ timeout: 20_000 });
+      await expect
+        .poll(() => requests.length, {
+          timeout: 20_000,
+          message: "goal reload should refetch component Git status",
+        })
+        .toBeGreaterThan(requestCountBeforeReload);
+      await expectNamedRepoSections(
+        page,
+        page.locator(".dashboard-git-row git-status-widget").first(),
+        ["number-lib"],
+      );
+    } finally {
+      await deleteGoal(goalId, true);
+    }
+  });
+});

--- a/tests2/browser/journeys/polyrepo-git-status.journey.spec.ts
+++ b/tests2/browser/journeys/polyrepo-git-status.journey.spec.ts
@@ -121,6 +121,16 @@ async function expectNamedRepoSections(
   for (const name of expectedNames) {
     await expect(dropdown.locator(`[data-repo-name="${name}"]`)).toBeVisible();
   }
+
+  // Named-component envelopes are aggregate status only: the branch/counts
+  // remain visible, but root-targeting actions and history links do not.
+  await expect(dropdown.locator('[data-testid="git-root-action"]')).toHaveCount(0);
+  await expect(
+    dropdown.locator('[data-testid="git-commit-history-trigger"]'),
+  ).toHaveCount(0);
+  await expect(
+    dropdown.locator('[data-testid="git-aggregate-status-count"]').first(),
+  ).toBeVisible();
 }
 
 async function expectExplicitFetch(
@@ -154,7 +164,7 @@ test.describe("Journey: Polyrepo Git status widgets", () => {
         aheadOfPrimary: 1,
         insertionsVsPrimary: 8,
       }),
-      "string-lib": repoStatus([]),
+      "string-lib": repoStatus([], { behindPrimary: 1 }),
       "hello-cli": repoStatus([{ file: "src/index.ts", status: "A" }], {
         ahead: 2,
         aheadOfPrimary: 2,
@@ -197,6 +207,90 @@ test.describe("Journey: Polyrepo Git status widgets", () => {
         page.locator("pi-chat-panel git-status-widget").first(),
         names,
       );
+    } finally {
+      await deleteSession(sessionId);
+    }
+  });
+
+  test("sole-dot session keeps flat root Git actions and dispatches them", async ({
+    page,
+  }) => {
+    test.setTimeout(60_000);
+    const sessionId = await createSession();
+    await waitForSessionStatus(sessionId, "idle");
+    await installGitStatusRoute(
+      page,
+      `/api/sessions/${sessionId}/git-status`,
+      componentEnvelope({
+        ".": repoStatus([], {
+          aheadOfPrimary: 2,
+          behindPrimary: 1,
+          insertionsVsPrimary: 4,
+        }),
+      }),
+    );
+    const rebaseRequests: string[] = [];
+    const commitRequests: string[] = [];
+    await page.route(
+      new RegExp(`/api/sessions/${sessionId}/git-merge-primary$`),
+      async (route: Route) => {
+        rebaseRequests.push(route.request().url());
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({}),
+        });
+      },
+    );
+    await page.route(
+      new RegExp(`/api/sessions/${sessionId}/commits(?:\\?.*)?$`),
+      async (route: Route) => {
+        commitRequests.push(route.request().url());
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({ commits: [] }),
+        });
+      },
+    );
+
+    try {
+      await openApp(page);
+      await navigateToHash(page, `#/session/${sessionId}`);
+      await expect(page.locator("message-editor textarea").first()).toBeVisible(
+        { timeout: 20_000 },
+      );
+
+      const widget = page.locator("pi-chat-panel git-status-widget").first();
+      await expect(widget).toBeVisible({ timeout: 20_000 });
+      await widget.evaluate((node) => {
+        node.addEventListener(
+          "git-merge-primary",
+          () => node.setAttribute("data-rebase-event", "seen"),
+          { once: true },
+        );
+      });
+      await widget.locator("button[data-state='ready']").first().click();
+
+      const dropdown = page.locator("#git-status-dropdown");
+      await expect(dropdown).toBeVisible();
+      await expect(dropdown.locator('[data-testid="multi-repo-sections"]')).toHaveCount(0);
+      await expect(
+        dropdown.locator('[data-testid="git-commit-history-trigger"]'),
+      ).toHaveCount(2);
+      const rebase = dropdown.locator(
+        '[data-testid="git-root-action"][data-git-action="rebase-primary"]',
+      );
+      await expect(rebase).toBeVisible();
+      await rebase.click();
+      await expect(widget).toHaveAttribute("data-rebase-event", "seen");
+      await expect.poll(() => rebaseRequests.length).toBe(1);
+
+      await dropdown
+        .locator('[data-testid="git-commit-history-trigger"]')
+        .first()
+        .click();
+      await expect.poll(() => commitRequests.length).toBe(1);
     } finally {
       await deleteSession(sessionId);
     }

--- a/tests2/core/git-status-envelope.test.ts
+++ b/tests2/core/git-status-envelope.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+	aggregateGitStatusProbes,
+	collectGitStatusEnvelope,
+	type GitStatusProbe,
+	type GitStatusResult,
+} from "../../src/server/skills/git-status-envelope.ts";
+
+function status(overrides: Partial<GitStatusResult> = {}): GitStatusResult {
+	return {
+		branch: "goal/test",
+		primaryBranch: "master",
+		primaryRef: "origin/master",
+		isOnPrimary: false,
+		status: [],
+		hasUpstream: true,
+		ahead: 0,
+		behind: 0,
+		aheadOfPrimary: 0,
+		behindPrimary: 0,
+		mergedIntoPrimary: false,
+		insertionsVsPrimary: 0,
+		deletionsVsPrimary: 0,
+		clean: true,
+		summary: "clean",
+		unpushed: false,
+		partial: false,
+		untrackedIncluded: true,
+		...overrides,
+	};
+}
+
+const notRepo = (diagnostic = "fatal: not a git repository"): GitStatusProbe => ({ kind: "not-repository", diagnostic });
+const failed = (diagnostic = "temporary failure"): GitStatusProbe => ({ kind: "error", error: new Error(diagnostic), diagnostic });
+const ok = (result: GitStatusResult): GitStatusProbe => ({ kind: "success", result });
+
+describe("aggregateGitStatusProbes", () => {
+	it("uses components authoritatively and synthesizes all aggregate fields", () => {
+		const root = status({ branch: "wrong-root", ahead: 99, clean: true });
+		const api = status({ branch: "component-branch", ahead: 2, behind: 1, aheadOfPrimary: 3, insertionsVsPrimary: 8, clean: true, unpushed: false });
+		const web = status({ branch: "component-branch", ahead: 4, behind: 5, behindPrimary: 7, deletionsVsPrimary: 9, clean: false, unpushed: true });
+		const collected = aggregateGitStatusProbes(ok(root), [
+			{ target: { repo: "api", worktreePath: "/api" }, probe: ok(api) },
+			{ target: { repo: "web", worktreePath: "/web" }, probe: ok(web) },
+		]);
+
+		expect(collected.kind).toBe("success");
+		if (collected.kind !== "success") return;
+		expect(collected.envelope.aggregate).toMatchObject({
+			branch: "component-branch",
+			ahead: 6,
+			behind: 6,
+			aheadOfPrimary: 3,
+			behindPrimary: 7,
+			insertionsVsPrimary: 8,
+			deletionsVsPrimary: 9,
+			clean: false,
+			unpushed: true,
+			partial: false,
+			untrackedIncluded: true,
+		});
+		expect(Object.keys(collected.envelope.repos)).toEqual(["api", "web"]);
+	});
+
+	it("keeps valid siblings and marks a failed configured component partial", () => {
+		const collected = aggregateGitStatusProbes(notRepo(), [
+			{ target: { repo: "api", worktreePath: "/api" }, probe: ok(status()) },
+			{ target: { repo: "missing", worktreePath: "/missing" }, probe: failed("missing") },
+		]);
+		expect(collected.kind).toBe("success");
+		if (collected.kind !== "success") return;
+		expect(Object.keys(collected.envelope.repos)).toEqual(["api"]);
+		expect(collected.envelope.aggregate.partial).toBe(true);
+		expect(collected.envelope.aggregate.untrackedIncluded).toBe(false);
+	});
+
+	it("supports one named component while preserving sole-dot flat compatibility", () => {
+		const namedResult = status({ status: [{ file: "a.ts", status: "M" }], clean: false });
+		const named = aggregateGitStatusProbes(notRepo(), [
+			{ target: { repo: "api", worktreePath: "/api" }, probe: ok(namedResult) },
+		]);
+		expect(named.kind).toBe("success");
+		if (named.kind !== "success") return;
+		expect(Object.keys(named.envelope.repos)).toEqual(["api"]);
+		expect(named.envelope.aggregate.status).toEqual([]);
+
+		const dot = aggregateGitStatusProbes(ok(namedResult), [
+			{ target: { repo: ".", worktreePath: "/root" }, probe: ok(namedResult) },
+		]);
+		expect(dot.kind).toBe("success");
+		if (dot.kind !== "success") return;
+		expect(dot.envelope.aggregate).toBe(namedResult);
+		expect(dot.envelope.status).toEqual(namedResult.status);
+	});
+
+	it("falls back to root, but returns terminal only when all probes are definitively non-Git", () => {
+		const root = status({ branch: "root" });
+		const fallback = aggregateGitStatusProbes(ok(root), [
+			{ target: { repo: "missing", worktreePath: "/missing" }, probe: failed() },
+		]);
+		expect(fallback.kind).toBe("success");
+		if (fallback.kind === "success") {
+			expect(fallback.envelope.branch).toBe("root");
+			expect(fallback.envelope.partial).toBe(true);
+			expect(Object.keys(fallback.envelope.repos)).toEqual(["."]);
+		}
+
+		expect(aggregateGitStatusProbes(notRepo(), [
+			{ target: { repo: "api", worktreePath: "/api" }, probe: notRepo() },
+		]).kind).toBe("not-repository");
+		expect(aggregateGitStatusProbes(notRepo(), [
+			{ target: { repo: "api", worktreePath: "/missing" }, probe: failed("missing") },
+		]).kind).toBe("error");
+	});
+});
+
+describe("collectGitStatusEnvelope", () => {
+	it("classifies missing host component paths as retryable while preserving valid repos", async () => {
+		const probes = new Map<string, GitStatusProbe>([
+			["/root", notRepo()],
+			["/api", ok(status())],
+		]);
+		const collected = await collectGitStatusEnvelope({
+			rootPath: "/root",
+			components: [
+				{ repo: "api", worktreePath: "/api" },
+				{ repo: "gone", worktreePath: "/gone" },
+			],
+			pathExists: path => path !== "/gone",
+			probe: async path => probes.get(path) ?? failed("unexpected"),
+		});
+		expect(collected.kind).toBe("success");
+		if (collected.kind === "success") {
+			expect(Object.keys(collected.envelope.repos)).toEqual(["api"]);
+			expect(collected.envelope.partial).toBe(true);
+		}
+	});
+
+	it("returns retryable error when every configured path is missing", async () => {
+		const collected = await collectGitStatusEnvelope({
+			rootPath: "/root",
+			components: [{ repo: "api", worktreePath: "/api" }],
+			pathExists: () => false,
+			probe: async () => notRepo(),
+		});
+		expect(collected.kind).toBe("error");
+		if (collected.kind === "error") expect(collected.diagnostic).toMatch(/not found/i);
+	});
+
+	it("fetches and invalidates every deduplicated target despite individual failures", async () => {
+		const fetched: string[] = [];
+		const invalidated: string[] = [];
+		const probe = vi.fn(async (path: string) => path === "/root" ? notRepo() : ok(status()));
+		const collected = await collectGitStatusEnvelope({
+			rootPath: "/root",
+			components: [
+				{ repo: "api", worktreePath: "/api" },
+				{ repo: "api-alias", worktreePath: "/api" },
+			],
+			pathExists: () => true,
+			fetchTarget: async path => {
+				fetched.push(path);
+				if (path === "/root") throw new Error("fetch failed");
+			},
+			invalidateTarget: path => invalidated.push(path),
+			probe,
+		});
+		expect(collected.kind).toBe("success");
+		expect(fetched).toEqual(["/root", "/api"]);
+		expect(invalidated).toEqual(["/root", "/api"]);
+		expect(probe).toHaveBeenCalledTimes(2);
+	});
+});

--- a/tests2/core/git-status-envelope.test.ts
+++ b/tests2/core/git-status-envelope.test.ts
@@ -62,15 +62,48 @@ describe("aggregateGitStatusProbes", () => {
 		expect(Object.keys(collected.envelope.repos)).toEqual(["api", "web"]);
 	});
 
+	it("reports merged when every successful component has a complete merged comparison", () => {
+		const collected = aggregateGitStatusProbes(notRepo(), [
+			{ target: { repo: "api", worktreePath: "/api" }, probe: ok(status({ mergedIntoPrimary: true })) },
+			{ target: { repo: "web", worktreePath: "/web" }, probe: ok(status({ mergedIntoPrimary: true })) },
+		]);
+		expect(collected.kind).toBe("success");
+		if (collected.kind !== "success") return;
+		expect(collected.envelope.aggregate.mergedIntoPrimary).toBe(true);
+	});
+
+	it("does not copy merged state from an untouched first component when a later component is ahead", () => {
+		const collected = aggregateGitStatusProbes(notRepo(), [
+			{ target: { repo: "api", worktreePath: "/api" }, probe: ok(status({ mergedIntoPrimary: true })) },
+			{ target: { repo: "web", worktreePath: "/web" }, probe: ok(status({ aheadOfPrimary: 1, mergedIntoPrimary: false })) },
+		]);
+		expect(collected.kind).toBe("success");
+		if (collected.kind !== "success") return;
+		expect(collected.envelope.aggregate.aheadOfPrimary).toBe(1);
+		expect(collected.envelope.aggregate.mergedIntoPrimary).toBe(false);
+	});
+
+	it("does not report merged when a successful component comparison is partial", () => {
+		const collected = aggregateGitStatusProbes(notRepo(), [
+			{ target: { repo: "api", worktreePath: "/api" }, probe: ok(status({ mergedIntoPrimary: true })) },
+			{ target: { repo: "web", worktreePath: "/web" }, probe: ok(status({ mergedIntoPrimary: true, partial: true })) },
+		]);
+		expect(collected.kind).toBe("success");
+		if (collected.kind !== "success") return;
+		expect(collected.envelope.aggregate.partial).toBe(true);
+		expect(collected.envelope.aggregate.mergedIntoPrimary).toBe(false);
+	});
+
 	it("keeps valid siblings and marks a failed configured component partial", () => {
 		const collected = aggregateGitStatusProbes(notRepo(), [
-			{ target: { repo: "api", worktreePath: "/api" }, probe: ok(status()) },
+			{ target: { repo: "api", worktreePath: "/api" }, probe: ok(status({ mergedIntoPrimary: true })) },
 			{ target: { repo: "missing", worktreePath: "/missing" }, probe: failed("missing") },
 		]);
 		expect(collected.kind).toBe("success");
 		if (collected.kind !== "success") return;
 		expect(Object.keys(collected.envelope.repos)).toEqual(["api"]);
 		expect(collected.envelope.aggregate.partial).toBe(true);
+		expect(collected.envelope.aggregate.mergedIntoPrimary).toBe(false);
 		expect(collected.envelope.aggregate.untrackedIncluded).toBe(false);
 	});
 

--- a/tests2/core/git-status-local-only-policy.test.ts
+++ b/tests2/core/git-status-local-only-policy.test.ts
@@ -40,9 +40,13 @@ describe("session git-status read-only contract", () => {
 
 		expect(envelopeSource).not.toMatch(/publishCurrentBranchToOrigin|sessionGitStatusAutoPublishDecision|remotePublication/);
 		expect(aggregateSource).toContain("const aggregate: GitStatusResult");
-		for (const field of ["branch", "primaryBranch", "primaryRef", "isOnPrimary", "hasUpstream", "mergedIntoPrimary"]) {
+		for (const field of ["branch", "primaryBranch", "primaryRef", "isOnPrimary", "hasUpstream"]) {
 			expect(aggregateSource).toMatch(new RegExp(`${field}:\\s*base\\.${field}`));
 		}
+		expect(aggregateSource).toMatch(
+			/mergedIntoPrimary:\s*!partial\s*&&\s*results\.every\(\s*\(result\)\s*=>\s*result\.mergedIntoPrimary\s*\)/,
+		);
+		expect(aggregateSource).not.toMatch(/mergedIntoPrimary:\s*base\.mergedIntoPrimary/);
 		expect(aggregateSource).toMatch(/components\.length === 1[\s\S]*target\.repo === "\."/);
 		expect(aggregateSource).toMatch(/envelope:\s*\{\s*\.\.\.result,\s*aggregate:\s*result,\s*repos\s*\}/);
 		expect(aggregateSource).toMatch(/envelope:\s*\{\s*\.\.\.aggregate,\s*aggregate,\s*repos\s*\}/);

--- a/tests2/core/git-status-local-only-policy.test.ts
+++ b/tests2/core/git-status-local-only-policy.test.ts
@@ -2,17 +2,22 @@ import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 
 const serverSource = readFileSync(new URL("../../src/server/server.ts", import.meta.url), "utf8");
+const envelopeSource = readFileSync(new URL("../../src/server/skills/git-status-envelope.ts", import.meta.url), "utf8");
+
+function sourceBetween(source: string, startMarker: string, endMarker: string): string {
+	const start = source.indexOf(startMarker);
+	const end = source.indexOf(endMarker, start + startMarker.length);
+	expect(start, `missing source marker: ${startMarker}`).toBeGreaterThanOrEqual(0);
+	expect(end, `missing source marker: ${endMarker}`).toBeGreaterThan(start);
+	return source.slice(start, end);
+}
 
 function routeSource(startMarker: string, endMarker: string): string {
-	const start = serverSource.indexOf(startMarker);
-	const end = serverSource.indexOf(endMarker, start + startMarker.length);
-	expect(start, `missing route marker: ${startMarker}`).toBeGreaterThanOrEqual(0);
-	expect(end, `missing route marker: ${endMarker}`).toBeGreaterThan(start);
-	return serverSource.slice(start, end);
+	return sourceBetween(serverSource, startMarker, endMarker);
 }
 
 describe("session git-status read-only contract", () => {
-	it("keeps the status route free of publication policy and publisher calls", () => {
+	it("delegates collection and response classification without publishing", () => {
 		const route = routeSource(
 			"// GET /api/sessions/:id/git-status",
 			"// GET /api/sessions/:id/tool-content",
@@ -20,9 +25,28 @@ describe("session git-status read-only contract", () => {
 
 		expect(route).not.toMatch(/publishCurrentBranchToOrigin|sessionGitStatusAutoPublishDecision|remotePublication/);
 		expect(route).toContain("configuredBaseRef: sessionBaseRef");
-		expect(route).toContain("hasUpstream: base.hasUpstream");
-		expect(route).toContain("json({ ...result, aggregate: result");
-		expect(route).toContain("json({ ...aggregate, aggregate, repos })");
+		expect(route).toMatch(/const collected = await collectGitStatusEnvelope\(\{/);
+		expect(route).toMatch(/collected\.kind === "success"[\s\S]*json\(collected\.envelope\)/);
+		expect(route).toMatch(/collected\.kind === "not-repository"[\s\S]*"Not a git repository"/);
+		expect(route).not.toMatch(/hasUpstream:\s*base\.hasUpstream|target\.repo === "\."|aggregate:\s*result/);
+	});
+
+	it("keeps identity, aggregation, and envelope compatibility in the shared helper", () => {
+		const aggregateSource = sourceBetween(
+			envelopeSource,
+			"export function aggregateGitStatusProbes(",
+			"/** Collect, classify, and aggregate one root plus zero or more components. */",
+		);
+
+		expect(envelopeSource).not.toMatch(/publishCurrentBranchToOrigin|sessionGitStatusAutoPublishDecision|remotePublication/);
+		expect(aggregateSource).toContain("const aggregate: GitStatusResult");
+		for (const field of ["branch", "primaryBranch", "primaryRef", "isOnPrimary", "hasUpstream", "mergedIntoPrimary"]) {
+			expect(aggregateSource).toMatch(new RegExp(`${field}:\\s*base\\.${field}`));
+		}
+		expect(aggregateSource).toMatch(/components\.length === 1[\s\S]*target\.repo === "\."/);
+		expect(aggregateSource).toMatch(/envelope:\s*\{\s*\.\.\.result,\s*aggregate:\s*result,\s*repos\s*\}/);
+		expect(aggregateSource).toMatch(/envelope:\s*\{\s*\.\.\.aggregate,\s*aggregate,\s*repos\s*\}/);
+		expect(envelopeSource).toMatch(/return aggregateGitStatusProbes\(root, componentProbes\);/);
 	});
 
 	it("retains publication only in the explicit session push route", () => {

--- a/tests2/core/git-status-native-classification.test.ts
+++ b/tests2/core/git-status-native-classification.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from "vitest";
+import type { CommandRunner } from "../../src/server/gateway-deps.ts";
+import {
+	probeBatchGitStatusNative,
+	runBatchGitStatusNative,
+} from "../../src/server/skills/git-status-native.ts";
+
+function rejected(message: string, fields: Record<string, unknown> = {}): Error {
+	return Object.assign(new Error(message), fields);
+}
+
+function failingHost(error: Error): CommandRunner {
+	return {
+		async execFile() {
+			throw error;
+		},
+	};
+}
+
+function containerReturning(stdout: string, inspectScript?: (script: string) => void): CommandRunner {
+	return {
+		async execFile(file, args) {
+			expect(file).toBe("docker");
+			inspectScript?.(args.at(-1) ?? "");
+			return { stdout, stderr: "" };
+		},
+	};
+}
+
+describe("classified native Git status probes", () => {
+	it("classifies only the known host outside-repository diagnostic as definitive", async () => {
+		const probe = await probeBatchGitStatusNative("/not-git", {
+			commandRunner: failingHost(rejected("git failed", {
+				code: 128,
+				stderr: "fatal: not a git repository (or any of the parent directories): .git",
+			})),
+		});
+		expect(probe.kind).toBe("not-repository");
+
+		// The legacy nullable wrapper remains compatible for direct callers.
+		await expect(runBatchGitStatusNative("/not-git", {
+			commandRunner: failingHost(rejected("git failed", { code: 128, stderr: "fatal: not a git repository" })),
+		})).resolves.toBeNull();
+	});
+
+	it("marks a host result partial and untracked-incomplete when porcelain fails", async () => {
+		const runner: CommandRunner = {
+			async execFile(_file, args) {
+				if (args.join(" ") === "rev-parse --abbrev-ref HEAD") return { stdout: "master\n", stderr: "" };
+				throw rejected("optional probe failed", { code: 128, stderr: "optional probe failed" });
+			},
+		};
+		const probe = await probeBatchGitStatusNative("/repo", { untracked: true, commandRunner: runner });
+		expect(probe.kind).toBe("success");
+		if (probe.kind === "success") {
+			expect(probe.result.partial).toBe(true);
+			expect(probe.result.untrackedIncluded).toBe(false);
+		}
+	});
+
+	it.each([
+		["missing executable", rejected("spawn git ENOENT", { code: "ENOENT" })],
+		["permission spawn with terminal-looking output", rejected("spawn git EACCES", { code: "EACCES", stderr: "fatal: not a git repository" })],
+		["timeout", rejected("Command timed out", { code: "ETIMEDOUT", killed: true, signal: "SIGTERM" })],
+		["timeout with terminal-looking output", rejected("Command timed out", { code: "ETIMEDOUT", killed: true, stderr: "fatal: not a git repository" })],
+		["dubious ownership", rejected("git failed", { code: 128, stderr: "fatal: detected dubious ownership in repository" })],
+		["permission", rejected("git failed", { code: 128, stderr: "fatal: cannot open .git/HEAD: Permission denied" })],
+		["unknown failure", rejected("git failed", { code: 128, stderr: "fatal: unexpected repository failure" })],
+	])("keeps host %s failures retryable", async (_label, error) => {
+		const probe = await probeBatchGitStatusNative("/repo", { commandRunner: failingHost(error) });
+		expect(probe.kind).toBe("error");
+	});
+
+	it("emits and parses a distinct container not-repository sentinel", async () => {
+		let script = "";
+		const probe = await probeBatchGitStatusNative("/workspace", {
+			containerId: "container",
+			commandRunner: containerReturning("__BOBBIT_GIT_STATUS__:NOT_REPOSITORY\0", value => { script = value; }),
+		});
+		expect(probe.kind).toBe("not-repository");
+		expect(script).toContain("__BOBBIT_GIT_STATUS__:NOT_REPOSITORY");
+		expect(script).toContain("__BOBBIT_GIT_STATUS__:PROBE_ERROR");
+		expect(script).toContain("not a git repository");
+	});
+
+	it("keeps container mandatory-probe diagnostics retryable", async () => {
+		const probe = await probeBatchGitStatusNative("/workspace", {
+			containerId: "container",
+			commandRunner: containerReturning("__BOBBIT_GIT_STATUS__:PROBE_ERROR:128:fatal: detected dubious ownership\0"),
+		});
+		expect(probe.kind).toBe("error");
+		if (probe.kind === "error") expect(probe.diagnostic).toMatch(/dubious ownership/);
+	});
+
+	it("marks successful container results partial when optional probes fail", async () => {
+		const stdout = [
+			"feature/test",
+			"__FAIL__",
+			"yes",
+			"no",
+			"__BOBBIT_GIT_STATUS__:OPTIONAL_ERROR",
+			"__FAIL__",
+			"__BOBBIT_GIT_STATUS__:OPTIONAL_ERROR",
+			"__BOBBIT_GIT_STATUS__:OPTIONAL_ERROR",
+			"__BOBBIT_GIT_STATUS__:OPTIONAL_ERROR",
+			"__BOBBIT_GIT_STATUS__:OPTIONAL_ERROR",
+			"__BOBBIT_GIT_STATUS__:OPTIONAL_ERROR",
+			"__BOBBIT_GIT_STATUS__:OPTIONAL_ERROR",
+			"master",
+		].join("\0");
+		const probe = await probeBatchGitStatusNative("/workspace", {
+			containerId: "container",
+			untracked: true,
+			commandRunner: containerReturning(stdout),
+		});
+		expect(probe.kind).toBe("success");
+		if (probe.kind === "success") {
+			expect(probe.result.partial).toBe(true);
+			expect(probe.result.untrackedIncluded).toBe(false);
+			expect(probe.result.status).toEqual([]);
+		}
+	});
+
+	it.each([
+		["docker missing", rejected("spawn docker ENOENT", { code: "ENOENT" })],
+		["docker timeout", rejected("docker timed out", { code: "ETIMEDOUT", killed: true })],
+		["unknown docker rejection", rejected("docker exec failed", { code: 125, stderr: "daemon unavailable" })],
+	])("keeps %s retryable", async (_label, error) => {
+		const probe = await probeBatchGitStatusNative("/workspace", {
+			containerId: "container",
+			commandRunner: failingHost(error),
+		});
+		expect(probe.kind).toBe("error");
+	});
+});

--- a/tests2/dom/git-status-widget-multi-repo.test.ts
+++ b/tests2/dom/git-status-widget-multi-repo.test.ts
@@ -16,6 +16,14 @@ if (!customElements.get("git-status-widget")) customElements.define("git-status-
 
 const dd = () => document.getElementById("git-status-dropdown");
 const pill = (el: HTMLElement) => el.querySelector("button")!;
+const rootAction = (root: ParentNode, action: string) =>
+	root.querySelector(`[data-testid="git-root-action"][data-git-action="${action}"]`) as HTMLButtonElement | null;
+
+function recordEvents(el: HTMLElement, types: string[]) {
+	const events: string[] = [];
+	for (const type of types) el.addEventListener(type, () => events.push(type));
+	return events;
+}
 
 const baseProps = {
 	loading: false,
@@ -142,6 +150,125 @@ describe("GitStatusWidget — multi-repo collapsibles", () => {
 		expect(sections[0].querySelector('[data-testid="repo-name"]')!.textContent!.trim()).toBe("api");
 		expect(sections[0].textContent).toContain("src/only.ts");
 		expect(dd()!.querySelector('[data-testid="multi-repo-badge"]')!.textContent!.trim()).toBe("1 repo");
+	});
+
+	it("named component aggregates keep status readable but expose no root Git actions or history triggers", async () => {
+		const fetchSpy = vi.fn(async () => new Response("{}", { status: 200 }));
+		vi.stubGlobal("fetch", fetchSpy);
+		const el = await mount({
+			branch: "goal/component-actions",
+			isOnPrimary: false,
+			aheadOfPrimary: 3,
+			behindPrimary: 2,
+			viewerIsAdmin: true,
+			repos: {
+				api: { statusFiles: [], clean: true, aheadOfPrimary: 3, behindPrimary: 2 },
+				web: { statusFiles: [], clean: true },
+			},
+		});
+		const events = recordEvents(el, ["git-pull", "git-push", "git-merge-primary", "git-squash-push"]);
+		await openDropdown(el);
+
+		expect(dd()!.textContent).toContain("3 ahead");
+		expect(dd()!.textContent).toContain("2 behind");
+		expect(dd()!.querySelectorAll('[data-testid="git-aggregate-status-count"]')).toHaveLength(2);
+		expect(dd()!.querySelector('[data-testid="git-commit-history-trigger"]')).toBeNull();
+		expect(dd()!.querySelector('[data-testid="git-root-action"]')).toBeNull();
+
+		// Exercise the direct-push and remote pull/push render branches while the
+		// portal is open. Every aggregate count remains a read-only span.
+		Object.assign(el, { aheadOfPrimary: 3, behindPrimary: 0 });
+		await (el as any).updateComplete;
+		expect(rootAction(dd()!, "squash-push")).toBeNull();
+		expect(dd()!.querySelector('[data-testid="git-commit-history-trigger"]')).toBeNull();
+
+		Object.assign(el, { isOnPrimary: true, ahead: 2, behind: 1 });
+		await (el as any).updateComplete;
+		expect(rootAction(dd()!, "pull")).toBeNull();
+		expect(dd()!.querySelectorAll('[data-testid="git-aggregate-status-count"]')).toHaveLength(2);
+
+		Object.assign(el, { ahead: 2, behind: 0 });
+		await (el as any).updateComplete;
+		expect(rootAction(dd()!, "push")).toBeNull();
+		Object.assign(el, { ahead: 0, behind: 2 });
+		await (el as any).updateComplete;
+		expect(rootAction(dd()!, "pull")).toBeNull();
+
+		for (const count of dd()!.querySelectorAll('[data-testid="git-aggregate-status-count"]')) {
+			(count as HTMLElement).click();
+		}
+		expect(events).toEqual([]);
+		expect(fetchSpy).not.toHaveBeenCalled();
+		expect(document.getElementById("git-commits-modal")).toBeNull();
+	});
+
+	it("named component aggregates retain safe PR display and merge behavior", async () => {
+		const el = await mount({
+			branch: "goal/component-pr",
+			isOnPrimary: false,
+			prState: "OPEN",
+			prNumber: 42,
+			prTitle: "Polyrepo change",
+			prUrl: "https://github.com/example/polyrepo/pull/42",
+			prMergeable: "MERGEABLE",
+			repos: { api: { statusFiles: [], clean: true } },
+		});
+		const events = recordEvents(el, ["pr-merge"]);
+		await openDropdown(el);
+
+		expect(dd()!.querySelector('[data-testid="git-root-action"]')).toBeNull();
+		const merge = Array.from(dd()!.querySelectorAll("button"))
+			.find((button) => button.textContent!.trim() === "Merge PR") as HTMLButtonElement;
+		expect(merge).toBeTruthy();
+		merge.click();
+		expect(events).toEqual(["pr-merge"]);
+	});
+
+	it("a sole root entry retains flat Git action buttons and events", async () => {
+		const repos = { ".": { statusFiles: [], clean: true } };
+
+		let el = await mount({
+			branch: "feature/ahead",
+			isOnPrimary: false,
+			aheadOfPrimary: 2,
+			behindPrimary: 0,
+			viewerIsAdmin: true,
+			repos,
+		});
+		let events = recordEvents(el, ["git-squash-push"]);
+		await openDropdown(el);
+		expect(rootAction(dd()!, "squash-push")).toBeTruthy();
+		expect(dd()!.querySelectorAll('[data-testid="git-commit-history-trigger"]')).toHaveLength(1);
+		rootAction(dd()!, "squash-push")!.click();
+		expect(events).toEqual(["git-squash-push"]);
+
+		el = await mount({
+			branch: "feature/diverged",
+			isOnPrimary: false,
+			aheadOfPrimary: 2,
+			behindPrimary: 1,
+			repos,
+		});
+		events = recordEvents(el, ["git-merge-primary"]);
+		await openDropdown(el);
+		expect(rootAction(dd()!, "rebase-primary")).toBeTruthy();
+		expect(dd()!.querySelectorAll('[data-testid="git-commit-history-trigger"]')).toHaveLength(2);
+		rootAction(dd()!, "rebase-primary")!.click();
+		expect(events).toEqual(["git-merge-primary"]);
+
+		el = await mount({ branch: "master", isOnPrimary: true, ahead: 2, behind: 0, repos });
+		events = recordEvents(el, ["git-push"]);
+		await openDropdown(el);
+		expect(rootAction(dd()!, "push")).toBeTruthy();
+		rootAction(dd()!, "push")!.click();
+		expect(events).toEqual(["git-push"]);
+
+		el = await mount({ branch: "master", isOnPrimary: true, ahead: 0, behind: 2, repos });
+		events = recordEvents(el, ["git-pull"]);
+		await openDropdown(el);
+		expect(rootAction(dd()!, "pull")).toBeTruthy();
+		rootAction(dd()!, "pull")!.click();
+		expect(events).toEqual(["git-pull"]);
 	});
 
 	it("dropdown shows one per-repo section per entry, with names and counts", async () => {

--- a/tests2/dom/git-status-widget-multi-repo.test.ts
+++ b/tests2/dom/git-status-widget-multi-repo.test.ts
@@ -119,11 +119,29 @@ describe("GitStatusWidget — multi-repo collapsibles", () => {
 		expect(text).not.toContain("↓");
 	});
 
-	it("single-repo (one entry) does NOT trigger multi-repo rendering", async () => {
+	it("sole root entry stays flat for single-repo compatibility", async () => {
 		const el = await mount({ clean: true, statusFiles: [], repos: { ".": { statusFiles: [], clean: true } } });
 		expect(el.querySelector('[data-testid="pill-multi-repo-aggregate"]')).toBeNull();
 		await openDropdown(el);
 		expect(dd()!.querySelector('[data-testid="multi-repo-sections"]')).toBeNull();
+	});
+
+	it("sole named component renders as multi-repo with its repository section", async () => {
+		const el = await mount({
+			repos: {
+				api: { status: [{ file: "src/only.ts", status: "M" }], clean: false },
+			},
+		});
+
+		expect(el.querySelector('[data-testid="pill-multi-repo-aggregate"]')!.textContent).toMatch(/1 changed across 1 repo/);
+		await openDropdown(el);
+
+		const sections = dd()!.querySelectorAll('[data-testid="multi-repo-entry"]');
+		expect(sections).toHaveLength(1);
+		expect(sections[0].getAttribute("data-repo-name")).toBe("api");
+		expect(sections[0].querySelector('[data-testid="repo-name"]')!.textContent!.trim()).toBe("api");
+		expect(sections[0].textContent).toContain("src/only.ts");
+		expect(dd()!.querySelector('[data-testid="multi-repo-badge"]')!.textContent!.trim()).toBe("1 repo");
 	});
 
 	it("dropdown shows one per-repo section per entry, with names and counts", async () => {

--- a/tests2/integration/git-status-local-only-policy.test.ts
+++ b/tests2/integration/git-status-local-only-policy.test.ts
@@ -188,7 +188,7 @@ test.describe("session git-status read-only contract", () => {
 		expect(response.status).toBe(200);
 		const body = await response.json();
 		expect(Object.keys(body.repos).sort()).toEqual(["api", "web"]);
-		expect(body.aggregate).toMatchObject({ branch: "session/multi-abcdef", ahead: 1 });
+		expect(body.aggregate).toMatchObject({ branch: "session/multi-abcdef", ahead: 2 });
 		expect(publishCalls).toHaveLength(0);
 	});
 

--- a/tests2/integration/git-status-polyrepo-fetch-policy.test.ts
+++ b/tests2/integration/git-status-polyrepo-fetch-policy.test.ts
@@ -1,0 +1,146 @@
+import { mkdirSync } from "node:fs";
+import { join } from "node:path";
+import { test, expect } from "./_e2e/in-process-harness.js";
+import {
+	apiFetch,
+	createGoal,
+	createSession,
+	defaultProjectId,
+	nonGitCwd,
+} from "./_e2e/e2e-setup.js";
+import { loadServerTestRuntime } from "../harness/server-runtime.js";
+
+let serverModule: any;
+
+test.beforeAll(async () => {
+	serverModule = (await loadServerTestRuntime()).server;
+});
+
+test.describe.configure({ mode: "serial", timeout: 60_000 });
+
+function status(ahead: number, untrackedIncluded: boolean) {
+	return {
+		branch: "goal/polyrepo-fetch",
+		primaryBranch: "master",
+		primaryRef: "origin/master",
+		isOnPrimary: false,
+		status: [],
+		hasUpstream: true,
+		ahead,
+		behind: 0,
+		aheadOfPrimary: ahead,
+		behindPrimary: 0,
+		mergedIntoPrimary: false,
+		insertionsVsPrimary: ahead,
+		deletionsVsPrimary: 0,
+		clean: true,
+		summary: "clean",
+		unpushed: ahead > 0,
+		partial: false,
+		untrackedIncluded,
+	};
+}
+
+function makePolyrepoRoot(tag: string): { root: string; api: string; web: string } {
+	const root = join(nonGitCwd(), `git-status-polyrepo-${tag}-${process.pid}-${Date.now()}`);
+	const api = join(root, "api");
+	const web = join(root, "web");
+	mkdirSync(api, { recursive: true });
+	mkdirSync(web, { recursive: true });
+	return { root, api, web };
+}
+
+test("goal and session fetch every component and invalidate summary plus untracked caches", async ({ gateway }) => {
+	const goalPaths = makePolyrepoRoot("goal");
+	const sessionPaths = makePolyrepoRoot("session");
+	const projectId = await defaultProjectId();
+	const goal = await createGoal({ title: `Polyrepo fetch goal ${Date.now()}`, cwd: goalPaths.root, projectId: projectId!, worktree: false });
+	const sessionId = await createSession({ cwd: sessionPaths.root, projectId: projectId! });
+
+	const goalContext = gateway.projectContextManager.getContextForGoal(goal.id as string);
+	const liveGoal = goalContext?.goalStore.get(goal.id as string) as any;
+	expect(liveGoal).toBeTruthy();
+	Object.assign(liveGoal, {
+		cwd: goalPaths.root,
+		worktreePath: goalPaths.root,
+		branch: "goal/polyrepo-fetch",
+		repoWorktrees: { api: goalPaths.api, web: goalPaths.web },
+	});
+
+	const liveSession = gateway.sessionManager.getSession(sessionId) as any;
+	expect(liveSession).toBeTruthy();
+	Object.assign(liveSession, {
+		cwd: sessionPaths.root,
+		repoWorktrees: [
+			{ repo: "api", repoPath: sessionPaths.api, worktreePath: sessionPaths.api },
+			{ repo: "web", repoPath: sessionPaths.web, worktreePath: sessionPaths.web },
+		],
+	});
+
+	const values = new Map<string, number>([
+		[goalPaths.api, 1], [goalPaths.web, 2],
+		[sessionPaths.api, 3], [sessionPaths.web, 4],
+	]);
+	const statusCalls = new Map<string, number>();
+	serverModule.__setGitStatusFake(async (cwd: string, _cid?: string, opts?: { untracked?: boolean }) => {
+		statusCalls.set(cwd, (statusCalls.get(cwd) ?? 0) + 1);
+		const ahead = values.get(cwd);
+		return ahead === undefined ? null : status(ahead, opts?.untracked === true);
+	});
+
+	const runner = (gateway.sessionManager as any).commandRunner;
+	const originalExecFile = runner.execFile;
+	const fetchCalls: string[] = [];
+	runner.execFile = async (file: string, args: readonly string[], options?: any) => {
+		if (file === "git" && args.join(" ") === "fetch --quiet") {
+			const cwd = String(options?.cwd ?? "");
+			fetchCalls.push(cwd);
+			if (cwd === goalPaths.root || cwd === sessionPaths.root) throw new Error("non-Git root fetch failed");
+			return { stdout: "", stderr: "" };
+		}
+		return originalExecFile(file, args, options);
+	};
+
+	try {
+		for (const endpoint of [`/api/goals/${goal.id}/git-status`, `/api/sessions/${sessionId}/git-status`]) {
+			expect((await apiFetch(endpoint)).status).toBe(200);
+			expect((await apiFetch(`${endpoint}?untracked=1`)).status).toBe(200);
+		}
+
+		values.set(goalPaths.api, 10);
+		values.set(goalPaths.web, 20);
+		values.set(sessionPaths.api, 30);
+		values.set(sessionPaths.web, 40);
+
+		const goalFetch = await apiFetch(`/api/goals/${goal.id}/git-status?fetch=true`);
+		expect(goalFetch.status).toBe(200);
+		expect(await goalFetch.json()).toMatchObject({ aggregate: { ahead: 30 }, repos: { api: { ahead: 10 }, web: { ahead: 20 } } });
+		const sessionFetch = await apiFetch(`/api/sessions/${sessionId}/git-status?fetch=true`);
+		expect(sessionFetch.status).toBe(200);
+		expect(await sessionFetch.json()).toMatchObject({ aggregate: { ahead: 70 }, repos: { api: { ahead: 30 }, web: { ahead: 40 } } });
+
+		// `fetch=true` invalidates both cache variants, not only the summary key.
+		const beforeUntracked = new Map(statusCalls);
+		const goalUntracked = await apiFetch(`/api/goals/${goal.id}/git-status?untracked=1`);
+		expect(goalUntracked.status).toBe(200);
+		expect(await goalUntracked.json()).toMatchObject({ aggregate: { ahead: 30, untrackedIncluded: true } });
+		const sessionUntracked = await apiFetch(`/api/sessions/${sessionId}/git-status?untracked=1`);
+		expect(sessionUntracked.status).toBe(200);
+		expect(await sessionUntracked.json()).toMatchObject({ aggregate: { ahead: 70, untrackedIncluded: true } });
+		for (const component of [goalPaths.api, goalPaths.web, sessionPaths.api, sessionPaths.web]) {
+			expect(statusCalls.get(component)).toBe((beforeUntracked.get(component) ?? 0) + 1);
+		}
+
+		expect(fetchCalls.sort()).toEqual([
+			goalPaths.api, goalPaths.root, goalPaths.web,
+			sessionPaths.api, sessionPaths.root, sessionPaths.web,
+		].sort());
+	} finally {
+		runner.execFile = originalExecFile;
+		serverModule.__clearGitStatusFake();
+		for (const worktreePath of [
+			goalPaths.root, goalPaths.api, goalPaths.web,
+			sessionPaths.root, sessionPaths.api, sessionPaths.web,
+		]) serverModule.invalidateGitStatusCache(worktreePath);
+	}
+});

--- a/tests2/integration/team-spawn-multi-repo-real-git.test.ts
+++ b/tests2/integration/team-spawn-multi-repo-real-git.test.ts
@@ -1,11 +1,18 @@
 import { appendFileSync, existsSync, mkdtempSync, rmSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 
+import { vi } from "vitest";
+
 import type { CommandRunner } from "../../src/server/gateway-deps.js";
 import { awaitableRm, pollUntil } from "../../tests/e2e/test-utils/cleanup.js";
 import { copyGitTemplate, prepareGitTemplate } from "../harness/git-template.js";
 import { test, expect } from "./_e2e/in-process-harness.js";
 import { apiFetch, deleteGoal, registerProject, teardownTeam } from "./_e2e/e2e-setup.js";
+
+// The E2E Vitest lane defaults to 30s. Give this real-Git lifecycle file the
+// same budget as the integration lane so Windows process and filesystem
+// contention cannot pre-empt its bounded provisioning and restoration checks.
+vi.setConfig({ testTimeout: 60_000 });
 
 const REPRO = "MULTI_REPO_TEAM_SPAWN_REGRESSION";
 const STATUS_REPRO = "POLYREPO_TEAM_LEAD_STATUS_REPRO";

--- a/tests2/integration/team-spawn-multi-repo-real-git.test.ts
+++ b/tests2/integration/team-spawn-multi-repo-real-git.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { appendFileSync, existsSync, mkdtempSync, rmSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 
 import type { CommandRunner } from "../../src/server/gateway-deps.js";
@@ -8,6 +8,7 @@ import { test, expect } from "./_e2e/in-process-harness.js";
 import { apiFetch, deleteGoal, registerProject, teardownTeam } from "./_e2e/e2e-setup.js";
 
 const REPRO = "MULTI_REPO_TEAM_SPAWN_REGRESSION";
+const STATUS_REPRO = "POLYREPO_TEAM_LEAD_STATUS_REPRO";
 const NESTED_COMPONENT = "packages/alpha" as const;
 const FAILED_COMPONENT = "beta" as const;
 const COMPONENTS = [NESTED_COMPONENT, FAILED_COMPONENT] as const;
@@ -652,6 +653,181 @@ test("direct and REST team spawn preserve exact local component HEADs across col
 		if (goalId) await deleteGoal(goalId).catch(() => undefined);
 		if (postSpawnFailedSessionId) await apiFetch(`/api/sessions/${postSpawnFailedSessionId}?purge=true`, { method: "DELETE" }).catch(() => undefined);
 		if (projectId) await apiFetch(`/api/projects/${encodeURIComponent(projectId)}`, { method: "DELETE" }).catch(() => undefined);
+		rmSync(fixtureRoot, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 });
+	}
+});
+
+// Failing-first owner for the non-Git polyrepo container lifecycle. Unlike the
+// worker-spawn coverage above, this pins the coordinates borrowed by the team
+// lead itself and exercises both public git-status routes before reporting all
+// contract violations under one stable reproduction marker.
+test("team lead borrows goal-owned polyrepo coordinates and both git-status routes aggregate component worktrees", async ({ gateway }) => {
+	await prepareGitTemplate();
+	const fixtureRoot = mkdtempSync(join(gateway.bobbitDir, "team-lead-status-polyrepo-"));
+	const projectRoot = join(fixtureRoot, "project");
+	const worktreeRoot = join(fixtureRoot, "worktrees");
+	let projectId: string | undefined;
+	let goalId: string | undefined;
+	let teamLeadSessionId: string | undefined;
+
+	try {
+		for (const repo of COMPONENTS) copyGitTemplate(join(projectRoot, repo));
+		if (existsSync(join(projectRoot, ".git"))) {
+			throw new Error("polyrepo status fixture root unexpectedly became a Git repository");
+		}
+
+		const project = await registerProject({
+			name: `team-lead-status-polyrepo-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+			rootPath: projectRoot,
+			components: COMPONENTS.map(repo => ({ name: repo.split("/").at(-1)!, repo })),
+			workflows: {
+				general: {
+					name: "General",
+					description: "Focused polyrepo team-lead git-status reproduction",
+					gates: [{ id: "implementation", name: "Implementation", depends_on: [] }],
+				},
+			},
+			seedWorkflows: false,
+		});
+		projectId = project.id;
+
+		const configResponse = await apiFetch(`/api/projects/${projectId}/config`, {
+			method: "PUT",
+			body: JSON.stringify({ worktree_root: worktreeRoot }),
+		});
+		if (configResponse.status !== 200) {
+			throw new Error(`polyrepo status fixture config failed (${configResponse.status}): ${JSON.stringify(await readJson(configResponse))}`);
+		}
+
+		const createResponse = await apiFetch("/api/goals", {
+			method: "POST",
+			body: JSON.stringify({
+				projectId,
+				title: "Polyrepo team lead status reproduction",
+				spec: "Retain the goal-owned component worktree coordinates on the team lead.",
+				workflowId: "general",
+				cwd: projectRoot,
+				worktree: true,
+				team: true,
+				autoStartTeam: false,
+			}),
+		});
+		const createdGoal = await readJson(createResponse);
+		if (createResponse.status !== 201 || !createdGoal.id) {
+			throw new Error(`polyrepo status fixture goal creation failed (${createResponse.status}): ${JSON.stringify(createdGoal)}`);
+		}
+		goalId = createdGoal.id;
+
+		const goal = await waitForGoalReady(goalId!);
+		if (goal.setupStatus !== "ready") {
+			throw new Error(`polyrepo status fixture provisioning failed: ${goal.setupError ?? "unknown"}`);
+		}
+		if (
+			!goal.worktreePath
+			|| !goal.repoPath
+			|| !goal.branch
+			|| JSON.stringify(Object.keys(goal.repoWorktrees ?? {}).sort()) !== JSON.stringify([...COMPONENTS].sort())
+			|| existsSync(join(goal.worktreePath, ".git"))
+		) {
+			throw new Error(`polyrepo status fixture produced invalid goal coordinates: ${JSON.stringify(goal)}`);
+		}
+
+		// Make every named component observably dirty so aggregate cleanliness and
+		// line counts cannot pass through an all-zero placeholder.
+		for (const repo of COMPONENTS) {
+			appendFileSync(join(goal.repoWorktrees[repo], "README.md"), `status reproduction ${repo}\n`, "utf8");
+		}
+
+		const startResponse = await apiFetch(`/api/goals/${goalId}/team/start`, { method: "POST" });
+		const startBody = await readJson(startResponse);
+		if (startResponse.status !== 201 || !startBody.sessionId) {
+			throw new Error(`polyrepo status fixture team start failed (${startResponse.status}): ${JSON.stringify(startBody)}`);
+		}
+		teamLeadSessionId = startBody.sessionId;
+
+		const context = gateway.projectContextManager.getContextForGoal(goalId!);
+		const liveLead = gateway.sessionManager.getSession(teamLeadSessionId!);
+		const persistedLead = context?.sessionStore.get(teamLeadSessionId!);
+		const goalStatusResponse = await apiFetch(`/api/goals/${goalId}/git-status`);
+		const goalStatus = await readJson(goalStatusResponse);
+		const leadStatusResponse = await apiFetch(`/api/sessions/${teamLeadSessionId}/git-status`);
+		const leadStatus = await readJson(leadStatusResponse);
+
+		const problems: string[] = [];
+		const expectedRepoWorktrees = goal.repoWorktrees as Record<string, string>;
+		const sortedEntries = (value: Record<string, string> | undefined) =>
+			Object.entries(value ?? {}).sort(([a], [b]) => a.localeCompare(b));
+		const checkCoordinates = (label: string, actual: any, repoWorktrees: Record<string, string>) => {
+			if (!actual) {
+				problems.push(`${label} metadata is missing`);
+				return;
+			}
+			if (actual.worktreePath !== goal.worktreePath) problems.push(`${label}.worktreePath=${JSON.stringify(actual.worktreePath)}`);
+			if (actual.repoPath !== goal.repoPath) problems.push(`${label}.repoPath=${JSON.stringify(actual.repoPath)}`);
+			if (actual.branch !== goal.branch) problems.push(`${label}.branch=${JSON.stringify(actual.branch)}`);
+			if (JSON.stringify(sortedEntries(repoWorktrees)) !== JSON.stringify(sortedEntries(expectedRepoWorktrees))) {
+				problems.push(`${label}.repoWorktrees=${JSON.stringify(repoWorktrees)}`);
+			}
+		};
+		checkCoordinates("live lead", liveLead, liveRepoWorktrees(liveLead));
+		checkCoordinates("persisted lead", persistedLead, persistedLead?.repoWorktrees ?? {});
+
+		const summedFields = [
+			"ahead",
+			"behind",
+			"aheadOfPrimary",
+			"behindPrimary",
+			"insertionsVsPrimary",
+			"deletionsVsPrimary",
+		] as const;
+		const checkStatusEnvelope = (label: string, response: Response, body: any) => {
+			if (response.status !== 200) {
+				problems.push(`${label} git-status=${response.status} ${JSON.stringify(body)}`);
+				return;
+			}
+			const repoKeys = Object.keys(body?.repos ?? {}).sort();
+			if (JSON.stringify(repoKeys) !== JSON.stringify([...COMPONENTS].sort())) {
+				problems.push(`${label}.repos=${JSON.stringify(repoKeys)}`);
+				return;
+			}
+			const repoResults = COMPONENTS.map(repo => body.repos[repo]);
+			const aggregate = body.aggregate;
+			if (!aggregate || aggregate.branch !== goal.branch || body.branch !== goal.branch) {
+				problems.push(`${label}.aggregate.branch=${JSON.stringify(aggregate?.branch)} top=${JSON.stringify(body?.branch)}`);
+				return;
+			}
+			for (const field of summedFields) {
+				if (repoResults.some(result => typeof result?.[field] !== "number")) {
+					problems.push(`${label}.repos missing numeric ${field}`);
+					continue;
+				}
+				const expected = repoResults.reduce((sum, result) => sum + result[field], 0);
+				if (aggregate[field] !== expected || body[field] !== expected) {
+					problems.push(`${label}.${field}=${JSON.stringify(aggregate[field])}, expected ${expected}`);
+				}
+			}
+			const expectedClean = repoResults.every(result => result.clean === true);
+			const expectedUnpushed = repoResults.some(result => result.unpushed === true);
+			if (aggregate.clean !== expectedClean || body.clean !== expectedClean) problems.push(`${label}.clean is not the component AND`);
+			if (aggregate.unpushed !== expectedUnpushed || body.unpushed !== expectedUnpushed) problems.push(`${label}.unpushed is not the component OR`);
+			if (aggregate.clean !== false) problems.push(`${label}.aggregate did not retain dirty component state`);
+			if (!(aggregate.insertionsVsPrimary > 0)) problems.push(`${label}.aggregate did not retain component line counts`);
+		};
+		checkStatusEnvelope("goal", goalStatusResponse, goalStatus);
+		checkStatusEnvelope("team lead", leadStatusResponse, leadStatus);
+
+		if (problems.length > 0) {
+			throw new Error(`${STATUS_REPRO}: ${problems.join("; ")}`);
+		}
+	} finally {
+		if (goalId) await teardownTeam(goalId).catch(() => undefined);
+		if (teamLeadSessionId) {
+			await apiFetch(`/api/sessions/${teamLeadSessionId}?purge=true`, { method: "DELETE" }).catch(() => undefined);
+		}
+		if (goalId) await deleteGoal(goalId).catch(() => undefined);
+		if (projectId) {
+			await apiFetch(`/api/projects/${encodeURIComponent(projectId)}`, { method: "DELETE" }).catch(() => undefined);
+		}
 		rmSync(fixtureRoot, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 });
 	}
 });

--- a/tests2/integration/team-spawn-multi-repo-real-git.test.ts
+++ b/tests2/integration/team-spawn-multi-repo-real-git.test.ts
@@ -666,9 +666,13 @@ test("team lead borrows goal-owned polyrepo coordinates and both git-status rout
 	const fixtureRoot = mkdtempSync(join(gateway.bobbitDir, "team-lead-status-polyrepo-"));
 	const projectRoot = join(fixtureRoot, "project");
 	const worktreeRoot = join(fixtureRoot, "worktrees");
+	const runner = gateway.sessionManager.commandRunner as CommandRunner;
 	let projectId: string | undefined;
 	let goalId: string | undefined;
 	let teamLeadSessionId: string | undefined;
+	let originalRestoreOneSession: any;
+	let teamTornDown = false;
+	let leadPurged = false;
 
 	try {
 		for (const repo of COMPONENTS) copyGitTemplate(join(projectRoot, repo));
@@ -732,10 +736,21 @@ test("team lead borrows goal-owned polyrepo coordinates and both git-status rout
 			throw new Error(`polyrepo status fixture produced invalid goal coordinates: ${JSON.stringify(goal)}`);
 		}
 
-		// Make every named component observably dirty so aggregate cleanliness and
-		// line counts cannot pass through an all-zero placeholder.
+		// Make every named component observably and asymmetrically dirty so the
+		// aggregate line count is pinned to a real sum, not an all-zero placeholder
+		// or one arbitrarily selected component.
+		const expectedInsertionsByRepo: Record<ComponentName, number> = {
+			[NESTED_COMPONENT]: 2,
+			[FAILED_COMPONENT]: 3,
+		};
+		const expectedComponentHeads = {} as Record<ComponentName, string>;
 		for (const repo of COMPONENTS) {
-			appendFileSync(join(goal.repoWorktrees[repo], "README.md"), `status reproduction ${repo}\n`, "utf8");
+			expectedComponentHeads[repo] = await git(runner, goal.repoWorktrees[repo], ["rev-parse", "HEAD"]);
+			const lines = Array.from(
+				{ length: expectedInsertionsByRepo[repo] },
+				(_, index) => `status reproduction ${repo} ${index + 1}\n`,
+			).join("");
+			appendFileSync(join(goal.repoWorktrees[repo], "README.md"), lines, "utf8");
 		}
 
 		const startResponse = await apiFetch(`/api/goals/${goalId}/team/start`, { method: "POST" });
@@ -754,7 +769,15 @@ test("team lead borrows goal-owned polyrepo coordinates and both git-status rout
 		const leadStatus = await readJson(leadStatusResponse);
 
 		const problems: string[] = [];
-		const expectedRepoWorktrees = goal.repoWorktrees as Record<string, string>;
+		const expectedRepoWorktrees = goal.repoWorktrees as Record<ComponentName, string>;
+		const expectedAggregateCounters = {
+			ahead: 0,
+			behind: 0,
+			aheadOfPrimary: 0,
+			behindPrimary: 0,
+			insertionsVsPrimary: Object.values(expectedInsertionsByRepo).reduce((sum, count) => sum + count, 0),
+			deletionsVsPrimary: 0,
+		};
 		const sortedEntries = (value: Record<string, string> | undefined) =>
 			Object.entries(value ?? {}).sort(([a], [b]) => a.localeCompare(b));
 		const checkCoordinates = (label: string, actual: any, repoWorktrees: Record<string, string>) => {
@@ -796,38 +819,145 @@ test("team lead borrows goal-owned polyrepo coordinates and both git-status rout
 				problems.push(`${label}.aggregate.branch=${JSON.stringify(aggregate?.branch)} top=${JSON.stringify(body?.branch)}`);
 				return;
 			}
+			for (const repo of COMPONENTS) {
+				const result = body.repos[repo];
+				if (result.branch !== goal.branch) problems.push(`${label}.repos[${repo}].branch=${JSON.stringify(result.branch)}`);
+				if (result.clean !== false) problems.push(`${label}.repos[${repo}].clean=${JSON.stringify(result.clean)}`);
+				if (result.unpushed !== false) problems.push(`${label}.repos[${repo}].unpushed=${JSON.stringify(result.unpushed)}`);
+				if (result.insertionsVsPrimary !== expectedInsertionsByRepo[repo]) {
+					problems.push(`${label}.repos[${repo}].insertionsVsPrimary=${JSON.stringify(result.insertionsVsPrimary)}`);
+				}
+				if (result.deletionsVsPrimary !== 0) problems.push(`${label}.repos[${repo}].deletionsVsPrimary=${JSON.stringify(result.deletionsVsPrimary)}`);
+			}
 			for (const field of summedFields) {
 				if (repoResults.some(result => typeof result?.[field] !== "number")) {
 					problems.push(`${label}.repos missing numeric ${field}`);
 					continue;
 				}
-				const expected = repoResults.reduce((sum, result) => sum + result[field], 0);
-				if (aggregate[field] !== expected || body[field] !== expected) {
-					problems.push(`${label}.${field}=${JSON.stringify(aggregate[field])}, expected ${expected}`);
+				const expectedSum = repoResults.reduce((sum, result) => sum + result[field], 0);
+				const pinnedValue = expectedAggregateCounters[field];
+				if (expectedSum !== pinnedValue || aggregate[field] !== pinnedValue || body[field] !== pinnedValue) {
+					problems.push(
+						`${label}.${field}=aggregate:${JSON.stringify(aggregate[field])},top:${JSON.stringify(body[field])},repos:${expectedSum},expected:${pinnedValue}`,
+					);
 				}
 			}
-			const expectedClean = repoResults.every(result => result.clean === true);
-			const expectedUnpushed = repoResults.some(result => result.unpushed === true);
-			if (aggregate.clean !== expectedClean || body.clean !== expectedClean) problems.push(`${label}.clean is not the component AND`);
-			if (aggregate.unpushed !== expectedUnpushed || body.unpushed !== expectedUnpushed) problems.push(`${label}.unpushed is not the component OR`);
-			if (aggregate.clean !== false) problems.push(`${label}.aggregate did not retain dirty component state`);
-			if (!(aggregate.insertionsVsPrimary > 0)) problems.push(`${label}.aggregate did not retain component line counts`);
+			if (aggregate.clean !== false || body.clean !== false) problems.push(`${label}.clean must be the dirty-component AND`);
+			if (aggregate.unpushed !== false || body.unpushed !== false) problems.push(`${label}.unpushed must be the component OR`);
+			if (!Array.isArray(aggregate.status) || aggregate.status.length !== 0) problems.push(`${label}.aggregate.status must defer to per-repo sections`);
 		};
 		checkStatusEnvelope("goal", goalStatusResponse, goalStatus);
 		checkStatusEnvelope("team lead", leadStatusResponse, leadStatus);
+
+		// Simulate the established gateway restart boundary: tear down the live
+		// SessionInfo, remove it from the in-memory map, and drive the same
+		// restoreSessions primitive used during boot. Other harness sessions remain
+		// live, so restrict only the per-session restore dispatch to this lead.
+		const sessionManager = gateway.sessionManager as any;
+		const liveBeforeRestart = sessionManager.sessions.get(teamLeadSessionId!);
+		if (!liveBeforeRestart) {
+			problems.push("team lead is not live before restoreSessions restart");
+		} else {
+			try {
+				liveBeforeRestart.unsubscribe();
+				try { await liveBeforeRestart.rpcClient.stop(); } catch { /* already stopped */ }
+				sessionManager.sessions.delete(teamLeadSessionId!);
+				originalRestoreOneSession = sessionManager.restoreOneSession;
+				sessionManager.restoreOneSession = async (persisted: any) => {
+					if (persisted.id === teamLeadSessionId) {
+						return originalRestoreOneSession.call(sessionManager, persisted);
+					}
+				};
+				await sessionManager.restoreSessions();
+			} catch (error) {
+				problems.push(`restoreSessions failed: ${error instanceof Error ? error.message : String(error)}`);
+			} finally {
+				if (originalRestoreOneSession) {
+					sessionManager.restoreOneSession = originalRestoreOneSession;
+					originalRestoreOneSession = undefined;
+				}
+			}
+		}
+
+		const restoredLiveLead = gateway.sessionManager.getSession(teamLeadSessionId!);
+		const restoredPersistedLead = context?.sessionStore.get(teamLeadSessionId!);
+		if (!sessionManager.isSessionLive(teamLeadSessionId!)) problems.push("restored team lead is not live");
+		checkCoordinates("restored live lead", restoredLiveLead, liveRepoWorktrees(restoredLiveLead));
+		checkCoordinates("restored persisted lead", restoredPersistedLead, restoredPersistedLead?.repoWorktrees ?? {});
+		const restoredLeadStatusResponse = await apiFetch(`/api/sessions/${teamLeadSessionId}/git-status`);
+		const restoredLeadStatus = await readJson(restoredLeadStatusResponse);
+		checkStatusEnvelope("restored team lead", restoredLeadStatusResponse, restoredLeadStatus);
+
+		const checkGoalComponentsUsable = async (label: string) => {
+			for (const repo of COMPONENTS) {
+				const worktreePath = expectedRepoWorktrees[repo];
+				if (!existsSync(worktreePath)) {
+					problems.push(`${label}: ${repo} goal-owned directory was removed`);
+					continue;
+				}
+				try {
+					const head = await git(runner, worktreePath, ["rev-parse", "HEAD"]);
+					if (head !== expectedComponentHeads[repo]) problems.push(`${label}: ${repo} HEAD changed to ${head}`);
+					const branch = await git(runner, worktreePath, ["branch", "--show-current"]);
+					if (branch !== goal.branch) problems.push(`${label}: ${repo} branch changed to ${branch}`);
+					const porcelain = await git(runner, worktreePath, ["status", "--porcelain", "--", "README.md"]);
+					if (!porcelain.includes("README.md")) problems.push(`${label}: ${repo} no longer reports its dirty README`);
+					const registrations = await git(runner, join(projectRoot, repo), ["worktree", "list", "--porcelain"]);
+					const registeredPaths = registrations
+						.split(/\r?\n/)
+						.filter(line => line.startsWith("worktree "))
+						.map(line => normalized(line.slice("worktree ".length)));
+					if (!registeredPaths.includes(normalized(worktreePath))) {
+						problems.push(`${label}: ${repo} lost Git worktree registration for ${worktreePath}`);
+					}
+				} catch (error) {
+					problems.push(`${label}: ${repo} is unusable: ${error instanceof Error ? error.message : String(error)}`);
+				}
+			}
+		};
+
+		// Team teardown archives the lead and removes the team-store owner. Purging
+		// that archived lead through the public DELETE route must consume only the
+		// borrowed session metadata, never the goal-owned directories/registrations.
+		try {
+			await gateway.teamManager.teardownTeam(goalId!);
+			teamTornDown = true;
+		} catch (error) {
+			problems.push(`team teardown failed: ${error instanceof Error ? error.message : String(error)}`);
+		}
+		const archivedLead = context?.sessionStore.get(teamLeadSessionId!);
+		if (!archivedLead?.archived) problems.push("team teardown did not archive the team lead");
+		checkCoordinates("archived lead", archivedLead, archivedLead?.repoWorktrees ?? {});
+		await checkGoalComponentsUsable("after team-lead archive");
+
+		const purgeLeadResponse = await apiFetch(`/api/sessions/${teamLeadSessionId}?purge=true`, { method: "DELETE" });
+		const purgeLeadBody = await readJson(purgeLeadResponse);
+		if (purgeLeadResponse.status !== 200) {
+			problems.push(`team-lead purge=${purgeLeadResponse.status} ${JSON.stringify(purgeLeadBody)}`);
+		}
+		leadPurged = !context?.sessionStore.get(teamLeadSessionId!);
+		if (!leadPurged) problems.push("team-lead persisted record survived purge");
+		if (gateway.sessionManager.getSession(teamLeadSessionId!)) problems.push("team-lead live record survived purge");
+		await checkGoalComponentsUsable("after team-lead purge");
 
 		if (problems.length > 0) {
 			throw new Error(`${STATUS_REPRO}: ${problems.join("; ")}`);
 		}
 	} finally {
-		if (goalId) await teardownTeam(goalId).catch(() => undefined);
-		if (teamLeadSessionId) {
+		if (originalRestoreOneSession) {
+			(gateway.sessionManager as any).restoreOneSession = originalRestoreOneSession;
+			originalRestoreOneSession = undefined;
+		}
+		if (goalId && !teamTornDown) await teardownTeam(goalId).catch(() => undefined);
+		if (teamLeadSessionId && !leadPurged) {
 			await apiFetch(`/api/sessions/${teamLeadSessionId}?purge=true`, { method: "DELETE" }).catch(() => undefined);
 		}
 		if (goalId) await deleteGoal(goalId).catch(() => undefined);
 		if (projectId) {
 			await apiFetch(`/api/projects/${encodeURIComponent(projectId)}`, { method: "DELETE" }).catch(() => undefined);
 		}
-		rmSync(fixtureRoot, { recursive: true, force: true, maxRetries: 5, retryDelay: 50 });
+		// Restored agent and Git child processes can release Windows directory
+		// handles a few ticks after their awaited shutdown completes.
+		rmSync(fixtureRoot, { recursive: true, force: true, maxRetries: 20, retryDelay: 100 });
 	}
 });

--- a/tests2/integration/team-spawn-multi-repo-real-git.test.ts
+++ b/tests2/integration/team-spawn-multi-repo-real-git.test.ts
@@ -2,7 +2,7 @@ import { appendFileSync, existsSync, mkdtempSync, rmSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 
 import type { CommandRunner } from "../../src/server/gateway-deps.js";
-import { pollUntil } from "../../tests/e2e/test-utils/cleanup.js";
+import { awaitableRm, pollUntil } from "../../tests/e2e/test-utils/cleanup.js";
 import { copyGitTemplate, prepareGitTemplate } from "../harness/git-template.js";
 import { test, expect } from "./_e2e/in-process-harness.js";
 import { apiFetch, deleteGoal, registerProject, teardownTeam } from "./_e2e/e2e-setup.js";
@@ -957,7 +957,9 @@ test("team lead borrows goal-owned polyrepo coordinates and both git-status rout
 			await apiFetch(`/api/projects/${encodeURIComponent(projectId)}`, { method: "DELETE" }).catch(() => undefined);
 		}
 		// Restored agent and Git child processes can release Windows directory
-		// handles a few ticks after their awaited shutdown completes.
-		rmSync(fixtureRoot, { recursive: true, force: true, maxRetries: 20, retryDelay: 100 });
+		// handles a few ticks after their awaited shutdown completes. Use the
+		// harness's async bounded retry, whose best-effort result cannot mask an
+		// earlier assertion or turn behaviorally green coverage red.
+		await awaitableRm(fixtureRoot, { maxAttempts: 6, backoffMs: 100 });
 	}
 });

--- a/tests2/tests-map.json
+++ b/tests2/tests-map.json
@@ -21,8 +21,44 @@
   },
   "v2Native": [
     {
+      "path": "tests2/core/git-status-envelope.test.ts",
+      "reason": "Pure aggregation contract coverage for component-authoritative Git status envelopes: sums numeric counters, derives boolean and partial fields, preserves named and sole-dot compatibility, isolates failed siblings, distinguishes terminal non-repositories from retryable errors, and deduplicates fetch/invalidation targets.",
+      "execution": {
+        "runner": "vitest",
+        "tier": "unit",
+        "project": "core"
+      }
+    },
+    {
+      "path": "tests2/core/git-status-native-classification.test.ts",
+      "reason": "Deterministic CommandRunner-seam coverage for host and container Git-status probe classification: only definitive outside-repository diagnostics become terminal, infrastructure and permission failures stay retryable, optional probe failures mark successful results partial, and the legacy nullable wrapper remains compatible.",
+      "execution": {
+        "runner": "vitest",
+        "tier": "unit",
+        "project": "core"
+      }
+    },
+    {
+      "path": "tests2/integration/git-status-polyrepo-fetch-policy.test.ts",
+      "reason": "In-process gateway coverage proving goal and session Git-status fetches tolerate non-Git roots, fetch and invalidate every component's summary and untracked cache variants, and return component-authoritative envelopes with summed aggregates.",
+      "execution": {
+        "runner": "vitest",
+        "tier": "unit",
+        "project": "integration"
+      }
+    },
+    {
+      "path": "tests2/browser/journeys/polyrepo-git-status.journey.spec.ts",
+      "reason": "Chromium journey proving session and goal-dashboard Git-status widgets remain visible for component-only envelopes, render named per-repository sections including a sole named component, explicitly refresh details, and survive page reload.",
+      "execution": {
+        "runner": "playwright",
+        "tier": "browser",
+        "project": "browser"
+      }
+    },
+    {
       "path": "tests2/integration/team-spawn-multi-repo-real-git.test.ts",
-      "reason": "Focused real-Git regression for a non-Git two-component project: drives direct TeamManager.spawnRole and one REST team/spawn request from unpublished divergent local goal-component HEADs; verifies exact-start branch-collision rejection before worktree attachment/upstream or remote mutation, rollback of an earlier component while preserving the divergent colliding branch, actual createSession agent-spawn then post-spawn setup failure without Git probes against either non-Git container, TeamManager-owned component/container cleanup, common branch-container layout, injected partial rollback, and cleanup coordinates in createSession's first durable write.",
+      "reason": "Focused real-Git regression for a non-Git two-component project: covers direct and REST worker spawn from unpublished divergent component HEADs, collision rejection, partial and post-spawn rollback, component-owned cleanup, and first-write cleanup coordinates; also proves the team lead borrows the goal's live and persisted worktree metadata, retains it across session restoration, returns summed per-component goal/session Git-status envelopes, and can be archived and purged without removing goal-owned component worktrees.",
       "execution": {
         "runner": "vitest",
         "tier": "e2e",


### PR DESCRIPTION
## Summary
- retain goal-owned multi-repo metadata on team-lead sessions across persistence and restart
- share classified component status collection and aggregation between goal and session endpoints
- keep named-repository widgets visible with per-repo sections across reloads
- preserve goal-owned cleanup safety and per-component fetch/cache behavior
- align project workflows with the new main branch and update multi-repo design documentation

## Verification
- build and type-check
- full unit, browser, and E2E suites
- real-Git non-Git-root polyrepo lifecycle/restart/cleanup regression
- focused component aggregation, native classification, fetch policy, and widget journeys

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)