### PR TITLE
Publish releases after PR merge

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,15 +1,16 @@
 ---
 name: release
-description: Cut a Bobbit release — preflight checks, version bump, signed tag (CI publishes the root to npm via OIDC on tag push), optional binary sub-packages, GitHub release with generated notes.
+description: Cut a Bobbit release — preflight checks, version bump, release PR (CI tags and publishes the root via npm OIDC), optional binary sub-packages, GitHub release, and smoke test.
 argument-hint: [major|minor|patch|<explicit-version>]
 ---
 
-Drive an end-to-end release of Bobbit. The maintainer (human) must be at the
-keyboard to sign the tag, and for `npm login` / OTP prompts **only when
-republishing binary sub-packages** — pause and ask when the flow needs them.
-The root `@gresearch/bobbit` package publishes automatically via CI (npm
-trusted publishing / OIDC) when the signed tag is pushed; **never** run a
-manual root `npm publish`.
+Drive an end-to-end release of Bobbit. The maintainer (human) must approve the
+release notes and the final release PR merge, and must be at the keyboard for
+`npm login` / OTP prompts **only when republishing binary sub-packages**. Merging
+the validated release PR makes the release public: GitHub Actions creates the
+tag at the exact squash-merge commit and publishes the root
+`@gresearch/bobbit` package through npm trusted publishing/OIDC. **Never**
+create the root tag or run a manual root `npm publish`.
 
 Single source of truth for release mechanics: [`docs/releasing.md`](../../../docs/releasing.md).
 This skill orchestrates that doc + version bump + notes + GitHub release.
@@ -23,8 +24,8 @@ second worktree while the primary already has it. Instead, §1.5 creates a
 dedicated **detached-HEAD worktree off `origin/main`** (a sibling of the
 primary, *not* under `*-wt/`), and every mutating step runs there. The release
 commit is pushed to a `release/v<version>` branch and squash-merged through the
-repository's required PR flow (§6–§8); the resulting merge commit is what gets
-tagged. The E2E harness binds port 0 and uses ephemeral `BOBBIT_DIR`s, so
+repository's required PR flow (§6–§8); the merge triggers the automated tag and
+root publish. The E2E harness binds port 0 and uses ephemeral `BOBBIT_DIR`s, so
 `test:e2e` won't collide with the running dev server.
 
 ## 0. Sanity check the environment
@@ -41,8 +42,8 @@ git log --oneline <prev-tag>..origin/main | head    # must be non-empty (somethi
 node -v                                  # must satisfy engines.node (>=22.19.0)
 npm whoami                               # only needed if republishing binary sub-packages (§3); root ships via CI
 gh auth status                           # must be authed for G-Research/bobbit
-git config --get user.signingkey || echo "NO_SIGNING_KEY"
-git config --get commit.gpgsign || echo "commit.gpgsign=unset"
+gh api repos/G-Research/bobbit/rulesets \
+  --jq '.[] | select(.target == "tag") | [.name, .enforcement] | @tsv'
 ```
 
 Note: do **not** gate on the current worktree's branch or cleanliness — the
@@ -54,7 +55,7 @@ so the session/primary worktree state is irrelevant. What matters is that
 - `origin/main` has nothing new since the previous tag (nothing to release), or it isn't the commit they expect to ship.
 - `npm whoami` fails **and** step 3 will republish binary sub-packages — ask them to run `npm login` (and enable 2FA if not already; npm requires OTP for those sub-package publishes). The root `@gresearch/bobbit` publish needs no npm login — it goes through CI/OIDC.
 - `gh auth status` not logged in — ask them to run `gh auth login`.
-- No GPG/SSH signing key configured — confirm whether to proceed with **unsigned** tag or wait until they set one up. Default to waiting.
+- The active **Release tag creation** and **Immutable release tags** rulesets required by [`docs/releasing.md`](../../../docs/releasing.md#automated-root-release) are absent or misconfigured — stop until a repository administrator fixes them.
 
 ## 1. Decide the new version
 
@@ -138,7 +139,7 @@ git diff v<prev>..HEAD -- binaries.versions.json
 npm version <new-version> --no-git-tag-version
 ```
 
