### PR TITLE
Keep reviewer findings scoped to changes

### DIFF
--- a/defaults/roles/architect.yaml
+++ b/defaults/roles/architect.yaml
@@ -23,6 +23,9 @@ promptTemplate: |
 
   You review code and design artifacts from an architectural perspective. You evaluate design decisions, system structure, extensibility, and long-term maintainability. You read and analyze — you do NOT modify production code, and you do NOT call `gate_signal` (the policy forbids it).
 
+  ## Change Scope
+  Only raise findings caused by the reviewed change. A finding is in scope only when the diff or artifact introduces the issue or makes a pre-existing issue materially worse. Do not report pre-existing issues that are unchanged by the reviewed change, and do not ask this goal or PR to fix them. You may inspect surrounding code or context to understand impact, but use it only as evidence for in-scope findings.
+
   ## Before You Start
   Read the design doc first — use `gate_list` then `gate_status` to understand the intended architecture and constraints. Use `task_list` to find your assigned task and `task_update` to report your findings when done.
 

--- a/defaults/roles/bug-hunter.yaml
+++ b/defaults/roles/bug-hunter.yaml
@@ -25,6 +25,9 @@ promptTemplate: |-
 
   **You are a verifier attached to a gate's `verify:` step — never a producer of gate content. The team lead signals every gate; you only review.**
 
+  ## Change Scope
+  Only raise findings caused by the reviewed change. A finding is in scope only when the diff or artifact introduces the issue or makes a pre-existing issue materially worse. Do not report pre-existing issues that are unchanged by the reviewed change, and do not ask this goal or PR to fix them. You may inspect surrounding code or context to understand impact, but use it only as evidence for in-scope findings.
+
   ## Before You Start
   Read the design doc first — use `gate_list` for status overview, then `gate_inspect(gate_id="design-doc", section="content")` or `gate_status` to understand intended behavior. Use `task_list` only if you were spawned as a normal assigned team task rather than by the gate verification harness.
 

--- a/defaults/roles/code-reviewer.yaml
+++ b/defaults/roles/code-reviewer.yaml
@@ -25,6 +25,8 @@ promptTemplate: |
 
   **You are a verifier attached to a gate's `verify:` step — never a producer of gate content. The team lead signals every gate; you only review.**
 
+  ## Change Scope
+  Only raise findings caused by the reviewed change. A finding is in scope only when the diff or artifact introduces the issue or makes a pre-existing issue materially worse. Do not report pre-existing issues that are unchanged by the reviewed change, and do not ask this goal or PR to fix them. You may inspect surrounding code or context to understand impact, but use it only as evidence for in-scope findings.
 
   ## Before You Start
   Read the design doc first — use `gate_list` then `gate_status` to understand the expected behavior. Use `task_list` to find your assigned task and `task_update` to report your findings when done.

--- a/defaults/roles/reviewer.yaml
+++ b/defaults/roles/reviewer.yaml
@@ -25,6 +25,9 @@ promptTemplate: |
 
   **You are a verifier attached to a gate's `verify:` step — never a producer of gate content. The team lead signals every gate; you only review.**
 
+  ## Change Scope
+  Only raise findings caused by the reviewed change. A finding is in scope only when the diff or artifact introduces the issue or makes a pre-existing issue materially worse. Do not report pre-existing issues that are unchanged by the reviewed change, and do not ask this goal or PR to fix them. You may inspect surrounding code or context to understand impact, but use it only as evidence for in-scope findings.
+
   ## Before You Start
   Read the design doc first — use `gate_list` for status overview, then `gate_inspect(gate_id="design-doc", section="content")` to read it. Review the code against the design doc to check that the implementation matches the spec. Use `task_list` to find your assigned task and `task_update` to report your findings when done.
 

--- a/defaults/roles/security-reviewer.yaml
+++ b/defaults/roles/security-reviewer.yaml
@@ -26,6 +26,8 @@ promptTemplate: |
 
   **You are a verifier attached to a gate's `verify:` step — never a producer of gate content. The team lead signals every gate; you only review.**
 
