### PR TITLE
Release on merge: publish, tag, and GitHub release from CI

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,15 +1,17 @@
 ---
 name: release
-description: Cut a Bobbit release — preflight checks, version bump, signed tag (CI publishes the root to npm via OIDC on tag push), optional binary sub-packages, GitHub release with generated notes.
+description: Cut a Bobbit release — preflight checks, version bump and release notes in a release PR; merging it makes CI publish to npm via OIDC, tag the commit, and create the GitHub release. Optional binary sub-packages stay manual.
 argument-hint: [major|minor|patch|<explicit-version>]
 ---
 
-Drive an end-to-end release of Bobbit. The maintainer (human) must be at the
-keyboard to sign the tag, and for `npm login` / OTP prompts **only when
-republishing binary sub-packages** — pause and ask when the flow needs them.
-The root `@gresearch/bobbit` package publishes automatically via CI (npm
-trusted publishing / OIDC) when the signed tag is pushed; **never** run a
-manual root `npm publish`.
+Drive an end-to-end release of Bobbit. The human's job is the **release PR**:
+version bump + release notes, reviewed and squash-merged. Merging it is what
+releases — `.github/workflows/release-publish.yml` builds and tests an immutable
+tarball without publish authority, publishes that exact tarball to npm
+(trusted publishing / OIDC, with provenance), creates the tag, and creates the
+GitHub release. **Never** create the release tag, run a root `npm publish`, or
+create the GitHub release by hand. `npm login` / OTP is needed **only when
+republishing binary sub-packages** — pause and ask when the flow needs it.
 
 Single source of truth for release mechanics: [`docs/releasing.md`](../../../docs/releasing.md).
 This skill orchestrates that doc + version bump + notes + GitHub release.
@@ -54,7 +56,7 @@ so the session/primary worktree state is irrelevant. What matters is that
 - `origin/main` has nothing new since the previous tag (nothing to release), or it isn't the commit they expect to ship.
 - `npm whoami` fails **and** step 3 will republish binary sub-packages — ask them to run `npm login` (and enable 2FA if not already; npm requires OTP for those sub-package publishes). The root `@gresearch/bobbit` publish needs no npm login — it goes through CI/OIDC.
 - `gh auth status` not logged in — ask them to run `gh auth login`.
-- No GPG/SSH signing key configured — confirm whether to proceed with **unsigned** tag or wait until they set one up. Default to waiting.
+- No GPG/SSH signing key configured — this only affects the release **commit**, not the tag (CI creates the tag and it is not signed). Confirm whether to proceed with an unsigned commit or wait. Default to waiting.
 
 ## 1. Decide the new version
 