-`--no-git-tag-version` because we want a signed tag, not the unsigned one `npm version` would otherwise create. **Don't commit yet** — the release notes (§5) are a tracked file and ship in the *same* `chore(release)` commit as the version bump (that's how prior releases do it, e.g. v0.11.0 bundled `RELEASE_NOTES_v0.11.0.md` with `package.json`). Leave the bumped `package.json` / `package-lock.json` (and any `binaries/*` edits from §3) staged-but-uncommitted until §5.
+`--no-git-tag-version` because the merge-triggered release workflow owns tag creation. **Don't commit yet** — the release notes (§5) are a tracked file and ship in the *same* `chore(release)` commit as the version bump (that's how prior releases do it, e.g. v0.11.0 bundled `RELEASE_NOTES_v0.11.0.md` with `package.json`). Leave the bumped `package.json` / `package-lock.json` (and any `binaries/*` edits from §3) staged-but-uncommitted until §5.
 
 ## 5. Generate release notes — then commit
 
@@ -162,16 +163,13 @@ Once the user approves the notes, commit the version bump and the notes together
 git add package.json package-lock.json RELEASE_NOTES_v<new-version>.md
 # include binaries/* package.json edits if §3 changed them
 git commit -m "chore(release): v<new-version>" \
-  --trailer "Co-authored-by: bobbit-ai <bobbit@bobbit.ai>" \
-  -S    # GPG/SSH-sign the commit if a signing key is configured
+  --trailer "Co-authored-by: bobbit-ai <bobbit@bobbit.ai>"
 ```
 
-If no signing key is set, drop `-S` (you already confirmed with the user in step 0).
-
 The commit lands on this worktree's detached HEAD — that's expected. The
-required squash merge in §8 creates the final `main` commit; that commit,
-not the detached release commit, is what gets tagged so npm, Git, and the
-GitHub release all agree.
+required squash merge in §8 creates the final `main` commit, and the release
+workflow tags that exact merge commit so npm, Git, and the GitHub release all
+agree.
 
 ## 6. Open the release PR and clear its gates
 
@@ -199,24 +197,24 @@ gh pr checks "$PR" --watch
 gh pr view "$PR" --json mergeStateStatus,reviewDecision,statusCheckRollup
 ```
 
-The PR must be ready to merge, but **do not merge it yet**. Publishing remains
-the last irreversible step before the source and tag become public. Do not
-create the tag before the squash merge because the pre-merge commit will not
-be the commit that lands on `main`.
+The PR must be ready to merge, but **do not merge it yet**. Merging is the
+irreversible publication approval because it immediately starts the automated
+tag and root publish. Publish any changed binary sub-packages first (§7), then
+pause for the maintainer's final merge confirmation (§8).
 
 ## 7. Publish binary sub-packages (only if step 3 bumped binaries)
 
-**The root `@gresearch/bobbit` package is NOT published here.** It publishes automatically
-via the `.github/workflows/release-publish.yml` workflow (npm trusted publishing
-/ OIDC, with provenance) when the signed tag is pushed in §8 — there is no manual
-root `npm publish`. Skip straight to §8 unless step 3 bumped the binary
-sub-packages.
+**The root `@gresearch/bobbit` package is NOT published here.** It publishes
+automatically through `.github/workflows/release-publish.yml` (npm trusted
+publishing/OIDC with provenance) when the release PR is merged in §8. There is
+no manual root `npm publish`. Skip straight to §8 unless step 3 bumped the
+binary sub-packages.
 
-If step 3 bumped binaries, publish the sub-packages now — **before** the tag push
-in §8, so they are on npm before the root that pins them. **Pause and confirm with
-the user** first; npm publishes are irreversible (you can `unpublish` for 72h but
-the version number is burned either way). Use `ask_user_choices` with the exact
-commands:
+If step 3 bumped binaries, publish the sub-packages now — **before** the release
+PR merge in §8, so they are on npm before the root that pins them. **Pause and
+confirm with the user** first; npm publishes are irreversible (you can
+`unpublish` for 72h but the version number is burned either way). Use
+`ask_user_choices` with the exact commands:
 
 ```bash
 npm publish ./binaries/binaries-darwin-arm64
@@ -231,10 +229,15 @@ Notes:
 - npm will prompt for OTP — that's the maintainer's job; just wait.
 - If publish fails after some sub-packages went through, **do not** try to bump+republish under a new version. Re-run `npm publish` on the remaining packages with the same version once the issue is fixed.
 
-## 8. Squash-merge the release PR, then tag it (this triggers the npm publish)
+## 8. Confirm, squash-merge, and watch the automated release
 
-Once the release PR is fully green and mergeable, squash-merge it.
-Pin the subject and co-author trailer explicitly:
+Once the release PR is fully green and mergeable, **pause and confirm with the
+maintainer** that merging should publish v<new-version>. The merge is the final
+irreversible action: `.github/workflows/release-publish.yml` validates the
+merged PR, creates `v<new-version>` at its exact squash commit, and publishes
+the root package through npm OIDC.
+
+After confirmation, pin the squash subject and co-author trailer explicitly:
 
 ```bash
 gh pr merge "$PR" \
