### PR TITLE
chore(release): v0.15.1

### DIFF
--- a/RELEASE_NOTES_v0.15.1.md
+++ b/RELEASE_NOTES_v0.15.1.md
@@ -1,0 +1,17 @@
+# Bobbit v0.15.1
+
+Upgrading from v0.15.0. This release adds Claude Opus 5 support and dedicated verifiable bug reviews, while improving model-selection and multi-repository Git status reliability.
+
+## ✨ New Features
+
+* 🤖 **Claude Opus 5 & Pi 0.82.1**: Bobbit now exposes Claude Opus 5 through the authoritative Pi model catalog. Provider, model, and thinking-level selections travel together through sessions, delegates, team workers, restarts, and recovery, with safe rollback when a requested runtime tuple cannot be verified.
+
+* 🔍 **Verifiable bug-hunt reviews**: Built-in implementation workflows now include a dedicated read-only reviewer focused on reproducible bugs in the current branch diff.
+
+## 🐛 Bug Fixes
+
+* 🧩 **Accurate polyrepo Git status**: Goal and session widgets now retain named component repositories, aggregate partial results conservatively, survive team-lead restart recovery, and avoid hiding valid component status when the project container itself is not a Git repository.
+
+---
+
+🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gresearch/bobbit",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@gresearch/bobbit",
-      "version": "0.15.0",
+      "version": "0.15.1",
       "dependencies": {
         "@earendil-works/pi-agent-core": "0.82.1",
         "@earendil-works/pi-ai": "0.82.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gresearch/bobbit",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "type": "module",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

Prepare Bobbit v0.15.1 for dual publication under the legacy and scoped npm package names.

- bump `package.json` and `package-lock.json` to 0.15.1
- add approved `RELEASE_NOTES_v0.15.1.md`
- keep bundled binary package versions unchanged

## Release validation

- `npm ci`: passed
- `npm audit --omit=dev`: passed, 0 vulnerabilities
- `npm run build`: passed
- `npm run audit:packed-consumer`: reported only the documented accepted-risk path `@earendil-works/pi-coding-agent@0.82.1 > minimatch@10.2.5 > brace-expansion@5.0.7` (`GHSA-mh99-v99m-4gvg`), 1 high vulnerability
- `npm run check`: passed
- Test suites were not rerun locally at maintainer direction; the source was pre-validated and the PR Build & Unit Gate passed
- `binaries.versions.json`: unchanged; no binary sub-package republish required
- `bobbit@0.15.1`: available on npm
- `@gresearch/bobbit@0.15.1`: available on npm

## Publishing

After required PR checks and review pass:

1. Temporarily stage the release package under the legacy `bobbit` name and manually publish `bobbit@0.15.1`.
2. Restore and verify the committed scoped manifest remains unchanged.
3. Squash-merge the release PR and push `v0.15.1` on the exact merge commit.
4. The tag triggers `.github/workflows/release-publish.yml` to publish `@gresearch/bobbit@0.15.1` through npm trusted publishing with provenance.

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)
