### PR TITLE
Add verifiable bug hunter reviews

### DIFF
--- a/.bobbit/config/project.yaml
+++ b/.bobbit/config/project.yaml
@@ -237,6 +237,11 @@ workflows:
               dangerous behavior. Fail only for critical/high actionable bugs;
               include file:line, reproduction conditions, consequence, and why
               it is a bug.
+          - name: Verifiable bug hunt
+            type: llm-review
+            role: verifiable-bug-hunter
+            phase: 4
+            prompt: Look for verifiable bugs in the implementation diff.
           - name: Security review
             type: llm-review
             role: security-reviewer
@@ -520,6 +525,11 @@ workflows:
               dangerous behavior. Fail only for critical/high actionable bugs;
               include file:line, reproduction conditions, consequence, and why
               it is a bug.
+          - name: Verifiable bug hunt
+            type: llm-review
+            role: verifiable-bug-hunter
+            phase: 4
+            prompt: Look for verifiable bugs in the implementation diff.
           - name: Security review
             type: llm-review
             role: security-reviewer
@@ -692,6 +702,11 @@ workflows:
               behavior. Fail only for critical/high actionable bugs; include
               file:line, reproduction conditions, consequence, and why it is a
               bug.
+          - name: Verifiable bug hunt
+            type: llm-review
+            role: verifiable-bug-hunter
+            phase: 4
+            prompt: Look for verifiable bugs in the implementation diff.
           - name: Security review
             type: llm-review
             role: security-reviewer
@@ -817,6 +832,11 @@ workflows:
               behavior. Fail only for critical/high actionable bugs; include
               file:line, reproduction conditions, consequence, and why it is a
               bug.
+          - name: Verifiable bug hunt
+            type: llm-review
+            role: verifiable-bug-hunter
+            phase: 4
+            prompt: Look for verifiable bugs in the implementation diff.
           - name: Systems interaction review
             type: llm-review
             role: systems-reviewer
@@ -891,6 +911,11 @@ workflows:
               behavior. Fail only for critical/high actionable bugs; include
               file:line, reproduction conditions, consequence, and why it is a
               bug.
+          - name: Verifiable bug hunt
+            type: llm-review
+            role: verifiable-bug-hunter
+            phase: 1
+            prompt: Look for verifiable bugs in the implementation diff.
           - name: Systems interaction review
             type: llm-review
             role: systems-reviewer

--- a/.bobbit/config/roles/spec-auditor.yaml
+++ b/.bobbit/config/roles/spec-auditor.yaml
@@ -15,6 +15,7 @@ toolPolicies:
   edit: never
   bash_bg: never
   team_delegate: never
+  read_session: never
   gate_signal: never
   goal_spawn_child: never
   goal_plan_propose: never

--- a/defaults/roles/architect.yaml
+++ b/defaults/roles/architect.yaml
@@ -3,6 +3,7 @@ label: Architect
 accessory: set-square
 toolPolicies:
   edit: never
+  read_session: never
   gate_signal: never
   goal_spawn_child: never
   goal_plan_propose: never

--- a/defaults/roles/bug-hunter.yaml
+++ b/defaults/roles/bug-hunter.yaml
@@ -5,6 +5,7 @@ toolPolicies:
   edit: never
   bash_bg: never
   team_delegate: never
+  read_session: never
   gate_signal: never
   goal_spawn_child: never
   goal_plan_propose: never

--- a/defaults/roles/code-reviewer.yaml
+++ b/defaults/roles/code-reviewer.yaml
@@ -5,6 +5,7 @@ toolPolicies:
   edit: never
   bash_bg: never
   team_delegate: never
+  read_session: never
   gate_signal: never
   goal_spawn_child: never
   goal_plan_propose: never

--- a/defaults/roles/reviewer.yaml
+++ b/defaults/roles/reviewer.yaml
@@ -5,6 +5,7 @@ toolPolicies:
   edit: never
   bash_bg: never
   team_delegate: never
+  read_session: never
   gate_signal: never
   goal_spawn_child: never
   goal_plan_propose: never

--- a/defaults/roles/security-reviewer.yaml
+++ b/defaults/roles/security-reviewer.yaml
@@ -5,6 +5,7 @@ toolPolicies:
   edit: never
   bash_bg: never
   team_delegate: never
+  read_session: never
   gate_signal: never
   goal_spawn_child: never
   goal_plan_propose: never

--- a/defaults/roles/spec-auditor.yaml
+++ b/defaults/roles/spec-auditor.yaml
@@ -5,6 +5,7 @@ toolPolicies:
   edit: never
   bash_bg: never
   team_delegate: never
+  read_session: never
   gate_signal: never
   goal_spawn_child: never
   goal_plan_propose: never

--- a/defaults/roles/systems-reviewer.yaml
+++ b/defaults/roles/systems-reviewer.yaml
@@ -5,6 +5,7 @@ toolPolicies:
   edit: never
   bash_bg: never
   team_delegate: never