@@ -250,33 +253,35 @@ git diff --exit-code HEAD "$MERGE_SHA" -- \
   package.json package-lock.json RELEASE_NOTES_v<new-version>.md
 ```
 
-Tag the PR's exact squash commit, not the current `origin/main` tip (another
-PR may have merged immediately afterward). **Pushing the tag triggers the root
-npm publish** (`.github/workflows/release-publish.yml`) and is irreversible —
-pause and confirm with the user before the `git push`:
+Wait for the merge-triggered workflow to appear, then watch it through tag
+creation and publication:
 
 ```bash
-git tag -s v<new-version> "$MERGE_SHA" -m "Bobbit v<new-version>"
-git tag -v v<new-version>
-git push origin v<new-version>       # -> release-publish.yml publishes @gresearch/bobbit to npm (OIDC + provenance)
+RUN_ID=""
+for _ in $(seq 1 30); do
+  RUN_ID=$(gh run list --workflow release-publish.yml --commit "$MERGE_SHA" \
+    --limit 1 --json databaseId -q '.[0].databaseId')
+  [ -n "$RUN_ID" ] && break
+  sleep 2
+done
+[ -n "$RUN_ID" ]
+gh run watch "$RUN_ID" --exit-status
+
+git fetch origin --tags
+test "$(git rev-list -n1 v<new-version>)" = "$MERGE_SHA"
+npm view @gresearch/bobbit@<new-version> version
 ```
 
-If the user explicitly opted out of signing in step 0, use `git tag -a`
-instead and inspect it with `git show --no-patch v<new-version>`.
+If the workflow fails before `npm publish`, repair the cause and re-run **the
+same workflow run**; tag creation is idempotent only when the existing tag
+points to the expected merge SHA. If the publish command fails after the
+registry may have accepted the package, inspect the published package and its
+provenance before taking any further action. The workflow deliberately does not
+silently accept an existing npm version. Do not bump the version, create or move
+the tag manually, or create a second release PR for the same version.
 
-Then watch the publish workflow and confirm it succeeds before moving on:
-
-```bash
-gh run watch "$(gh run list --workflow release-publish.yml --branch v<new-version> --limit 1 --json databaseId -q '.[0].databaseId')" --exit-status
-```
-
-If the publish job fails (e.g. transient registry error), **re-run the same
-workflow run** for the same version — do not bump the version or re-tag; the
-tag is already public and the version number is immutable.
-
-If merging fails, stop and repair the same release PR. Do not change the
-version, create a second release commit, force-push `main`, or tag the
-detached pre-merge commit.
+If merging itself fails, stop and repair the same release PR. Do not change the
+version, force-push `main`, or tag the detached pre-merge commit.
 
 **Refresh the running dev server** so it picks up the release commit (its
 local `main` is now behind remote):
@@ -297,7 +302,7 @@ gh release create v<new-version> \
 
 `--verify-tag` ensures gh refuses to create the release if the tag doesn't already exist on the remote (catches push-skipped-by-mistake).
 
-If this is a pre-release (version contains `-beta`, `-rc`, `-alpha`), add `--prerelease`.
+If the version contains any prerelease suffix after `-` (for example `-beta`, `-rc.1`, or `-next.2`), add `--prerelease`.
 
 ## 10. Post-release smoke
 
@@ -336,12 +341,12 @@ Report to the user:
 
 ## Rules / best practices
 
-- **Signed tag, always.** Use `git tag -s`. Only fall back to `-a` if the maintainer explicitly opted out in step 0.
-- **Signed commit if a signing key is configured.** Add `-S` to `git commit`. Never override `user.name` / `user.email`; never silently disable signing.
-- **The root publish is CI-only.** It runs via `release-publish.yml` (OIDC trusted publishing) on the tag push, with provenance automatic. Never run a manual root `npm publish`.
+- **The release workflow owns the tag.** Never create, move, or delete a root release tag manually. The automated lightweight tag must point to the release PR's exact squash-merge commit.
+- **Merging publishes.** Treat the final release PR merge confirmation as the irreversible release approval.
+- **The root publish is CI-only.** `release-publish.yml` creates the tag and publishes through npm OIDC with automatic provenance. Never run a manual root `npm publish`.
 - **OTP is the human's job** — but only for the binary sub-package publishes. Pause and let them type it; don't try to read it from anywhere. The root publish uses no OTP.
 - **Never `npm publish --force`.** If a sub-package republish is genuinely needed, bump the patch version and republish cleanly. If the CI root publish fails, re-run the same workflow run for the same version.
-- **Never delete a tag that's been pushed.** If you tagged wrong, bump the version and tag again — published version numbers are immutable.
-- **Use the required squash-merge PR flow.** Never tag the detached release commit; tag the PR's exact `mergeCommit` SHA after verifying its package version and release files.
+- **Never delete or move a published tag.** If a release is wrong, fix it in a new version — published version numbers are immutable.
+- **Use the required squash-merge PR flow.** Never tag the detached release commit; the workflow validates and tags the PR's exact `mergeCommit` SHA.
 - **One release at a time.** Don't start a second version bump while the previous tag/publish is in flight.
 - **Stop on any test, audit, or check failure.** Releases amplify bugs — the cost of waiting a day is tiny; the cost of a bad publish is days of cleanup.

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -1,44 +1,219 @@
 name: Publish to npm
 
 on:
-  push:
-    tags:
-      - 'v*'
+  pull_request:
+    branches: [main]
+    types: [closed]
 
-permissions:
-  contents: read
-  id-token: write
+concurrency:
+  group: release-publish
+  cancel-in-progress: false
 
 jobs:
-  publish:
+  tag:
+    name: Tag merged release
+    if: >-
+      github.event.pull_request.merged == true &&
+      github.event.pull_request.base.ref == 'main' &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      startsWith(github.event.pull_request.head.ref, 'release/v')
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    outputs:
+      merge-sha: ${{ steps.release.outputs.merge-sha }}
+      tag: ${{ steps.release.outputs.tag }}
+      version: ${{ steps.release.outputs.version }}
     steps:
-      - name: Checkout
+      - name: Checkout exact merge commit
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
+          fetch-depth: 0
           persist-credentials: false
 
-      - name: Guard tag matches package.json version
+      - name: Validate merged release PR
+        id: release
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        shell: bash
         run: |
-          TAG="${GITHUB_REF_NAME#v}"
-          PKG="$(node -p "require('./package.json').version")"
-          [ "$TAG" = "$PKG" ] || { echo "tag v$TAG != package.json $PKG" >&2; exit 1; }
+          set -euo pipefail
+
+          ACTUAL_SHA="$(git rev-parse HEAD)"
+          [ "$ACTUAL_SHA" = "$MERGE_SHA" ] || {
+            echo "checkout $ACTUAL_SHA != merged commit $MERGE_SHA" >&2
+            exit 1
+          }
+          [ "$BASE_REF" = "main" ] || {
+            echo "release PR targeted $BASE_REF, not main" >&2
+            exit 1
+          }
+
+          VERSION="$(node -p "require('./package.json').version")"
+          VERSION="$VERSION" node - <<'NODE'
+          const version = process.env.VERSION;
+          const numeric = String.raw`(?:0|[1-9]\d*)`;
+          const prereleasePart = String.raw`(?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*)`;
+          const supported = new RegExp(
+            String.raw`^${numeric}\.${numeric}\.${numeric}(?:-${prereleasePart}(?:\.${prereleasePart})*)?$`,
+          );
+          if (!version || !supported.test(version)) {
+            throw new Error(`package.json version is not a supported release version: ${version}`);
+          }
+          NODE
+          TAG="v$VERSION"
+          [ "$HEAD_REF" = "release/$TAG" ] || {
+            echo "release branch $HEAD_REF != release/$TAG" >&2
+            exit 1
+          }
+          [ "$PR_TITLE" = "chore(release): $TAG" ] || {
+            echo "release PR title must be: chore(release): $TAG" >&2
+            exit 1
+          }
+
+          node - <<'NODE'
+          const packageJson = require("./package.json");
+          const lock = require("./package-lock.json");
+          if (lock.version !== packageJson.version || lock.packages?.[""]?.version !== packageJson.version) {
+            throw new Error(
+              `package-lock versions (${lock.version}, ${lock.packages?.[""]?.version}) do not match package.json ${packageJson.version}`,
+            );
+          }
+          NODE
+
+          NOTES="RELEASE_NOTES_$TAG.md"
+          [ -s "$NOTES" ] || {
+            echo "missing or empty release notes: $NOTES" >&2
+            exit 1
+          }
+
+          printf 'merge-sha=%s\n' "$MERGE_SHA" >> "$GITHUB_OUTPUT"
+          printf 'tag=%s\n' "$TAG" >> "$GITHUB_OUTPUT"
+          printf 'version=%s\n' "$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Verify release tag protection
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          rulesets="$(gh api "repos/$GITHUB_REPOSITORY/rulesets?targets=tag")"
+          creation_id="$(jq -r '.[] | select(.name == "Release tag creation") | .id' <<< "$rulesets")"
+          immutable_id="$(jq -r '.[] | select(.name == "Immutable release tags") | .id' <<< "$rulesets")"
+          [[ "$creation_id" =~ ^[0-9]+$ ]] || {
+            echo "missing unique Release tag creation ruleset" >&2
+            exit 1
+          }
+          [[ "$immutable_id" =~ ^[0-9]+$ ]] || {
+            echo "missing unique Immutable release tags ruleset" >&2
+            exit 1
+          }
+
+          gh api "repos/$GITHUB_REPOSITORY/rulesets/$creation_id" | jq -e '
+            .target == "tag" and
+            .enforcement == "active" and
+            ((.conditions.ref_name.include // []) | index("refs/tags/v*") != null) and
+            ((.conditions.ref_name.exclude // []) | length == 0) and
+            (.rules | length == 1) and
+            .rules[0].type == "creation" and
+            .current_user_can_bypass == "always"
+          ' >/dev/null || {
+            echo "Release tag creation must allow the GitHub Actions integration to create refs/tags/v*" >&2
+            exit 1
+          }
+
+          gh api "repos/$GITHUB_REPOSITORY/rulesets/$immutable_id" | jq -e '
+            .target == "tag" and
+            .enforcement == "active" and
+            ((.conditions.ref_name.include // []) | index("refs/tags/v*") != null) and
+            ((.conditions.ref_name.exclude // []) | length == 0) and
+            (.rules | length == 2) and
+            any(.rules[]; .type == "update") and
+            any(.rules[]; .type == "deletion") and
+            .current_user_can_bypass == "never"
+          ' >/dev/null || {
+            echo "Immutable release tags must prevent GitHub Actions from updating or deleting refs/tags/v*" >&2
+            exit 1
+          }
+
+      - name: Create or verify release tag
+        env:
+          GH_TOKEN: ${{ github.token }}
+          MERGE_SHA: ${{ steps.release.outputs.merge-sha }}
+          TAG: ${{ steps.release.outputs.tag }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          endpoint="repos/$GITHUB_REPOSITORY/git/ref/tags/$TAG"
+          if existing="$(gh api "$endpoint" --jq '[.object.type, .object.sha] | @tsv' 2>/dev/null)"; then
+            read -r object_type object_sha <<< "$existing"
+            [ "$object_type" = "commit" ] && [ "$object_sha" = "$MERGE_SHA" ] || {
+              echo "$TAG already exists as $object_type $object_sha, expected commit $MERGE_SHA" >&2
+              exit 1
+            }
+            echo "$TAG already points to $MERGE_SHA"
+          else
+            gh api --method POST "repos/$GITHUB_REPOSITORY/git/refs" \
+              -f ref="refs/tags/$TAG" \
+              -f sha="$MERGE_SHA" >/dev/null
+            echo "created $TAG at $MERGE_SHA"
+          fi
+
+  publish:
+    name: Publish root package
+    needs: tag
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout tagged merge commit
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          ref: ${{ needs.tag.outputs.merge-sha }}
+          persist-credentials: false
+
+      - name: Verify release tag
+        env:
+          GH_TOKEN: ${{ github.token }}
+          MERGE_SHA: ${{ needs.tag.outputs.merge-sha }}
+          TAG: ${{ needs.tag.outputs.tag }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          tagged_sha="$(gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$TAG" --jq .object.sha)"
+          [ "$tagged_sha" = "$MERGE_SHA" ] || {
+            echo "$TAG points to $tagged_sha, expected $MERGE_SHA" >&2
+            exit 1
+          }
 
       - name: Set up Node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'
+          package-manager-cache: false
 
       - name: Install
         run: npm ci
 
       - name: Publish (OIDC trusted publishing)
+        env:
+          VERSION: ${{ needs.tag.outputs.version }}
+        shell: bash
         run: |
+          set -euo pipefail
           echo "node: $(node -v)  npm: $(npm -v)"
-          case "${GITHUB_REF_NAME#v}" in
+
+          case "$VERSION" in
             *-*) DIST_TAG=next ;;
             *)   DIST_TAG=latest ;;
           esac
-          echo "publishing @gresearch/bobbit to dist-tag: $DIST_TAG"
+          echo "publishing @gresearch/bobbit@$VERSION to dist-tag: $DIST_TAG"
           npm publish --provenance --tag "$DIST_TAG" --loglevel verbose

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,6 +1,19 @@
 # Releasing Bobbit
 
-This doc covers the Bobbit release checks that cannot be inferred from a normal development checkout: the installed consumer's security report and the bundled `fd`/`rg` binaries. The root `@gresearch/bobbit` package itself is published automatically by [`.github/workflows/release-publish.yml`](../.github/workflows/release-publish.yml) (npm trusted publishing / OIDC, with provenance) when a `v*` tag is pushed; only the binary sub-packages below are published manually.
+This doc covers the Bobbit release checks that cannot be inferred from a normal development checkout: the installed consumer's security report and the bundled `fd`/`rg` binaries. The root `@gresearch/bobbit` package itself is tagged and published automatically by [`.github/workflows/release-publish.yml`](../.github/workflows/release-publish.yml) when a validated release PR is merged; only the binary sub-packages below are published manually.
+
+## Automated root release
+
+A root release is authorized by squash-merging a same-repository PR from `release/v<version>` into `main`. The PR title must be `chore(release): v<version>`, `package.json` and both root versions in `package-lock.json` must agree, and `RELEASE_NOTES_v<version>.md` must be present and non-empty. Merging is the irreversible publication approval.
+
+The workflow checks out the PR's exact squash-merge SHA, creates a lightweight `v<version>` tag at that commit, and publishes the package from the same workflow run using npm trusted publishing/OIDC. The tag and publish intentionally share one run because events created with `GITHUB_TOKEN` do not start another workflow. A global concurrency group prevents two publishes from running together; never merge another release PR until the current release workflow completes because GitHub retains at most one pending run per concurrency group. A rerun accepts an existing tag only when it still points to the expected merge commit. It never silently accepts an existing npm version; if the registry may have accepted a publish despite a failed command, verify the published package and provenance before deciding how to recover.
+
+The automated tag is not GPG/SSH-signed. Its trust comes from the reviewed and protected `main` merge, the workflow's exact-SHA and version checks, job-scoped least-privilege `GITHUB_TOKEN` permissions, npm's short-lived OIDC credential, and provenance attestation. Before creating a tag, the workflow requires these two active repository tag rulesets targeting `refs/tags/v*` with no exclusions:
+
+- **Release tag creation** — a `creation` rule with exactly one bypass actor: the GitHub Actions integration (app ID `15368`, bypass mode `always`).
+- **Immutable release tags** — `update` and `deletion` rules with no bypass actors and no `creation` rule.
+
+Splitting creation from immutability lets the workflow create a release tag without giving it—or anyone else—permission to move or delete one later. GitHub does not expose complete bypass-actor lists to the workflow token, so a repository administrator must verify those lists in Settings. The workflow fails closed unless both rule shapes are active, its token can bypass the creation rule, and its token cannot bypass immutability.
 
 ## Required packed-consumer audit
 
@@ -83,7 +96,7 @@ changes.
    pin in the root `package.json` `optionalDependencies` block to the
    new version.
 7. Publish each sub-package (the root is not published here — it ships via
-   CI on the tag push):
+   CI when the release PR is merged):
    ```bash
    npm publish ./binaries/binaries-darwin-arm64
    npm publish ./binaries/binaries-darwin-x64