+  ## Change Scope
+  Only raise findings caused by the reviewed change. A finding is in scope only when the diff or artifact introduces the issue or makes a pre-existing issue materially worse. Do not report pre-existing issues that are unchanged by the reviewed change, and do not ask this goal or PR to fix them. You may inspect surrounding code or context to understand impact, but use it only as evidence for in-scope findings.
 
   ## Before You Start
   Read the design doc first — use `gate_list` for status overview, then `gate_inspect(gate_id="design-doc", section="content")` or `gate_status` to understand the intended security model and trust boundaries. Use `task_list` only if you were spawned as a normal assigned team task rather than by the gate verification harness.

--- a/defaults/roles/spec-auditor.yaml
+++ b/defaults/roles/spec-auditor.yaml
@@ -31,6 +31,9 @@ promptTemplate: |
 
   Always follow the review step instructions provided — they define exactly what to check at this stage.
 
+  ## Change Scope
+  Only raise findings caused by the reviewed change. A finding is in scope only when the diff or artifact introduces the issue or makes a pre-existing issue materially worse. Do not report pre-existing issues that are unchanged by the reviewed change, and do not ask this goal or PR to fix them. You may inspect surrounding code or context to understand impact, but use it only as evidence for in-scope findings.
+
   ## Before You Start
   Read ALL upstream context — use `gate_list` to see all gates, then `gate_inspect(gate_id="<gateId>", section="content")` to read every passed gate's content. Use `task_list` to find your assigned task and `task_update` to report your findings when done.
 

--- a/defaults/roles/systems-reviewer.yaml
+++ b/defaults/roles/systems-reviewer.yaml
@@ -20,6 +20,9 @@ updatedAt: 1785192800000
 promptTemplate: |
   You are a **Systems Interaction Reviewer** (id: {{AGENT_ID}}). You are a read-only verifier attached to an implementation gate. Review the implementation evidence and changed files identified in the supplied goal, design, and gate context. Do not modify files, start background processes, delegate, mutate goals/tasks/gates, switch branches, access GitHub or the network, or post externally.
 
+  ## Change Scope
+  Only raise findings caused by the reviewed change. A finding is in scope only when the diff or artifact introduces the issue or makes a pre-existing issue materially worse. Do not report pre-existing issues that are unchanged by the reviewed change, and do not ask this goal or PR to fix them. You may inspect surrounding code or context to understand impact, but use it only as evidence for in-scope findings.
+
   For every changed behavior spanning modules or layers, deliberately verify:
 
   1. **State trace** — producer → aggregation/normalization → API/transport → persistence/cache → UI consumer.

--- a/market-packs/pr-walkthrough/roles/pr-reviewer.yaml
+++ b/market-packs/pr-walkthrough/roles/pr-reviewer.yaml
@@ -50,6 +50,9 @@ toolPolicies:
 promptTemplate: |
   You are a read-only PR walkthrough agent. Build a guided review narrative for this PR using only the PR Walkthrough tools. Report rough percentage progress in chat as you work.
 
+  ## Change Scope
+  Only raise findings caused by the reviewed change. A finding is in scope only when the diff or artifact introduces the issue or makes a pre-existing issue materially worse. Do not report pre-existing issues that are unchanged by the reviewed change, and do not ask this goal or PR to fix them. You may inspect surrounding code or context to understand impact, but use it only as evidence for in-scope findings.
+
   Start by calling `read_pr_walkthrough_bundle mode=manifest format=compact`; it is the authoritative launch-time PR metadata, file categories, hunk ids, generated/truncated flags, and diff summary for this job. Plan logical review cards from that manifest before reading code bodies.
   Then read only the hunks needed for the current logical card with bounded compact file reads, for example `read_pr_walkthrough_bundle mode=file path=src/example.ts format=compact hunkOffset=0 hunkLimit=1`. Use `format=legacy` only when you need exact line ids, old_line, or new_line metadata.
   Read receipts from bundle reads are part of review coverage. After compaction/retry/restart, after compact chunk saves when you need complete status, or before finalization, call `read_pr_walkthrough_submission_status` to see saved chunks, read hunk ids, unread/truncated receipts, coverage counts, repeated references, skipped hunks, and remaining completion-sweep work.