@@ -138,11 +140,40 @@ git diff v<prev>..HEAD -- binaries.versions.json
 npm version <new-version> --no-git-tag-version
 ```
 
-`--no-git-tag-version` because we want a signed tag, not the unsigned one `npm version` would otherwise create. **Don't commit yet** — the release notes (§5) are a tracked file and ship in the *same* `chore(release)` commit as the version bump (that's how prior releases do it, e.g. v0.11.0 bundled `RELEASE_NOTES_v0.11.0.md` with `package.json`). Leave the bumped `package.json` / `package-lock.json` (and any `binaries/*` edits from §3) staged-but-uncommitted until §5.
+`--no-git-tag-version` because the release tag is created by CI at the merge
+commit, not locally — a local tag here would point at a commit that never
+lands on `main`. **Don't commit yet** — the release notes (§5) ship in the *same* `chore(release)` commit as the version bump. Leave the bumped `package.json` / `package-lock.json` (and any `binaries/*` edits from §3) staged-but-uncommitted until §5.
 
 ## 5. Generate release notes — then commit
 
-Write `RELEASE_NOTES_v<new-version>.md`. Match the format of the most recent existing `RELEASE_NOTES_v*.md` — short intro, then `## ✨ New Features` and `## 🐛 Bug Fixes` sections, emoji-prefixed bullets with bold lead-ins, friendly tone, no marketing fluff. End with the standard Bobbit footer.
+**Prepend** a new section to `CHANGELOG.md`, directly under the file's intro and
+above the previous release. Newest first — the release workflow rejects a
+changelog whose top section is not the version being released.
+
+```markdown
+## v<new-version>
+
+Short intro naming the previous version.
+
+### ✨ New Features
+
+* 🎯 **Bold lead-in**: what changed and why it matters to a user.
+
+### 🐛 Bug Fixes
+
+* 🧩 **Bold lead-in**: what was broken and what now happens instead.
+```
+
+Match the tone of the entries already in the file — friendly, concrete, no
+marketing fluff. Headings inside an entry are `###` or deeper; `##` is reserved
+for version headings, and the workflow splits on it.
+
+**Never edit an existing entry.** The run compares `CHANGELOG.md` against the
+parent commit and refuses any change to an already-released section — those are
+the record of what shipped.
+
+Show the drafted section to the user and iterate before committing; these notes
+become the public GitHub release.
 
 How to build the input:
 
@@ -159,7 +190,7 @@ Show the draft to the user via `review_open` before committing. Iterate until th
 Once the user approves the notes, commit the version bump and the notes together as a single `chore(release)` commit:
 
 ```bash
-git add package.json package-lock.json RELEASE_NOTES_v<new-version>.md
+git add package.json package-lock.json CHANGELOG.md
 # include binaries/* package.json edits if §3 changed them
 git commit -m "chore(release): v<new-version>" \
   --trailer "Co-authored-by: bobbit-ai <bobbit@bobbit.ai>" \
@@ -177,7 +208,19 @@ GitHub release all agree.
 
 Direct pushes to `main` are blocked by repository rules, and squash is the
 only enabled merge strategy. Push the detached HEAD to a release branch and
-open a PR:
+open a PR.
+
+**The release branch must live in `G-Research/bobbit`, never in a fork.** The
+release contract requires the merged PR to come from this repository, and both
+the pre-merge check and the release run reject a fork PR. If `git push origin`
+below is rejected, you do not have push access to the repository — stop and
+hand the release to a maintainer who does, rather than pushing the branch to a
+fork.
+
+The `Release contract` check on the PR enforces the branch name, the title, the
+lockfile, the notes and the binary sub-package pins **before** the merge. Treat
+a failure there as a blocker to fix on this branch: after the merge the same
+rules run again, but by then a failure has already spent the version number.
 
 ```bash
 RELBRANCH="release/v<new-version>"
@@ -208,11 +251,11 @@ be the commit that lands on `main`.
 
 **The root `@gresearch/bobbit` package is NOT published here.** It publishes automatically
 via the `.github/workflows/release-publish.yml` workflow (npm trusted publishing
-/ OIDC, with provenance) when the signed tag is pushed in §8 — there is no manual
+/ OIDC, with provenance) when the release PR is merged in §8 — there is no manual
 root `npm publish`. Skip straight to §8 unless step 3 bumped the binary
 sub-packages.
 
-If step 3 bumped binaries, publish the sub-packages now — **before** the tag push
+If step 3 bumped binaries, publish the sub-packages now — **before** the merge
 in §8, so they are on npm before the root that pins them. **Pause and confirm with
 the user** first; npm publishes are irreversible (you can `unpublish` for 72h but
 the version number is burned either way). Use `ask_user_choices` with the exact
@@ -231,10 +274,24 @@ Notes:
 - npm will prompt for OTP — that's the maintainer's job; just wait.
 - If publish fails after some sub-packages went through, **do not** try to bump+republish under a new version. Re-run `npm publish` on the remaining packages with the same version once the issue is fixed.
 
-## 8. Squash-merge the release PR, then tag it (this triggers the npm publish)
+## 8. Squash-merge the release PR (the merge is the release)
 
-Once the release PR is fully green and mergeable, squash-merge it.
-Pin the subject and co-author trailer explicitly:
+**STOP. Merging is the publish.** The squash merge pushes the release commit to
+`main`, and that push is the release trigger:
+`.github/workflows/release-publish.yml` validates, builds, tests, and packs the
+commit without OIDC authority, then publishes the verified tarball without
+running lifecycle scripts, creates the `v<new-version>` tag, and creates the
+GitHub release. Nothing after this point is reversible — npm version
+numbers are immutable and release tags cannot be moved or deleted.
+
+**Pause here and confirm with the user before running any command in this
+section.** Use `ask_user_choices` with the exact `gh pr merge` command shown
+below. Do not run it until they have said yes.
+
+**Do not create the tag by hand** — CI does it.
+
+Once the release PR is fully green and mergeable, and the user has confirmed,
+squash-merge it. Pin the subject and co-author trailer explicitly:
 
 ```bash
 gh pr merge "$PR" \
@@ -247,36 +304,34 @@ git fetch origin main --tags
 git merge-base --is-ancestor "$MERGE_SHA" origin/main
 git show "$MERGE_SHA":package.json | grep '"version": "<new-version>"'
 git diff --exit-code HEAD "$MERGE_SHA" -- \
-  package.json package-lock.json RELEASE_NOTES_v<new-version>.md
+  package.json package-lock.json CHANGELOG.md
 ```
 
-Tag the PR's exact squash commit, not the current `origin/main` tip (another
-PR may have merged immediately afterward). **Pushing the tag triggers the root
-npm publish** (`.github/workflows/release-publish.yml`) and is irreversible —
-pause and confirm with the user before the `git push`:
+The workflow only accepts a release commit that satisfies every one of these, so
+keep §6's branch and title conventions exactly:
+
+- produced by a merged PR from `release/v<new-version>` in this repository into `main`
+- PR title `chore(release): v<new-version>`
+- `package.json` and `package-lock.json` both at `<new-version>`, bumped by *this* commit
+- a substantial `## v<new-version>` section at the top of `CHANGELOG.md`, with no edits to earlier entries
+- `<new-version>` not already on npm
+
+Watch the run for **this commit** — every push to `main` starts a run of this
+workflow, so `--limit 1` can hand you an unrelated one:
 
 ```bash
-git tag -s v<new-version> "$MERGE_SHA" -m "Bobbit v<new-version>"
-git tag -v v<new-version>
-git push origin v<new-version>       # -> release-publish.yml publishes @gresearch/bobbit to npm (OIDC + provenance)
+gh run watch "$(gh run list --workflow release-publish.yml --commit "$MERGE_SHA" --limit 1 --json databaseId -q '.[0].databaseId')" --exit-status
 ```
 
-If the user explicitly opted out of signing in step 0, use `git tag -a`
-instead and inspect it with `git show --no-patch v<new-version>`.
-
-Then watch the publish workflow and confirm it succeeds before moving on:
-
-```bash
-gh run watch "$(gh run list --workflow release-publish.yml --branch v<new-version> --limit 1 --json databaseId -q '.[0].databaseId')" --exit-status
-```
-
-If the publish job fails (e.g. transient registry error), **re-run the same
-workflow run** for the same version — do not bump the version or re-tag; the
-tag is already public and the version number is immutable.
+If a step fails (e.g. transient registry error), use **Re-run all jobs** on the
+same workflow run — not **Re-run failed jobs**. A fresh validation pass safely
+re-checks npm provenance before deciding whether publication is still needed.
+Never create a tag by hand to work around a failed run. If the run is unusable entirely,
+cut the next patch version through a fresh release PR; there is no manual
+dispatch to release an arbitrary commit, deliberately.
 
 If merging fails, stop and repair the same release PR. Do not change the
-version, create a second release commit, force-push `main`, or tag the
-detached pre-merge commit.
+version, create a second release commit, or force-push `main`.
 
 **Refresh the running dev server** so it picks up the release commit (its
 local `main` is now behind remote):
@@ -286,18 +341,19 @@ cd "$PRIMARY" && git pull origin main    # fast-forward the primary worktree on 
 # then restart the dev server if needed (npm run restart-server)
 ```
 
-## 9. Create the GitHub release
+## 9. Verify the GitHub release
+
+The workflow already created the tag and the GitHub release: this version's
+`CHANGELOG.md` entry first, with GitHub's generated list of merged pull
+requests appended beneath it, marked `--prerelease` when the version carries a
+`-rc`/`-beta`/`-alpha` suffix. Confirm rather than create:
 
 ```bash
-gh release create v<new-version> \
-  --title "Bobbit v<new-version>" \
-  --notes-file RELEASE_NOTES_v<new-version>.md \
-  --verify-tag
+gh release view v<new-version> --json url,isPrerelease,tagName
 ```
 
-`--verify-tag` ensures gh refuses to create the release if the tag doesn't already exist on the remote (catches push-skipped-by-mistake).
-
-If this is a pre-release (version contains `-beta`, `-rc`, `-alpha`), add `--prerelease`.
+If it is missing while the npm publish succeeded, re-run the workflow run —
+do not create the release by hand.
 
 ## 10. Post-release smoke
 
@@ -336,12 +392,13 @@ Report to the user:
 
 ## Rules / best practices
 
-- **Signed tag, always.** Use `git tag -s`. Only fall back to `-a` if the maintainer explicitly opted out in step 0.
+- **Never tag by hand.** CI creates the immutable public source tag. Safe reruns are authorized by npm's verified provenance for this workflow and commit, not by the repository-wide GitHub Actions tag bypass.
 - **Signed commit if a signing key is configured.** Add `-S` to `git commit`. Never override `user.name` / `user.email`; never silently disable signing.
-- **The root publish is CI-only.** It runs via `release-publish.yml` (OIDC trusted publishing) on the tag push, with provenance automatic. Never run a manual root `npm publish`.
+- **Publish, tag, and GitHub release are CI-only.** They run via `release-publish.yml` (OIDC trusted publishing) on the merge to `main`, with provenance automatic. Never run them manually.
 - **OTP is the human's job** — but only for the binary sub-package publishes. Pause and let them type it; don't try to read it from anywhere. The root publish uses no OTP.
-- **Never `npm publish --force`.** If a sub-package republish is genuinely needed, bump the patch version and republish cleanly. If the CI root publish fails, re-run the same workflow run for the same version.
+- **Never `npm publish --force`.** If a sub-package republish is genuinely needed, bump the patch version and republish cleanly. If the CI root publish fails, re-run all jobs in the same workflow run for the same version.
 - **Never delete a tag that's been pushed.** If you tagged wrong, bump the version and tag again — published version numbers are immutable.
-- **Use the required squash-merge PR flow.** Never tag the detached release commit; tag the PR's exact `mergeCommit` SHA after verifying its package version and release files.
-- **One release at a time.** Don't start a second version bump while the previous tag/publish is in flight.
+- **Use the required squash-merge PR flow.** Merging the release PR is what publishes; verify the merged commit carries the intended version and release files.
+- **One release at a time.** Never merge a second release PR while the previous release run is still going: publish jobs serialise on `release-publish-root`, and GitHub keeps at most one pending job per group. After taking the lock, the job requires the npm dist-tag to match the state verification approved; tagging happens only after publication. Wait for the run to finish.
+- **An already-published version fails closed.** It proceeds only when npm's verified provenance identifies this workflow and commit. Otherwise confirm what was published and release the next version.
 - **Stop on any test, audit, or check failure.** Releases amplify bugs — the cost of waiting a day is tiny; the cost of a bad publish is days of cleanup.

--- a/.github/workflows/build-unit-gate.yml
+++ b/.github/workflows/build-unit-gate.yml
@@ -9,6 +9,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 concurrency:
   group: pr-${{ github.workflow }}-${{ github.ref }}
@@ -84,3 +85,26 @@ jobs:
 
       - name: Unit gate
         run: npm run test:unit
+
+  release-contract:
+    name: Release contract
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          fetch-depth: 2
+          persist-credentials: false
+
+      - name: Set up Node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: '22.19.0'
+
+      - name: Validate release contract
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: node scripts/release/validate-release-commit.mjs --mode pre-merge --pull-request "$PR_NUMBER"

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -2,43 +2,240 @@ name: Publish to npm
 
 on:
   push:
-    tags:
-      - 'v*'
+    branches: [main]
 
 permissions:
   contents: read
-  id-token: write
+  pull-requests: read
 
 jobs:
-  publish:
+  detect:
+    name: Detect release commit
     runs-on: ubuntu-latest
+    timeout-minutes: 10
+    outputs:
+      is-release: ${{ steps.detect.outputs.is-release }}
     steps:
       - name: Checkout
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
+          fetch-depth: 2
           persist-credentials: false
 
-      - name: Guard tag matches package.json version
+      - name: Did this commit bump the version?
+        id: detect
         run: |
-          TAG="${GITHUB_REF_NAME#v}"
-          PKG="$(node -p "require('./package.json').version")"
-          [ "$TAG" = "$PKG" ] || { echo "tag v$TAG != package.json $PKG" >&2; exit 1; }
+          set -euo pipefail
+          VERSION="$(node -p "require('./package.json').version")"
+          PARENT_VERSION="$(git show "HEAD^:package.json" | node -pe 'JSON.parse(require("fs").readFileSync(0, "utf8")).version')"
+          if [ "$VERSION" = "$PARENT_VERSION" ]; then
+            echo "no version change ($VERSION); not a release commit"
+            echo "is-release=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "version bumped $PARENT_VERSION -> $VERSION"
+            echo "is-release=true" >> "$GITHUB_OUTPUT"
+          fi
 
+  verify:
+    name: Verify release commit
+    needs: detect
+    if: needs.detect.outputs.is-release == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    outputs:
+      tag: ${{ steps.state.outputs.tag }}
+      version: ${{ steps.state.outputs.version }}
+      dist-tag: ${{ steps.state.outputs.dist-tag }}
+      dist_tag_base: ${{ steps.state.outputs.dist_tag_base }}
+      need-publish: ${{ steps.state.outputs.need-publish }}
+      need-release: ${{ steps.state.outputs.need-release }}
+      artifact_name: ${{ steps.package.outputs.artifact_name }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          fetch-depth: 2
+          persist-credentials: false
+
+      - name: Set up Node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: '22.19.0'
+          cache: npm
+
+      - name: Validate release contract
+        id: state
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: node scripts/release/validate-release-commit.mjs --mode merged
+
+      - name: Install
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Type-check
+        run: npm run check
+
+      - name: Unit gate
+        run: npm run test:unit
+
+      - name: Prepare verified release artifacts
+        id: package
+        env:
+          VERSION: ${{ steps.state.outputs.version }}
+        run: |
+          set -euo pipefail
+          ARTIFACT_NAME="bobbit-release-${GITHUB_SHA}-${GITHUB_RUN_ATTEMPT}"
+          mkdir -p release-artifact
+          PACK_JSON="$(npm pack --ignore-scripts --json --pack-destination release-artifact)"
+          FILENAME="$(printf '%s' "$PACK_JSON" | node -e '
+            const entries = JSON.parse(require("fs").readFileSync(0, "utf8"));
+            if (!Array.isArray(entries) || entries.length !== 1 || typeof entries[0]?.filename !== "string") {
+              throw new Error("npm pack did not report exactly one tarball");
+            }
+            process.stdout.write(entries[0].filename);
+          ')"
+          mv "release-artifact/$FILENAME" release-artifact/bobbit.tgz
+          node scripts/release/changelog-section.mjs --version "$VERSION" > release-artifact/release-notes.md
+          test -s release-artifact/bobbit.tgz
+          test -s release-artifact/release-notes.md
+          echo "artifact_name=$ARTIFACT_NAME" >> "$GITHUB_OUTPUT"
+
+      - name: Upload verified release artifacts
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: ${{ steps.package.outputs.artifact_name }}
+          path: release-artifact/
+          if-no-files-found: error
+          retention-days: 30
+
+  publish:
+    name: Publish to npm
+    needs: verify
+    if: needs.verify.outputs.need-publish == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    concurrency:
+      group: release-publish-root
+      cancel-in-progress: false
+    permissions:
+      contents: read
+      id-token: write
+    steps:
       - name: Set up Node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'
 
-      - name: Install
-        run: npm ci
-
-      - name: Publish (OIDC trusted publishing)
+      - name: Confirm dist-tag state is unchanged
+        env:
+          PACKAGE_NAME: '@gresearch/bobbit'
+          DIST_TAG: ${{ needs.verify.outputs.dist-tag }}
+          EXPECTED_BASE: ${{ needs.verify.outputs.dist_tag_base }}
         run: |
+          node --input-type=module - <<'NODE'
+          const { PACKAGE_NAME: name, DIST_TAG: tag, EXPECTED_BASE: expected = "" } = process.env;
+          const url = `https://registry.npmjs.org/${encodeURIComponent(name)}/${encodeURIComponent(tag)}`;
+          const response = await fetch(url, { headers: { accept: "application/json" } });
+          let current = "";
+          if (response.status !== 404) {
+            if (!response.ok) throw new Error(`dist-tag lookup returned ${response.status}`);
+            const body = await response.json();
+            if (typeof body.version !== "string") throw new Error("dist-tag lookup returned no version");
+            current = body.version;
+          }
+          if (current !== expected) {
+            throw new Error(`dist-tag ${tag} changed while this release waited: ${expected || "<absent>"} -> ${current || "<absent>"}`);
+          }
+          console.log(`dist-tag ${tag} is unchanged at ${current || "<absent>"}`);
+          NODE
+
+      - name: Download verified release artifacts
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
+        with:
+          name: ${{ needs.verify.outputs.artifact_name }}
+          path: release-artifact
+
+      - name: Publish verified artifact (OIDC trusted publishing)
+        env:
+          DIST_TAG: ${{ needs.verify.outputs.dist-tag }}
+          VERSION: ${{ needs.verify.outputs.version }}
+          MIN_NPM: '11.5.1'
+        run: |
+          set -euo pipefail
           echo "node: $(node -v)  npm: $(npm -v)"
-          case "${GITHUB_REF_NAME#v}" in
-            *-*) DIST_TAG=next ;;
-            *)   DIST_TAG=latest ;;
-          esac
-          echo "publishing @gresearch/bobbit to dist-tag: $DIST_TAG"
-          npm publish --provenance --tag "$DIST_TAG" --loglevel verbose
+          NPM_VERSION="$(npm -v)" node - <<'NODE'
+          const have = process.env.NPM_VERSION;
+          const need = process.env.MIN_NPM;
+          const parse = value => value.split(".").map(Number);
+          const [h, n] = [parse(have), parse(need)];
+          const older = h[0] !== n[0] ? h[0] < n[0] : h[1] !== n[1] ? h[1] < n[1] : h[2] < n[2];
+          if (older) {
+            throw new Error(`npm ${have} cannot use OIDC trusted publishing; needs >= ${need}`);
+          }
+          NODE
+          test -s release-artifact/bobbit.tgz
+          echo "publishing verified @gresearch/bobbit@$VERSION from $GITHUB_SHA to dist-tag: $DIST_TAG"
+          npm publish release-artifact/bobbit.tgz --ignore-scripts --provenance --tag "$DIST_TAG" --loglevel verbose
+
+  tag:
+    name: Tag release commit
+    needs: [verify, publish]
+    if: always() && needs.verify.result == 'success' && (needs.publish.result == 'success' || needs.publish.result == 'skipped')
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
+    steps:
+      - name: Create release tag
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ needs.verify.outputs.tag }}
+        run: |
+          set -euo pipefail
+          existing="$(gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$TAG" --jq .object.sha 2>/dev/null || true)"
+          if [ -n "$existing" ]; then
+            [ "$existing" = "$GITHUB_SHA" ] || {
+              echo "::error::$TAG points at $existing, not $GITHUB_SHA"
+              exit 1
+            }
+            echo "$TAG already exists at $GITHUB_SHA"
+          else
+            gh api --method POST "repos/$GITHUB_REPOSITORY/git/refs" \
+              -f ref="refs/tags/$TAG" -f sha="$GITHUB_SHA" >/dev/null
+            echo "created $TAG at $GITHUB_SHA"
+          fi
+
+  release:
+    name: Create GitHub release
+    needs: [verify, tag]
+    if: always() && needs.tag.result == 'success' && needs.verify.outputs.need-release == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: write
+    steps:
+      - name: Download verified release artifacts
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
+        with:
+          name: ${{ needs.verify.outputs.artifact_name }}
+          path: release-artifact
+
+      - name: Create release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ needs.verify.outputs.tag }}
+          DIST_TAG: ${{ needs.verify.outputs.dist-tag }}
+        run: |
+          set -euo pipefail
+          PRERELEASE=()
+          if [ "$DIST_TAG" = next ]; then PRERELEASE=(--prerelease); fi
+          gh release create "$TAG" \
+            --verify-tag \
+            --title "Bobbit $TAG" \
+            --notes-file release-artifact/release-notes.md \
+            --generate-notes \
+            "${PRERELEASE[@]}"

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,6 +1,145 @@
 # Releasing Bobbit
 
-This doc covers the Bobbit release checks that cannot be inferred from a normal development checkout: the installed consumer's security report and the bundled `fd`/`rg` binaries. The root `@gresearch/bobbit` package itself is published automatically by [`.github/workflows/release-publish.yml`](../.github/workflows/release-publish.yml) (npm trusted publishing / OIDC, with provenance) when a `v*` tag is pushed; only the binary sub-packages below are published manually.
+This doc covers the Bobbit release checks that cannot be inferred from a normal development checkout: the installed consumer's security report and the bundled `fd`/`rg` binaries. The root `@gresearch/bobbit` package is released automatically by [`.github/workflows/release-publish.yml`](../.github/workflows/release-publish.yml); only the binary sub-packages below are published manually.
+
+## Automated root release
+
+A release is authorized by squash-merging a same-repository PR from `release/v<version>` into `main`. Merging is the irreversible publication approval.
+
+**The trigger is the push to `main`, not the pull request.** Three things follow from that, and each of them is the reason for the choice:
+
+- **The checks cannot be swapped out.** A `push` run always executes the workflow file as it exists on `main`. A `workflow_dispatch` run executes the file as it exists on the *dispatched ref*, so anyone able to push a branch could delete every check below, dispatch their branch, and still receive the tag permission and the npm OIDC identity — npm's trusted publisher is bound to the repository and workflow filename, not to a protected source ref. There is deliberately no dispatch input on this workflow.
+- **Provenance names the right commit.** `npm publish --provenance` builds its attestation from `GITHUB_SHA`. On a `push` that is the squash commit itself. Under `pull_request` it would be the ephemeral `refs/pull/<n>/merge` commit, which is not on `main` and cannot be checked out by anyone verifying the attestation — the published tarball and the attested source would name different commits.
+- **There is one authorization path.** The release is authorized by a reviewed pull request and nothing else.
+
+The `detect` job decides whether a push is a release by comparing `package.json` at the commit against its parent — the version bump is the signal, not the commit message. If the version is unchanged the run stops there.
+
+For a release commit, `verify` then enforces the whole contract, in [`scripts/release/validate-release-commit.mjs`](../scripts/release/validate-release-commit.mjs), before anything expensive runs and before `npm ci` executes a single third-party lifecycle script:
+
+- a merged pull request produced this exact commit — resolved from the commit, not read from the event — and it came from `release/v<version>` in **this repository, not a fork**, titled exactly `chore(release): v<version>`. That the commit was reviewed and squash-merged is not re-checked; the branch rulesets on `main` already guarantee it. What this establishes is *intent*: since a release is triggered by the version changing, without it any merged PR that happened to touch the version — a dependency bump, a conflict resolution, a revert — would publish to npm
+- the commit is the one that **introduced** the version, and the version **increases** by semver precedence — a change alone is not enough, since a lower version still takes the `latest` dist-tag and would downgrade every consumer
+- `<version>` is release-shaped, and `package.json` and both root versions in `package-lock.json` agree on it
+- `CHANGELOG.md` has a `## v<version>` section, it is the **first** section in the file, and it says something — that section becomes the public GitHub release. The release may add its own entry and nothing else: every previously released section must survive byte-identical, so a release PR cannot quietly rewrite the record of what an earlier version shipped
+- every `optionalDependencies` entry is an exact version rather than a mutable range or dist-tag, and that version already resolves on the registry, so the root can never ship pointing at binary sub-packages that were not published
+- the version is **not** already on npm, unless its registry-verified provenance names this repository, this workflow file and this exact commit — which makes skipping publication safe on a rerun (see **Reruns** below)
+
+Only then does the run build, type-check and unit-test the commit, and pack the resulting files into an immutable workflow artifact. The serialized publishing job publishes that exact tarball with provenance, the tag job then creates `v<version>`, and the GitHub release follows. Pre-release versions (`0.16.0-rc.1`) go to the `next` dist-tag and are marked as prereleases; stable versions go to `latest`.
+
+Re-verifying here is deliberate. The PR's own checks run against a merge preview rather than the squash commit that is actually published, and no ruleset currently requires those checks to pass, so without this step a release could publish code that nothing had built or tested in the form it ships.
+
+**The same contract also runs before the merge.** `build-unit-gate.yml` runs `validate-release-commit.mjs --mode pre-merge` on every pull request. It decides whether a PR is a release the same way `detect` does — by comparing `package.json` against the base — and exits immediately when the version is unchanged. Every content rule then runs against that base, including the append-only changelog check and the version-increase check, so a wrong branch name, title, lockfile, changelog entry, backwards version or unpublished binary pin fails while it still costs one push — rather than after the merge, when the version is on `main` and the number is spent. The post-merge run is the authority; the pre-merge run is there so the authority rarely has to say no.
+
+### Why browser and e2e tests are not in the release gate
+
+`npm run test:browser` and `npm run test:e2e` are **not** part of this workflow, or of any workflow. They are not runner-shaped yet:
+
+- **browser** — carries a 3600 s wall budget, and `playwright-v2.config.ts` reserves workers from `scripts/testing-v2/ledger.mjs`. That ledger exists to share one 24-core development machine between concurrent agent sessions; on a single-tenant runner it reserves against contention that does not exist, so the numbers it produces are meaningless there.
+- **e2e** — needs a Docker daemon and real git worktrees.
+
+Adding them to a workflow today would not gate anything; it would fail or mislead. Making them runner-shaped is separate work, and until it happens the automated release gate is build + type-check + unit. Run the full suite locally before opening the release PR — the skill's pre-flight does exactly that.
+
+Publish, tag and release are separate jobs so each holds only the permissions it needs: `id-token: write` to publish, `contents: write` to tag, `contents: write` to create the release. None checks out the repository, installs dependencies, or runs package lifecycle scripts. Before the publishable artifact enters the OIDC-enabled job, that job uses a small inline registry check to confirm the dist-tag still has the value recorded by verification. It then downloads and publishes the verified tarball with `--ignore-scripts`; the release job downloads the reviewed notes from the same immutable artifact. Dependency lifecycle code therefore never receives publish or repository-write authority, and the tarball produced after all gates is the tarball sent to npm.
+
+**Publication happens before tagging.** A workflow cancelled while waiting for the publish lock therefore leaves no immutable tag behind. If npm accepts the package but tagging subsequently fails, a full rerun verifies the package's provenance, skips the immutable publish safely, and retries the idempotent tag step. Tag rulesets protect the public source pointer, but do not participate in rerun authorization.
+
+**The publish job runs a different Node from the test jobs, on purpose.** Trusted publishing needs npm >= 11.5.1 for the OIDC exchange. Node 22.19.0 — what `engines.node` requires and what the build, type-check and unit jobs pin — bundles npm 10.9.x, which cannot do it at all, so a publish from that toolchain would look for a token it does not have and fail at the one moment that is expensive. The publish job therefore pins Node 24 and sets `registry-url`, which is what makes `setup-node` write the `.npmrc` the publish targets; v0.15.1 published from node v24.18.0 with npm 11.16.0. The job also checks the npm version at runtime, so a change to the runner image fails before the publish rather than during it.
+
+**Release one at a time.** Publish jobs share a `release-publish-root` concurrency group; ordinary pushes never enter it. GitHub retains at most one *pending* job per group, so wait for the current release workflow to finish before merging the next release PR. A pending job cancelled by a newer release has only verified and built artifacts; it has neither published nor tagged anything.
+
+Serialization alone does not define order: a newer release can finish verification before an older one. Verification therefore proves that the new version advances the current `latest` or `next` value and records that value. After acquiring the publish lock, the job publishes only if the dist-tag is unchanged. Any intervening release makes the comparison fail closed; a full rerun validates against the new state rather than moving consumers backwards.
+
+**Reruns.** Re-running the entire release workflow is the supported recovery, and every job is idempotent: the tag step accepts a tag that already points at this commit, the publish is skipped when the version is already on the registry, and the release is skipped if it exists. Use **Re-run all jobs**, not **Re-run failed jobs**: a publish can reach npm immediately before its runner is cancelled, and only a fresh `verify` job re-checks registry provenance and updates the downstream decision safely.
+
+An already-published npm version **fails the run** unless the attestation npm serves for it names this repository, this workflow file, and this exact commit. npm verifies provenance signatures before accepting them, so that check answers the only recovery question that matters: *is the immutable artifact on the registry the one this workflow published from this source?*
+
+The tag is deliberately not part of this decision. Its rulesets protect the public source pointer, but their GitHub Actions bypass cannot identify one workflow among all workflows in the repository. If provenance does not match, the recovery is always to release the next version, never to reconcile with the old one.
+
+**If no run exists to re-run at all** — it was cancelled, or the commit predates this workflow — cut the next patch version through a normal release PR. There is intentionally no manual dispatch to release an arbitrary commit: a second, unreviewed path holding the tag permission and the npm OIDC identity is worth more than the version number it would save.
+
+### Release notes live in CHANGELOG.md
+
+Notes are **written**, not generated. The release skill drafts them, the maintainer reviews and iterates on the draft, and the result lands in the release PR where reviewers see exactly what will be published. GitHub's auto-generated notes cannot serve this purpose — they only exist after the tag does, so nobody reviews them.
+
+One file, newest first:
+
+```markdown
+# Changelog
+
+## v0.16.0
+
+<this release>
+
+## v0.15.1
+
+<previous release>
+```
+
+`## v<version>` starts a release entry; headings inside an entry are `###` or deeper, which is what lets the workflow extract one entry unambiguously. `scripts/release/changelog-section.mjs --version <version>` prints it, and the release job publishes that as the release body with GitHub's generated pull-request list appended underneath.
+
+A single file rather than one `RELEASE_NOTES_v*.md` per version buys three things: a readable history in the place npm consumers look for it; an append-only guarantee, since the run compares against the parent commit and rejects any edit to an already-released entry; and free serialisation, because two concurrent release PRs both touch `CHANGELOG.md` and conflict, which is the "one release at a time" rule enforced by git rather than by documentation.
+
+### Version on `main` between releases
+
+`main` carries the last released version, not a `-SNAPSHOT`/`-DEVELOPMENT` placeholder. That is the npm convention (unlike Maven, where the released version never sits on the default branch), and it is what makes `detect` possible: a push is a release exactly when it changes `package.json`'s version, which is unambiguous only if the version is otherwise stable. The cost is that a commit on `main` does not tell you whether it is before or after the release of the version it names; use the tag for that.
+
+### Required tag rulesets
+
+The automated tag is not GPG/SSH-signed. Its trust comes from the reviewed, protected `main` merge, the workflow's exact-SHA and version checks, job-scoped least-privilege permissions, npm's short-lived OIDC credential, and provenance — backed by two tag rulesets. These are the organisation's standard pair, managed in `github-terraformer`:
+
+```yaml
+- enforcement: active
+  name: App can create version tags
+  rules:
+    creation: true
+  target: tag
+  conditions:
+    ref_name:
+      include:
+        - refs/tags/v*
+  bypass_actors:
+    # The tag job runs under GITHUB_TOKEN as github-actions[bot]. No user
+    # or other app may create a v* tag; workflow identity is checked through
+    # npm provenance rather than this repository-wide app bypass.
+    - name: app/github-actions   # app id 15368
+      bypass_mode: always
+
+- enforcement: active
+  name: Immutable version tags
+  rules:
+    deletion: true
+    non_fast_forward: true
+    update: true
+  target: tag
+  conditions:
+    ref_name:
+      include:
+        - refs/tags/v*
+```
+
+Together they say: only the GitHub Actions app may create a `v*` tag, and once created nobody can move or delete it. Splitting creation from immutability lets the workflow create a release tag without giving it — or anyone else — the power to rewrite one afterwards. The creation rule is repository-wide for that app; npm provenance, not the tag, establishes the publishing workflow identity.
+
+**Two details that decide whether the release works at all:**
+
+- **The bypass actor must be GitHub Actions**, not some other app. `.github/workflows/release-publish.yml` creates the tag with `${{ github.token }}`, which authenticates as `github-actions[bot]`. If the creation rule names a different app, npm publication succeeds but the tag step is refused. This is recoverable: correct the ruleset and rerun all jobs; provenance makes verification skip the already-published immutable version and retry the tag. The alternative is minting an installation token for a dedicated app (`actions/create-github-app-token`), but that reintroduces a stored credential and gives up the property that this workflow holds no secrets; it is not worth it here.
+- **The creation rule must be scoped to `refs/tags/v*`.** A `creation` rule with no `conditions.ref_name` applies to *every* tag in the repository, so nobody but the release app could create any tag at all — including ordinary, unrelated ones.
+
+**These rulesets are a prerequisite for the first automated release.** As of this writing every active ruleset in this repository targets branches, and nothing targets `refs/tags/*`. Until they exist the public source tag is mutable.
+
+#### Decision: the rulesets are the check, and the code that duplicated them was deleted
+
+Earlier revisions of the release workflow re-checked in code what these rulesets guarantee. That was removed deliberately, not overlooked. Two things went:
+
+- **`scripts/release/check-tag-rulesets.mjs`** — read the rulesets back from the API during the release run and failed if they were missing or bypassable. Deleted along with its step in the `tag` job and its call in the release skill's pre-flight.
+- **`create-release-tag.mjs`** — a script wrapping the two API calls that create an annotated tag. The `tag` job now makes one `gh api` call inline and creates a lightweight tag; nothing here reads tag objects, so the annotation bought nothing.
+
+The reasoning is the same for both. A ruleset is enforced by GitHub against every actor, at every moment, whether or not a workflow is running. A check in the release run observes it only while the job happens to be running, only for the actor the job happens to be, and only if the token may read it — which `GITHUB_TOKEN` may not, since the rulesets API needs `administration: read`. It could fail to see a real problem and it could go stale against the terraform that actually manages the rules. Duplicating a guarantee in the weaker place is worse than not duplicating it.
+
+Two consequences worth stating plainly, so nobody rediscovers them as bugs:
+
+- **If the rulesets are absent or wrong, nothing here will say so.** The release may succeed with a mutable source tag or fail when it tries to create one. That is why they are a prerequisite an administrator has to satisfy once.
+- **The tag is not publishing evidence.** The creation bypass identifies the GitHub Actions app, not one workflow. Rerun validation therefore trusts only npm's verified provenance; the tag rulesets protect the public source reference.
+
+The tag is lightweight rather than annotated. Nothing in this repository reads tag objects — no `git describe`, no signature verification — and its trust comes from the rulesets rather than from anything recorded in it, so the distinction costs nothing here.
 
 ## Required packed-consumer audit
 
@@ -87,7 +226,7 @@ changes.
    pin in the root `package.json` `optionalDependencies` block to the
    new version.
 7. Publish each sub-package (the root is not published here — it ships via
-   CI on the tag push):
+   CI when the release PR is merged):
    ```bash
    npm publish ./binaries/binaries-darwin-arm64
    npm publish ./binaries/binaries-darwin-x64
@@ -95,8 +234,8 @@ changes.
    npm publish ./binaries/binaries-linux-arm64
    npm publish ./binaries/binaries-win32-x64
    ```
-   Do this **before** pushing the release tag, so the sub-packages are on npm
-   before the root that pins them. `publishConfig.access: "public"` is baked
+   Do this **before** merging the release PR, so the sub-packages are on npm
+   before the root package that pins them is published. `publishConfig.access: "public"` is baked
    into each sub-package, so `--access public` is not needed on the CLI.
 
 ### Decoupled versioning

--- a/scripts/release/changelog-section.mjs
+++ b/scripts/release/changelog-section.mjs
@@ -1,0 +1,26 @@
+#!/usr/bin/env node
+
+import { readFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { CHANGELOG_PATH, changelogSectionFor } from "./release-contract.mjs";
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
+
+const invokedPath = process.argv[1] ? resolve(process.argv[1]) : "";
+if (invokedPath === fileURLToPath(import.meta.url)) {
+	const argv = process.argv.slice(2);
+	const index = argv.indexOf("--version");
+	const version = index === -1 ? undefined : argv[index + 1];
+	if (!version) {
+		console.error("::error::--version is required");
+		process.exit(1);
+	}
+	const section = changelogSectionFor(readFileSync(join(REPO_ROOT, CHANGELOG_PATH), "utf8"), version);
+	if (section === null) {
+		console.error(`::error::${CHANGELOG_PATH} has no \`## v${version}\` section`);
+		process.exit(1);
+	}
+	process.stdout.write(`${section}\n`);
+}

--- a/scripts/release/dist-tag-guard.mjs
+++ b/scripts/release/dist-tag-guard.mjs
@@ -1,0 +1,64 @@
+const NUMERIC = String.raw`(?:0|[1-9]\d*)`;
+const PRERELEASE_ID = String.raw`(?:${NUMERIC}|\d*[A-Za-z-][0-9A-Za-z-]*)`;
+const BUILD_ID = String.raw`[0-9A-Za-z-]+`;
+const VERSION_PATTERN = new RegExp(
+	String.raw`^(${NUMERIC})\.(${NUMERIC})\.(${NUMERIC})` +
+		String.raw`(?:-(${PRERELEASE_ID}(?:\.${PRERELEASE_ID})*))?` +
+		String.raw`(?:\+${BUILD_ID}(?:\.${BUILD_ID})*)?$`,
+);
+
+export function isExactVersion(value) {
+	return typeof value === "string" && VERSION_PATTERN.test(value);
+}
+
+function parseVersion(value) {
+	const match = VERSION_PATTERN.exec(value);
+	if (!match) throw new Error(`invalid version: ${value}`);
+	return {
+		core: match.slice(1, 4).map(BigInt),
+		prerelease: match[4]?.split(".") ?? [],
+	};
+}
+
+// SemVer gives numeric identifiers lower precedence than non-numeric ones;
+// build metadata is parsed but intentionally does not affect ordering.
+function comparePrerelease(left, right) {
+	if (left.length === 0 || right.length === 0) {
+		return left.length === right.length ? 0 : left.length === 0 ? 1 : -1;
+	}
+	for (let index = 0; index < Math.max(left.length, right.length); index += 1) {
+		if (index >= left.length) return -1;
+		if (index >= right.length) return 1;
+		const [a, b] = [left[index], right[index]];
+		const [aNumeric, bNumeric] = [/^\d+$/.test(a), /^\d+$/.test(b)];
+		if (aNumeric && bNumeric && BigInt(a) !== BigInt(b)) return BigInt(a) < BigInt(b) ? -1 : 1;
+		if (aNumeric !== bNumeric) return aNumeric ? -1 : 1;
+		if (!aNumeric && a !== b) return a < b ? -1 : 1;
+	}
+	return 0;
+}
+
+export function compareReleaseVersions(leftValue, rightValue) {
+	const [left, right] = [parseVersion(leftValue), parseVersion(rightValue)];
+	for (let index = 0; index < 3; index += 1) {
+		if (left.core[index] !== right.core[index]) return left.core[index] < right.core[index] ? -1 : 1;
+	}
+	return comparePrerelease(left.prerelease, right.prerelease);
+}
+
+export async function assertDistTagAdvances({ packageName, distTag, version, fetchImpl = fetch }) {
+	const url = `https://registry.npmjs.org/${encodeURIComponent(packageName)}/${encodeURIComponent(distTag)}`;
+	const response = await fetchImpl(url, { headers: { accept: "application/json" } });
+	if (response.status === 404) {
+		console.log(`dist-tag ${distTag} does not exist yet`);
+		return null;
+	}
+	if (!response.ok) throw new Error(`dist-tag lookup returned ${response.status}`);
+
+	const current = (await response.json()).version;
+	if (compareReleaseVersions(version, current) <= 0) {
+		throw new Error(`refusing to move ${distTag} backwards: ${current} -> ${version}`);
+	}
+	console.log(`${distTag} will advance ${current} -> ${version}`);
+	return current;
+}

--- a/scripts/release/release-contract.mjs
+++ b/scripts/release/release-contract.mjs
@@ -1,0 +1,304 @@
+import { compareReleaseVersions, isExactVersion } from "./dist-tag-guard.mjs";
+
+export { compareReleaseVersions } from "./dist-tag-guard.mjs";
+
+export const PUBLIC_NPM_REGISTRY = "https://registry.npmjs.org";
+export const GITHUB_API = "https://api.github.com";
+
+const MIN_RELEASE_NOTES_CHARS = 80;
+
+export const CHANGELOG_PATH = "CHANGELOG.md";
+
+export class ReleaseContractError extends Error {
+	constructor(message) {
+		super(message);
+		this.name = "ReleaseContractError";
+	}
+}
+
+function fail(message) {
+	throw new ReleaseContractError(message);
+}
+
+export function releaseTagFor(version) {
+	return `v${version}`;
+}
+
+function parseChangelog(changelog) {
+	const text = String(changelog ?? "");
+	const headings = [...text.matchAll(/^## v(\S+)[^\S\n]*$/gm)];
+	const sections = headings.map((heading, index) => {
+		const start = heading.index;
+		const end = headings[index + 1]?.index ?? text.length;
+		return {
+			version: heading[1],
+			body: text.slice(start + heading[0].length, end).trim(),
+			raw: text.slice(start, end),
+		};
+	});
+	return {
+		preamble: text.slice(0, headings[0]?.index ?? text.length),
+		sections,
+	};
+}
+
+export function changelogSections(changelog) {
+	return parseChangelog(changelog).sections.map(({ version, body }) => ({ version, body }));
+}
+
+export function changelogSectionFor(changelog, version) {
+	return changelogSections(changelog).find(section => section.version === version)?.body ?? null;
+}
+
+function assertUniqueChangelogVersions(sections) {
+	const seen = new Set();
+	for (const { version } of sections) {
+		if (seen.has(version)) {
+			fail(`${CHANGELOG_PATH} contains more than one \`## v${version}\` section`);
+		}
+		seen.add(version);
+	}
+}
+
+export function assertChangelogSection(changelog, version) {
+	const { sections } = parseChangelog(changelog);
+	assertUniqueChangelogVersions(sections);
+	const section = sections.find(entry => entry.version === version);
+	if (!section) {
+		fail(
+			`${CHANGELOG_PATH} has no \`## v${version}\` section. The release notes are ` +
+				"written by hand and reviewed in the release PR; they are not generated.",
+		);
+	}
+	if (sections[0].version !== version) {
+		fail(
+			`${CHANGELOG_PATH} lists v${sections[0].version} above v${version}. ` +
+				"Newest release first: prepend the new section rather than appending it.",
+		);
+	}
+	if (section.body.length < MIN_RELEASE_NOTES_CHARS) {
+		fail(
+			`the \`## v${version}\` section is too short to publish ` +
+				`(${section.body.length} chars, need ${MIN_RELEASE_NOTES_CHARS}). ` +
+				"It becomes the public GitHub release.",
+		);
+	}
+	return section.body;
+}
+
+export function assertChangelogAppendOnly(previousChangelog, currentChangelog) {
+	const previous = parseChangelog(previousChangelog);
+	const current = parseChangelog(currentChangelog);
+	assertUniqueChangelogVersions(previous.sections);
+	assertUniqueChangelogVersions(current.sections);
+	if (String(previousChangelog ?? "") !== "" && current.preamble !== previous.preamble) {
+		fail(`${CHANGELOG_PATH} rewrites text before the first release; a release may add its own entry only`);
+	}
+
+	const currentByVersion = new Map(current.sections.map(section => [section.version, section.raw]));
+	for (const { version, raw } of previous.sections) {
+		if (!currentByVersion.has(version)) {
+			fail(`${CHANGELOG_PATH} drops the released v${version} section; releases are a record`);
+		}
+		if (currentByVersion.get(version) !== raw) {
+			fail(
+				`${CHANGELOG_PATH} rewrites the released v${version} section. ` +
+					"A release may add its own entry and nothing else.",
+			);
+		}
+	}
+}
+
+export function fileAtCommit(rev, path, run) {
+	const resolved = run(["rev-parse", "--verify", `${rev}^{commit}`]);
+	if (resolved.status !== 0) {
+		throw new Error(
+			`cannot resolve ${rev}: ${resolved.stderr?.trim() || `git exited ${resolved.status}`}. ` +
+				"Fetch enough history to reach it — treating it as absent would skip the append-only check.",
+		);
+	}
+	const shown = run(["show", `${rev}:${path}`]);
+	return shown.status === 0 ? shown.stdout : null;
+}
+
+export function releaseBranchFor(version) {
+	return `release/v${version}`;
+}
+
+export function releaseTitleFor(version) {
+	return `chore(release): v${version}`;
+}
+
+export function distTagFor(version) {
+	return version.includes("-") ? "next" : "latest";
+}
+
+export function assertReleaseVersion(version) {
+	if (!isExactVersion(version) || version.includes("+")) {
+		fail(`package.json version is not a release version: ${version}`);
+	}
+	return version;
+}
+
+export function assertLockfileAgreement(pkg, lock) {
+	const root = lock?.packages?.[""]?.version;
+	if (lock?.version !== pkg?.version || root !== pkg?.version) {
+		fail(
+			`package-lock (${lock?.version}, ${root}) does not match package.json ${pkg?.version}. ` +
+				"Run `npm install --package-lock-only` on the release branch.",
+		);
+	}
+}
+
+export function assertExactOptionalDependencyPins(pkg) {
+	for (const [name, version] of Object.entries(pkg?.optionalDependencies ?? {})) {
+		if (!isExactVersion(version)) {
+			fail(
+				`optionalDependencies.${name} must be pinned to an exact version, got ${String(version)}. ` +
+					"Ranges and dist-tags can change after the root package is published.",
+			);
+		}
+	}
+}
+
+export function assertVersionBump(parentVersion, version, sha) {
+	const order = compareReleaseVersions(version, parentVersion);
+	if (order === 0) {
+		fail(
+			`${sha} does not bump the version; its parent is already ${version}. ` +
+				"Only the release merge commit itself may be released.",
+		);
+	}
+	if (order < 0) {
+		fail(
+			`${sha} moves the version backwards: ${parentVersion} -> ${version}. ` +
+				"A lower version still takes the latest dist-tag, which would downgrade every consumer.",
+		);
+	}
+}
+
+export function assertPullRequestContract(pr, { version, repository, sha }) {
+	if (!pr) {
+		fail(
+			`no merged pull request produced ${sha}. A release must come from a ` +
+				`${releaseBranchFor(version)} pull request merged into main.`,
+		);
+	}
+	if (pr.base?.ref !== "main") {
+		fail(`release pull request #${pr.number} targets ${pr.base?.ref}, expected main`);
+	}
+	if (pr.head?.repo?.full_name !== repository) {
+		fail(
+			`release pull request #${pr.number} comes from ${pr.head?.repo?.full_name ?? "an unknown repository"}, ` +
+				`expected ${repository}. Release branches must live in this repository.`,
+		);
+	}
+	if (pr.head?.ref !== releaseBranchFor(version)) {
+		fail(
+			`release branch ${pr.head?.ref} does not match version ${version} ` +
+				`(expected ${releaseBranchFor(version)}). A release must be opened as a release, ` +
+				"not be the side effect of a version change.",
+		);
+	}
+	if (pr.title !== releaseTitleFor(version)) {
+		fail(`release pull request title must be: ${releaseTitleFor(version)}`);
+	}
+	return pr;
+}
+
+export const RELEASE_WORKFLOW_PATH = ".github/workflows/release-publish.yml";
+
+export function extractProvenanceSource(response) {
+	const attestations = Array.isArray(response?.attestations) ? response.attestations : [];
+	const provenance = attestations.find(entry =>
+		String(entry?.predicateType ?? "").startsWith("https://slsa.dev/provenance/"),
+	);
+	const payload = provenance?.bundle?.dsseEnvelope?.payload;
+	if (typeof payload !== "string") return null;
+
+	let statement;
+	try {
+		statement = JSON.parse(Buffer.from(payload, "base64").toString("utf8"));
+	} catch {
+		return null;
+	}
+
+	const build = statement?.predicate?.buildDefinition ?? {};
+	const dependencies = Array.isArray(build.resolvedDependencies) ? build.resolvedDependencies : [];
+	const workflow = build?.externalParameters?.workflow ?? {};
+	const repository = typeof workflow.repository === "string" ? workflow.repository : null;
+	const source = repository
+		? dependencies.find(
+				entry =>
+					typeof entry?.digest?.gitCommit === "string" &&
+					typeof entry?.uri === "string" &&
+					entry.uri.startsWith(`git+${repository}@`),
+			)
+		: null;
+
+	return {
+		sha: source?.digest?.gitCommit ?? null,
+		repository,
+		path: typeof workflow.path === "string" ? workflow.path : null,
+	};
+}
+
+export function assertPublishedArtifactMatches(source, { spec, repository, sha }) {
+	const recover =
+		`${spec} is already on the registry and npm versions are immutable. ` +
+		"Confirm what was published, then release the next version instead.";
+
+	if (!source) {
+		fail(`${spec} is already published but carries no readable provenance attestation. ${recover}`);
+	}
+	if (source.sha !== sha) {
+		fail(`${spec} was published from commit ${source.sha ?? "<unknown>"}, not ${sha}. ${recover}`);
+	}
+	const expectedRepository = `https://github.com/${repository}`;
+	if (source.repository !== expectedRepository) {
+		fail(
+			`${spec} was published from ${source.repository ?? "<unknown>"}, not ${expectedRepository}. ${recover}`,
+		);
+	}
+	if (source.path !== RELEASE_WORKFLOW_PATH) {
+		fail(
+			`${spec} was published by ${source.path ?? "<unknown>"}, not ${RELEASE_WORKFLOW_PATH}. ${recover}`,
+		);
+	}
+	return true;
+}
+
+export function npmAttestationUrl(name, version) {
+	return `${PUBLIC_NPM_REGISTRY}/-/npm/v1/attestations/${encodeURIComponent(name)}@${encodeURIComponent(version)}`;
+}
+
+export async function fetchJson(url, { headers = {}, fetchImpl = fetch, attempts = 3 } = {}) {
+	let lastError;
+	for (let attempt = 1; attempt <= attempts; attempt += 1) {
+		try {
+			const response = await fetchImpl(url, { headers: { accept: "application/json", ...headers } });
+			if (response.status === 404) return { status: 404, body: null };
+			if (response.ok) return { status: response.status, body: await response.json() };
+			if (response.status < 500 && response.status !== 429) {
+				return { status: response.status, body: null };
+			}
+			lastError = new Error(`${url} responded ${response.status}`);
+		} catch (error) {
+			lastError = error;
+		}
+		if (attempt < attempts) await new Promise(resolve => setTimeout(resolve, 500 * attempt));
+	}
+	throw new Error(`request failed after ${attempts} attempts: ${url}`, { cause: lastError });
+}
+
+export function githubHeaders(token) {
+	return {
+		accept: "application/vnd.github+json",
+		"x-github-api-version": "2022-11-28",
+		...(token ? { authorization: `Bearer ${token}` } : {}),
+	};
+}
+
+export function npmPackageUrl(name, version) {
+	return `${PUBLIC_NPM_REGISTRY}/${encodeURIComponent(name)}/${encodeURIComponent(version)}`;
+}

--- a/scripts/release/validate-release-commit.mjs
+++ b/scripts/release/validate-release-commit.mjs
@@ -1,0 +1,203 @@
+#!/usr/bin/env node
+
+import { spawnSync } from "node:child_process";
+import { appendFileSync, readFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { assertDistTagAdvances } from "./dist-tag-guard.mjs";
+import {
+	assertChangelogAppendOnly,
+	assertChangelogSection,
+	assertExactOptionalDependencyPins,
+	assertLockfileAgreement,
+	assertPublishedArtifactMatches,
+	assertPullRequestContract,
+	assertReleaseVersion,
+	assertVersionBump,
+	distTagFor,
+	extractProvenanceSource,
+	fetchJson,
+	fileAtCommit,
+	GITHUB_API,
+	githubHeaders,
+	CHANGELOG_PATH,
+	npmAttestationUrl,
+	npmPackageUrl,
+	releaseTagFor,
+	ReleaseContractError,
+} from "./release-contract.mjs";
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
+
+function parseArgs(argv) {
+	const args = { mode: "merged" };
+	for (let i = 0; i < argv.length; i += 1) {
+		const flag = argv[i];
+		if (!flag.startsWith("--")) continue;
+		const key = flag.slice(2);
+		const value = argv[i + 1] && !argv[i + 1].startsWith("--") ? argv[(i += 1)] : "true";
+		args[key] = value;
+	}
+	return args;
+}
+
+function readJson(relativePath) {
+	return JSON.parse(readFileSync(join(REPO_ROOT, relativePath), "utf8"));
+}
+
+const runGit = args => spawnSync("git", args, { cwd: REPO_ROOT, encoding: "utf8" });
+
+function git(...args) {
+	const result = runGit(args);
+	if (result.status !== 0) {
+		throw new Error(`git ${args.join(" ")} failed: ${result.stderr?.trim() || result.status}`);
+	}
+	return result.stdout;
+}
+
+async function resolvePullRequest({ repository, sha, number, token }) {
+	if (number) {
+		const { body } = await fetchJson(`${GITHUB_API}/repos/${repository}/pulls/${number}`, {
+			headers: githubHeaders(token),
+		});
+		return body;
+	}
+	const { body } = await fetchJson(`${GITHUB_API}/repos/${repository}/commits/${sha}/pulls`, {
+		headers: githubHeaders(token),
+	});
+	const candidates = Array.isArray(body) ? body : [];
+	return (
+		candidates.find(pr => pr.merged_at && pr.base?.ref === "main" && pr.merge_commit_sha === sha) ??
+		null
+	);
+}
+
+async function isPublished(name, version) {
+	const { status } = await fetchJson(npmPackageUrl(name, version));
+	if (status === 404) return false;
+	if (status === 200) return true;
+	throw new Error(`registry lookup for ${name}@${version} returned ${status}`);
+}
+
+async function assertOptionalDependenciesPublished(pkg) {
+	const pins = Object.entries(pkg.optionalDependencies ?? {});
+	const missing = [];
+	for (const [name, version] of pins) {
+		if (!(await isPublished(name, version))) missing.push(`${name}@${version}`);
+	}
+	if (missing.length > 0) {
+		throw new ReleaseContractError(
+			`optionalDependencies pins are not on the registry: ${missing.join(", ")}. ` +
+				"Publish the binary sub-packages before merging the release PR.",
+		);
+	}
+}
+
+async function releaseExists({ repository, tag, token }) {
+	const { status } = await fetchJson(`${GITHUB_API}/repos/${repository}/releases/tags/${tag}`, {
+		headers: githubHeaders(token),
+	});
+	if (status === 200) return true;
+	if (status === 404) return false;
+	throw new Error(`release lookup for ${tag} returned ${status}`);
+}
+
+export async function validateReleaseCommit(args, env = process.env) {
+	const mode = args.mode ?? "merged";
+	if (mode !== "merged" && mode !== "pre-merge") {
+		throw new Error(`unknown --mode ${mode} (expected merged or pre-merge)`);
+	}
+
+	const repository = args.repository ?? env.GITHUB_REPOSITORY;
+	const sha = args.sha ?? env.GITHUB_SHA;
+	const token = args.token ?? env.GITHUB_TOKEN ?? env.GH_TOKEN;
+	if (!repository) throw new Error("--repository or GITHUB_REPOSITORY is required");
+	if (!sha) throw new Error("--sha or GITHUB_SHA is required");
+
+	const pkg = readJson("package.json");
+	const version = assertReleaseVersion(pkg.version);
+	const tag = releaseTagFor(version);
+
+	const baseRev = mode === "pre-merge" ? "HEAD^1" : `${sha}^`;
+	const baseVersion = JSON.parse(git("show", `${baseRev}:package.json`)).version;
+
+	if (mode === "pre-merge" && baseVersion === version) {
+		console.log(`package.json is unchanged at ${version}; not a release pull request`);
+		return null;
+	}
+
+	assertLockfileAgreement(pkg, readJson("package-lock.json"));
+	assertExactOptionalDependencyPins(pkg);
+
+	let changelog = "";
+	try {
+		changelog = readFileSync(join(REPO_ROOT, CHANGELOG_PATH), "utf8");
+	} catch {
+		throw new ReleaseContractError(`missing ${CHANGELOG_PATH}`);
+	}
+	assertChangelogSection(changelog, version);
+	assertVersionBump(baseVersion, version, sha);
+	assertChangelogAppendOnly(fileAtCommit(baseRev, CHANGELOG_PATH, runGit) ?? "", changelog);
+
+	const pr = await resolvePullRequest({
+		repository,
+		sha,
+		number: args["pull-request"],
+		token,
+	});
+	assertPullRequestContract(pr, { version, repository, sha });
+
+	await assertOptionalDependenciesPublished(pkg);
+
+	const spec = `${pkg.name}@${version}`;
+	const published = await isPublished(pkg.name, version);
+	let distTagBase = null;
+	if (published) {
+		const { body } = await fetchJson(npmAttestationUrl(pkg.name, version));
+		assertPublishedArtifactMatches(extractProvenanceSource(body), { spec, repository, sha });
+		console.log(`${spec} was already published from ${sha}; this run will not republish it`);
+	} else {
+		distTagBase = await assertDistTagAdvances({
+			packageName: pkg.name,
+			distTag: distTagFor(version),
+			version,
+		});
+	}
+
+	const result = {
+		tag,
+		version,
+		"dist-tag": distTagFor(version),
+		dist_tag_base: distTagBase ?? "",
+		"need-publish": String(!published),
+		"need-release": mode === "merged" ? String(!(await releaseExists({ repository, tag, token }))) : "false",
+		"pull-request": String(pr?.number ?? ""),
+	};
+
+	console.log(`${spec} -> ${tag} at ${sha} (dist-tag ${result["dist-tag"]}), PR #${result["pull-request"]}`);
+	return result;
+}
+
+const invokedPath = process.argv[1] ? resolve(process.argv[1]) : "";
+if (invokedPath === fileURLToPath(import.meta.url)) {
+	const args = parseArgs(process.argv.slice(2));
+	validateReleaseCommit(args)
+		.then(result => {
+			const outputPath = args.output ?? process.env.GITHUB_OUTPUT;
+			if (result && outputPath && args.mode !== "pre-merge") {
+				appendFileSync(
+					outputPath,
+					Object.entries(result)
+						.map(([key, value]) => `${key}=${value}\n`)
+						.join(""),
+				);
+			}
+		})
+		.catch(error => {
+			const message = error instanceof Error ? error.message : String(error);
+			console.error(`::error::${message}`);
+			if (!(error instanceof ReleaseContractError)) console.error(error);
+			process.exitCode = 1;
+		});
+}

--- a/tests2/core/build-unit-gate-ci.test.ts
+++ b/tests2/core/build-unit-gate-ci.test.ts
@@ -19,7 +19,7 @@ type BuildUnitGateWorkflow = {
 		push: BranchTrigger;
 		workflow_dispatch: NoInputDispatch;
 	};
-	permissions: { contents: string };
+	permissions: { contents: string; "pull-requests": string };
 	jobs: {
 		"affected-feedback": {
 			if: string;
@@ -83,7 +83,7 @@ describe("native CI qualification workflows", () => {
 		assert.deepEqual(workflow.on.pull_request.branches, ["main"]);
 		assert.deepEqual(workflow.on.push.branches, ["main"]);
 		assert.deepEqual(workflow.on.workflow_dispatch, {});
-		assert.deepEqual(workflow.permissions, { contents: "read" });
+		assert.deepEqual(workflow.permissions, { contents: "read", "pull-requests": "read" });
 	});
 
 	it("runs the unit inventory natively on every supported OS with Node 26 coverage", () => {

--- a/tests2/core/release-skill-preflight-order.test.ts
+++ b/tests2/core/release-skill-preflight-order.test.ts
@@ -4,6 +4,7 @@ import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { describe, it } from "vitest";
+import { parse as parseYaml } from "yaml";
 import {
 	buildRestrictedNpmEnv,
 	evaluatePackedConsumerAudit,
@@ -13,8 +14,79 @@ import {
 	parseAuditJson,
 	runPackedConsumerAudit,
 } from "../../scripts/release-packed-consumer-audit.mjs";
+import {
+	assertLockfileAgreement,
+	assertPublishedArtifactMatches,
+	assertPullRequestContract,
+	assertChangelogAppendOnly,
+	assertChangelogSection,
+	assertExactOptionalDependencyPins,
+	assertReleaseVersion,
+	assertVersionBump,
+	changelogSectionFor,
+	compareReleaseVersions,
+	distTagFor,
+	extractProvenanceSource,
+	npmAttestationUrl,
+	npmPackageUrl,
+	RELEASE_WORKFLOW_PATH,
+	fileAtCommit,
+} from "../../scripts/release/release-contract.mjs";
+import { assertDistTagAdvances } from "../../scripts/release/dist-tag-guard.mjs";
 
 const skill = readFileSync(resolve(process.cwd(), ".claude/skills/release/SKILL.md"), "utf8");
+
+type WorkflowStep = { name?: string; uses?: string; with?: Record<string, unknown>; run?: string };
+type WorkflowJob = {
+	if?: string;
+	needs?: string | string[];
+	outputs?: Record<string, string>;
+	permissions?: Record<string, string>;
+	concurrency?: { group?: string; "cancel-in-progress"?: boolean };
+	steps?: WorkflowStep[];
+	strategy?: { matrix?: { node?: string[]; include?: { node?: string }[] } };
+};
+const releaseWorkflow = parseYaml(
+	readFileSync(resolve(process.cwd(), ".github/workflows/release-publish.yml"), "utf8"),
+) as {
+	on?: {
+		push?: { branches?: string[] };
+		pull_request?: unknown;
+		pull_request_target?: unknown;
+		workflow_dispatch?: unknown;
+	};
+	concurrency?: { group?: string; "cancel-in-progress"?: boolean };
+	permissions?: Record<string, string>;
+	jobs?: Record<string, WorkflowJob>;
+};
+
+const prGateWorkflow = parseYaml(
+	readFileSync(resolve(process.cwd(), ".github/workflows/build-unit-gate.yml"), "utf8"),
+) as { jobs?: Record<string, WorkflowJob> };
+
+function toolchainOf(job: WorkflowJob | undefined): { node?: unknown; cache?: unknown; runs: string[] } {
+	const steps = job?.steps ?? [];
+	const setup = steps.find(step => (step.uses ?? "").startsWith("actions/setup-node@"));
+	return {
+		node: setup?.with?.["node-version"],
+		cache: setup?.with?.cache,
+		runs: steps
+			.map(step => (step.run ?? "").trim())
+			.filter(run => run.startsWith("npm ")),
+	};
+}
+
+function releaseJob(name: string): WorkflowJob {
+	const job = releaseWorkflow.jobs?.[name];
+	assert.ok(job, `release workflow is missing job: ${name}`);
+	return job;
+}
+
+function releaseStep(job: string, name: string): WorkflowStep {
+	const step = releaseJob(job).steps?.find(candidate => candidate.name === name);
+	assert.ok(step, `release workflow job ${job} is missing step: ${name}`);
+	return step;
+}
 const packageJson = JSON.parse(readFileSync(resolve(process.cwd(), "package.json"), "utf8")) as {
 	name?: string;
 	scripts?: Record<string, string>;
@@ -73,6 +145,597 @@ describe("release skill primary branch", () => {
 		assert.match(skill, /git merge-base --is-ancestor "\$MERGE_SHA" origin\/main/);
 		assert.match(skill, /git pull origin main/);
 		assert.doesNotMatch(skill, /origin\/master|--base master|origin master/);
+	});
+});
+
+describe("push-triggered release workflow", () => {
+	it("releases from the push to main and offers no second authorization path", () => {
+		assert.deepEqual(releaseWorkflow.on?.push, { branches: ["main"] });
+		assert.equal(releaseWorkflow.on?.workflow_dispatch, undefined);
+		assert.equal(releaseWorkflow.on?.pull_request, undefined);
+		assert.equal(releaseWorkflow.on?.pull_request_target, undefined);
+	});
+
+	it("never checks out a ref chosen by an expression", () => {
+		for (const [name, job] of Object.entries(releaseWorkflow.jobs ?? {})) {
+			for (const step of job.steps ?? []) {
+				if (!(step.uses ?? "").startsWith("actions/checkout@")) continue;
+				assert.equal(
+					step.with?.ref,
+					undefined,
+					`release job ${name} pins a checkout ref instead of using GITHUB_SHA`,
+				);
+			}
+		}
+	});
+
+	it("serialises only publishing and rejects stale dist-tag state", () => {
+		assert.equal(releaseWorkflow.concurrency, undefined);
+		assert.deepEqual(releaseJob("publish").concurrency, {
+			group: "release-publish-root",
+			"cancel-in-progress": false,
+		});
+		const check = releaseStep("publish", "Confirm dist-tag state is unchanged").run ?? "";
+		assert.match(check, /node --input-type=module/);
+		assert.match(check, /registry\.npmjs\.org/);
+		assert.match(check, /current !== expected/);
+		assert.doesNotMatch(check, /gh api|dist-tag-guard\.mjs/);
+		const validator = readFileSync(
+			resolve(process.cwd(), "scripts/release/validate-release-commit.mjs"),
+			"utf8",
+		);
+		assert.match(validator, /distTagBase = await assertDistTagAdvances/);
+		assert.match(releaseJob("verify").outputs?.dist_tag_base ?? "", /steps\.state\.outputs\.dist_tag_base/);
+		const publishSteps = releaseJob("publish").steps ?? [];
+		assert.ok(
+			publishSteps.indexOf(releaseStep("publish", "Confirm dist-tag state is unchanged")) <
+				publishSteps.indexOf(
+					releaseStep("publish", "Publish verified artifact (OIDC trusted publishing)"),
+				),
+		);
+	});
+
+	it("decides that a push is a release by the version bump, not by its message", () => {
+		const detect = releaseStep("detect", "Did this commit bump the version?").run ?? "";
+		assert.match(detect, /HEAD\^:package\.json/);
+		assert.match(detect, /is-release=true/);
+		assert.match(detect, /is-release=false/);
+		assert.equal(releaseJob("verify").needs, "detect");
+		assert.match(releaseJob("verify").if ?? "", /needs\.detect\.outputs\.is-release == 'true'/);
+	});
+
+	it("verifies provenance before treating an existing npm version as a safe rerun", () => {
+		const validator = readFileSync(
+			resolve(process.cwd(), "scripts/release/validate-release-commit.mjs"),
+			"utf8",
+		);
+		const guard = validator.slice(validator.indexOf("if (published) {"));
+		assert.match(guard, /assertPublishedArtifactMatches\(extractProvenanceSource\(/);
+	});
+
+	it("validates the release contract before running anything expensive", () => {
+		const steps = releaseJob("verify").steps ?? [];
+		const names = steps.map(step => step.name ?? "");
+		const validateIndex = names.indexOf("Validate release contract");
+		const installIndex = names.indexOf("Install");
+		assert.ok(validateIndex >= 0, "verify must validate the release contract");
+		assert.ok(
+			installIndex > validateIndex,
+			"validation must run before `npm ci` executes third-party lifecycle scripts",
+		);
+		const setupIndex = steps.findIndex(step => (step.uses ?? "").startsWith("actions/setup-node@"));
+		assert.ok(setupIndex >= 0 && setupIndex < validateIndex, "validation must run on the pinned Node");
+		assert.match(steps[validateIndex]?.run ?? "", /validate-release-commit\.mjs --mode merged/);
+	});
+
+	it("builds, type-checks, and unit-tests the release commit before anything ships", () => {
+		const runs = (releaseJob("verify").steps ?? []).map(step => step.run ?? "");
+		assert.ok(runs.some(run => run.includes("npm run build")));
+		assert.ok(runs.some(run => run.includes("npm run check")));
+		assert.ok(runs.some(run => run.includes("npm run test:unit")));
+		assert.ok(!runs.some(run => /npm audit|audit:packed-consumer/.test(run)));
+		assert.equal(releaseJob("publish").needs, "verify");
+	});
+
+	it("gates the release with a toolchain the PR gate actually exercises", () => {
+		const gate = prGateWorkflow.jobs?.verify;
+		const release = toolchainOf(releaseJob("verify"));
+
+		// The PR gate fans out across operating systems and Node versions; the
+		// release publishes from one. Identical config is therefore the wrong
+		// thing to require -- what matters is that the version the release is
+		// gated on is one the PR gate really ran.
+		const matrix = gate?.strategy?.matrix;
+		const gateNodes = [
+			...(matrix?.node ?? []),
+			...(matrix?.include ?? []).map(entry => entry.node).filter(Boolean),
+		];
+		assert.ok(gateNodes.length > 0, "the PR gate must pin its Node versions");
+		assert.ok(
+			gateNodes.includes(String(release.node)),
+			`release verify runs Node ${release.node}, which the PR gate never exercises (${gateNodes.join(", ")})`,
+		);
+
+		// The commands themselves must not drift.
+		assert.deepEqual(release.runs, toolchainOf(gate).runs);
+		assert.equal(release.cache, toolchainOf(gate).cache);
+	});
+
+	it("bounds every release job", () => {
+		for (const [name, job] of Object.entries(releaseWorkflow.jobs ?? {})) {
+			assert.equal(
+				typeof (job as { "timeout-minutes"?: number })["timeout-minutes"],
+				"number",
+				`release job ${name} needs a timeout-minutes`,
+			);
+		}
+	});
+
+	it("never grants repository write access to the verifying or publishing jobs", () => {
+		assert.deepEqual(releaseWorkflow.permissions, {
+			contents: "read",
+			"pull-requests": "read",
+		});
+		assert.equal(releaseJob("detect").permissions, undefined);
+		assert.equal(releaseJob("verify").permissions, undefined);
+		assert.deepEqual(releaseJob("publish").permissions, {
+			"contents": "read",
+			"id-token": "write",
+		});
+		assert.deepEqual(releaseJob("tag").permissions, { contents: "write" });
+		assert.deepEqual(releaseJob("release").permissions, { contents: "write" });
+		assert.equal(releaseJob("tag").permissions?.["id-token"], undefined);
+		assert.equal(releaseJob("release").permissions?.["id-token"], undefined);
+	});
+
+	it("publishes before creating the immutable source tag", () => {
+		assert.equal(releaseJob("publish").needs, "verify");
+		assert.deepEqual(releaseJob("tag").needs, ["verify", "publish"]);
+		assert.match(releaseJob("tag").if ?? "", /needs\.publish\.result == 'success'/);
+		assert.match(releaseJob("tag").if ?? "", /needs\.publish\.result == 'skipped'/);
+		assert.deepEqual(releaseJob("release").needs, ["verify", "tag"]);
+
+		const tagStep = releaseStep("tag", "Create release tag").run ?? "";
+		assert.match(tagStep, /git\/ref\/tags\/\$TAG/);
+		assert.match(tagStep, /points at \$existing, not \$GITHUB_SHA/);
+		assert.match(tagStep, /-f ref="refs\/tags\/\$TAG" -f sha="\$GITHUB_SHA"/);
+
+		assert.match(releaseStep("release", "Create release").run ?? "", /--verify-tag/);
+
+		const mergeSection = skill.match(/## 8\. Squash-merge[\s\S]*?## 9\./)?.[0] ?? "";
+		assert.ok(
+			mergeSection.indexOf("publishes the verified tarball") <
+				mergeSection.indexOf("creates the `v<new-version>` tag"),
+			"the release skill must document publish-before-tag ordering",
+		);
+	});
+
+	it("publishes only artifacts built and tested without OIDC authority", () => {
+		const prepare = releaseStep("verify", "Prepare verified release artifacts").run ?? "";
+		assert.match(prepare, /npm pack --ignore-scripts --json/);
+		assert.match(prepare, /release-artifact\/bobbit\.tgz/);
+		assert.match(prepare, /release-artifact\/release-notes\.md/);
+		const upload = releaseStep("verify", "Upload verified release artifacts");
+		assert.match(upload.uses ?? "", /^actions\/upload-artifact@[0-9a-f]{40}$/);
+		assert.equal(upload.with?.["if-no-files-found"], "error");
+
+		for (const privilegedJob of ["publish", "release"]) {
+			const steps = releaseJob(privilegedJob).steps ?? [];
+			assert.ok(!steps.some(step => (step.uses ?? "").startsWith("actions/checkout@")));
+			assert.ok(!steps.some(step => /npm ci|npm run|node scripts\//.test(step.run ?? "")));
+			const download = releaseStep(privilegedJob, "Download verified release artifacts");
+			assert.match(download.uses ?? "", /^actions\/download-artifact@[0-9a-f]{40}$/);
+			assert.match(String(download.with?.name ?? ""), /needs\.verify\.outputs\.artifact_name/);
+		}
+		const publishSteps = releaseJob("publish").steps ?? [];
+		assert.ok(
+			publishSteps.indexOf(releaseStep("publish", "Confirm dist-tag state is unchanged")) <
+				publishSteps.indexOf(releaseStep("publish", "Download verified release artifacts")),
+			"the registry state check must run before the publish tarball enters the privileged job",
+		);
+	});
+
+	it("gives the publish job an npm new enough for OIDC trusted publishing", () => {
+		const setup = (releaseJob("publish").steps ?? []).find(step =>
+			(step.uses ?? "").startsWith("actions/setup-node@"),
+		);
+		const nodeVersion = String(setup?.with?.["node-version"] ?? "");
+		assert.ok(nodeVersion, "publish must configure Node explicitly");
+		assert.ok(
+			Number.parseInt(nodeVersion, 10) >= 24,
+			`publish needs a Node major bundling npm >= 11.5.1, got ${nodeVersion}`,
+		);
+		assert.equal(setup?.with?.["registry-url"], "https://registry.npmjs.org");
+
+		const publish =
+			releaseStep("publish", "Publish verified artifact (OIDC trusted publishing)").run ?? "";
+		assert.match(publish, /cannot use OIDC trusted publishing/);
+	});
+
+	it("publishes the verified tarball with provenance and no lifecycle scripts", () => {
+		const publish =
+			releaseStep("publish", "Publish verified artifact (OIDC trusted publishing)").run ?? "";
+		assert.match(
+			publish,
+			/npm publish release-artifact\/bobbit\.tgz --ignore-scripts --provenance --tag "\$DIST_TAG"/,
+		);
+		assert.doesNotMatch(publish, /NODE_AUTH_TOKEN|NPM_TOKEN/);
+		assert.equal(distTagFor("0.16.0"), "latest");
+		assert.equal(distTagFor("0.16.0-rc.1"), "next");
+	});
+
+	it("leads with the verified notes and appends the generated changelog", () => {
+		assert.deepEqual(releaseJob("release").needs, ["verify", "tag"]);
+		const release = releaseStep("release", "Create release").run ?? "";
+		assert.match(release, /gh release create "\$TAG"/);
+		assert.match(release, /--notes-file release-artifact\/release-notes\.md/);
+		assert.match(release, /--generate-notes/);
+		assert.match(release, /PRERELEASE=\(\)/);
+		assert.match(release, /"\$\{PRERELEASE\[@\]\}"/);
+	});
+
+	it("pins every action to a full commit sha", () => {
+		const uses = Object.values(releaseWorkflow.jobs ?? {})
+			.flatMap(job => job.steps ?? [])
+			.map(step => step.uses)
+			.filter((value): value is string => typeof value === "string");
+		assert.ok(uses.length > 0, "release workflow must use at least one action");
+		for (const action of uses) {
+			assert.match(action, /@[0-9a-f]{40}$/, `action is not pinned to a sha: ${action}`);
+		}
+	});
+
+	it("checks the release contract before the merge, not only after it", () => {
+		const gate = prGateWorkflow.jobs?.["release-contract"];
+		assert.ok(gate, "the PR gate must check release PRs against the same contract");
+		const validate = (gate.steps ?? []).find(step => step.name === "Validate release contract");
+		assert.match(validate?.run ?? "", /validate-release-commit\.mjs --mode pre-merge/);
+
+		assert.doesNotMatch(
+			gate.if ?? "",
+			/head_ref/,
+			"gating on the branch name means the job never runs except on a release PR, " +
+				"so its wiring is first exercised by a real release",
+		);
+		assert.match(gate.if ?? "", /github\.event_name == 'pull_request'/);
+
+		const checkout = (gate.steps ?? []).find(step => (step.uses ?? "").startsWith("actions/checkout@"));
+		assert.equal(checkout?.with?.["fetch-depth"], 2, "the base version is read from HEAD^1");
+	});
+});
+
+describe("release contract rules", () => {
+	const repository = "G-Research/bobbit";
+	const sha = "f4f8137f21d1d13d41bf52a7e1f871e0ba615cda";
+	const mergedPr = {
+		number: 1063,
+		title: "chore(release): v0.16.0",
+		base: { ref: "main" },
+		head: { ref: "release/v0.16.0", repo: { full_name: repository } },
+		merged_at: "2026-07-30T10:00:00Z",
+		merge_commit_sha: sha,
+	};
+	const contract = { version: "0.16.0", repository, sha };
+
+	it("accepts only release-shaped versions", () => {
+		for (const good of ["0.15.1", "1.0.0", "0.16.0-rc.1", "2.3.4-beta.10"]) {
+			assert.equal(assertReleaseVersion(good), good);
+		}
+		for (const bad of ["0.15", "v0.15.1", "0.15.1+build", "01.2.3", ""]) {
+			assert.throws(() => assertReleaseVersion(bad), /not a release version/);
+		}
+	});
+
+	it("requires package.json and both package-lock versions to agree", () => {
+		const pkg = { version: "0.16.0" };
+		assertLockfileAgreement(pkg, { version: "0.16.0", packages: { "": { version: "0.16.0" } } });
+		assert.throws(
+			() => assertLockfileAgreement(pkg, { version: "0.16.0", packages: { "": { version: "0.15.1" } } }),
+			/does not match package\.json/,
+		);
+		assert.throws(
+			() => assertLockfileAgreement(pkg, { version: "0.15.1", packages: { "": { version: "0.16.0" } } }),
+			/does not match package\.json/,
+		);
+	});
+
+	it("requires optional dependencies to be immutable exact-version pins", () => {
+		assertExactOptionalDependencyPins({
+			optionalDependencies: {
+				"@bobbit/binaries-linux-x64": "0.9.0",
+				"@example/build": "1.2.3+build.7",
+			},
+		});
+		for (const mutable of ["latest", "^0.9.0", "~0.9.0", ">=0.9.0", "*"]) {
+			assert.throws(
+				() =>
+					assertExactOptionalDependencyPins({
+						optionalDependencies: { "@bobbit/binaries-linux-x64": mutable },
+					}),
+				/must be pinned to an exact version/,
+			);
+		}
+	});
+
+	it("requires this release's changelog entry, at the top, with substance", () => {
+		const entry = (version: string, body: string) => `## v${version}\n\n${body}\n\n`;
+		const real = "x".repeat(200);
+
+		const good = `# Changelog\n\n${entry("0.16.0", real)}${entry("0.15.1", real)}`;
+		assert.equal(assertChangelogSection(good, "0.16.0"), real);
+		assert.equal(changelogSectionFor(good, "0.15.1"), real);
+		assert.equal(changelogSectionFor(good, "9.9.9"), null);
+
+		assert.throws(
+			() => assertChangelogSection(`# Changelog\n\n${entry("0.15.1", real)}`, "0.16.0"),
+			/has no `## v0\.16\.0` section/,
+		);
+		assert.throws(
+			() => assertChangelogSection(`# Changelog\n\n${entry("0.15.1", real)}${entry("0.16.0", real)}`, "0.16.0"),
+			/Newest release first/,
+		);
+		assert.throws(
+			() => assertChangelogSection(`# Changelog\n\n${entry("0.16.0", "tiny")}`, "0.16.0"),
+			/too short to publish/,
+		);
+		const nested = `# Changelog\n\n## v0.16.0\n\n### Features\n\n${real}\n`;
+		assert.match(assertChangelogSection(nested, "0.16.0"), /### Features/);
+
+		const duplicate = `# Changelog\n\n${entry("0.16.0", real)}${entry("0.15.1", "forged")}${entry("0.15.1", real)}`;
+		assert.throws(() => assertChangelogSection(duplicate, "0.16.0"), /more than one `## v0\.15\.1`/);
+	});
+
+	it("lets a release add its own entry and nothing else", () => {
+		const before = `# Changelog\n\n## v0.15.1\n\n${"x".repeat(200)}\n`;
+		const added = `# Changelog\n\n## v0.16.0\n\n${"y".repeat(200)}\n\n## v0.15.1\n\n${"x".repeat(200)}\n`;
+		assertChangelogAppendOnly("", before);
+		assertChangelogAppendOnly(before, added);
+
+		const rewritten = `# Changelog\n\n## v0.16.0\n\n${"y".repeat(200)}\n\n## v0.15.1\n\n${"z".repeat(200)}\n`;
+		assert.throws(() => assertChangelogAppendOnly(before, rewritten), /rewrites the released v0\.15\.1/);
+		assert.throws(
+			() => assertChangelogAppendOnly(before, `# Changelog\n\n## v0.16.0\n\n${"y".repeat(200)}\n`),
+			/drops the released v0\.15\.1/,
+		);
+		assert.throws(
+			() => assertChangelogAppendOnly(`${before}\n## v0.15.1\n\nduplicate\n`, added),
+			/more than one `## v0\.15\.1`/,
+		);
+		assert.throws(
+			() => assertChangelogAppendOnly(before, added.replace("# Changelog", "# Release history")),
+			/rewrites text before the first release/,
+		);
+		assert.throws(
+			() => assertChangelogAppendOnly(before, added.replace("x".repeat(200), `${"x".repeat(200)} `)),
+			/rewrites the released v0\.15\.1/,
+		);
+	});
+
+	it("requires the version to increase, not merely to change", () => {
+		assertVersionBump("0.15.1", "0.16.0", sha);
+		assertVersionBump("0.16.0-rc.1", "0.16.0", sha);
+
+		assert.throws(() => assertVersionBump("0.16.0", "0.16.0", sha), /does not bump the version/);
+		// Only 0.15.x is on the registry, so a 0.1.0 release PR passes every other
+		// rule — and would take the `latest` dist-tag, downgrading every consumer.
+		assert.throws(() => assertVersionBump("0.15.1", "0.1.0", sha), /moves the version backwards/);
+		assert.throws(() => assertVersionBump("0.16.0", "0.16.0-rc.1", sha), /moves the version backwards/);
+	});
+
+	it("refuses to move an npm dist-tag backwards", async () => {
+		const response = (status: number, version?: string) => ({
+			status,
+			ok: status >= 200 && status < 300,
+			json: async () => ({ version }),
+		});
+		const args = { packageName: "@gresearch/bobbit", distTag: "latest", version: "0.16.0" };
+		assert.equal(await assertDistTagAdvances({ ...args, fetchImpl: async () => response(404) }), null);
+		assert.equal(
+			await assertDistTagAdvances({ ...args, fetchImpl: async () => response(200, "0.15.1") }),
+			"0.15.1",
+		);
+		await assert.rejects(
+			assertDistTagAdvances({ ...args, fetchImpl: async () => response(200, "0.16.0") }),
+			/refusing to move latest backwards/,
+		);
+		await assert.rejects(
+			assertDistTagAdvances({ ...args, fetchImpl: async () => response(200, "0.17.0") }),
+			/refusing to move latest backwards/,
+		);
+	});
+
+	it("orders versions by semver precedence, not by string", () => {
+		const cases: [string, string, number][] = [
+			["0.16.0", "0.15.1", 1],
+			["0.1.0", "0.15.1", -1],
+			["0.15.1", "0.15.1", 0],
+			["1.0.0", "0.99.99", 1],
+			// A prerelease sorts below its release, numeric identifiers compare as
+			// numbers, and a longer identifier set wins a tie.
+			["0.16.0", "0.16.0-rc.1", 1],
+			["0.16.0-rc.2", "0.16.0-rc.10", -1],
+			["0.16.0-alpha", "0.16.0-beta", -1],
+			["0.16.0-rc.1", "0.16.0-rc.1.1", -1],
+			["9007199254740993.0.0", "9007199254740992.0.0", 1],
+			["0.16.0-rc.9007199254740993", "0.16.0-rc.9007199254740992", 1],
+		];
+		for (const [a, b, expected] of cases) {
+			assert.equal(compareReleaseVersions(a, b), expected, `${a} vs ${b}`);
+			assert.equal(compareReleaseVersions(b, a), -expected || 0, `${b} vs ${a}`);
+		}
+	});
+
+	it("escapes every path segment of a package name in registry urls", () => {
+		assert.equal(
+			npmPackageUrl("@gresearch/bobbit", "0.15.1"),
+			"https://registry.npmjs.org/%40gresearch%2Fbobbit/0.15.1",
+		);
+		// Encoding only the first slash left the rest as live path segments, which
+		// fetch normalises — a crafted optionalDependencies key could then resolve
+		// against an unrelated registry path and read as "already published".
+		const crafted = npmPackageUrl("@evil/../../-/user/x", "1.0.0");
+		assert.ok(!crafted.includes("/../"), crafted);
+		assert.equal(crafted.split("/").length, "https://registry.npmjs.org/x/y".split("/").length);
+	});
+
+	it("requires the release to have been opened as a release", () => {
+		assertPullRequestContract(mergedPr, contract);
+
+		assert.throws(() => assertPullRequestContract(null, contract), /no merged pull request produced/);
+		assert.throws(
+			() => assertPullRequestContract({ ...mergedPr, base: { ref: "develop" } }, contract),
+			/targets develop/,
+		);
+		assert.throws(
+			() =>
+				assertPullRequestContract(
+					{ ...mergedPr, head: { ...mergedPr.head, repo: { full_name: "someone/bobbit" } } },
+					contract,
+				),
+			/Release branches must live in this repository/,
+		);
+		assert.throws(
+			() => assertPullRequestContract({ ...mergedPr, head: { ...mergedPr.head, ref: "deps/bump" } }, contract),
+			/not be the side effect of a version change/,
+		);
+		assert.throws(
+			() => assertPullRequestContract({ ...mergedPr, title: "release 0.16.0" }, contract),
+			/title must be/,
+		);
+	});
+
+	it("checks the published artifact's own provenance, not just the tag", () => {
+		// Tag rulesets identify the repository-wide Actions app, not this workflow.
+		// Only registry-verified provenance identifies the publishing path and commit.
+		const spec = "@gresearch/bobbit@0.16.0";
+		const repository = "G-Research/bobbit";
+		const good = {
+			sha,
+			repository: `https://github.com/${repository}`,
+			path: RELEASE_WORKFLOW_PATH,
+		};
+		assert.equal(assertPublishedArtifactMatches(good, { spec, repository, sha }), true);
+
+		assert.throws(
+			() => assertPublishedArtifactMatches(null, { spec, repository, sha }),
+			/no readable provenance attestation/,
+		);
+		assert.throws(
+			() => assertPublishedArtifactMatches({ ...good, sha: "0".repeat(40) }, { spec, repository, sha }),
+			/was published from commit/,
+		);
+		assert.throws(
+			() =>
+				assertPublishedArtifactMatches(
+					{ ...good, repository: "https://github.com/someone/bobbit" },
+					{ spec, repository, sha },
+				),
+			/was published from https:\/\/github\.com\/someone\/bobbit/,
+		);
+		assert.throws(
+			() =>
+				assertPublishedArtifactMatches(
+					{ ...good, repository: "https://evil.example/G-Research/bobbit" },
+					{ spec, repository, sha },
+				),
+			/was published from https:\/\/evil\.example/,
+		);
+		// A different workflow in this repository is still not this release path.
+		assert.throws(
+			() =>
+				assertPublishedArtifactMatches(
+					{ ...good, path: ".github/workflows/something-else.yml" },
+					{ spec, repository, sha },
+				),
+			/was published by \.github\/workflows\/something-else\.yml/,
+		);
+	});
+
+	it("reads the source commit, repository and workflow out of an attestation", () => {
+		const statement = {
+			predicate: {
+				buildDefinition: {
+					externalParameters: {
+						workflow: { repository: "https://github.com/G-Research/bobbit", path: RELEASE_WORKFLOW_PATH },
+					},
+					resolvedDependencies: [
+						{ uri: "git+https://github.com/evil/example@refs/heads/main", digest: { gitCommit: "bad" } },
+						{
+							uri: "git+https://github.com/G-Research/bobbit@refs/heads/main",
+							digest: { gitCommit: sha },
+						},
+					],
+				},
+			},
+		};
+		const response = {
+			attestations: [
+				{ predicateType: "https://github.com/npm/attestation/tree/main/specs/publish/v0.1", bundle: {} },
+				{
+					predicateType: "https://slsa.dev/provenance/v1",
+					bundle: {
+						dsseEnvelope: { payload: Buffer.from(JSON.stringify(statement), "utf8").toString("base64") },
+					},
+				},
+			],
+		};
+		assert.deepEqual(extractProvenanceSource(response), {
+			sha,
+			repository: "https://github.com/G-Research/bobbit",
+			path: RELEASE_WORKFLOW_PATH,
+		});
+		assert.equal(extractProvenanceSource({ attestations: [] }), null);
+		assert.equal(extractProvenanceSource(null), null);
+	});
+
+	it("escapes the package name in the attestation url too", () => {
+		assert.equal(
+			npmAttestationUrl("@gresearch/bobbit", "0.15.1"),
+			"https://registry.npmjs.org/-/npm/v1/attestations/%40gresearch%2Fbobbit@0.15.1",
+		);
+	});
+
+	it("never reads an unreachable commit as an empty file", () => {
+		type GitResult = { status: number; stdout: string; stderr: string };
+		const ok = (stdout: string): GitResult => ({ status: 0, stdout, stderr: "" });
+		const no = (stderr: string): GitResult => ({ status: 128, stdout: "", stderr });
+		const runner =
+			(replies: Record<string, GitResult>) =>
+			(args: string[]): GitResult =>
+				replies[args[0]] ?? no("unexpected git call");
+
+		assert.equal(
+			fileAtCommit("HEAD^", "CHANGELOG.md", runner({ "rev-parse": ok("sha\n"), show: ok("# Changelog\n") })),
+			"# Changelog\n",
+		);
+
+		// The parent is reachable and simply has no such file — the first release
+		// after CHANGELOG.md is introduced. Nothing to compare against.
+		assert.equal(
+			fileAtCommit(
+				"HEAD^",
+				"CHANGELOG.md",
+				runner({ "rev-parse": ok("sha\n"), show: no("fatal: path 'CHANGELOG.md' does not exist in 'HEAD^'") }),
+			),
+			null,
+		);
+
+		// git reports a missing *object* with the same "…but not in…" wording it
+		// uses for a missing *path*. A clone too shallow to hold the parent must
+		// raise: resolving it to null would leave assertChangelogAppendOnly
+		// comparing against an empty file, silently passing every rewrite.
+		assert.throws(
+			() =>
+				fileAtCommit(
+					"HEAD^",
+					"CHANGELOG.md",
+					runner({
+						"rev-parse": no("fatal: Needed a single revision"),
+						show: no("fatal: path 'CHANGELOG.md' exists on disk, but not in 'HEAD^'"),
+					}),
+				),
+			/cannot resolve HEAD\^.*append-only/s,
+		);
 	});
 });
 

--- a/tests2/tests-map.json
+++ b/tests2/tests-map.json
@@ -1445,7 +1445,7 @@
     },
     {
       "path": "tests2/core/release-skill-preflight-order.test.ts",
-      "reason": "Pins the scoped npm identity used by release verification/reporting and the clean-release pre-flight order required by emitted test declarations.",
+      "reason": "Pins the merge-authorized release workflow, least-privilege artifact handoff, serialized dist-tag advancement, provenance-based reruns, GitHub release creation, and release contract rules for PR intent, versions, lockfile, changelog, and optional dependency pins.",
       "execution": {
         "runner": "vitest",
         "tier": "unit",


### PR DESCRIPTION
## Objective

Make merging a reviewed release PR the only authorization path for publishing the root package, creating its immutable tag, and creating the GitHub release.

## Flow

Release PR (`release/vX.Y.Z`, version bump + new `CHANGELOG.md` entry) → review and checks → squash merge to `main` → verify → serialized publish → tag → GitHub release.

The workflow is triggered only by a push to `main`; it has no dispatch or arbitrary-ref path.

## Security model

- `verify` runs repository and dependency code without OIDC or repository-write authority. It validates the release contract, builds, type-checks, runs the unit gate, packs the tarball, and uploads the tarball plus reviewed release notes as an immutable artifact.
- `publish` has `id-token: write`, but no checkout, install, repository script, or lifecycle script. It publishes only the verified tarball with `--ignore-scripts --provenance`.
- `tag` has only `contents: write` and runs after publication.
- `release` has only `contents: write`, downloads the reviewed notes artifact, and creates the GitHub release after the tag exists.

Publication happens before tagging so a cancelled job waiting for the publish lock cannot strand a tag. If npm accepts the package and tagging later fails, a full rerun verifies npm provenance, skips the immutable publish, and retries the idempotent tag.

## Ordering and concurrency

Only publish jobs enter `release-publish-root`; ordinary pushes never do. Verification proves the proposed version advances the current `latest` or `next` dist-tag and records that baseline. After acquiring the publish lock, the privileged job confirms the dist-tag is unchanged before downloading the artifact. An intervening release therefore fails closed instead of moving consumers backwards.

## Release contract

The same validator runs before merge and on the merged release commit. It requires:

- the exact merge commit of a same-repository `release/vX.Y.Z` PR targeting `main`, with the exact release title;
- a strictly increasing, release-shaped SemVer shared by `package.json` and both lockfile roots;
- a substantial topmost `CHANGELOG.md` section, with all earlier content byte-identical and no duplicate version headings;
- exact immutable optional-dependency pins that already exist on npm;
- an unpublished root version, or registry-verified provenance naming this repository, workflow, and commit on a safe rerun.

Unexpected GitHub or npm responses fail closed. Pre-releases use `next`; stable releases use `latest`.

## External prerequisite

Before the first automated release, configure the documented `refs/tags/v*` creation and immutability rulesets. The tag protects the public source pointer; npm provenance, not the repository-wide GitHub Actions app bypass, authorizes reruns.

## Scope

Runtime audit policy is unchanged and audits do not run in this workflow. Browser/E2E runner work and validator-level integration coverage remain separate follow-ups.

## Validation

- `npm run build`
- `npm run check`
- 51 targeted release/build-gate tests passed
- Full CI matrix passes on current `main` (`a52733f27`): affected-unit feedback, Ubuntu Node 22/26, Windows, macOS, release contract, CodeQL, and security checks.
- workflow YAML parsing, live npm provenance parsing, live dist-tag baseline lookup, artifact packing, and `git diff --check` passed

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)