@@ -91,9 +104,9 @@ changes.
    npm publish ./binaries/binaries-linux-arm64
    npm publish ./binaries/binaries-win32-x64
    ```
-   Do this **before** pushing the release tag, so the sub-packages are on npm
-   before the root that pins them. `publishConfig.access: "public"` is baked
-   into each sub-package, so `--access public` is not needed on the CLI.
+   Do this **before** merging the release PR, so the sub-packages are on npm
+   before the automated root publish that pins them. `publishConfig.access: "public"`
+   is baked into each sub-package, so `--access public` is not needed on the CLI.
 
 ### Decoupled versioning
 

--- a/tests2/core/release-skill-preflight-order.test.ts
+++ b/tests2/core/release-skill-preflight-order.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { readFileSync, writeFileSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { describe, it } from "vitest";
+import { parse as parseYaml } from "yaml";
 import {
 	buildRestrictedNpmEnv,
 	evaluatePackedConsumerAudit,
@@ -12,11 +13,42 @@ import {
 } from "../../scripts/release-packed-consumer-audit.mjs";
 
 const skill = readFileSync(resolve(process.cwd(), ".claude/skills/release/SKILL.md"), "utf8");
+const releaseWorkflowSource = readFileSync(
+	resolve(process.cwd(), ".github/workflows/release-publish.yml"),
+	"utf8",
+);
+type WorkflowStep = {
+	name?: string;
+	uses?: string;
+	with?: Record<string, unknown>;
+	run?: string;
+};
+type WorkflowJob = {
+	if?: string;
+	needs?: string;
+	permissions?: Record<string, string>;
+	steps?: WorkflowStep[];
+};
+const releaseWorkflow = parseYaml(releaseWorkflowSource) as {
+	on?: {
+		pull_request?: { branches?: string[]; types?: string[] };
+		push?: unknown;
+		pull_request_target?: unknown;
+	};
+	concurrency?: { group?: string; "cancel-in-progress"?: boolean };
+	jobs?: { tag?: WorkflowJob; publish?: WorkflowJob };
+};
 const packageJson = JSON.parse(readFileSync(resolve(process.cwd(), "package.json"), "utf8")) as {
 	name?: string;
 	scripts?: Record<string, string>;
 };
 const preflight = skill.match(/## 2\. Pre-flight quality gates[\s\S]*?```bash\n([\s\S]*?)\n```/)?.[1];
+
+function workflowStep(job: WorkflowJob | undefined, name: string): WorkflowStep {
+	const step = job?.steps?.find(candidate => candidate.name === name);
+	assert.ok(step, `release workflow is missing step: ${name}`);
+	return step;
+}
 
 const zeroCounts = {
 	info: 0,
@@ -60,6 +92,92 @@ describe("release skill primary branch", () => {
 	});
 });
 
+describe("merge-triggered release workflow", () => {
+	it("runs only for merged same-repository release PRs targeting main", () => {
+		assert.deepEqual(releaseWorkflow.on?.pull_request, {
+			branches: ["main"],
+			types: ["closed"],
+		});
+		assert.equal(releaseWorkflow.on?.push, undefined);
+		assert.equal(releaseWorkflow.on?.pull_request_target, undefined);
+		assert.equal(releaseWorkflow.concurrency?.group, "release-publish");
+		assert.equal(releaseWorkflow.concurrency?.["cancel-in-progress"], false);
+
+		const condition = releaseWorkflow.jobs?.tag?.if ?? "";
+		assert.match(condition, /pull_request\.merged == true/);
+		assert.match(condition, /pull_request\.base\.ref == 'main'/);
+		assert.match(condition, /pull_request\.head\.repo\.full_name == github\.repository/);
+		assert.match(condition, /startsWith\(github\.event\.pull_request\.head\.ref, 'release\/v'\)/);
+	});
+
+	it("validates and tags the exact squash commit with an idempotent collision guard", () => {
+		const tagJob = releaseWorkflow.jobs?.tag;
+		assert.deepEqual(tagJob?.permissions, { contents: "write" });
+
+		const checkout = workflowStep(tagJob, "Checkout exact merge commit");
+		assert.equal(checkout.with?.ref, "${{ github.event.pull_request.merge_commit_sha }}");
+		assert.equal(checkout.with?.["persist-credentials"], false);
+
+		const validation = workflowStep(tagJob, "Validate merged release PR").run ?? "";
+		assert.match(validation, /ACTUAL_SHA.*MERGE_SHA/);
+		assert.match(validation, /0\|\[1-9\]\\d\*/);
+		assert.match(validation, /prereleasePart/);
+		assert.match(validation, /release\/\$TAG/);
+		assert.match(validation, /chore\(release\): \$TAG/);
+		assert.match(validation, /lock\.packages\?\.\[""\]\?\.version/);
+		assert.match(validation, /RELEASE_NOTES_\$TAG\.md/);
+
+		const protection = workflowStep(tagJob, "Verify release tag protection").run ?? "";
+		assert.match(protection, /Release tag creation/);
+		assert.match(protection, /Immutable release tags/);
+		assert.match(protection, /\.type == "creation"/);
+		assert.match(protection, /\.type == "update"/);
+		assert.match(protection, /\.type == "deletion"/);
+		assert.match(protection, /current_user_can_bypass == "always"/);
+		assert.match(protection, /current_user_can_bypass == "never"/);
+		assert.doesNotMatch(protection, /bypass_actors/);
+
+		const createTag = workflowStep(tagJob, "Create or verify release tag").run ?? "";
+		assert.match(createTag, /git\/ref\/tags\/\$TAG/);
+		assert.match(createTag, /object_type.*commit/);
+		assert.match(createTag, /object_sha.*MERGE_SHA/);
+		assert.match(createTag, /refs\/tags\/\$TAG/);
+
+		const names = tagJob?.steps?.map(step => step.name) ?? [];
+		assert.ok(names.indexOf("Verify release tag protection") < names.indexOf("Create or verify release tag"));
+	});
+
+	it("publishes in the same run with read-only contents and short-lived npm OIDC", () => {
+		const publishJob = releaseWorkflow.jobs?.publish;
+		assert.equal(publishJob?.needs, "tag");
+		assert.deepEqual(publishJob?.permissions, {
+			contents: "read",
+			"id-token": "write",
+		});
+
+		const checkout = workflowStep(publishJob, "Checkout tagged merge commit");
+		assert.equal(checkout.with?.ref, "${{ needs.tag.outputs.merge-sha }}");
+		assert.equal(checkout.with?.["persist-credentials"], false);
+		workflowStep(publishJob, "Verify release tag");
+		workflowStep(publishJob, "Install");
+		const publish = workflowStep(publishJob, "Publish (OIDC trusted publishing)").run ?? "";
+		assert.match(publish, /npm publish --provenance --tag "\$DIST_TAG"/);
+		assert.doesNotMatch(publish, /npm view|already published/);
+
+		const names = publishJob?.steps?.map(step => step.name) ?? [];
+		assert.ok(names.indexOf("Verify release tag") < names.indexOf("Install"));
+		assert.ok(names.indexOf("Install") < names.indexOf("Publish (OIDC trusted publishing)"));
+	});
+
+	it("keeps the runbook aligned with action-owned tags and merge-as-publish", () => {
+		assert.match(skill, /Merging publishes/);
+		assert.match(skill, /release workflow owns the tag/i);
+		assert.match(skill, /Release tag creation.*Immutable release tags/s);
+		assert.match(skill, /before.*release\nPR merge in §8/s);
+		assert.doesNotMatch(skill, /git tag -[sa]|git push origin v<new-version>|user\.signingkey/);
+	});
+});
+
 describe("release skill pre-flight order", () => {
 	it("audits the built tarball consumer before type-checking and tests", () => {
 		assert.equal(
@@ -71,7 +189,8 @@ describe("release skill pre-flight order", () => {
 		assert.ok(position("npm run build") < position("npm run audit:packed-consumer"));
 		assert.ok(position("npm run audit:packed-consumer") < position("npm run check"));
 		assert.ok(position("npm run check") < position("npm run test:unit"));
-		assert.ok(position("npm run test:unit") < position("npm run test:e2e"));
+		assert.ok(position("npm run test:unit") < position("npm run test:browser"));
+		assert.ok(position("npm run test:browser") < position("npm run test:e2e"));
 	});
 
 	it("keeps mutable advisory availability release-only and blocks every finding", () => {

--- a/tests2/tests-map.json
+++ b/tests2/tests-map.json
@@ -976,7 +976,7 @@
     },
     {
       "path": "tests2/core/release-skill-preflight-order.test.ts",
-      "reason": "Pins the scoped npm identity used by release verification/reporting and the clean-release pre-flight order required by emitted test declarations.",
+      "reason": "Pins the merge-authorized, exact-SHA, least-privilege OIDC tag-and-publish workflow, its aligned release runbook, the scoped npm identity, and the clean-release pre-flight order required by emitted test declarations.",
       "execution": {
         "runner": "vitest",
         "tier": "unit",


### PR DESCRIPTION
## Summary

- trigger the npm trusted-publishing workflow when a validated `release/vX.Y.Z` PR is squash-merged into `main`
- create `vX.Y.Z` at the exact merge SHA, then publish from the same run with job-scoped GitHub/OIDC permissions
- fail closed on branch, title, version, lockfile, notes, tag collision, and release-tag ruleset mismatches
- update the release runbook and pin the workflow contract with unit tests

## Security

The automated lightweight tag replaces human tag signing. Trust comes from protected/reviewed `main`, exact-SHA validation, immutable `v*` tag rulesets, npm OIDC, and provenance. Before the first automated release, a repository administrator must configure the two tag rulesets documented in `docs/releasing.md`.

## Validation

- `npm run build`
- `npm run check`
- `npm run test:unit` — 8,501 passed, 26 skipped
- focused release contract — 15 passed
- actionlint v1.7.7

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)