+  read_session: never
   gate_signal: never
   goal_spawn_child: never
   goal_plan_propose: never

--- a/defaults/roles/verifiable-bug-hunter.yaml
+++ b/defaults/roles/verifiable-bug-hunter.yaml
@@ -1,0 +1,24 @@
+name: verifiable-bug-hunter
+label: Verifiable Bug Hunter
+accessory: magnifier
+toolPolicies:
+  edit: never
+  bash_bg: never
+  team_delegate: never
+  read_session: never
+  gate_signal: never
+  goal_spawn_child: never
+  goal_plan_propose: never
+  goal_plan_status: never
+  goal_merge_child: never
+  goal_pause: never
+  goal_resume: never
+  goal_archive_child: never
+  goal_decide_mutation: never
+  goal_set_policy: never
+createdAt: 1785308024754
+updatedAt: 1785308024754
+promptTemplate: |-
+  Review the current branch against its base using the diff described below. Look for verifiable bugs.
+
+  {{REVIEW_CONTEXT}}

--- a/market-packs/pr-walkthrough/roles/pr-reviewer.yaml
+++ b/market-packs/pr-walkthrough/roles/pr-reviewer.yaml
@@ -30,6 +30,7 @@ toolPolicies:
   "PR Walkthrough": allow
   "mcp__": never
   "Agent": never
+  read_session: never
   "Ask": never
   "Bobbit": never
   "Browser": never

--- a/tests2/core/reviewer-read-session-policy.test.ts
+++ b/tests2/core/reviewer-read-session-policy.test.ts
@@ -1,0 +1,44 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import YAML from "yaml";
+
+import { resolveGrantPolicy, type GroupPolicyProvider } from "../../src/server/agent/tool-activation.ts";
+import type { GrantPolicy } from "../../src/server/agent/role-store.ts";
+
+const repoRoot = path.resolve(import.meta.dirname, "..", "..");
+const groupPolicies = YAML.parse(
+	fs.readFileSync(path.join(repoRoot, "defaults", "tool-group-policies.yaml"), "utf8"),
+) as Record<string, GrantPolicy>;
+
+const reviewerRoleFiles = [
+	"defaults/roles/reviewer.yaml",
+	"defaults/roles/code-reviewer.yaml",
+	"defaults/roles/bug-hunter.yaml",
+	"defaults/roles/verifiable-bug-hunter.yaml",
+	"defaults/roles/security-reviewer.yaml",
+	"defaults/roles/systems-reviewer.yaml",
+	"defaults/roles/architect.yaml",
+	"defaults/roles/spec-auditor.yaml",
+	".bobbit/config/roles/spec-auditor.yaml",
+	"market-packs/pr-walkthrough/roles/pr-reviewer.yaml",
+];
+
+const groupPolicyStore: GroupPolicyProvider = {
+	getGroupPolicy: (group) => groupPolicies[group] ?? null,
+	getAll: () => groupPolicies,
+	getSubgoalsEnabled: () => true,
+};
+
+describe("reviewer roles cannot read other session transcripts", () => {
+	for (const relativePath of reviewerRoleFiles) {
+		it(`${relativePath} explicitly denies read_session`, () => {
+			const role = YAML.parse(fs.readFileSync(path.join(repoRoot, relativePath), "utf8")) as {
+				toolPolicies?: Record<string, GrantPolicy>;
+			};
+
+			expect(role.toolPolicies?.read_session).toBe("never");
+			expect(resolveGrantPolicy("read_session", "Agent", role, undefined, groupPolicyStore)).toBe("never");
+		});
+	}
+});

--- a/tests2/tests-map.json
+++ b/tests2/tests-map.json
@@ -21,6 +21,15 @@
   },
   "v2Native": [
     {
+      "path": "tests2/core/reviewer-read-session-policy.test.ts",
+      "reason": "Resolved tool-policy coverage proving every first-party reviewer role and project override explicitly denies cross-session transcript reads through read_session.",
+      "execution": {
+        "runner": "vitest",
+        "tier": "unit",
+        "project": "core"
+      }
+    },
+    {
       "path": "tests2/core/runtime-model-zombie-recovery-repro.test.ts",
       "reason": "Focused failing-first real SessionManager/runtime-selection recovery regression proving an unverifiable partial tuple mutation in a role-less pre-transcript session cannot be left live after zombie recovery archives its unchanged durable tuple.",
       "execution": {


### PR DESCRIPTION
## Summary

- add a concise `verifiable-bug-hunter` reviewer role
- run it alongside existing bug-hunt checks in every Bobbit implementation workflow
- deny `read_session` across reviewer-family roles, including project and marketplace overrides
- add resolved-policy regression coverage

## Validation

- `npm run check`
- reviewer policy tests: 38 passed
- validated all five staged implementation workflows with the production validator

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)