--- a/tests2/core/reviewer-diff-scope-prompts.test.ts
+++ b/tests2/core/reviewer-diff-scope-prompts.test.ts
@@ -1,0 +1,34 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import YAML from "yaml";
+
+const repoRoot = path.resolve(import.meta.dirname, "..", "..");
+
+const REVIEWER_ROLE_FILES = [
+	"defaults/roles/reviewer.yaml",
+	"defaults/roles/code-reviewer.yaml",
+	"defaults/roles/bug-hunter.yaml",
+	"defaults/roles/security-reviewer.yaml",
+	"defaults/roles/systems-reviewer.yaml",
+	"defaults/roles/architect.yaml",
+	"defaults/roles/spec-auditor.yaml",
+	"market-packs/pr-walkthrough/roles/pr-reviewer.yaml",
+];
+
+function loadPrompt(relativePath: string): string {
+	const role = YAML.parse(fs.readFileSync(path.join(repoRoot, relativePath), "utf8")) as { promptTemplate?: string };
+	return role.promptTemplate ?? "";
+}
+
+describe("reviewer change-scope prompts", () => {
+	for (const roleFile of REVIEWER_ROLE_FILES) {
+		it(`${roleFile} limits findings to issues caused or worsened by the reviewed change`, () => {
+			const prompt = loadPrompt(roleFile);
+			expect(prompt).toMatch(/only raise findings caused by the reviewed change/i);
+			expect(prompt).toMatch(/introduces the issue or makes a pre-existing issue materially worse/i);
+			expect(prompt).toMatch(/do not report pre-existing issues that are unchanged/i);
+			expect(prompt).toMatch(/do not ask this goal or PR to fix them/i);
+		});
+	}
+});

--- a/tests2/tests-map.json
+++ b/tests2/tests-map.json
@@ -2,11 +2,11 @@
   "$schema": "./tests-map.schema (informal): { generatedBy, censusTotal, buckets, methods, v2Native[{path,reason,execution}], journeys, entries[{file,bucket,method,replacement,rationale,migrated?,v2Path?,execution?}] }",
   "generatedBy": "scripts/testing-v2/gen-inventory.mjs, preserving reconciled v2Path/v2Native ownership",
   "note": "Re-run `node scripts/testing-v2/gen-inventory.mjs` after census changes. Classification overrides live in this generator; execution ownership is derived by test-map-execution.mjs.",
-  "censusTotal": 1137,
+  "censusTotal": 1138,
   "buckets": {
     "daily": 62,
     "v2-browser": 216,
-    "v2-core": 512,
+    "v2-core": 513,
     "v2-dom": 144,
     "v2-integration": 203
   },
@@ -20,6 +20,15 @@
     "vitest-e2e": 2
   },
   "v2Native": [
+    {
+      "path": "tests2/core/reviewer-diff-scope-prompts.test.ts",
+      "reason": "Pure prompt-contract coverage ensuring every first-party reviewer raises only issues introduced or materially worsened by the reviewed change and does not expand goals or PRs to fix unchanged pre-existing issues.",
+      "execution": {
+        "runner": "vitest",
+        "tier": "unit",
+        "project": "core"
+      }
+    },
     {
       "path": "tests2/core/git-status-envelope.test.ts",
       "reason": "Pure aggregation contract coverage for component-authoritative Git status envelopes: sums numeric counters, derives boolean and partial fields, preserves named and sole-dot compatibility, isolates failed siblings, distinguishes terminal non-repositories from retryable errors, and deduplicates fetch/invalidation targets.",


### PR DESCRIPTION
## Summary
- limit every first-party reviewer/verifier to findings introduced or materially worsened by the reviewed change
- explicitly exclude unchanged pre-existing issues so reviews cannot expand goal or PR scope
- add prompt-contract coverage for workflow reviewers and the PR Walkthrough reviewer

## Testing
- `npm run check`
- `npm run test:unit` (974 files passed, 8,515 tests passed)

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)