### PR TITLE
Harden exact tuple transitions

### DIFF
--- a/docs/pi-runtime-compatibility.md
+++ b/docs/pi-runtime-compatibility.md
@@ -12,25 +12,48 @@ A mixed Pi line can compile while still breaking the spawned-agent runtime contr
 
 ## Pi `0.82.1` compatibility outcome
 
+### PR #1057 disposition (historical)
+
+This table records the decision when PR #1057 was accepted. It remains the audit history for that delivery; the tuple-transition findings have since been resolved or closed as described in the current-status section below.
+
 | Decision | Status |
 |---|---|
-| Compatibility | **Accepted with deferred findings.** Dependency alignment, Opus 5 catalog/ranking, exact live selection, and the covered persistence, spawn, and inheritance paths passed. The conflicting role/default restore case described below remains deferred. |
+| Compatibility | **Accepted with deferred findings at merge.** Dependency alignment, Opus 5 catalog/ranking, exact live selection, and the then-covered persistence, spawn, and inheritance paths passed. The conflicting role/default restore case remained deferred for follow-up. |
 | Tests | **Passed.** The final verification run passed `npm run build`, `npm run check`, `npm run test:unit`, `npm run test:browser`, and `npm run test:e2e`. Security review passed; optional agent QA was not enabled. |
 | Immutable upstream audit | **Non-zero.** The isolated packed-consumer audit reports one high finding: Pi coding-agent's published shrinkwrap pins `brace-expansion@5.0.7`, affected by [`GHSA-mh99-v99m-4gvg`](https://github.com/advisories/GHSA-mh99-v99m-4gvg). This is immutable class C upstream packaging, not an audit-clean result. |
 | Accepted-risk status | **Accepted.** The exact `brace-expansion@5.0.7` finding remains visible and was explicitly accepted without an audit fix, override, vendor, fork, repack, or weakened check. It is not a merge or release-eligibility blocker for this delivery. |
-| Implementation verification | **Human-bypassed.** The latest implementation review failed on the deferred findings below. A human overseer advanced the gate for urgency; bypass is not a passing review result. |
-| Release eligibility | **True under the amended acceptance and explicit human decision.** This delivery is release-eligible, but it is neither audit-clean nor free of deferred findings. Any additional audit finding or unaccepted release failure remains blocking. |
+| Implementation verification | **Human-bypassed for PR #1057.** The final implementation review failed on the findings below. A human overseer advanced the gate for urgency; bypass is not a passing review result. |
+| Release eligibility | **True for PR #1057 under the amended acceptance and explicit human decision.** At that decision, the delivery was release-eligible but neither audit-clean nor free of deferred findings. Any additional audit finding or unaccepted release failure remained blocking. |
 
-### Verification disposition and deferred findings
+### PR #1057 verification disposition and deferred findings (historical)
 
 At final implementation commit `68dc74a4`, the build, type-check, unit, browser, and E2E command gates passed. The security review also passed. Optional agent QA was skipped because it was not enabled.
 
-The latest static review then raised the following unresolved items:
+The final static review then raised these unresolved items at the time:
 
-- **Deferred restore finding:** a role-backed session may prefer its role's configured thinking level over a later verified durable `effectiveThinkingLevel` during cold restore or force-abort replacement. Multiple reviewers traced this path, but no executable failing regression was run before the human decision to proceed. The proposed **Harden Tuple Transitions** follow-up, dependent on PR #1057, owns this restore/force-abort precedence concern and is intended to reproduce and fix it without broadening recovery architecture.
-- **Unexecuted review hypotheses:** the systems review proposed races involving wrong-target quarantine after restart, rollback of a concurrently committed tuple during staged role replacement, and reconnect publishing an in-flight mixed tuple. These were not demonstrated by executable reproductions on this branch and are not reported here as confirmed defects. The same follow-up will reproduce each hypothesis and fix only defects confirmed by deterministic tests.
+- **Deferred restore finding:** a role-backed session could prefer its role's configured thinking level over a later verified durable `effectiveThinkingLevel` during cold restore or force-abort replacement. Multiple reviewers traced this path, but no executable failing regression was run before the human decision to proceed. The later **Harden Tuple Transitions** follow-up owned deterministic reproduction and a focused fix.
+- **Unexecuted review hypotheses:** the systems review proposed races involving wrong-target quarantine after restart, rollback of a concurrently committed tuple during staged role replacement, and reconnect publishing an in-flight mixed tuple. These were not demonstrated by executable reproductions in PR #1057 and were not reported there as confirmed defects. The follow-up exercised each hypothesis deterministically and changed production behavior only for confirmed defects.
 
-A human overseer bypassed the failed Implementation gate for **Urgency** after reviewing the aggregate. The bypass allows the documentation and merge workflow to continue, but it does not erase the findings, convert failed reviews into passes, or make the optional QA step executed. Release eligibility above reflects that explicit decision and the amended accepted-risk policy.
+For PR #1057, a human overseer bypassed the failed Implementation gate for **Urgency** after reviewing the aggregate. The bypass allowed the documentation and merge workflow to continue, but it did not erase the findings, convert failed reviews into passes, or make the optional QA step executed. The historical release eligibility above reflects that explicit decision and the amended accepted-risk policy.
+
+### Harden Tuple Transitions follow-up (current status)
+
+The follow-up ran deterministic reproductions after PR #1057. The historical implementation bypass remains recorded above, but these tuple-transition items are no longer deferred:
+
+- **Restore and force-abort precedence is fixed.** When a complete durable `{provider, modelId, effectiveThinkingLevel}` exists, its thinking level wins during cold restore and force-abort. An already attached role is not new user intent. A new explicit `assignRole` remains role-first, with its requested thinking clamped against the exact selected model before read-back and persistence.
+- **Runtime recovery is fenced to exact bridge ownership.** A stale mutation or restart bridge cannot stop, terminate, archive, or publish state for a newer role/restart replacement. Recovery rechecks canonical session and RPC bridge identity around asynchronous read-back, and publishes a newer bridge only when its complete read-back still matches current durability. The empty-transcript zombie decision uses the same coordinated ownership admission: an owned direct restart still fails closed and archives a genuine zombie, while queued stale recovery cannot archive a verified replacement.
+- **The staged rollback hypothesis is closed without an extra production fix.** The existing deterministic A/B ordering test already proves that a failed staged role replacement cannot restore captured tuple A over a concurrently verified runtime tuple B. This narrow hypothesis required no duplicate test or behavior change.
+- **Reconnect and `get_state` retain complete durability during mutation.** If the model step has moved to B while thinking is still from A, proactive attach and explicit state requests publish the previous complete durable tuple A, not mixed `{B, A-thinking}` state. The snapshot retains unrelated status, cost, and preparation fields. Matching live identity may preserve dynamic metadata; mismatched live identity cannot lend B's metadata to durable A. The complete B tuple becomes authoritative only after final verification and atomic persistence.
+- **Fallback and inherited thinking remain tuple-correct.** When controlled fallback changes the selected model, Bobbit re-clamps the original explicit role, durable, or inherited thinking request against the exact current fallback `ApiModel`. It does not reuse a clamp from the failed model or replace inherited thinking with the global default. Normal and worktree setup persist a fallback tuple only after verification, and clear temporary setup authority on both success and failure.
+
+Focused evidence:
+
+- `tests2/core/orphan-tool-result-rehydration-boundaries.test.ts` covers durable-first cold restore and force-abort in both directions, explicit `assignRole` precedence, the existing A/B rollback ordering, stale recovery queued behind role replacement, and empty-transcript zombie admission.
+- `tests2/core/runtime-model-recovery-ownership.test.ts` covers role bridge B replacing recovery bridge R during read-back, B committing before quarantine admission, and replacement C winning while B verification is held.
+- `tests2/integration/context-bar-reconnect.test.ts` covers explicit `get_state`, second-connection hydration during partial mutation, complete durable metadata, and matching dynamic live metadata.
+- `tests2/core/controlled-model-fallback.test.ts` covers exact fallback tuple verification, fresh and staged role reclamping, durable-thinking reclamping, and inherited thinking through normal and worktree setup.
+- `tests2/core/runtime-model-zombie-recovery-repro.test.ts` retains the fail-closed canary for a genuinely owned, unverifiable recovery bridge.
+- `tests2/core/rpc-bridge-spawn-args.test.ts` and `tests2/integration/host-agents-sandbox-inheritance.test.ts` retain exact tuple propagation across the shared host/sandbox argument boundary and inherited child sessions.
 
 ### Authoritative Claude Opus 5 catalog
 
@@ -81,7 +104,7 @@ For a live model selection, the gateway validates the exact provider/model again
 
 Failure keeps the previous durable tuple unchanged. Bobbit broadcasts a complete observed or durable tuple to correct both optimistic model and thinking state, makes one bounded rollback to the previous tuple, and verifies it. If live state or rollback is incomplete, unreachable, or unverifiable, the existing agent restart path replaces the bridge from unchanged durability; a partially mutated bridge does not continue live. The client also requests authoritative state after either model or thinking selection errors.
 
-Persistence adds only `effectiveThinkingLevel` beside the existing exact provider/model fields. Settled reconnect, reload, archived-state, and covered rehydration paths use the verified tuple rather than a placeholder. The conflicting role-default cold-restore/force-abort case is the deferred review finding recorded above and is not claimed as verified by this report. Legacy rows remain readable, but a new complete tuple becomes durable only after runtime verification.
+Persistence adds only `effectiveThinkingLevel` beside the existing exact provider/model fields. Settled reconnect, reload, archived-state, and rehydration paths use the verified tuple rather than a placeholder. A complete durable tuple now also takes precedence over an attached role default during cold restore and force-abort; only a new explicit role assignment applies new role thinking. Legacy rows remain readable, but a new complete tuple becomes durable only after runtime verification.
 
 Host and sandbox processes use the same argument builder and receive separate arguments:
 
@@ -98,9 +121,9 @@ Pi `0.82.1` adds provider and login capabilities that Bobbit does not adopt in t
 
 This boundary compares the provider exactly; it does not scan model IDs for `kimi`. Kimi-named IDs remain valid under an existing selectable AIGW, custom, local, Moonshot, or legacy gateway provider. Existing custom/local providers, legacy gateway models, OpenRouter API-key models, and supported login paths therefore retain their previous behavior.
 
-### Focused coverage
+### PR #1057 focused coverage (historical)
 
-The focused canaries cover:
+The PR #1057 focused canaries covered:
 
 - exact aligned Pi `0.82.1` root, nested, and packed-consumer structure;
 - the Anthropic and five Bedrock catalog rows, full metadata, shared rank, and `xhigh`/`max` clamping;
@@ -109,7 +132,7 @@ The focused canaries cover:
 - correction of both optimistic fields, verified rollback, and restart after an unverifiable partial mutation; and
 - the established browser-import, OAuth, RPC correlation/retry/thinking, tool lifecycle, compaction, transcript, extension, binary-resolution, and sandbox-status compatibility boundaries.
 
-The registered browser journey selects `anthropic/claude-opus-5`, verifies its authoritative limits, image/reasoning flags and complete thinking ladder, sends the combined `xhigh` tuple through a mock-backed session, reloads and re-verifies authoritative state, then deletes the session and restores preferences.
+The PR #1057 browser journey selected `anthropic/claude-opus-5`, verified its authoritative limits, image/reasoning flags and complete thinking ladder, sent the combined `xhigh` tuple through a mock-backed session, reloaded and re-verified authoritative state, then deleted the session and restored preferences.
 
 ## Pi `0.82.1` dependency-only Phase 0 baseline
 

--- a/src/server/agent/session-manager.ts
+++ b/src/server/agent/session-manager.ts
@@ -9044,6 +9044,25 @@ export class SessionManager {
 			session.spawnPinnedThinkingLevel = effectiveThinking;
 			verifiedSpawnTuple = tuple;
 		};
+		// A controlled fallback changes the model against which thinking must be
+		// clamped. Choose the raw authority for this setup context before looking at
+		// the provisional spawn pin, which was clamped for the model that just failed.
+		const resolveControlledFallbackThinking = () => {
+			const persisted = this.resolveStoreForSession(session.id).get(session.id);
+			const roleThinking = isKnownThinkingLevel(this.resolveRoleThinkingLevel(session));
+			const durableThinking = persisted?.modelProvider && persisted?.modelId
+				? isKnownThinkingLevel(persisted.effectiveThinkingLevel)
+				: undefined;
+			const defaultThinking = isKnownThinkingLevel(
+				this.preferencesStore?.get("default.sessionThinkingLevel") as string | undefined,
+			);
+			const provisionalThinking = isKnownThinkingLevel(session.spawnPinnedThinkingLevel);
+			if (Reflect.get(session, "_deferVerifiedTupleCommit") === true) {
+				return roleThinking ?? durableThinking ?? defaultThinking ?? provisionalThinking ?? "medium";
+			}
+			if (durableThinking) return durableThinking;
+			return roleThinking ?? defaultThinking ?? provisionalThinking ?? "medium";
+		};
 
 		// Spawn-pinned models are explicit selections too (restore/respawn persisted
 		// model, role/default pin from initial setup, or caller-supplied initialModel).
@@ -9089,13 +9108,10 @@ export class SessionManager {
 						await applyModelString(session.rpcClient, currentFallbackSessionModel, {
 							contextLabel: "default.sessionModel fallback",
 						});
-						// A staged assignRole pin already carries thinking clamped for the
-						// failed role model. Re-clamp the raw explicit role request against
-						// the fallback that actually won; restore/respawn pins remain durable-first.
-						const explicitRoleFallbackThinking = Reflect.get(session, "_deferVerifiedTupleCommit") === true
-							? isKnownThinkingLevel(this.resolveRoleThinkingLevel(session))
-							: undefined;
-						await commitExactSpawnTuple(currentFallbackSessionModel, explicitRoleFallbackThinking);
+						await commitExactSpawnTuple(
+							currentFallbackSessionModel,
+							resolveControlledFallbackThinking(),
+						);
 						console.log(`[session-manager] Controlled fallback selected default.sessionModel "${currentFallbackSessionModel}" for session ${session.id} after spawn-pinned model "${pinnedModel}" failed`);
 						return verifiedSpawnTuple;
 					} catch (fallbackErr) {
@@ -9154,7 +9170,10 @@ export class SessionManager {
 							contextLabel: "default.sessionModel fallback",
 							skipSetModel: spawnPinned && normalizeAigwModelString(session.spawnPinnedModel || "") === currentFallbackSessionModel,
 						});
-						await commitExactSpawnTuple(currentFallbackSessionModel);
+						await commitExactSpawnTuple(
+							currentFallbackSessionModel,
+							resolveControlledFallbackThinking(),
+						);
 						console.log(`[session-manager] Controlled fallback selected default.sessionModel "${currentFallbackSessionModel}" for session ${session.id} after role model "${roleModel}" failed`);
 						return verifiedSpawnTuple;
 					} catch (fallbackErr) {
@@ -10059,12 +10078,16 @@ export class SessionManager {
 				await this.switchSessionForRehydration(rpcClient, rolePs, agentSessionFile);
 			}
 			verifiedReplacementTuple = await this.tryAutoSelectModel(stagedSession);
-			try {
-				verifiedReplacementTuple = await this.tryApplyDefaultThinkingLevel(stagedSession);
-			} catch (err) {
-				if (respawnPersisted?.effectiveThinkingLevel !== undefined) throw err;
-				verifiedReplacementTuple = undefined;
-				console.warn(`[session-manager] Legacy session ${id} could not verify effective thinking during role replacement:`, err);
+			// tryAutoSelectModel verifies a complete tuple. Only use the standalone
+			// thinking helper when model selection produced no tuple; re-reading an
+			// already-complete legacy candidate can fail and must not discard it.
+			if (!verifiedReplacementTuple) {
+				try {
+					verifiedReplacementTuple = await this.tryApplyDefaultThinkingLevel(stagedSession);
+				} catch (err) {
+					if (respawnPersisted?.effectiveThinkingLevel !== undefined) throw err;
+					console.warn(`[session-manager] Legacy session ${id} could not verify effective thinking during role replacement:`, err);
+				}
 			}
 			if (respawnPersisted?.effectiveThinkingLevel !== undefined && !verifiedReplacementTuple) {
 				throw new Error(`Cannot assign role for session ${id}: replacement model tuple was not verified`);

--- a/src/server/agent/session-manager.ts
+++ b/src/server/agent/session-manager.ts
@@ -6579,7 +6579,10 @@ export class SessionManager {
 	): Promise<SessionInfo | undefined> {
 		return this._coordinateSessionReplacement(session.id, "respawn", (token) =>
 			this._respawnAgentInPlaceOwned(session.id, session, ps, opts, token), {
-				coalesceKey: "rehydrate",
+				// Owner-sensitive recovery must reach its own serialized admission
+				// check; joining a generic rehydrate would inherit another operation's
+				// replacement without ever proving ownership of its stopped bridge.
+				coalesceKey: opts?.expectedOwner ? undefined : "rehydrate",
 				drainOnRelease: opts?.deferQueueDrain !== true,
 				cancelOnTerminal: () => undefined,
 			});
@@ -8982,12 +8985,16 @@ export class SessionManager {
 		// mutation must also apply and read back the effective thinking level before
 		// any store, model-name mirror, or client success frame is updated.
 		let verifiedSpawnTuple;
-		const commitExactSpawnTuple = async (modelString: string): Promise<void> => {
+		const commitExactSpawnTuple = async (
+			modelString: string,
+			explicitPreferredThinking?: ThinkingLevel,
+		): Promise<void> => {
 			const slash = modelString.indexOf("/");
 			const provider = modelString.slice(0, slash);
 			const modelId = modelString.slice(slash + 1);
 			const persisted = this.resolveStoreForSession(session.id).get(session.id);
-			const requestedThinking = isKnownThinkingLevel(session.spawnPinnedThinkingLevel)
+			const requestedThinking = explicitPreferredThinking
+				?? isKnownThinkingLevel(session.spawnPinnedThinkingLevel)
 				?? isKnownThinkingLevel(this.resolveRoleThinkingLevel(session))
 				?? isKnownThinkingLevel(persisted?.effectiveThinkingLevel)
 				?? isKnownThinkingLevel(this.preferencesStore?.get("default.sessionThinkingLevel") as string | undefined)
@@ -9082,7 +9089,13 @@ export class SessionManager {
 						await applyModelString(session.rpcClient, currentFallbackSessionModel, {
 							contextLabel: "default.sessionModel fallback",
 						});
-						await commitExactSpawnTuple(currentFallbackSessionModel);
+						// A staged assignRole pin already carries thinking clamped for the
+						// failed role model. Re-clamp the raw explicit role request against
+						// the fallback that actually won; restore/respawn pins remain durable-first.
+						const explicitRoleFallbackThinking = Reflect.get(session, "_deferVerifiedTupleCommit") === true
+							? isKnownThinkingLevel(this.resolveRoleThinkingLevel(session))
+							: undefined;
+						await commitExactSpawnTuple(currentFallbackSessionModel, explicitRoleFallbackThinking);
 						console.log(`[session-manager] Controlled fallback selected default.sessionModel "${currentFallbackSessionModel}" for session ${session.id} after spawn-pinned model "${pinnedModel}" failed`);
 						return verifiedSpawnTuple;
 					} catch (fallbackErr) {

--- a/src/server/agent/session-manager.ts
+++ b/src/server/agent/session-manager.ts
@@ -730,6 +730,8 @@ export interface SessionInfo {
 	spawnPinnedModel?: string;
 	/** Thinking level passed via `--thinking` at spawn time, if any. */
 	spawnPinnedThinkingLevel?: string;
+	/** Staged role candidates verify without advancing shared durable/client authority. */
+	_deferVerifiedTupleCommit?: boolean;
 	/** True if the last agent turn ended due to a model/API error */
 	lastTurnErrored?: boolean;
 	/** Error message from the last errored turn (e.g. streaming JSON parse failure) */
@@ -889,6 +891,10 @@ type VerifiedSessionModelTuple = {
 	modelId: string;
 	thinkingLevel: ThinkingLevel;
 };
+
+type SetupInitialThinkingAuthority = Readonly<{
+	initialThinkingLevel: ThinkingLevel;
+}>;
 
 // `spliceInFlightMessage` lives in its own module so unit tests can import
 // it without dragging in the full session-manager module graph (which
@@ -1899,6 +1905,12 @@ export class SessionManager {
 	 * `promptOwner` until the final replacement commits or rolls back.
 	 */
 	private _sessionReplacementCoordinators = new Map<string, SessionReplacementCoordinator>();
+	/**
+	 * Raw explicit/inherited thinking requests retained only while initial setup is
+	 * verifying its spawn tuple. The provisional spawn pin may already have been
+	 * clamped for a model that controlled fallback later replaces.
+	 */
+	private _setupInitialThinkingAuthorities = new Map<string, SetupInitialThinkingAuthority>();
 	/** User-driven orphan-history recoveries include their redrive so duplicate Retry clicks join instead of dispatching twice. */
 	private _poisonedHistoryRecoveries = new Map<string, Promise<void>>();
 	/** Latest lifecycle generation for each session; stale SessionInfo writers must no-op when behind this value. */
@@ -1916,6 +1928,18 @@ export class SessionManager {
 	/** Clear auto-selection discovery state after configure, refresh, or removal. */
 	invalidateAigwModelCache(): void {
 		this._aigwModelCache = null;
+	}
+
+	private retainSetupInitialThinkingAuthority(sessionId: string, rawInitialThinkingLevel: string | undefined): () => void {
+		const initialThinkingLevel = isKnownThinkingLevel(rawInitialThinkingLevel);
+		if (!initialThinkingLevel) return () => {};
+		const authority: SetupInitialThinkingAuthority = { initialThinkingLevel };
+		this._setupInitialThinkingAuthorities.set(sessionId, authority);
+		return () => {
+			if (this._setupInitialThinkingAuthorities.get(sessionId) === authority) {
+				this._setupInitialThinkingAuthorities.delete(sessionId);
+			}
+		};
 	}
 
 	private _idleWaiters = new Map<string, Set<IdleWaiter>>();
@@ -8085,6 +8109,10 @@ export class SessionManager {
 			// and let setup complete in the background. Continue-Archived opts in to
 			// awaiting setup so fresh worktree/base-ref failures are returned by the POST
 			// instead of surfacing later as an asynchronously archived session.
+			const releaseSetupThinkingAuthority = this.retainSetupInitialThinkingAuthority(
+				id,
+				opts?.initialThinkingLevel,
+			);
 			const setupPromise = executeWorktreeAsync(plan, session, ctx, claimed?.worktreePath).then(() => {
 				// agentSessionFile is now persisted synchronously by spawnAgent before
 				// status flips to idle (see session-setup.ts). The post-resolve persist
@@ -8096,7 +8124,7 @@ export class SessionManager {
 				session.pendingMetadataPersist = this.persistSessionMetadata(session).catch((err) => {
 					console.warn(`[session-manager] Early persist failed for worktree session ${session.id}:`, err);
 				}).finally(() => { session.pendingMetadataPersist = undefined; });
-			});
+			}).finally(releaseSetupThinkingAuthority);
 
 			if (opts?.awaitWorktreeSetup) {
 				try {
@@ -8165,26 +8193,34 @@ export class SessionManager {
 			bridgeOptions: { cwd },
 		};
 
-		const session = await executePlan(plan, ctx);
-		if (projectId) session.projectId = projectId;
-		// Verification/reviewer sessions deliberately skip the ordinary post-spawn
-		// selectors because their tuple was pinned in argv. They still need the same
-		// exact read-back and one atomic durable tuple commit before create returns.
-		if (opts?.skipAutoModel && opts.skipAutoThinking && selectedSpawnModel) {
-			await this.tryAutoSelectModel(session);
-		}
-		this.notifySessionCreated(session);
+		const releaseSetupThinkingAuthority = this.retainSetupInitialThinkingAuthority(
+			id,
+			opts?.initialThinkingLevel,
+		);
+		try {
+			const session = await executePlan(plan, ctx);
+			if (projectId) session.projectId = projectId;
+			// Verification/reviewer sessions deliberately skip the ordinary post-spawn
+			// selectors because their tuple was pinned in argv. They still need the same
+			// exact read-back and one atomic durable tuple commit before create returns.
+			if (opts?.skipAutoModel && opts.skipAutoThinking && selectedSpawnModel) {
+				await this.tryAutoSelectModel(session);
+			}
+			this.notifySessionCreated(session);
 
-		// Persist session metadata (fire-and-forget, but tracked for terminate).
-		// Rehydrated sessions already have a cloned/adopted transcript path recorded;
-		// avoid a redundant get_state that can rewrite runtime-only metadata.
-		if (!plan.preExistingAgentSessionFile) {
-			session.pendingMetadataPersist = this.persistSessionMetadata(session).catch((err) => {
-				console.warn(`[session-manager] Early persist failed for ${session.id}:`, err);
-			}).finally(() => { session.pendingMetadataPersist = undefined; });
-		}
+			// Persist session metadata (fire-and-forget, but tracked for terminate).
+			// Rehydrated sessions already have a cloned/adopted transcript path recorded;
+			// avoid a redundant get_state that can rewrite runtime-only metadata.
+			if (!plan.preExistingAgentSessionFile) {
+				session.pendingMetadataPersist = this.persistSessionMetadata(session).catch((err) => {
+					console.warn(`[session-manager] Early persist failed for ${session.id}:`, err);
+				}).finally(() => { session.pendingMetadataPersist = undefined; });
+			}
 
-		return session;
+			return session;
+		} finally {
+			releaseSetupThinkingAuthority();
+		}
 	}
 
 	/**
@@ -8389,7 +8425,16 @@ export class SessionManager {
 			bridgeOptions: { cwd: opts.cwd },
 		};
 
-		const session = await executePlan(plan, ctx);
+		const releaseSetupThinkingAuthority = this.retainSetupInitialThinkingAuthority(
+			plan.id,
+			delegateThinkingCandidate,
+		);
+		let session: SessionInfo;
+		try {
+			session = await executePlan(plan, ctx);
+		} finally {
+			releaseSetupThinkingAuthority();
+		}
 		if (parentProjectId) session.projectId = parentProjectId;
 		// Persist the effective-goal stamp on BOTH the live session and the store
 		// record so it survives restart/respawn (the initial structural put happens
@@ -9032,7 +9077,7 @@ export class SessionManager {
 			const tuple = { provider, modelId, thinkingLevel: effectiveThinking };
 			// Staged role candidates verify against Pi through the ordinary helper but
 			// cannot advance shared authority until their lifecycle commit wins.
-			if (Reflect.get(session, "_deferVerifiedTupleCommit") !== true) {
+			if (session._deferVerifiedTupleCommit !== true) {
 				this.persistSessionModel(session.id, provider, modelId, effectiveThinking);
 				this._writeModelNameFile(session.id, modelString);
 				broadcast(session.clients, {
@@ -9053,15 +9098,27 @@ export class SessionManager {
 			const durableThinking = persisted?.modelProvider && persisted?.modelId
 				? isKnownThinkingLevel(persisted.effectiveThinkingLevel)
 				: undefined;
+			const explicitInitialThinking = this._setupInitialThinkingAuthorities.get(
+				session.id,
+			)?.initialThinkingLevel;
 			const defaultThinking = isKnownThinkingLevel(
 				this.preferencesStore?.get("default.sessionThinkingLevel") as string | undefined,
 			);
 			const provisionalThinking = isKnownThinkingLevel(session.spawnPinnedThinkingLevel);
-			if (Reflect.get(session, "_deferVerifiedTupleCommit") === true) {
-				return roleThinking ?? durableThinking ?? defaultThinking ?? provisionalThinking ?? "medium";
+			if (session._deferVerifiedTupleCommit === true) {
+				return roleThinking
+					?? durableThinking
+					?? explicitInitialThinking
+					?? defaultThinking
+					?? provisionalThinking
+					?? "medium";
 			}
-			if (durableThinking) return durableThinking;
-			return roleThinking ?? defaultThinking ?? provisionalThinking ?? "medium";
+			return durableThinking
+				?? roleThinking
+				?? explicitInitialThinking
+				?? defaultThinking
+				?? provisionalThinking
+				?? "medium";
 		};
 
 		// Spawn-pinned models are explicit selections too (restore/respawn persisted
@@ -9324,7 +9381,7 @@ export class SessionManager {
 			if (verifiedProvider !== provider || verifiedModelId !== modelId || verifiedThinking !== effective) {
 				throw new Error(`thinking selection read-back mismatch for ${provider}/${modelId}`);
 			}
-			if (Reflect.get(session, "_deferVerifiedTupleCommit") !== true) {
+			if (session._deferVerifiedTupleCommit !== true) {
 				this.persistSessionModel(session.id, provider, modelId, effective);
 			}
 			session.spawnPinnedModel = `${provider}/${modelId}`;

--- a/src/server/agent/session-manager.ts
+++ b/src/server/agent/session-manager.ts
@@ -7516,12 +7516,23 @@ export class SessionManager {
 		// model/thinking tuple below. tryAutoSelectModel owns the single atomic
 		// durable commit, so any failed start, switch, or read-back retains the
 		// original verified tuple byte-for-byte.
-		const initThinking = await this.resolveCurrentCatalogThinkingLevel(
-			bridgeOptions.initialModel,
-			ps.role,
-			ps.projectId,
-			ps.effectiveThinkingLevel,
+		const restoreHasDurableTuple = !!(
+			psPersistedModel
+			&& isKnownThinkingLevel(ps.effectiveThinkingLevel)
 		);
+		const initThinking = restoreHasDurableTuple
+			? await this.resolveCurrentCatalogPreferredThinkingLevel(
+				bridgeOptions.initialModel,
+				ps.role,
+				ps.projectId,
+				ps.effectiveThinkingLevel,
+			)
+			: await this.resolveCurrentCatalogThinkingLevel(
+				bridgeOptions.initialModel,
+				ps.role,
+				ps.projectId,
+				ps.effectiveThinkingLevel,
+			);
 		if (initThinking) bridgeOptions.initialThinkingLevel = initThinking;
 		const restoreSpawnProvider = bridgeOptions.initialModel?.slice(0, bridgeOptions.initialModel.indexOf("/"));
 		this.applyDirectProviderEnv(bridgeOptions, !!ps.sandboxed, restoreSpawnProvider);
@@ -8821,11 +8832,14 @@ export class SessionManager {
 		projectId: string | undefined,
 		preferred?: string,
 		catalogModel?: Awaited<ReturnType<typeof getAvailableModels>>[number],
+		preferPreferred = false,
 	): ThinkingLevel | undefined {
-		let candidate = role
+		const preferredCandidate = isKnownThinkingLevel(preferred);
+		const roleCandidate = role
 			? isKnownThinkingLevel(this.resolveRoleThinkingLevelValue(role, projectId))
 			: undefined;
-		if (!candidate) candidate = isKnownThinkingLevel(preferred);
+		let candidate = preferPreferred ? preferredCandidate : roleCandidate;
+		if (!candidate) candidate = preferPreferred ? roleCandidate : preferredCandidate;
 		if (!candidate) {
 			candidate = isKnownThinkingLevel(
 				this.preferencesStore?.get("default.sessionThinkingLevel") as string | undefined,
@@ -8851,14 +8865,15 @@ export class SessionManager {
 		preferred?: string,
 		models?: Awaited<ReturnType<typeof getAvailableModels>>,
 		allowUnlistedRawModel = false,
+		preferPreferred = false,
 	): Promise<ThinkingLevel | undefined> {
 		if (!model || !this.preferencesStore) {
-			return this.resolveThinkingLevelForModel(model, role, projectId, preferred);
+			return this.resolveThinkingLevelForModel(model, role, projectId, preferred, undefined, preferPreferred);
 		}
 		const normalized = normalizeAigwModelString(model);
 		const slash = normalized.indexOf("/");
 		if (slash <= 0 || slash === normalized.length - 1) {
-			return this.resolveThinkingLevelForModel(normalized, role, projectId, preferred);
+			return this.resolveThinkingLevelForModel(normalized, role, projectId, preferred, undefined, preferPreferred);
 		}
 		const currentModels = models ?? await getAvailableModels(this.preferencesStore);
 		const catalogModel = findSessionSelectableModel(
@@ -8868,11 +8883,29 @@ export class SessionManager {
 		);
 		if (!catalogModel) {
 			if (allowUnlistedRawModel) {
-				return this.resolveThinkingLevelForModel(normalized, role, projectId, preferred);
+				return this.resolveThinkingLevelForModel(normalized, role, projectId, preferred, undefined, preferPreferred);
 			}
 			throw new Error(`Model "${normalized}" is not currently available for session selection`);
 		}
-		return this.resolveThinkingLevelForModel(normalized, role, projectId, preferred, catalogModel);
+		return this.resolveThinkingLevelForModel(normalized, role, projectId, preferred, catalogModel, preferPreferred);
+	}
+
+	/** Preserve an already-chosen explicit/durable candidate ahead of role defaults. */
+	private resolveCurrentCatalogPreferredThinkingLevel(
+		model: string | undefined,
+		role: string | undefined,
+		projectId: string | undefined,
+		preferred: string | undefined,
+	): Promise<ThinkingLevel | undefined> {
+		return this.resolveCurrentCatalogThinkingLevel(
+			model,
+			role,
+			projectId,
+			preferred,
+			undefined,
+			false,
+			true,
+		);
 	}
 
 	/**
@@ -8931,7 +8964,7 @@ export class SessionManager {
 				?? isKnownThinkingLevel(persisted?.effectiveThinkingLevel)
 				?? isKnownThinkingLevel(this.preferencesStore?.get("default.sessionThinkingLevel") as string | undefined)
 				?? "medium";
-			const effectiveThinking = await this.resolveCurrentCatalogThinkingLevel(
+			const effectiveThinking = await this.resolveCurrentCatalogPreferredThinkingLevel(
 				modelString,
 				session.role,
 				session.projectId,
@@ -12361,15 +12394,23 @@ export class SessionManager {
 					forceInitialModel,
 					forceDefaultModel,
 				]);
-			const forceRoleThinkingOverride = isKnownThinkingLevel(
-				this.resolveRoleThinkingLevelValue(session.role, session.projectId),
+			const forceRespawnHasDurableTuple = !!(
+				forceRespawnPersistedModel
+				&& isKnownThinkingLevel(forceRespawnPersisted?.effectiveThinkingLevel)
 			);
-			const initThinking = await this.resolveCurrentCatalogThinkingLevel(
-				bridgeOptions.initialModel,
-				session.role,
-				session.projectId,
-				forceRoleThinkingOverride ?? forceRespawnPersisted?.effectiveThinkingLevel,
-			);
+			const initThinking = forceRespawnHasDurableTuple
+				? await this.resolveCurrentCatalogPreferredThinkingLevel(
+					bridgeOptions.initialModel,
+					session.role,
+					session.projectId,
+					forceRespawnPersisted?.effectiveThinkingLevel,
+				)
+				: await this.resolveCurrentCatalogThinkingLevel(
+					bridgeOptions.initialModel,
+					session.role,
+					session.projectId,
+					forceRespawnPersisted?.effectiveThinkingLevel,
+				);
 			if (initThinking) bridgeOptions.initialThinkingLevel = initThinking;
 			const forceSpawnProvider = bridgeOptions.initialModel?.slice(0, bridgeOptions.initialModel.indexOf("/"));
 			this.applyDirectProviderEnv(bridgeOptions, !!session.sandboxed, forceSpawnProvider);

--- a/src/server/agent/session-manager.ts
+++ b/src/server/agent/session-manager.ts
@@ -878,6 +878,18 @@ export interface SessionInfo {
 	};
 }
 
+/** Exact canonical bridge identity required by ownership-sensitive respawns. */
+export type SessionBridgeOwner = {
+	session: Pick<SessionInfo, "id" | "rpcClient">;
+	rpcClient: SessionInfo["rpcClient"];
+};
+
+type VerifiedSessionModelTuple = {
+	provider: string;
+	modelId: string;
+	thinkingLevel: ThinkingLevel;
+};
+
 // `spliceInFlightMessage` lives in its own module so unit tests can import
 // it without dragging in the full session-manager module graph (which
 // transitively pulls flexsearch, pi-coding-agent, etc.). Re-exported here
@@ -2654,8 +2666,8 @@ export class SessionManager {
 			trackCostFromEvent: (session, event) => this.trackCostFromEvent(session, event),
 			recordPiExtensionDiagnostic: (session, diagnostic, extension) => this.recordPiExtensionDiagnostic(session, diagnostic, extension),
 			broadcast: (clients, msg) => broadcast(clients, msg),
-			tryAutoSelectModel: (session) => this.tryAutoSelectModel(session),
-			tryApplyDefaultThinkingLevel: (session) => this.tryApplyDefaultThinkingLevel(session),
+			tryAutoSelectModel: async (session) => { await this.tryAutoSelectModel(session); },
+			tryApplyDefaultThinkingLevel: async (session) => { await this.tryApplyDefaultThinkingLevel(session); },
 			buildWorkflowList: (projectId?: string) => this._buildWorkflowList(projectId),
 			resolveInitialModel: (role, projectId) => this.resolveInitialModel(role, projectId),
 			resolveInitialThinkingLevel: (role, projectId) => this.resolveInitialThinkingLevel(role, projectId),
@@ -6561,6 +6573,8 @@ export class SessionManager {
 			preserveSandboxRealm?: boolean;
 			/** Poison redrive must dispatch its superseding intent before parked rows. */
 			deferQueueDrain?: boolean;
+			/** Reject at coordinated admission unless this exact bridge still owns the slot. */
+			expectedOwner?: SessionBridgeOwner;
 		},
 	): Promise<SessionInfo | undefined> {
 		return this._coordinateSessionReplacement(session.id, "respawn", (token) =>
@@ -6580,12 +6594,24 @@ export class SessionManager {
 			finalStatus?: SessionStatus;
 			preserveSandboxRealm?: boolean;
 			deferQueueDrain?: boolean;
+			expectedOwner?: SessionBridgeOwner;
 		} | undefined,
 		token: SessionReplacementToken,
 	): Promise<SessionInfo | undefined> {
 		// A role/restart queued ahead of us may already have replaced the object.
-		// Resolve canonical ownership only when this serialized operation starts.
-		const session = this.sessions.get(id) ?? requestedSession;
+		// Ownership-sensitive recovery must reject at serialized admission instead
+		// of re-resolving and stopping that newer canonical bridge.
+		const canonical = this.sessions.get(id);
+		if (
+			opts?.expectedOwner
+			&& (
+				canonical !== opts.expectedOwner.session
+				|| canonical?.rpcClient !== opts.expectedOwner.rpcClient
+			)
+		) {
+			throw new Error(`Session ${id} respawn expected bridge ownership changed before coordinated admission`);
+		}
+		const session = canonical ?? requestedSession;
 		const ps = this.resolveStoreForId(id)?.get(id) ?? requestedPs;
 		const savedClients = new Set(session.clients);
 		session.unsubscribe();
@@ -6650,7 +6676,7 @@ export class SessionManager {
 	 * Stops any remnant process, then restores from persisted state.
 	 * Re-attaches existing WS clients so the user can keep working.
 	 */
-	async restartAgent(sessionId: string): Promise<void> {
+	async restartAgent(sessionId: string, expectedOwner?: SessionBridgeOwner): Promise<void> {
 		const session = this.sessions.get(sessionId);
 		if (!session) throw new Error("Session not found");
 
@@ -6690,6 +6716,7 @@ export class SessionManager {
 				if (overrideAllowedTools) (p as any)._overrideAllowedTools = overrideAllowedTools;
 				if (overrideGrantedTools) (p as any)._overrideGrantedTools = overrideGrantedTools;
 			},
+			expectedOwner,
 		});
 
 		if (restored) {
@@ -8942,7 +8969,7 @@ export class SessionManager {
 		return undefined;
 	}
 
-	private async tryAutoSelectModel(session: SessionInfo): Promise<void> {
+	private async tryAutoSelectModel(session: SessionInfo): Promise<VerifiedSessionModelTuple | undefined> {
 		// If the agent was spawned with `--model <provider>/<modelId>` already,
 		// skip the redundant `setModel` RPC — read-back verification still runs
 		// and hard-fails on mismatch.
@@ -8954,6 +8981,7 @@ export class SessionManager {
 		// Model verification alone is not a durable commit. A successful model
 		// mutation must also apply and read back the effective thinking level before
 		// any store, model-name mirror, or client success frame is updated.
+		let verifiedSpawnTuple;
 		const commitExactSpawnTuple = async (modelString: string): Promise<void> => {
 			const slash = modelString.indexOf("/");
 			const provider = modelString.slice(0, slash);
@@ -8994,14 +9022,20 @@ export class SessionManager {
 				throw new Error(`spawn tuple read-back mismatch for ${modelString}`);
 			}
 
-			this.persistSessionModel(session.id, provider, modelId, effectiveThinking);
-			this._writeModelNameFile(session.id, modelString);
+			const tuple = { provider, modelId, thinkingLevel: effectiveThinking };
+			// Staged role candidates verify against Pi through the ordinary helper but
+			// cannot advance shared authority until their lifecycle commit wins.
+			if (Reflect.get(session, "_deferVerifiedTupleCommit") !== true) {
+				this.persistSessionModel(session.id, provider, modelId, effectiveThinking);
+				this._writeModelNameFile(session.id, modelString);
+				broadcast(session.clients, {
+					type: "state",
+					data: { ...buildModelStateData(provider, modelId), thinkingLevel: effectiveThinking },
+				});
+			}
 			session.spawnPinnedModel = modelString;
 			session.spawnPinnedThinkingLevel = effectiveThinking;
-			broadcast(session.clients, {
-				type: "state",
-				data: { ...buildModelStateData(provider, modelId), thinkingLevel: effectiveThinking },
-			});
+			verifiedSpawnTuple = tuple;
 		};
 
 		// Spawn-pinned models are explicit selections too (restore/respawn persisted
@@ -9024,7 +9058,7 @@ export class SessionManager {
 					});
 					await commitExactSpawnTuple(pinnedModel);
 					if (process.env.BOBBIT_DEBUG) console.log(`[session-manager] Verified spawn-pinned model "${pinnedModel}" for session ${session.id}`);
-					return;
+					return verifiedSpawnTuple;
 				} catch (err) {
 					pinnedModelError = err;
 				}
@@ -9050,7 +9084,7 @@ export class SessionManager {
 						});
 						await commitExactSpawnTuple(currentFallbackSessionModel);
 						console.log(`[session-manager] Controlled fallback selected default.sessionModel "${currentFallbackSessionModel}" for session ${session.id} after spawn-pinned model "${pinnedModel}" failed`);
-						return;
+						return verifiedSpawnTuple;
 					} catch (fallbackErr) {
 						controlledFallbackError = fallbackErr;
 					}
@@ -9082,7 +9116,7 @@ export class SessionManager {
 					});
 					await commitExactSpawnTuple(roleModel);
 					console.log(`[session-manager] Set role-override model "${roleModel}" for session ${session.id} (role=${session.role})`);
-					return;
+					return verifiedSpawnTuple;
 				} catch (err) {
 					roleModelError = err;
 				}
@@ -9109,7 +9143,7 @@ export class SessionManager {
 						});
 						await commitExactSpawnTuple(currentFallbackSessionModel);
 						console.log(`[session-manager] Controlled fallback selected default.sessionModel "${currentFallbackSessionModel}" for session ${session.id} after role model "${roleModel}" failed`);
-						return;
+						return verifiedSpawnTuple;
 					} catch (fallbackErr) {
 						controlledFallbackError = fallbackErr;
 					}
@@ -9147,7 +9181,7 @@ export class SessionManager {
 				});
 				await commitExactSpawnTuple(sessionModelPref);
 				if (process.env.BOBBIT_DEBUG) console.log(`[session-manager] Set preferred model "${sessionModelPref}" for session ${session.id}${preSpawnPinned ? " (spawn-pinned)" : ""}`);
-				return;
+				return verifiedSpawnTuple;
 			} catch (err) {
 				console.error(`[session-manager] default.sessionModel "${safeSessionModelPref}" failed for ${session.id}; controlled fallback is not eligible for the default session model: ${sanitizeModelErrorForLog(err)}`);
 				throw (err instanceof Error && err.message === sanitizeModelErrorText(err)) ? err : new Error(sanitizeModelErrorText(err));
@@ -9185,10 +9219,11 @@ export class SessionManager {
 		}
 		await commitExactSpawnTuple(aigwModel);
 		console.log(`[session-manager] Auto-selected aigw model "${modelToUse.id}" for session ${session.id}`);
+		return verifiedSpawnTuple;
 	}
 
 	/** Apply, read back, and atomically persist thinking with the exact live model. */
-	private async tryApplyDefaultThinkingLevel(session: SessionInfo): Promise<void> {
+	private async tryApplyDefaultThinkingLevel(session: SessionInfo): Promise<VerifiedSessionModelTuple> {
 		const persisted = this.resolveStoreForSession(session.id).get(session.id);
 		const spawnPinnedThinking = isKnownThinkingLevel(session.spawnPinnedThinkingLevel);
 		const spawnPinnedModel = session.spawnPinnedModel
@@ -9206,7 +9241,11 @@ export class SessionManager {
 			&& persisted?.modelId === spawnPinnedModel.slice(spawnModelSlash + 1)
 			&& persisted?.effectiveThinkingLevel === spawnPinnedThinking
 		) {
-			return;
+			return {
+				provider: spawnPinnedModel.slice(0, spawnModelSlash),
+				modelId: spawnPinnedModel.slice(spawnModelSlash + 1),
+				thinkingLevel: spawnPinnedThinking,
+			};
 		}
 		const roleThinking = isKnownThinkingLevel(this.resolveRoleThinkingLevel(session));
 		const durableThinking = isKnownThinkingLevel(persisted?.effectiveThinkingLevel);
@@ -9215,7 +9254,7 @@ export class SessionManager {
 		);
 		const requested = spawnPinnedThinking ?? roleThinking ?? durableThinking ?? preferenceThinking ?? "medium";
 
-		const applyAndVerify = async (candidate: ThinkingLevel): Promise<ThinkingLevel> => {
+		const applyAndVerify = async (candidate: ThinkingLevel): Promise<VerifiedSessionModelTuple> => {
 			const beforeResp = await session.rpcClient.getState();
 			if (beforeResp?.success === false) throw new Error("get_state failed before thinking selection");
 			const before = beforeResp?.data ?? beforeResp;
@@ -9237,7 +9276,7 @@ export class SessionManager {
 				&& persisted?.effectiveThinkingLevel === effective
 				&& isKnownThinkingLevel(before?.thinkingLevel) === effective
 			) {
-				return effective;
+				return { provider, modelId, thinkingLevel: effective };
 			}
 			if (before?.thinkingLevel !== effective) {
 				const setResp = await session.rpcClient.setThinkingLevel(effective);
@@ -9253,14 +9292,19 @@ export class SessionManager {
 			if (verifiedProvider !== provider || verifiedModelId !== modelId || verifiedThinking !== effective) {
 				throw new Error(`thinking selection read-back mismatch for ${provider}/${modelId}`);
 			}
-			this.persistSessionModel(session.id, provider, modelId, effective);
-			return effective;
+			if (Reflect.get(session, "_deferVerifiedTupleCommit") !== true) {
+				this.persistSessionModel(session.id, provider, modelId, effective);
+			}
+			session.spawnPinnedModel = `${provider}/${modelId}`;
+			session.spawnPinnedThinkingLevel = effective;
+			return { provider, modelId, thinkingLevel: effective };
 		};
 
-		const effective = await applyAndVerify(requested);
+		const verifiedTuple = await applyAndVerify(requested);
 		if (process.env.BOBBIT_DEBUG) {
-			console.log(`[session-manager] Verified effective thinking level "${effective}" for session ${session.id}`);
+			console.log(`[session-manager] Verified effective thinking level "${verifiedTuple.thinkingLevel}" for session ${session.id}`);
 		}
+		return verifiedTuple;
 	}
 
 	async persistSessionMetadata(session: SessionInfo): Promise<void> {
@@ -9803,43 +9847,6 @@ export class SessionManager {
 		// start from the durable value and replace it only with a non-empty live one.
 		const roleStore = this.resolveStoreForSession(id);
 		const persistedBeforeRole = roleStore.get(id);
-		const durableTupleBeforeRole = {
-			modelProvider: persistedBeforeRole?.modelProvider,
-			modelId: persistedBeforeRole?.modelId,
-			effectiveThinkingLevel: persistedBeforeRole?.effectiveThinkingLevel,
-		};
-		const durableModelBeforeRole = durableTupleBeforeRole.modelProvider && durableTupleBeforeRole.modelId
-			? `${durableTupleBeforeRole.modelProvider}/${durableTupleBeforeRole.modelId}`
-			: undefined;
-		const restoreDurableTupleBeforeRole = (): void => {
-			// Runtime selection may verify and commit a newer tuple on the still-live
-			// original bridge while this replacement is staged. Its canonical spawn
-			// mirrors and the authoritative store advance together. Preserve that tuple
-			// instead of replaying this operation's stale snapshot; staged verification
-			// writes do not advance the original mirrors and still roll back normally.
-			const currentDurable = roleStore.get(id);
-			const currentModel = session.spawnPinnedModel;
-			const slash = currentModel?.indexOf("/") ?? -1;
-			const currentThinking = isKnownThinkingLevel(session.spawnPinnedThinkingLevel);
-			const canonicalTupleIsDurable = slash > 0
-				&& slash < (currentModel?.length ?? 0) - 1
-				&& !!currentThinking
-				&& currentDurable?.modelProvider === currentModel?.slice(0, slash)
-				&& currentDurable?.modelId === currentModel?.slice(slash + 1)
-				&& currentDurable?.effectiveThinkingLevel === currentThinking;
-			const durableTupleToRestore = canonicalTupleIsDurable
-				? {
-					modelProvider: currentDurable?.modelProvider,
-					modelId: currentDurable?.modelId,
-					effectiveThinkingLevel: currentThinking,
-				}
-				: durableTupleBeforeRole;
-			roleStore.update(id, durableTupleToRestore);
-			const durableModelToRestore = durableTupleToRestore.modelProvider && durableTupleToRestore.modelId
-				? `${durableTupleToRestore.modelProvider}/${durableTupleToRestore.modelId}`
-				: durableModelBeforeRole;
-			if (durableModelToRestore) this._writeModelNameFile(id, durableModelToRestore);
-		};
 		let agentSessionFile = persistedBeforeRole?.agentSessionFile;
 		try {
 			const stateResp = await session.rpcClient.getState();
@@ -10024,7 +10031,9 @@ export class SessionManager {
 			role: role.name,
 			accessory: role.accessory,
 			allowedTools: effectiveAllowedNames,
-			// Model verification must not broadcast replacement state before commit.
+			// Model verification must not mutate durable/model-name/client authority
+			// before this candidate wins the lifecycle commit.
+			_deferVerifiedTupleCommit: true,
 			clients: new Set<WebSocket>(),
 		} as SessionInfo;
 
@@ -10036,31 +10045,17 @@ export class SessionManager {
 				}
 				await this.switchSessionForRehydration(rpcClient, rolePs, agentSessionFile);
 			}
-			await this.tryAutoSelectModel(stagedSession);
-			let replacementTupleVerified = true;
+			verifiedReplacementTuple = await this.tryAutoSelectModel(stagedSession);
 			try {
-				await this.tryApplyDefaultThinkingLevel(stagedSession);
+				verifiedReplacementTuple = await this.tryApplyDefaultThinkingLevel(stagedSession);
 			} catch (err) {
 				if (respawnPersisted?.effectiveThinkingLevel !== undefined) throw err;
-				replacementTupleVerified = false;
+				verifiedReplacementTuple = undefined;
 				console.warn(`[session-manager] Legacy session ${id} could not verify effective thinking during role replacement:`, err);
 			}
-			if (replacementTupleVerified) {
-				const verifiedPersisted = roleStore.get(id);
-				const verifiedThinking = isKnownThinkingLevel(verifiedPersisted?.effectiveThinkingLevel);
-				if (!verifiedPersisted?.modelProvider || !verifiedPersisted.modelId || !verifiedThinking) {
-					throw new Error(`Cannot assign role for session ${id}: replacement model tuple was not durably verified`);
-				}
-				verifiedReplacementTuple = {
-					provider: verifiedPersisted.modelProvider,
-					modelId: verifiedPersisted.modelId,
-					thinkingLevel: verifiedThinking,
-				};
+			if (respawnPersisted?.effectiveThinkingLevel !== undefined && !verifiedReplacementTuple) {
+				throw new Error(`Cannot assign role for session ${id}: replacement model tuple was not verified`);
 			}
-			// Model/thinking setup reuses the ordinary verification helpers, which
-			// persist as they complete. Keep the old tuple authoritative until this
-			// staged bridge wins the lifecycle commit below.
-			restoreDurableTupleBeforeRole();
 
 			// Another lifecycle replacement may have won while this bridge was being
 			// prepared. Never stop or overwrite that newer canonical session; the catch
@@ -10087,7 +10082,6 @@ export class SessionManager {
 				throw new Error(`Session ${id} role replacement was superseded after old bridge stop`);
 			}
 		} catch (err) {
-			restoreDurableTupleBeforeRole();
 			unsub();
 			await rpcClient.stop().catch(() => {});
 			// If terminal cancellation landed during the irreversible old stop, both
@@ -10104,6 +10098,10 @@ export class SessionManager {
 		session.unsubscribe = unsub;
 		session.spawnPinnedModel = bridgeOptions.initialModel;
 		session.spawnPinnedThinkingLevel = bridgeOptions.initialThinkingLevel;
+		if (verifiedReplacementTuple) {
+			session.spawnPinnedModel = `${verifiedReplacementTuple.provider}/${verifiedReplacementTuple.modelId}`;
+			session.spawnPinnedThinkingLevel = verifiedReplacementTuple.thinkingLevel;
+		}
 		session.role = role.name;
 		session.accessory = role.accessory;
 		session.allowedTools = effectiveAllowedNames;

--- a/src/server/agent/session-manager.ts
+++ b/src/server/agent/session-manager.ts
@@ -6599,6 +6599,8 @@ export class SessionManager {
 			deferQueueDrain?: boolean;
 			/** Reject at coordinated admission unless this exact bridge still owns the slot. */
 			expectedOwner?: SessionBridgeOwner;
+			/** Apply restartAgent's persisted zombie guard only after serialized ownership admission. */
+			restartZombieGuard?: boolean;
 		},
 	): Promise<SessionInfo | undefined> {
 		return this._coordinateSessionReplacement(session.id, "respawn", (token) =>
@@ -6622,6 +6624,7 @@ export class SessionManager {
 			preserveSandboxRealm?: boolean;
 			deferQueueDrain?: boolean;
 			expectedOwner?: SessionBridgeOwner;
+			restartZombieGuard?: boolean;
 		} | undefined,
 		token: SessionReplacementToken,
 	): Promise<SessionInfo | undefined> {
@@ -6639,7 +6642,9 @@ export class SessionManager {
 			throw new Error(`Session ${id} respawn expected bridge ownership changed before coordinated admission`);
 		}
 		const session = canonical ?? requestedSession;
-		const ps = this.resolveStoreForId(id)?.get(id) ?? requestedPs;
+		const ps = opts?.restartZombieGuard
+			? this._admitRestartPersistedSession(id)
+			: this.resolveStoreForId(id)?.get(id) ?? requestedPs;
 		const savedClients = new Set(session.clients);
 		session.unsubscribe();
 		const frameOfRef = this._snapshotStreamingFrameOfReference(session);
@@ -6699,6 +6704,36 @@ export class SessionManager {
 	}
 
 	/**
+	 * Read and admit restartAgent's canonical durable row while the replacement
+	 * coordinator owns the session. Owner-sensitive callers reach this only after
+	 * their exact bridge has passed admission, so a stale recovery cannot archive
+	 * a row that an earlier replacement has already advanced.
+	 */
+	private _admitRestartPersistedSession(id: string): PersistedSession {
+		const store = this.resolveStoreForId(id);
+		if (!store) throw new Error("No persisted session data");
+		const ps = store.get(id);
+		if (!ps) throw new Error("No persisted session data");
+		if (ps.agentSessionFile || ps.role) return ps;
+
+		console.warn(
+			`[session-manager] Session ${id} is an unrecoverable zombie ` +
+			`(no agentSessionFile, no role) — archiving instead of restarting.`,
+		);
+		try {
+			store.update(id, { archived: true, archivedAt: this.clock.now() });
+		} catch (err) {
+			console.error(`[session-manager] Failed to archive zombie session ${id}:`, err);
+		}
+		const zombieErr: Error & { code?: string } = new Error(
+			`Session ${id} could not be restarted — neither an agent session file nor ` +
+			`a role was persisted. The session has been archived; create a fresh session to continue.`,
+		);
+		zombieErr.code = "SESSION_UNRECOVERABLE_ARCHIVED";
+		throw zombieErr;
+	}
+
+	/**
 	 * Restart the agent process for a session whose process has died.
 	 * Stops any remnant process, then restores from persisted state.
 	 * Re-attaches existing WS clients so the user can keep working.
@@ -6709,27 +6744,6 @@ export class SessionManager {
 
 		const ps = this.resolveStoreForSession(session.id).get(session.id);
 		if (!ps) throw new Error("No persisted session data");
-
-		// Zombie-archive guard: a record with neither an agent session file nor a role
-		// can't be bootstrapped by `_respawnAgentInPlace`. Archive it surface-side
-		// instead of throwing opaquely on every Restart click.
-		if (!ps.agentSessionFile && !ps.role) {
-			console.warn(
-				`[session-manager] Session ${sessionId} is an unrecoverable zombie ` +
-				`(no agentSessionFile, no role) — archiving instead of restarting.`,
-			);
-			try {
-				this.resolveStoreForSession(sessionId).update(sessionId, { archived: true, archivedAt: this.clock.now() });
-			} catch (err) {
-				console.error(`[session-manager] Failed to archive zombie session ${sessionId}:`, err);
-			}
-			const zombieErr: Error & { code?: string } = new Error(
-				`Session ${sessionId} could not be restarted — neither an agent session file nor ` +
-				`a role was persisted. The session has been archived; create a fresh session to continue.`,
-			);
-			zombieErr.code = "SESSION_UNRECOVERABLE_ARCHIVED";
-			throw zombieErr;
-		}
 
 		const savedSessionOnlyGrantedTools = session.sessionOnlyGrantedTools ? [...session.sessionOnlyGrantedTools] : undefined;
 		const savedOneTimeGrantedTools = session.oneTimeGrantedTools ? [...session.oneTimeGrantedTools] : undefined;
@@ -6744,6 +6758,7 @@ export class SessionManager {
 				if (overrideGrantedTools) (p as any)._overrideGrantedTools = overrideGrantedTools;
 			},
 			expectedOwner,
+			restartZombieGuard: true,
 		});
 
 		if (restored) {

--- a/src/server/ws/handler.ts
+++ b/src/server/ws/handler.ts
@@ -176,10 +176,9 @@ function sendStateWithCost(ws: WebSocket, sessionManager: SessionManager, sessio
 
 /**
  * Dispatch a successful live getState snapshot without splitting the durable
- * model/thinking tuple. Older/incomplete bridges can omit thinkingLevel even
- * when the verified durable tuple has one. Reuse it only when the live model
- * exactly matches; otherwise prefer the complete persisted fallback rather
- * than grafting durable thinking onto a different live model.
+ * model/thinking tuple. A complete durable tuple remains authoritative while a
+ * runtime mutation is in flight: live model metadata is reusable only when the
+ * raw live provider, model, and thinking level all match durability exactly.
  */
 function sendLiveStateSnapshot(
 	ws: WebSocket,
@@ -187,11 +186,31 @@ function sendLiveStateSnapshot(
 	sessionId: string,
 	data: Record<string, unknown>,
 ): void {
-	const hadLiveModel = !!data.model && typeof data.model === "object";
+	const liveModel = data.model && typeof data.model === "object"
+		? data.model as Record<string, unknown>
+		: undefined;
+	const hadLiveModel = liveModel !== undefined;
 	let normalized = normalizeStateModelSnapshot(data, sessionManager, sessionId);
 	const model = normalized.model as Record<string, unknown> | undefined;
 	const persisted = sessionManager.getPersistedSession(sessionId);
-	if (model && normalized.thinkingLevel === undefined && persisted?.effectiveThinkingLevel !== undefined) {
+	const durableProvider = persisted?.modelProvider;
+	const durableModelId = persisted?.modelId;
+	const durableThinkingLevel = persisted?.effectiveThinkingLevel;
+	let rebuiltFromDurableTuple = false;
+
+	if (durableProvider && durableModelId && durableThinkingLevel !== undefined) {
+		const liveMatchesDurableTuple = liveModel?.provider === durableProvider
+			&& liveModel?.id === durableModelId
+			&& data.thinkingLevel === durableThinkingLevel;
+		if (!liveMatchesDurableTuple) {
+			normalized = {
+				...normalized,
+				model: buildResolvedModelStateModel(durableProvider, durableModelId),
+				thinkingLevel: durableThinkingLevel,
+			};
+			rebuiltFromDurableTuple = true;
+		}
+	} else if (model && normalized.thinkingLevel === undefined && persisted?.effectiveThinkingLevel !== undefined) {
 		const matchesDurableModel = model.provider === persisted.modelProvider && model.id === persisted.modelId;
 		if (!matchesDurableModel) {
 			sendFallbackModelState(ws, sessionManager, sessionId);
@@ -202,7 +221,7 @@ function sendLiveStateSnapshot(
 
 	sendStateWithCost(ws, sessionManager, sessionId, normalized);
 	sendImageModelState(ws, sessionManager, sessionId);
-	if (!hadLiveModel) sendFallbackModelState(ws, sessionManager, sessionId);
+	if (!hadLiveModel && !rebuiltFromDurableTuple) sendFallbackModelState(ws, sessionManager, sessionId);
 }
 
 function sendSessionCostUpdate(ws: WebSocket, sessionManager: SessionManager, sessionId: string): void {

--- a/src/server/ws/handler.ts
+++ b/src/server/ws/handler.ts
@@ -177,8 +177,8 @@ function sendStateWithCost(ws: WebSocket, sessionManager: SessionManager, sessio
 /**
  * Dispatch a successful live getState snapshot without splitting the durable
  * model/thinking tuple. A complete durable tuple remains authoritative while a
- * runtime mutation is in flight: live model metadata is reusable only when the
- * raw live provider, model, and thinking level all match durability exactly.
+ * runtime mutation is in flight. Live model metadata is reusable when its raw
+ * provider/model identity matches durability; thinking is repaired separately.
  */
 function sendLiveStateSnapshot(
 	ws: WebSocket,
@@ -199,13 +199,18 @@ function sendLiveStateSnapshot(
 	let rebuiltFromDurableTuple = false;
 
 	if (durableProvider && durableModelId && durableThinkingLevel !== undefined) {
-		const liveMatchesDurableTuple = liveModel?.provider === durableProvider
-			&& liveModel?.id === durableModelId
+		const liveMatchesDurableIdentity = liveModel?.provider === durableProvider
+			&& liveModel?.id === durableModelId;
+		const liveMatchesDurableTuple = liveMatchesDurableIdentity
 			&& data.thinkingLevel === durableThinkingLevel;
 		if (!liveMatchesDurableTuple) {
 			normalized = {
 				...normalized,
-				model: buildResolvedModelStateModel(durableProvider, durableModelId),
+				model: buildResolvedModelStateModel(
+					durableProvider,
+					durableModelId,
+					liveMatchesDurableIdentity ? liveModel : undefined,
+				),
 				thinkingLevel: durableThinkingLevel,
 			};
 			rebuiltFromDurableTuple = true;

--- a/src/server/ws/runtime-model-selection.ts
+++ b/src/server/ws/runtime-model-selection.ts
@@ -30,6 +30,10 @@ type RuntimeModelSession = Pick<
 	"id" | "rpcClient" | "clients" | "spawnPinnedModel" | "spawnPinnedThinkingLevel"
 >;
 type RuntimeModelRpcClient = RuntimeModelSession["rpcClient"];
+type RuntimeRecoveryOwner = {
+	session: RuntimeModelSession;
+	rpcClient: RuntimeModelRpcClient;
+};
 type BroadcastFn = (clients: RuntimeModelSession["clients"], msg: ServerMessage) => void;
 
 export type RuntimeModelTuple = {
@@ -170,6 +174,26 @@ async function rollbackRuntimeTuple(
 
 class StaleRuntimeBridgeRecoveryError extends Error {}
 
+class OwnedRuntimeRecoveryError extends Error {
+	readonly owner: RuntimeRecoveryOwner;
+	readonly recoveryError: unknown;
+
+	constructor(recoveryError: unknown, owner: RuntimeRecoveryOwner) {
+		super(errorText(recoveryError));
+		this.name = "OwnedRuntimeRecoveryError";
+		this.owner = owner;
+		this.recoveryError = recoveryError;
+	}
+}
+
+function recoveryOwnerIsCanonical(
+	sessionManager: RuntimeModelSessionManager,
+	owner: RuntimeRecoveryOwner,
+): boolean {
+	const canonical = sessionManager.getSession(owner.session.id);
+	return canonical === owner.session && canonical.rpcClient === owner.rpcClient;
+}
+
 /**
  * A role/respawn may replace a SessionInfo's bridge in place while an older RPC
  * is still settling. Once that happens, only the detached bridge may be fenced;
@@ -177,28 +201,45 @@ class StaleRuntimeBridgeRecoveryError extends Error {}
  */
 async function retainVerifiedCanonicalReplacement(
 	sessionManager: RuntimeModelSessionManager,
-	session: RuntimeModelSession,
-	mutationRpcClient: RuntimeModelRpcClient,
+	owner: RuntimeRecoveryOwner,
 	broadcastModelState: BroadcastFn | undefined,
 ): Promise<boolean> {
-	const canonical = sessionManager.getSession(session.id);
-	if (!canonical || (canonical === session && canonical.rpcClient === mutationRpcClient)) return false;
+	const initialCanonical = sessionManager.getSession(owner.session.id);
+	if (!initialCanonical || (initialCanonical === owner.session && initialCanonical.rpcClient === owner.rpcClient)) return false;
 
-	const latestDurable = persistedTuple(sessionManager, session.id);
-	const canonicalState = await readRuntimeModelSnapshot(canonical);
 	try {
-		await mutationRpcClient.stop();
+		await owner.rpcClient.stop();
 	} catch (stopError) {
 		throw new StaleRuntimeBridgeRecoveryError(
 			`the superseded runtime bridge could not be stopped: ${errorText(stopError)}`,
 		);
 	}
-	if (!latestDurable || !tuplesEqual(canonicalState, latestDurable)) {
+
+	// Stopping the detached owner awaited an RPC. Capture the candidate and its
+	// complete durable authority only afterwards, then fence both again once its
+	// asynchronous read-back settles.
+	const candidate = sessionManager.getSession(owner.session.id);
+	const candidateDurable = persistedTuple(sessionManager, owner.session.id);
+	if (!candidate || !candidateDurable || (candidate === owner.session && candidate.rpcClient === owner.rpcClient)) {
 		throw new StaleRuntimeBridgeRecoveryError(
-			"a newer canonical session exists, but its latest durable model tuple could not be verified",
+			"the superseded bridge was stopped, but no complete newer canonical tuple was available to verify",
 		);
 	}
-	if (broadcastModelState) broadcastTuple(canonical, latestDurable, broadcastModelState);
+	const candidateRpcClient = candidate.rpcClient;
+	const candidateState = await readRuntimeModelBridgeSnapshot(candidateRpcClient);
+	const current = sessionManager.getSession(owner.session.id);
+	const currentDurable = persistedTuple(sessionManager, owner.session.id);
+	if (
+		current !== candidate
+		|| current.rpcClient !== candidateRpcClient
+		|| !currentDurable
+		|| !tuplesEqual(candidateState, currentDurable)
+	) {
+		throw new StaleRuntimeBridgeRecoveryError(
+			"a newer canonical session exists, but its latest durable model tuple could not be verified without another ownership change",
+		);
+	}
+	if (broadcastModelState) broadcastTuple(candidate, currentDurable, broadcastModelState);
 	return true;
 }
 
@@ -224,8 +265,7 @@ async function recoverRuntimeTupleMutation(
 	// SessionInfo object, so bridge identity—not only session identity—is required.
 	if (await retainVerifiedCanonicalReplacement(
 		sessionManager,
-		session,
-		mutationRpcClient,
+		{ session, rpcClient: mutationRpcClient },
 		broadcastModelState,
 	)) return;
 
@@ -250,38 +290,61 @@ async function recoverRuntimeTupleMutation(
 	// Recheck ownership immediately before the session-id restart boundary.
 	if (await retainVerifiedCanonicalReplacement(
 		sessionManager,
-		session,
-		mutationRpcClient,
+		{ session, rpcClient: mutationRpcClient },
 		broadcastModelState,
 	)) return;
 
 	await sessionManager.restartAgent(session.id);
 	const replacement = sessionManager.getSession(session.id);
 	if (!replacement) throw new Error("runtime selection recovery restart returned no live session");
-	const replacementState = await readRuntimeModelSnapshot(replacement);
-	const replacementTuple = completeTuple(replacementState);
-	if (!replacementTuple) throw new Error("runtime selection recovery restart state is incomplete or unreachable");
-	if (durable && !tuplesEqual(replacementTuple, durable)) {
-		throw new Error(
-			`runtime selection recovery restart mismatch: expected ${durable.provider}/${durable.id}/${durable.thinkingLevel}, ` +
-			`agent reports ${replacementTuple.provider}/${replacementTuple.id}/${replacementTuple.thinkingLevel}`,
-		);
+	const recoveryOwner: RuntimeRecoveryOwner = { session: replacement, rpcClient: replacement.rpcClient };
+	try {
+		const replacementState = await readRuntimeModelBridgeSnapshot(recoveryOwner.rpcClient);
+		const replacementTuple = completeTuple(replacementState);
+		if (!replacementTuple) throw new Error("runtime selection recovery restart state is incomplete or unreachable");
+		if (durable && !tuplesEqual(replacementTuple, durable)) {
+			throw new Error(
+				`runtime selection recovery restart mismatch: expected ${durable.provider}/${durable.id}/${durable.thinkingLevel}, ` +
+				`agent reports ${replacementTuple.provider}/${replacementTuple.id}/${replacementTuple.thinkingLevel}`,
+			);
+		}
+		const currentDurable = persistedTuple(sessionManager, session.id, replacementState);
+		if (!recoveryOwnerIsCanonical(sessionManager, recoveryOwner) || !currentDurable || !tuplesEqual(replacementTuple, currentDurable)) {
+			throw new Error("runtime selection recovery restart was superseded before its complete durable tuple could be accepted");
+		}
+		if (broadcastModelState) broadcastTuple(replacement, replacementTuple, broadcastModelState);
+	} catch (recoveryError) {
+		throw new OwnedRuntimeRecoveryError(recoveryError, recoveryOwner);
 	}
-	if (broadcastModelState) broadcastTuple(replacement, replacementTuple, broadcastModelState);
 }
 
 function errorText(error: unknown): string {
 	return sanitizeModelErrorText(error);
 }
 
-async function quarantineUnverifiableRuntimeSession(
+async function quarantineOwnedRuntimeSession(
 	sessionManager: RuntimeModelSessionManager,
-	sessionId: string,
-): Promise<void> {
-	const terminated = await sessionManager.terminateSession(sessionId);
-	if (terminated) return;
-	if (await sessionManager.storeArchive(sessionId)) return;
+	owner: RuntimeRecoveryOwner,
+): Promise<boolean> {
+	// The comparison and coordinated termination admission are intentionally
+	// synchronous. Once terminateSession is invoked, its existing replacement
+	// coordinator owns terminal intent for this exact canonical bridge.
+	if (!recoveryOwnerIsCanonical(sessionManager, owner)) return false;
+	const terminated = await sessionManager.terminateSession(owner.session.id);
+	if (terminated) return true;
+
+	// terminateSession awaited. Never archive by id if a replacement acquired the
+	// canonical slot while termination was settling.
+	if (!recoveryOwnerIsCanonical(sessionManager, owner)) return false;
+	if (await sessionManager.storeArchive(owner.session.id)) return true;
 	throw new Error("the unsafe session could not be terminated or archived");
+}
+
+function staleRuntimeRecoveryFailure(error: unknown, recoveryError: unknown): Error {
+	return new Error(
+		`${errorText(error)}; stale runtime bridge recovery failed: ${errorText(recoveryError)}. ` +
+		"The newer canonical session was retained; retry the selection after reconnecting.",
+	);
 }
 
 async function throwAfterRuntimeRecovery(
@@ -302,25 +365,49 @@ async function throwAfterRuntimeRecovery(
 			broadcastModelState,
 			mutationStarted,
 		);
-	} catch (recoveryError) {
-		if (recoveryError instanceof StaleRuntimeBridgeRecoveryError) {
-			throw new Error(
-				`${errorText(error)}; stale runtime bridge recovery failed: ${errorText(recoveryError)}. ` +
-				"The newer canonical session was retained; retry the selection after reconnecting.",
-			);
+	} catch (caughtRecoveryError) {
+		if (caughtRecoveryError instanceof StaleRuntimeBridgeRecoveryError) {
+			throw staleRuntimeRecoveryFailure(error, caughtRecoveryError);
 		}
+
+		const recoveryOwner = caughtRecoveryError instanceof OwnedRuntimeRecoveryError
+			? caughtRecoveryError.owner
+			: { session, rpcClient: mutationRpcClient };
+		const recoveryError = caughtRecoveryError instanceof OwnedRuntimeRecoveryError
+			? caughtRecoveryError.recoveryError
+			: caughtRecoveryError;
+
+		let quarantined: boolean;
 		try {
-			await quarantineUnverifiableRuntimeSession(sessionManager, session.id);
+			quarantined = await quarantineOwnedRuntimeSession(sessionManager, recoveryOwner);
 		} catch (quarantineError) {
 			throw new Error(
 				`${errorText(error)}; runtime selection recovery failed: ${errorText(recoveryError)}; ` +
 				`unsafe session quarantine failed: ${errorText(quarantineError)}`,
 			);
 		}
-		throw new Error(
-			`${errorText(error)}; runtime selection recovery failed: ${errorText(recoveryError)}. ` +
-			"The session was terminated and archived because its runtime model state could not be verified; create a fresh session to continue.",
-		);
+		if (quarantined) {
+			throw new Error(
+				`${errorText(error)}; runtime selection recovery failed: ${errorText(recoveryError)}. ` +
+				"The session was terminated and archived because its runtime model state could not be verified; create a fresh session to continue.",
+			);
+		}
+
+		try {
+			const retained = await retainVerifiedCanonicalReplacement(
+				sessionManager,
+				recoveryOwner,
+				broadcastModelState,
+			);
+			if (!retained) {
+				throw new StaleRuntimeBridgeRecoveryError(
+					"the recovery owner lost its canonical slot, but no newer canonical session was available to verify",
+				);
+			}
+		} catch (staleError) {
+			throw staleRuntimeRecoveryFailure(error, staleError);
+		}
+		throw staleRuntimeRecoveryFailure(error, recoveryError);
 	}
 	throw error;
 }

--- a/src/server/ws/runtime-model-selection.ts
+++ b/src/server/ws/runtime-model-selection.ts
@@ -1,6 +1,6 @@
 import type { ThinkingLevel } from "../../shared/thinking-levels.js";
 import { clampThinkingLevel, isKnownThinkingLevel } from "../../shared/thinking-levels.js";
-import type { SessionInfo, SessionManager } from "../agent/session-manager.js";
+import type { SessionBridgeOwner, SessionInfo, SessionManager } from "../agent/session-manager.js";
 import type { PreferencesStore } from "../agent/preferences-store.js";
 import { sanitizeModelErrorText } from "../agent/model-error-sanitizer.js";
 import { applyModelString } from "../agent/review-model-override.js";
@@ -18,9 +18,10 @@ type RuntimeModelSessionManager = Omit<
 		SessionManager,
 		"getPersistedSession" | "updateModelNameFile" | "restartAgent" | "getSession" | "terminateSession" | "storeArchive"
 	>,
-	"getPersistedSession"
+	"getPersistedSession" | "restartAgent"
 > & {
 	getPersistedSession(sessionId: string): RuntimePersistedSession | undefined;
+	restartAgent(sessionId: string, expectedOwner?: SessionBridgeOwner): Promise<void>;
 	/** Atomic durable tuple seam; SessionManager owns the store implementation. */
 	persistSessionModel(sessionId: string, provider: string, modelId: string, effectiveThinkingLevel?: ThinkingLevel): void;
 };
@@ -294,7 +295,7 @@ async function recoverRuntimeTupleMutation(
 		broadcastModelState,
 	)) return;
 
-	await sessionManager.restartAgent(session.id);
+	await sessionManager.restartAgent(session.id, { session, rpcClient: mutationRpcClient });
 	const replacement = sessionManager.getSession(session.id);
 	if (!replacement) throw new Error("runtime selection recovery restart returned no live session");
 	const recoveryOwner: RuntimeRecoveryOwner = { session: replacement, rpcClient: replacement.rpcClient };

--- a/tests2/core/controlled-model-fallback.test.ts
+++ b/tests2/core/controlled-model-fallback.test.ts
@@ -200,13 +200,13 @@ async function exerciseAutoSelect(options: {
 	spawnPinnedThinkingLevel?: string;
 	explicitRoleAssignment?: boolean;
 	initialBound?: { provider: string; id: string; thinkingLevel?: string };
-	initialDurable?: { provider: string; id: string; thinkingLevel: string };
+	initialDurable?: { provider: string; id: string; thinkingLevel: string } | null;
 }): Promise<{
 	error: unknown;
 	setModelCalls: ModelPair[];
 	setThinkingCalls: string[];
 	persisted: Array<Record<string, unknown>>;
-	durable: { provider: string; id: string; thinkingLevel: string };
+	durable: { provider: string; id: string; thinkingLevel: string } | undefined;
 	modelFiles: string[];
 	broadcastModels: Array<{ provider: string; id: string }>;
 	broadcastTuples: Array<{ provider: string; id: string; thinkingLevel: string | undefined }>;
@@ -216,28 +216,30 @@ async function exerciseAutoSelect(options: {
 	const setThinkingCalls: string[] = [];
 	const persisted: Array<Record<string, unknown>> = [];
 	const modelFiles: string[] = [];
-	const initialDurable = options.initialDurable ?? { provider: "anthropic", id: "durable-model", thinkingLevel: "high" };
-	let durable = { ...initialDurable };
+	const defaultDurable = { provider: "anthropic", id: "durable-model", thinkingLevel: "high" };
+	let durable = options.initialDurable === null
+		? undefined
+		: { ...(options.initialDurable ?? defaultDurable) };
 	let bound = {
-		provider: options.initialBound?.provider ?? initialDurable.provider,
-		id: options.initialBound?.id ?? initialDurable.id,
-		thinkingLevel: options.initialBound?.thinkingLevel ?? initialDurable.thinkingLevel,
+		provider: options.initialBound?.provider ?? durable?.provider ?? "unset",
+		id: options.initialBound?.id ?? durable?.id ?? "unset",
+		thinkingLevel: options.initialBound?.thinkingLevel ?? durable?.thinkingLevel ?? "medium",
 	};
 	const failModels = new Set(options.failModels ?? []);
 	const failThinkingLevels = new Set(options.failThinkingLevels ?? []);
 	const client = { messages: [] as any[] };
 	const store = {
-		get: () => ({
+		get: () => durable ? {
 			modelProvider: durable.provider,
 			modelId: durable.id,
 			effectiveThinkingLevel: durable.thinkingLevel,
-		}),
+		} : undefined,
 		update: (_sessionId: string, update: Record<string, unknown>) => {
 			persisted.push(update);
 			durable = {
-				provider: typeof update.modelProvider === "string" ? update.modelProvider : durable.provider,
-				id: typeof update.modelId === "string" ? update.modelId : durable.id,
-				thinkingLevel: typeof update.effectiveThinkingLevel === "string" ? update.effectiveThinkingLevel : durable.thinkingLevel,
+				provider: typeof update.modelProvider === "string" ? update.modelProvider : durable?.provider ?? "",
+				id: typeof update.modelId === "string" ? update.modelId : durable?.id ?? "",
+				thinkingLevel: typeof update.effectiveThinkingLevel === "string" ? update.effectiveThinkingLevel : durable?.thinkingLevel ?? "medium",
 			};
 		},
 	};
@@ -770,7 +772,7 @@ describe("controlled model fallback policy — session auto-selection", () => {
 		assert.deepEqual(result.modelFiles, ["openai/fallback-session"]);
 	});
 
-	it("re-clamps raw explicit-role thinking against the model that actually wins controlled fallback", async () => {
+	it("re-clamps a fresh explicit role's raw thinking override against the model that wins controlled fallback", async () => {
 		const result = await exerciseAutoSelect({
 			prefs: {
 				allowSessionModelFallback: true,
@@ -779,7 +781,36 @@ describe("controlled model fallback policy — session auto-selection", () => {
 			roleModel: "openai/dead-fallback",
 			roleThinking: "xhigh",
 			spawnPinnedModel: "openai/dead-fallback",
-			// The role's xhigh request was clamped for the failed pinned model.
+			// The role's xhigh request was provisionally clamped for the failed model.
+			spawnPinnedThinkingLevel: "high",
+			initialDurable: null,
+			initialBound: { provider: "unset", id: "unset", thinkingLevel: "high" },
+		});
+
+		assert.equal(result.error, undefined);
+		assert.deepEqual(result.setModelCalls, [["anthropic", "claude-opus-5"]]);
+		assert.deepEqual(
+			result.setThinkingCalls,
+			["xhigh"],
+			"FRESH_ROLE_FALLBACK_REUSED_THINKING_CLAMPED_FOR_FAILED_MODEL",
+		);
+		assert.deepEqual(result.durable, {
+			provider: "anthropic",
+			id: "claude-opus-5",
+			thinkingLevel: "xhigh",
+		});
+	});
+
+	it("re-clamps a staged explicit role's raw thinking override against the model that wins controlled fallback", async () => {
+		const result = await exerciseAutoSelect({
+			prefs: {
+				allowSessionModelFallback: true,
+				"default.sessionModel": "anthropic/claude-opus-5",
+			},
+			roleModel: "openai/dead-fallback",
+			roleThinking: "xhigh",
+			spawnPinnedModel: "openai/dead-fallback",
+			// The role's xhigh request was provisionally clamped for the failed model.
 			spawnPinnedThinkingLevel: "high",
 			explicitRoleAssignment: true,
 			initialBound: { provider: "unset", id: "unset", thinkingLevel: "high" },
@@ -790,10 +821,41 @@ describe("controlled model fallback policy — session auto-selection", () => {
 		assert.deepEqual(
 			result.setThinkingCalls,
 			["xhigh"],
-			"EXPLICIT_ROLE_FALLBACK_REUSED_THINKING_CLAMPED_FOR_FAILED_MODEL",
+			"STAGED_ROLE_FALLBACK_REUSED_THINKING_CLAMPED_FOR_FAILED_MODEL",
 		);
 		assert.equal(result.spawnPinnedThinkingLevel, "xhigh");
 		assert.deepEqual(result.persisted, [], "a staged explicit role must remain side-effect-free before lifecycle commit");
+	});
+
+	it("re-clamps raw durable thinking when a staged role without a thinking override falls back", async () => {
+		const result = await exerciseAutoSelect({
+			prefs: {
+				allowSessionModelFallback: true,
+				"default.sessionModel": "anthropic/claude-opus-5",
+			},
+			roleModel: "openai/dead-fallback",
+			spawnPinnedModel: "openai/dead-fallback",
+			// Durable xhigh was provisionally clamped for the failed role model.
+			spawnPinnedThinkingLevel: "high",
+			explicitRoleAssignment: true,
+			initialDurable: { provider: "anthropic", id: "durable-model", thinkingLevel: "xhigh" },
+			initialBound: { provider: "unset", id: "unset", thinkingLevel: "high" },
+		});
+
+		assert.equal(result.error, undefined);
+		assert.deepEqual(result.setModelCalls, [["anthropic", "claude-opus-5"]]);
+		assert.deepEqual(
+			result.setThinkingCalls,
+			["xhigh"],
+			"STAGED_ROLE_FALLBACK_DISCARDED_RAW_DURABLE_THINKING",
+		);
+		assert.equal(result.spawnPinnedThinkingLevel, "xhigh");
+		assert.deepEqual(result.persisted, [], "a staged fallback must not advance durability before lifecycle commit");
+		assert.deepEqual(result.durable, {
+			provider: "anthropic",
+			id: "durable-model",
+			thinkingLevel: "xhigh",
+		});
 	});
 
 	it("rejects a hidden-provider role fallback before mutating any observable state", async () => {

--- a/tests2/core/controlled-model-fallback.test.ts
+++ b/tests2/core/controlled-model-fallback.test.ts
@@ -246,6 +246,14 @@ async function exerciseAutoSelect(options: {
 		async resolveCurrentCatalogThinkingLevel(model: string, _role: string | undefined, _projectId: string | undefined, preferred: string) {
 			return model.includes("opus-5") || !["xhigh", "max"].includes(preferred) ? preferred : "high";
 		},
+		async resolveCurrentCatalogPreferredThinkingLevel(
+			model: string,
+			role: string | undefined,
+			projectId: string | undefined,
+			preferred: string,
+		) {
+			return this.resolveCurrentCatalogThinkingLevel(model, role, projectId, preferred);
+		},
 		resolveStoreForSession: () => store,
 		async requireCurrentCatalogSpawnModel(model: string) {
 			if (!currentCatalogModels.has(model)) {

--- a/tests2/core/controlled-model-fallback.test.ts
+++ b/tests2/core/controlled-model-fallback.test.ts
@@ -101,6 +101,10 @@ function loadTryAutoSelectModel(): (this: any, session: any) => Promise<void> {
 	body = body
 		.replace(/\s+as\s+string\s*\|\s*undefined/g, "")
 		.replace(/async \(modelString: string\): Promise<void> =>/g, "async (modelString) =>")
+		.replace(
+			/async \(\s*modelString: string,\s*explicitPreferredThinking\?: ThinkingLevel,\s*\): Promise<void> =>/g,
+			"async (modelString, explicitPreferredThinking) =>",
+		)
 		.replace(/SessionManager\.AIGW_CACHE_TTL_MS/g, "60_000");
 
 	// The extracted production method now normalizes legacy provider-prefixed AIGW
@@ -194,6 +198,7 @@ async function exerciseAutoSelect(options: {
 	failThinkingLevels?: string[];
 	spawnPinnedModel?: string;
 	spawnPinnedThinkingLevel?: string;
+	explicitRoleAssignment?: boolean;
 	initialBound?: { provider: string; id: string; thinkingLevel?: string };
 	initialDurable?: { provider: string; id: string; thinkingLevel: string };
 }): Promise<{
@@ -205,6 +210,7 @@ async function exerciseAutoSelect(options: {
 	modelFiles: string[];
 	broadcastModels: Array<{ provider: string; id: string }>;
 	broadcastTuples: Array<{ provider: string; id: string; thinkingLevel: string | undefined }>;
+	spawnPinnedThinkingLevel: string | undefined;
 }> {
 	const setModelCalls: ModelPair[] = [];
 	const setThinkingCalls: string[] = [];
@@ -236,6 +242,7 @@ async function exerciseAutoSelect(options: {
 		},
 	};
 	const currentCatalogModels = new Set([
+		"anthropic/claude-opus-5",
 		"openai/fallback-session",
 		"openai/dead-fallback",
 	]);
@@ -272,6 +279,7 @@ async function exerciseAutoSelect(options: {
 		role: "coder",
 		spawnPinnedModel: options.spawnPinnedModel,
 		spawnPinnedThinkingLevel: options.spawnPinnedThinkingLevel,
+		...(options.explicitRoleAssignment ? { _deferVerifiedTupleCommit: true } : {}),
 		clients: new Set([client]),
 		rpcClient: {
 			async setModel(provider: string, modelId: string) {
@@ -318,6 +326,7 @@ async function exerciseAutoSelect(options: {
 				id: msg.data.model.id,
 				thinkingLevel: msg.data.thinkingLevel,
 			})),
+		spawnPinnedThinkingLevel: session.spawnPinnedThinkingLevel,
 	};
 }
 
@@ -759,6 +768,32 @@ describe("controlled model fallback policy — session auto-selection", () => {
 		);
 		assert.deepEqual(result.broadcastModels, [{ provider: "openai", id: "fallback-session" }]);
 		assert.deepEqual(result.modelFiles, ["openai/fallback-session"]);
+	});
+
+	it("re-clamps raw explicit-role thinking against the model that actually wins controlled fallback", async () => {
+		const result = await exerciseAutoSelect({
+			prefs: {
+				allowSessionModelFallback: true,
+				"default.sessionModel": "anthropic/claude-opus-5",
+			},
+			roleModel: "openai/dead-fallback",
+			roleThinking: "xhigh",
+			spawnPinnedModel: "openai/dead-fallback",
+			// The role's xhigh request was clamped for the failed pinned model.
+			spawnPinnedThinkingLevel: "high",
+			explicitRoleAssignment: true,
+			initialBound: { provider: "unset", id: "unset", thinkingLevel: "high" },
+		});
+
+		assert.equal(result.error, undefined);
+		assert.deepEqual(result.setModelCalls, [["anthropic", "claude-opus-5"]]);
+		assert.deepEqual(
+			result.setThinkingCalls,
+			["xhigh"],
+			"EXPLICIT_ROLE_FALLBACK_REUSED_THINKING_CLAMPED_FOR_FAILED_MODEL",
+		);
+		assert.equal(result.spawnPinnedThinkingLevel, "xhigh");
+		assert.deepEqual(result.persisted, [], "a staged explicit role must remain side-effect-free before lifecycle commit");
 	});
 
 	it("rejects a hidden-provider role fallback before mutating any observable state", async () => {

--- a/tests2/core/controlled-model-fallback.test.ts
+++ b/tests2/core/controlled-model-fallback.test.ts
@@ -48,7 +48,7 @@ process.env.BOBBIT_TEST_NO_EXTERNAL = "1";
 const { resetAgentDirStateForTests } = await import("../../src/server/bobbit-dir.ts");
 resetAgentDirStateForTests?.();
 const { SessionManager } = await import("../../src/server/agent/session-manager.ts");
-const { invalidateModelCache } = await import("../../src/server/agent/model-registry.ts");
+const { getAvailableModels, invalidateModelCache } = await import("../../src/server/agent/model-registry.ts");
 const { registerRpcBridgeFactory } = await import("../../src/server/agent/rpc-bridge.ts");
 const { initAuthorSidecarDir } = await import("../../src/server/agent/author-sidecar.ts");
 const { initPromptDirs } = await import("../../src/server/agent/system-prompt.ts");
@@ -587,6 +587,150 @@ function boundaryTuple(record: BoundaryRecord | undefined): Record<string, unkno
 	};
 }
 
+const INHERITED_SELECTED_PROVIDER = "inherited-selected";
+const INHERITED_SELECTED_MODEL_ID = "limited-reasoner";
+const INHERITED_SELECTED_MODEL = `${INHERITED_SELECTED_PROVIDER}/${INHERITED_SELECTED_MODEL_ID}`;
+const INHERITED_FALLBACK_PROVIDER = "inherited-fallback";
+const INHERITED_FALLBACK_MODEL_ID = "extended-reasoner";
+const INHERITED_FALLBACK_MODEL = `${INHERITED_FALLBACK_PROVIDER}/${INHERITED_FALLBACK_MODEL_ID}`;
+
+type InheritedSetupMode = "normal" | "worktree";
+
+async function makeInheritedThinkingFixture(
+	label: string,
+	opts: { failFallback?: boolean } = {},
+): Promise<{
+	manager: any;
+	store: BoundaryStore;
+	startedOptions: Record<string, any>[];
+	setModelCalls: ModelPair[];
+	setThinkingCalls: string[];
+}> {
+	const preferences = new PreferencesStore(
+		path.resolve(`/memfs/controlled-fallback-inherited-${label}`),
+		createMemFs(),
+	);
+	preferences.set("customProviders", [
+		{
+			id: INHERITED_SELECTED_PROVIDER,
+			name: INHERITED_SELECTED_PROVIDER,
+			type: "manual",
+			baseUrl: "http://127.0.0.1:9",
+			apiKey: "test-key",
+			models: [{ id: INHERITED_SELECTED_MODEL_ID, name: "Limited reasoner" }],
+		},
+		{
+			id: INHERITED_FALLBACK_PROVIDER,
+			name: INHERITED_FALLBACK_PROVIDER,
+			type: "manual",
+			baseUrl: "http://127.0.0.1:9",
+			apiKey: "test-key",
+			models: [{ id: INHERITED_FALLBACK_MODEL_ID, name: "Extended reasoner" }],
+		},
+	]);
+	preferences.set("default.sessionModel", INHERITED_FALLBACK_MODEL);
+	preferences.set("default.sessionThinkingLevel", "low");
+	preferences.set("allowSessionModelFallback", true as any);
+	invalidateModelCache();
+	const models = await getAvailableModels(preferences);
+	const selected = models.find((model: any) => (
+		model.provider === INHERITED_SELECTED_PROVIDER && model.id === INHERITED_SELECTED_MODEL_ID
+	));
+	const fallback = models.find((model: any) => (
+		model.provider === INHERITED_FALLBACK_PROVIDER && model.id === INHERITED_FALLBACK_MODEL_ID
+	));
+	assert.ok(selected && fallback, "fixture requires both current custom catalog rows");
+	// The selected model clamps xhigh down to high. The fallback supports xhigh,
+	// so the selector must re-clamp the raw inherited request rather than reuse
+	// either that provisional high or the unrelated global low default.
+	selected.reasoning = true;
+	fallback.reasoning = true;
+	fallback.thinkingLevelMap = { xhigh: "xhigh" };
+
+	const store = new BoundaryStore();
+	const startedOptions: Record<string, any>[] = [];
+	const setModelCalls: ModelPair[] = [];
+	const setThinkingCalls: string[] = [];
+	registerRpcBridgeFactory((options: Record<string, any>) => {
+		let model = { provider: "fixture-runtime", id: "spawn-readback-mismatch" };
+		let thinkingLevel = options.initialThinkingLevel ?? "medium";
+		return {
+			running: true,
+			start: vi.fn(async () => { startedOptions.push({ ...options }); }),
+			stop: vi.fn(async () => {}),
+			waitForReady: vi.fn(async () => {}),
+			promptWhenReady: vi.fn(async () => ({ success: true })),
+			prompt: vi.fn(async () => ({ success: true })),
+			steer: vi.fn(async () => ({ success: true })),
+			abort: vi.fn(async () => ({ success: true })),
+			getState: vi.fn(async () => ({
+				success: true,
+				data: {
+					model,
+					thinkingLevel,
+					sessionFile: path.join(BOUNDARY_AGENT_DIR, "sessions", `${label}.jsonl`),
+				},
+			})),
+			getMessages: vi.fn(async () => ({ success: true, data: { messages: [] } })),
+			setModel: vi.fn(async (provider: string, id: string) => {
+				setModelCalls.push([provider, id]);
+				if (opts.failFallback && `${provider}/${id}` === INHERITED_FALLBACK_MODEL) {
+					throw new Error("fixture fallback bind failed");
+				}
+				model = { provider, id };
+				return { success: true };
+			}),
+			setThinkingLevel: vi.fn(async (level: string) => {
+				setThinkingCalls.push(level);
+				thinkingLevel = level;
+				return { success: true };
+			}),
+			compact: vi.fn(async () => ({ success: true })),
+			sendCommand: vi.fn(async () => ({ success: true })),
+			onEvent: vi.fn(() => () => {}),
+		};
+	});
+	const manager: any = new SessionManager({
+		preferencesStore: preferences,
+		stateDir: BOUNDARY_STATE_DIR,
+	});
+	manager._testStore = store;
+	boundaryManagers.push(manager);
+	return { manager, store, startedOptions, setModelCalls, setThinkingCalls };
+}
+
+async function createInheritedThinkingSession(
+	fixture: Awaited<ReturnType<typeof makeInheritedThinkingFixture>>,
+	mode: InheritedSetupMode,
+	sessionId: string,
+): Promise<any> {
+	const createOpts: Record<string, any> = {
+		sessionId,
+		initialModel: INHERITED_SELECTED_MODEL,
+		initialThinkingLevel: "xhigh",
+	};
+	if (mode === "worktree") {
+		const projectId = `project-${sessionId}`;
+		const worktreePath = path.join(BOUNDARY_TMP_ROOT, `prebuilt-${sessionId}`);
+		fs.mkdirSync(worktreePath, { recursive: true });
+		fixture.manager.worktreePools.set(projectId, {
+			claim: vi.fn(async () => ({ worktreePath })),
+		});
+		Object.assign(createOpts, {
+			projectId,
+			worktreeOpts: { repoPath: BOUNDARY_TMP_ROOT },
+			awaitWorktreeSetup: true,
+		});
+	}
+	return fixture.manager.createSession(
+		BOUNDARY_TMP_ROOT,
+		[],
+		undefined,
+		undefined,
+		createOpts,
+	);
+}
+
 const boundaryManagers: any[] = [];
 
 afterEach(() => {
@@ -678,6 +822,57 @@ describe("controlled model fallback policy — real SessionManager preflight", (
 			"ROLE_FALLBACK_PREFLIGHT: an unavailable role on an eligible new session must use the current default.sessionModel instead of being rejected before controlled fallback can run",
 		);
 	});
+
+	it.each(["normal", "worktree"] as const)(
+		"preserves an explicit inherited thinking request through %s post-spawn controlled fallback",
+		async (mode) => {
+			const fixture = await makeInheritedThinkingFixture(`success-${mode}`);
+			const sessionId = `inherited-thinking-${mode}`;
+			const session = await createInheritedThinkingSession(fixture, mode, sessionId);
+			if (session.pendingMetadataPersist) await session.pendingMetadataPersist;
+
+			assert.equal(fixture.startedOptions.at(-1)?.initialModel, INHERITED_SELECTED_MODEL);
+			assert.equal(
+				fixture.startedOptions.at(-1)?.initialThinkingLevel,
+				"high",
+				"the spawn pin is only the provisional clamp for the selected model",
+			);
+			assert.deepEqual(fixture.setModelCalls, [[INHERITED_FALLBACK_PROVIDER, INHERITED_FALLBACK_MODEL_ID]]);
+			assert.deepEqual(
+				fixture.setThinkingCalls,
+				["xhigh"],
+				"EXPLICIT_INHERITED_FALLBACK_THINKING_LOST_TO_GLOBAL_DEFAULT",
+			);
+			assert.deepEqual(boundaryTuple(fixture.store.get(sessionId)), {
+				provider: INHERITED_FALLBACK_PROVIDER,
+				modelId: INHERITED_FALLBACK_MODEL_ID,
+				thinkingLevel: "xhigh",
+			});
+			assert.equal(
+				fixture.manager._setupInitialThinkingAuthorities?.size ?? 0,
+				0,
+				"temporary raw setup authority must clear after successful setup",
+			);
+		},
+	);
+
+	it.each(["normal", "worktree"] as const)(
+		"clears explicit inherited thinking authority when %s post-spawn fallback fails",
+		async (mode) => {
+			const fixture = await makeInheritedThinkingFixture(`failure-${mode}`, { failFallback: true });
+			const sessionId = `inherited-thinking-failure-${mode}`;
+
+			await assert.rejects(
+				createInheritedThinkingSession(fixture, mode, sessionId),
+				/controlled fallback did not bind|fixture fallback bind failed/i,
+			);
+			assert.equal(
+				fixture.manager._setupInitialThinkingAuthorities?.size ?? 0,
+				0,
+				"temporary raw setup authority must clear after failed setup",
+			);
+		},
+	);
 });
 
 describe("controlled model fallback policy — session auto-selection", () => {

--- a/tests2/core/controlled-model-fallback.test.ts
+++ b/tests2/core/controlled-model-fallback.test.ts
@@ -250,6 +250,7 @@ async function exerciseAutoSelect(options: {
 	]);
 	const manager = {
 		preferencesStore: { get: (key: string) => options.prefs[key] },
+		_setupInitialThinkingAuthorities: new Map(),
 		resolveRoleModel: () => options.roleModel,
 		resolveRoleThinkingLevel: () => options.roleThinking,
 		async resolveCurrentCatalogThinkingLevel(model: string, _role: string | undefined, _projectId: string | undefined, preferred: string) {
@@ -713,6 +714,20 @@ async function createInheritedThinkingSession(
 		const projectId = `project-${sessionId}`;
 		const worktreePath = path.join(BOUNDARY_TMP_ROOT, `prebuilt-${sessionId}`);
 		fs.mkdirSync(worktreePath, { recursive: true });
+		// The setup-failure canary deliberately rejects after claiming this fake
+		// prebuilt worktree. Seed a second live owner so failure cleanup exercises
+		// the shared-worktree guard instead of launching an unrelated real Git cleanup.
+		fixture.store.put({
+			id: `shared-owner-${sessionId}`,
+			title: "Shared fixture owner",
+			cwd: worktreePath,
+			worktreePath,
+			repoPath: BOUNDARY_TMP_ROOT,
+			branch: `fixture/${sessionId}`,
+			createdAt: Date.now(),
+			lastActivity: Date.now(),
+			agentSessionFile: "",
+		});
 		fixture.manager.worktreePools.set(projectId, {
 			claim: vi.fn(async () => ({ worktreePath })),
 		});

--- a/tests2/core/orphan-tool-result-rehydration-boundaries.test.ts
+++ b/tests2/core/orphan-tool-result-rehydration-boundaries.test.ts
@@ -487,6 +487,32 @@ describe("executable SessionManager rehydration boundaries", () => {
 		});
 	});
 
+	it("cold restore retains durable thinking over an attached role default", async () => {
+		invalidateModelCache();
+		const file = hostTranscript("cold-restore-durable-thinking");
+		const ps = persisted("cold-restore-durable-thinking", file, {
+			role: "thinking-role",
+			modelProvider: "anthropic",
+			modelId: "claude-opus-5",
+			effectiveThinkingLevel: "xhigh",
+		});
+		const store = mutableStore(ps);
+		const { manager } = makeRoleThinkingManager("cold-restore-durable-thinking", "high");
+		manager._testStore = store;
+		const optionsSeen: Record<string, any>[] = [];
+		registerRpcBridgeFactory((options: Record<string, any>) => {
+			optionsSeen.push({ ...options });
+			return recordingBridge(() => {}, bridgeTuple(options));
+		});
+
+		await manager.restoreSession(ps);
+
+		expect(optionsSeen[0]?.initialModel).toBe("anthropic/claude-opus-5");
+		expect(optionsSeen[0]?.initialThinkingLevel).toBe("xhigh");
+		expect(ps.effectiveThinkingLevel).toBe("xhigh");
+		expect(manager.sessions.get(ps.id)?.spawnPinnedThinkingLevel).toBe("xhigh");
+	});
+
 	it.each([
 		{ roleThinkingLevel: "xhigh", expected: "xhigh" },
 		{ roleThinkingLevel: undefined, expected: "high" },
@@ -522,19 +548,19 @@ describe("executable SessionManager rehydration boundaries", () => {
 	});
 
 	it.each([
-		{ roleThinkingLevel: "xhigh", expected: "xhigh" },
-		{ roleThinkingLevel: undefined, expected: "high" },
-	])("forceAbort gives explicit role thinking $roleThinkingLevel precedence and otherwise retains durable thinking", async ({ roleThinkingLevel, expected }) => {
+		{ roleThinkingLevel: "high", durableThinkingLevel: "xhigh" },
+		{ roleThinkingLevel: "xhigh", durableThinkingLevel: "high" },
+	])("forceAbort retains durable thinking $durableThinkingLevel over attached role default $roleThinkingLevel", async ({ roleThinkingLevel, durableThinkingLevel }) => {
 		invalidateModelCache();
-		const file = hostTranscript(`force-abort-thinking-${roleThinkingLevel ?? "durable"}`);
-		const ps = persisted(`force-abort-thinking-${roleThinkingLevel ?? "durable"}`, file, {
+		const file = hostTranscript(`force-abort-thinking-${durableThinkingLevel}-over-${roleThinkingLevel}`);
+		const ps = persisted(`force-abort-thinking-${durableThinkingLevel}-over-${roleThinkingLevel}`, file, {
 			role: "thinking-role",
 			modelProvider: "anthropic",
 			modelId: "claude-opus-5",
-			effectiveThinkingLevel: "high",
+			effectiveThinkingLevel: durableThinkingLevel,
 		});
 		const store = mutableStore(ps);
-		const { manager } = makeRoleThinkingManager(`force-abort-thinking-${roleThinkingLevel ?? "durable"}`, roleThinkingLevel);
+		const { manager } = makeRoleThinkingManager(`force-abort-thinking-${durableThinkingLevel}-over-${roleThinkingLevel}`, roleThinkingLevel);
 		manager._testStore = store;
 		const optionsSeen: Record<string, any>[] = [];
 		registerRpcBridgeFactory((options: Record<string, any>) => {
@@ -544,7 +570,7 @@ describe("executable SessionManager rehydration boundaries", () => {
 		const oldBridge = recordingBridge(() => {}, {
 			modelProvider: "anthropic",
 			modelId: "claude-opus-5",
-			thinkingLevel: "high",
+			thinkingLevel: durableThinkingLevel,
 		});
 		oldBridge.abort = vi.fn(() => new Promise(() => {}));
 		oldBridge.stop = vi.fn(async () => {});
@@ -559,8 +585,9 @@ describe("executable SessionManager rehydration boundaries", () => {
 		await manager.forceAbort(ps.id, 1);
 
 		expect(optionsSeen[0]?.initialModel).toBe("anthropic/claude-opus-5");
-		expect(optionsSeen[0]?.initialThinkingLevel).toBe(expected);
-		expect(ps.effectiveThinkingLevel).toBe(expected);
+		expect(optionsSeen[0]?.initialThinkingLevel).toBe(durableThinkingLevel);
+		expect(ps.effectiveThinkingLevel).toBe(durableThinkingLevel);
+		expect(manager.sessions.get(ps.id)?.spawnPinnedThinkingLevel).toBe(durableThinkingLevel);
 	});
 	it("repairs a cold-restored host transcript before switch_session observes it", async () => {
 		const file = hostTranscript("cold-restore");

--- a/tests2/core/orphan-tool-result-rehydration-boundaries.test.ts
+++ b/tests2/core/orphan-tool-result-rehydration-boundaries.test.ts
@@ -1259,6 +1259,126 @@ describe("executable SessionManager rehydration boundaries", () => {
 		}).toEqual(tupleB);
 	});
 
+	it("does not let owner-sensitive recovery join a generic rehydrate queued behind role replacement", async () => {
+		invalidateModelCache();
+		const file = hostTranscript("owner-sensitive-recovery-coalesce");
+		const raceProvider = "owner-sensitive-recovery-coalesce";
+		const tupleA = { provider: raceProvider, id: "tuple-a", thinkingLevel: "off" as const };
+		const tupleB = { provider: raceProvider, id: "tuple-b", thinkingLevel: "off" as const };
+		const racePreferences = new PreferencesStore(
+			path.resolve("/memfs/owner-sensitive-recovery-coalesce"),
+			createMemFs(),
+		);
+		racePreferences.set("customProviders", [{
+			id: raceProvider,
+			name: raceProvider,
+			type: "manual",
+			baseUrl: "http://127.0.0.1:9",
+			apiKey: "test-key",
+			models: [tupleA.id, tupleB.id].map((id) => ({ id, name: id })),
+		}]);
+		const role = {
+			name: "coalesce-replacement-role",
+			label: "Coalesce replacement role",
+			promptTemplate: "Coalesce replacement role",
+			accessory: "replacement-accessory",
+			model: `${tupleB.provider}/${tupleB.id}`,
+			thinkingLevel: tupleB.thinkingLevel,
+		};
+		const roleManager = {
+			getRole: vi.fn((name: string) => name === role.name ? role : undefined),
+			listRoles: vi.fn(() => [role]),
+		};
+		const ps = persisted("owner-sensitive-recovery-coalesce", file, {
+			modelProvider: tupleA.provider,
+			modelId: tupleA.id,
+			effectiveThinkingLevel: tupleA.thinkingLevel,
+		});
+		const store = mutableStore(ps);
+		store.archiveAsync = vi.fn(async () => {
+			ps.archived = true;
+			return true;
+		});
+
+		const roleStartSeen = deferred<void>();
+		const releaseRoleStart = deferred<void>();
+		const roleBridge = recordingBridge(() => {}, {
+			modelProvider: tupleB.provider,
+			modelId: tupleB.id,
+			thinkingLevel: tupleB.thinkingLevel,
+		});
+		roleBridge.start = vi.fn(async () => {
+			roleStartSeen.resolve();
+			await releaseRoleStart.promise;
+		});
+		roleBridge.stop = vi.fn(async () => { roleBridge.running = false; });
+		let genericRehydrateBridge: any;
+		let factoryCalls = 0;
+		registerRpcBridgeFactory((options: Record<string, any>) => {
+			factoryCalls += 1;
+			if (factoryCalls === 1) return roleBridge;
+			genericRehydrateBridge = recordingBridge(() => {}, bridgeTuple(options));
+			genericRehydrateBridge.stop = vi.fn(async () => { genericRehydrateBridge.running = false; });
+			return genericRehydrateBridge;
+		});
+
+		const manager: any = new BaseSessionManager({ preferencesStore: racePreferences, roleManager: roleManager as any });
+		manager._testStore = store;
+		managers.push(manager);
+		const restartSpy = vi.spyOn(manager, "restartAgent");
+		const terminateSpy = vi.spyOn(manager, "terminateSession");
+		let originalReads = 0;
+		const original = recordingBridge(() => {}, {
+			modelProvider: tupleA.provider,
+			modelId: tupleA.id,
+			thinkingLevel: tupleA.thinkingLevel,
+		});
+		original.getState = vi.fn(async () => {
+			originalReads += 1;
+			const tuple = originalReads <= 2
+				? tupleA
+				: { provider: tupleA.provider, id: "unverified-partial", thinkingLevel: tupleA.thinkingLevel };
+			return { success: true, data: { model: { provider: tuple.provider, id: tuple.id }, thinkingLevel: tuple.thinkingLevel } };
+		});
+		original.setModel = vi.fn(async () => ({ success: false, error: "fixture rollback failed" }));
+		original.stop = vi.fn(async () => { original.running = false; });
+		const session = liveSession(ps.id, original, {
+			spawnPinnedModel: `${tupleA.provider}/${tupleA.id}`,
+			spawnPinnedThinkingLevel: tupleA.thinkingLevel,
+		});
+		manager.sessions.set(ps.id, session);
+
+		const assignment = manager.assignRole(ps.id, role);
+		await roleStartSeen.promise;
+		const genericRestart = manager.restartAgent(ps.id);
+		const selection = applyRuntimeSessionThinkingSelection(manager, session, "medium");
+		await vi.waitFor(() => expect(restartSpy).toHaveBeenCalledTimes(2));
+		const recoveryRestartArgs = restartSpy.mock.calls[1] as any[];
+		releaseRoleStart.resolve();
+
+		await expect(assignment).resolves.toBe(true);
+		await expect(genericRestart).resolves.toBeUndefined();
+		const genericRehydrateSession = manager.sessions.get(ps.id);
+		await expect(selection).rejects.toThrow();
+
+		expect(recoveryRestartArgs[1]?.session, "OWNER_SENSITIVE_RESPAWN_MISSING_EXPECTED_SESSION").toBe(session);
+		expect(recoveryRestartArgs[1]?.rpcClient, "OWNER_SENSITIVE_RESPAWN_MISSING_EXPECTED_RPC").toBe(original);
+		expect(factoryCalls).toBe(2);
+		expect(roleBridge.stop).toHaveBeenCalledTimes(1);
+		expect(genericRehydrateBridge.stop, "OWNER_SENSITIVE_RESPAWN_QUARANTINED_UNOWNED_REHYDRATE").not.toHaveBeenCalled();
+		expect(terminateSpy, "OWNER_SENSITIVE_RESPAWN_TERMINATED_UNOWNED_REHYDRATE").not.toHaveBeenCalled();
+		expect(store.archiveAsync, "OWNER_SENSITIVE_RESPAWN_ARCHIVED_UNOWNED_REHYDRATE").not.toHaveBeenCalled();
+		expect(ps.archived).not.toBe(true);
+		expect(manager.sessions.get(ps.id)).toBe(genericRehydrateSession);
+		expect(manager.sessions.get(ps.id)?.rpcClient).toBe(genericRehydrateBridge);
+		expect(genericRehydrateBridge.running).toBe(true);
+		expect({
+			provider: ps.modelProvider,
+			id: ps.modelId,
+			thinkingLevel: ps.effectiveThinkingLevel,
+		}).toEqual(tupleB);
+	});
+
 	it("keeps staged role verification side-effect-free while recovered A remains canonical", async () => {
 		invalidateModelCache();
 		const file = hostTranscript("staged-role-verification-durability");
@@ -1417,6 +1537,143 @@ describe("executable SessionManager rehydration boundaries", () => {
 		expect(recoveredBridge.stop).toHaveBeenCalledTimes(1);
 		expect(roleBridge.stop).not.toHaveBeenCalled();
 		expect(manager.sessions.get(ps.id)?.rpcClient).toBe(roleBridge);
+		expect({
+			provider: ps.modelProvider,
+			id: ps.modelId,
+			thinkingLevel: ps.effectiveThinkingLevel,
+		}).toEqual(tupleB);
+	});
+
+	it("retains actual assigned role B when it commits while recovery R read-back is held", async () => {
+		invalidateModelCache();
+		const file = hostTranscript("recovery-read-held-role-commit");
+		const raceProvider = "recovery-read-held-role-commit";
+		const tupleA = { provider: raceProvider, id: "tuple-a", thinkingLevel: "off" as const };
+		const tupleB = { provider: raceProvider, id: "tuple-b", thinkingLevel: "off" as const };
+		const racePreferences = new PreferencesStore(
+			path.resolve("/memfs/recovery-read-held-role-commit"),
+			createMemFs(),
+		);
+		racePreferences.set("customProviders", [{
+			id: raceProvider,
+			name: raceProvider,
+			type: "manual",
+			baseUrl: "http://127.0.0.1:9",
+			apiKey: "test-key",
+			models: [tupleA.id, tupleB.id].map((id) => ({ id, name: id })),
+		}]);
+		const role = {
+			name: "read-held-replacement-role",
+			label: "Read-held replacement role",
+			promptTemplate: "Read-held replacement role",
+			accessory: "replacement-accessory",
+			model: `${tupleB.provider}/${tupleB.id}`,
+			thinkingLevel: tupleB.thinkingLevel,
+		};
+		const roleManager = {
+			getRole: vi.fn((name: string) => name === role.name ? role : undefined),
+			listRoles: vi.fn(() => [role]),
+		};
+		const ps = persisted("recovery-read-held-role-commit", file, {
+			modelProvider: tupleA.provider,
+			modelId: tupleA.id,
+			effectiveThinkingLevel: tupleA.thinkingLevel,
+		});
+		const store = mutableStore(ps);
+		store.archiveAsync = vi.fn(async () => {
+			ps.archived = true;
+			return true;
+		});
+
+		let restartCompleted = false;
+		let recoveryReadHeld = false;
+		const recoveryReadStarted = deferred<void>();
+		const releaseRecoveryRead = deferred<unknown>();
+		let recoveredBridge: any;
+		let roleBridge: any;
+		let factoryCalls = 0;
+		registerRpcBridgeFactory((options: Record<string, any>) => {
+			factoryCalls += 1;
+			const tuple = bridgeTuple(options);
+			if (factoryCalls === 1) {
+				recoveredBridge = recordingBridge(() => {}, tuple);
+				const normalGetState = recoveredBridge.getState.bind(recoveredBridge);
+				recoveredBridge.getState = vi.fn(async () => {
+					if (restartCompleted && !recoveryReadHeld) {
+						recoveryReadHeld = true;
+						recoveryReadStarted.resolve();
+						return releaseRecoveryRead.promise;
+					}
+					return normalGetState();
+				});
+				recoveredBridge.stop = vi.fn(async () => { recoveredBridge.running = false; });
+				return recoveredBridge;
+			}
+			roleBridge = recordingBridge(() => {}, tuple);
+			roleBridge.stop = vi.fn(async () => { roleBridge.running = false; });
+			return roleBridge;
+		});
+
+		const manager: any = new BaseSessionManager({ preferencesStore: racePreferences, roleManager: roleManager as any });
+		manager._testStore = store;
+		managers.push(manager);
+		const realRestartAgent = manager.restartAgent.bind(manager);
+		manager.restartAgent = vi.fn(async (...args: any[]) => {
+			await realRestartAgent(...args);
+			restartCompleted = true;
+		});
+		const terminateSpy = vi.spyOn(manager, "terminateSession");
+
+		let originalReads = 0;
+		const original = recordingBridge(() => {}, {
+			modelProvider: tupleA.provider,
+			modelId: tupleA.id,
+			thinkingLevel: tupleA.thinkingLevel,
+		});
+		original.getState = vi.fn(async () => {
+			originalReads += 1;
+			const tuple = originalReads === 1
+				? tupleA
+				: { provider: tupleA.provider, id: "unverified-partial", thinkingLevel: tupleA.thinkingLevel };
+			return { success: true, data: { model: { provider: tuple.provider, id: tuple.id }, thinkingLevel: tuple.thinkingLevel } };
+		});
+		original.setModel = vi.fn(async () => ({ success: false, error: "fixture rollback failed" }));
+		original.stop = vi.fn(async () => { original.running = false; });
+		const session = liveSession(ps.id, original, {
+			spawnPinnedModel: `${tupleA.provider}/${tupleA.id}`,
+			spawnPinnedThinkingLevel: tupleA.thinkingLevel,
+		});
+		manager.sessions.set(ps.id, session);
+
+		const selection = applyRuntimeSessionThinkingSelection(manager, session, "medium");
+		const selectionOutcome = selection.then(
+			(value) => ({ value, error: undefined as unknown }),
+			(error) => ({ value: undefined, error }),
+		);
+		await recoveryReadStarted.promise;
+		const recoveredSession = manager.sessions.get(ps.id);
+		await expect(manager.assignRole(ps.id, role)).resolves.toBe(true);
+		expect(manager.sessions.get(ps.id)?.rpcClient).toBe(roleBridge);
+		expect({
+			provider: ps.modelProvider,
+			id: ps.modelId,
+			thinkingLevel: ps.effectiveThinkingLevel,
+		}).toEqual(tupleB);
+
+		releaseRecoveryRead.resolve({ success: false, error: "fixture stale recovery read failed" });
+		const settledSelection = await selectionOutcome;
+
+		expect(settledSelection.error).toBeInstanceOf(Error);
+		expect(factoryCalls).toBe(2);
+		expect(manager.restartAgent).toHaveBeenCalledTimes(1);
+		expect(recoveredBridge.stop).toHaveBeenCalled();
+		expect(roleBridge.stop, "RECOVERY_READ_HELD_STOPPED_COMMITTED_ROLE_BRIDGE").not.toHaveBeenCalled();
+		expect(terminateSpy, "RECOVERY_READ_HELD_TERMINATED_COMMITTED_ROLE_BRIDGE").not.toHaveBeenCalled();
+		expect(store.archiveAsync, "RECOVERY_READ_HELD_ARCHIVED_COMMITTED_ROLE_BRIDGE").not.toHaveBeenCalled();
+		expect(ps.archived).not.toBe(true);
+		expect(manager.sessions.get(ps.id)).toBe(recoveredSession);
+		expect(manager.sessions.get(ps.id)?.rpcClient).toBe(roleBridge);
+		expect(roleBridge.running).toBe(true);
 		expect({
 			provider: ps.modelProvider,
 			id: ps.modelId,

--- a/tests2/core/orphan-tool-result-rehydration-boundaries.test.ts
+++ b/tests2/core/orphan-tool-result-rehydration-boundaries.test.ts
@@ -978,6 +978,70 @@ describe("executable SessionManager rehydration boundaries", () => {
 		expect(manager.sessions.get(ps.id)?.promptQueue.isEmpty).toBe(true);
 	});
 
+	it("retains a complete staged auto-selection tuple for a legacy role replacement without a redundant thinking read", async () => {
+		invalidateModelCache();
+		const file = hostTranscript("assign-role-legacy-complete-tuple");
+		const role = {
+			name: "legacy-complete-tuple-role",
+			label: "Legacy complete tuple role",
+			promptTemplate: "Preserve the complete verified tuple",
+			accessory: "replacement-accessory",
+			model: `${FIXTURE_MODEL_PROVIDER}/${FIXTURE_MODEL_ID}`,
+		};
+		const roleManager = {
+			getRole: vi.fn((name: string) => name === role.name ? role : undefined),
+			listRoles: vi.fn(() => [role]),
+		};
+		const ps = persisted("assign-role-legacy-complete-tuple", file, {
+			effectiveThinkingLevel: undefined,
+		});
+		const store = mutableStore(ps);
+		let replacementStateReads = 0;
+		let replacement: any;
+		registerRpcBridgeFactory((options: Record<string, any>) => {
+			replacement = recordingBridge(() => {}, bridgeTuple(options));
+			const readState = replacement.getState.bind(replacement);
+			replacement.getState = vi.fn(async () => {
+				replacementStateReads += 1;
+				if (replacementStateReads === 4) {
+					return { success: false, error: "fixture redundant thinking read failed" };
+				}
+				return readState();
+			});
+			return replacement;
+		});
+		const manager: any = new BaseSessionManager({
+			preferencesStore,
+			roleManager: roleManager as any,
+		});
+		manager._testStore = store;
+		managers.push(manager);
+		const applyThinking = vi.spyOn(manager, "tryApplyDefaultThinkingLevel");
+		const oldBridge = recordingBridge(() => { throw new Error("old process must not switch"); });
+		oldBridge.stop = vi.fn(async () => {});
+		const original = liveSession(ps.id, oldBridge, { unsubscribe: vi.fn() });
+		manager.sessions.set(ps.id, original);
+
+		await expect(manager.assignRole(ps.id, role)).resolves.toBe(true);
+
+		expect(applyThinking, "LEGACY_STAGED_COMPLETE_TUPLE_RAN_REDUNDANT_THINKING_READ").not.toHaveBeenCalled();
+		expect(tupleUpdates(store), "LEGACY_STAGED_COMPLETE_TUPLE_WAS_DISCARDED").toEqual([{
+			modelProvider: FIXTURE_MODEL_PROVIDER,
+			modelId: FIXTURE_MODEL_ID,
+			effectiveThinkingLevel: FIXTURE_THINKING_LEVEL,
+		}]);
+		expect({
+			provider: ps.modelProvider,
+			modelId: ps.modelId,
+			thinkingLevel: ps.effectiveThinkingLevel,
+		}).toEqual({
+			provider: FIXTURE_MODEL_PROVIDER,
+			modelId: FIXTURE_MODEL_ID,
+			thinkingLevel: FIXTURE_THINKING_LEVEL,
+		});
+		expect(manager.sessions.get(ps.id)?.rpcClient).toBe(replacement);
+	});
+
 	it.each([
 		{ label: "generic errored", error: "fixture provider failure" },
 		{ label: "poisoned-history", error: ORPHAN_ERROR },
@@ -1461,9 +1525,9 @@ describe("executable SessionManager rehydration boundaries", () => {
 		const modelNameSpy = vi.spyOn(manager, "_writeModelNameFile");
 		const roleTupleVerified = deferred<void>();
 		const releaseRoleVerification = deferred<void>();
-		const realTryApplyThinking = manager.tryApplyDefaultThinkingLevel.bind(manager);
-		manager.tryApplyDefaultThinkingLevel = vi.fn(async (target: any) => {
-			const result = await realTryApplyThinking(target);
+		const realTryAutoSelect = manager.tryAutoSelectModel.bind(manager);
+		manager.tryAutoSelectModel = vi.fn(async (target: any) => {
+			const result = await realTryAutoSelect(target);
 			if (target.rpcClient === roleBridge) {
 				roleTupleVerified.resolve();
 				await releaseRoleVerification.promise;

--- a/tests2/core/orphan-tool-result-rehydration-boundaries.test.ts
+++ b/tests2/core/orphan-tool-result-rehydration-boundaries.test.ts
@@ -1323,6 +1323,159 @@ describe("executable SessionManager rehydration boundaries", () => {
 		}).toEqual(tupleB);
 	});
 
+	it("admits an empty-transcript zombie decision only after an earlier verified role replacement", async () => {
+		invalidateModelCache();
+		const raceProvider = "empty-transcript-recovery-admission";
+		const tupleA = { provider: raceProvider, id: "tuple-a", thinkingLevel: "off" as const };
+		const tupleB = { provider: raceProvider, id: "tuple-b", thinkingLevel: "off" as const };
+		const racePreferences = new PreferencesStore(
+			path.resolve("/memfs/empty-transcript-recovery-admission"),
+			createMemFs(),
+		);
+		racePreferences.set("customProviders", [{
+			id: raceProvider,
+			name: raceProvider,
+			type: "manual",
+			baseUrl: "http://127.0.0.1:9",
+			apiKey: "test-key",
+			models: [tupleA.id, tupleB.id].map((id) => ({ id, name: id })),
+		}]);
+		const role = {
+			name: "empty-transcript-replacement-role",
+			label: "Empty transcript replacement role",
+			promptTemplate: "Empty transcript replacement role",
+			accessory: "replacement-accessory",
+			model: `${tupleB.provider}/${tupleB.id}`,
+			thinkingLevel: tupleB.thinkingLevel,
+		};
+		const roleManager = {
+			getRole: vi.fn((name: string) => name === role.name ? role : undefined),
+			listRoles: vi.fn(() => [role]),
+		};
+		const ps = persisted("empty-transcript-recovery-admission", "", {
+			modelProvider: tupleA.provider,
+			modelId: tupleA.id,
+			effectiveThinkingLevel: tupleA.thinkingLevel,
+		});
+		const store = mutableStore(ps);
+		store.archiveAsync = vi.fn(async () => {
+			ps.archived = true;
+			ps.archivedAt = Date.now();
+			return true;
+		});
+
+		const roleBridge = recordingBridge(() => {}, {
+			modelProvider: tupleB.provider,
+			modelId: tupleB.id,
+			thinkingLevel: tupleB.thinkingLevel,
+		});
+		roleBridge.stop = vi.fn(async () => { roleBridge.running = false; });
+		let factoryCalls = 0;
+		registerRpcBridgeFactory(() => {
+			factoryCalls += 1;
+			return roleBridge;
+		});
+
+		const manager: any = new BaseSessionManager({ preferencesStore: racePreferences, roleManager: roleManager as any });
+		manager._testStore = store;
+		managers.push(manager);
+		const restartSpy = vi.spyOn(manager, "restartAgent");
+		const terminateSpy = vi.spyOn(manager, "terminateSession");
+		const roleTupleVerified = deferred<void>();
+		const releaseRoleCommit = deferred<void>();
+		const realTryAutoSelect = manager.tryAutoSelectModel.bind(manager);
+		manager.tryAutoSelectModel = vi.fn(async (target: any) => {
+			const result = await realTryAutoSelect(target);
+			if (target.rpcClient === roleBridge) {
+				roleTupleVerified.resolve();
+				await releaseRoleCommit.promise;
+			}
+			return result;
+		});
+
+		let originalReads = 0;
+		const original = recordingBridge(() => {}, {
+			modelProvider: tupleA.provider,
+			modelId: tupleA.id,
+			thinkingLevel: tupleA.thinkingLevel,
+		});
+		original.getState = vi.fn(async () => {
+			originalReads += 1;
+			const tuple = originalReads <= 2
+				? tupleA
+				: { provider: tupleA.provider, id: "unverified-partial", thinkingLevel: tupleA.thinkingLevel };
+			return { success: true, data: { model: { provider: tuple.provider, id: tuple.id }, thinkingLevel: tuple.thinkingLevel } };
+		});
+		original.setModel = vi.fn(async () => ({ success: false, error: "fixture rollback failed" }));
+		original.stop = vi.fn(async () => { original.running = false; });
+		const session = liveSession(ps.id, original, {
+			spawnPinnedModel: `${tupleA.provider}/${tupleA.id}`,
+			spawnPinnedThinkingLevel: tupleA.thinkingLevel,
+		});
+		manager.sessions.set(ps.id, session);
+
+		const assignmentOutcome = manager.assignRole(ps.id, role).then(
+			(value: boolean) => ({ value, error: undefined as unknown }),
+			(error: unknown) => ({ value: undefined, error }),
+		);
+		await roleTupleVerified.promise;
+		const selectionOutcome = applyRuntimeSessionThinkingSelection(manager, session, "medium").then(
+			(value) => ({ value, error: undefined as unknown }),
+			(error) => ({ value: undefined, error }),
+		);
+		await vi.waitFor(() => {
+			expect(restartSpy).toHaveBeenCalledTimes(1);
+			expect(manager._sessionReplacementCoordinators.get(ps.id)?.pending).toBe(2);
+		});
+		const restartArgs = restartSpy.mock.calls[0] as any[];
+		releaseRoleCommit.resolve();
+		const [settledAssignment, settledSelection] = await Promise.all([assignmentOutcome, selectionOutcome]);
+
+		expect(restartArgs[1]?.session, "EMPTY_ZOMBIE_RECOVERY_MISSING_EXPECTED_SESSION_OWNER").toBe(session);
+		expect(restartArgs[1]?.rpcClient, "EMPTY_ZOMBIE_RECOVERY_MISSING_EXPECTED_RPC_OWNER").toBe(original);
+		expect(settledAssignment.error, "EMPTY_ZOMBIE_RECOVERY_CANCELLED_EARLIER_ROLE_ASSIGNMENT").toBeUndefined();
+		expect(settledAssignment.value).toBe(true);
+		expect(settledSelection.error).toBeInstanceOf(Error);
+		expect(terminateSpy, "EMPTY_ZOMBIE_RECOVERY_TERMINATED_ROLE_REPLACEMENT").not.toHaveBeenCalled();
+		expect(store.archiveAsync, "EMPTY_ZOMBIE_RECOVERY_ARCHIVED_ROLE_REPLACEMENT").not.toHaveBeenCalled();
+		expect(store.updates.some((patch: Record<string, any>) => patch.archived === true),
+			"EMPTY_ZOMBIE_RECOVERY_ARCHIVED_BEFORE_OWNER_ADMISSION").toBe(false);
+		expect(ps.archived).not.toBe(true);
+		expect(ps.archivedAt).toBeUndefined();
+		expect(factoryCalls).toBe(1);
+		expect(roleBridge.stop, "EMPTY_ZOMBIE_RECOVERY_STOPPED_ROLE_REPLACEMENT").not.toHaveBeenCalled();
+		expect(manager.sessions.get(ps.id)).toBe(session);
+		expect(manager.sessions.get(ps.id)?.rpcClient).toBe(roleBridge);
+		expect({
+			role: ps.role,
+			provider: ps.modelProvider,
+			id: ps.modelId,
+			thinkingLevel: ps.effectiveThinkingLevel,
+		}).toEqual({ role: role.name, ...tupleB });
+	});
+
+	it("preserves direct restart zombie archival after serialized admission", async () => {
+		const ps = persisted("direct-empty-transcript-restart", "");
+		const store = mutableStore(ps);
+		const manager: any = new SessionManager();
+		manager._testStore = store;
+		managers.push(manager);
+		const bridge = recordingBridge(() => {});
+		bridge.stop = vi.fn(async () => { bridge.running = false; });
+		const session = liveSession(ps.id, bridge);
+		manager.sessions.set(ps.id, session);
+
+		await expect(manager.restartAgent(ps.id)).rejects.toMatchObject({
+			code: "SESSION_UNRECOVERABLE_ARCHIVED",
+		});
+
+		expect(store.updates.some((patch: Record<string, any>) => patch.archived === true)).toBe(true);
+		expect(ps.archived).toBe(true);
+		expect(ps.archivedAt).toEqual(expect.any(Number));
+		expect(bridge.stop, "DIRECT_ZOMBIE_RESTART_STOPPED_UNRECOVERABLE_BRIDGE").not.toHaveBeenCalled();
+		expect(manager.sessions.get(ps.id)).toBe(session);
+	});
+
 	it("does not let owner-sensitive recovery join a generic rehydrate queued behind role replacement", async () => {
 		invalidateModelCache();
 		const file = hostTranscript("owner-sensitive-recovery-coalesce");

--- a/tests2/core/orphan-tool-result-rehydration-boundaries.test.ts
+++ b/tests2/core/orphan-tool-result-rehydration-boundaries.test.ts
@@ -32,7 +32,10 @@ const { SessionManager: BaseSessionManager, switchSessionPathForAgent } = await 
 const { executePlan } = await import("../../src/server/agent/session-setup.ts");
 const { initPromptDirs } = await import("../../src/server/agent/system-prompt.ts");
 const { loadOrCreateToken } = await import("../../src/server/auth/token.ts");
-const { applyRuntimeSessionModelSelection } = await import("../../src/server/ws/runtime-model-selection.ts");
+const {
+	applyRuntimeSessionModelSelection,
+	applyRuntimeSessionThinkingSelection,
+} = await import("../../src/server/ws/runtime-model-selection.ts");
 
 const FIXTURE_MODEL_PROVIDER = "orphan-boundary-mock";
 const FIXTURE_MODEL_ID = "orphan-boundary-model";
@@ -1136,6 +1139,289 @@ describe("executable SessionManager rehydration boundaries", () => {
 			thinkingLevel: ps.effectiveThinkingLevel,
 		}, "SELECTION_REPLACEMENT_RACE: failed role replacement restored stale tuple A over committed tuple B")
 			.toEqual(tupleB);
+	});
+
+	it("rejects a stale recovery respawn queued behind a committed role bridge", async () => {
+		invalidateModelCache();
+		const file = hostTranscript("queued-stale-recovery-respawn");
+		const raceProvider = "queued-stale-recovery";
+		const tupleA = { provider: raceProvider, id: "tuple-a", thinkingLevel: "off" as const };
+		const tupleB = { provider: raceProvider, id: "tuple-b", thinkingLevel: "off" as const };
+		const racePreferences = new PreferencesStore(
+			path.resolve("/memfs/queued-stale-recovery-respawn"),
+			createMemFs(),
+		);
+		racePreferences.set("customProviders", [{
+			id: raceProvider,
+			name: raceProvider,
+			type: "manual",
+			baseUrl: "http://127.0.0.1:9",
+			apiKey: "test-key",
+			models: [tupleA.id, tupleB.id].map((id) => ({ id, name: id })),
+		}]);
+		const role = {
+			name: "queued-replacement-role",
+			label: "Queued replacement role",
+			promptTemplate: "Queued replacement role",
+			accessory: "replacement-accessory",
+			model: `${tupleB.provider}/${tupleB.id}`,
+			thinkingLevel: tupleB.thinkingLevel,
+		};
+		const roleManager = {
+			getRole: vi.fn((name: string) => name === role.name ? role : undefined),
+			listRoles: vi.fn(() => [role]),
+		};
+		const ps = persisted("queued-stale-recovery-respawn", file, {
+			modelProvider: tupleA.provider,
+			modelId: tupleA.id,
+			effectiveThinkingLevel: tupleA.thinkingLevel,
+		});
+		const store = mutableStore(ps);
+		store.archiveAsync = vi.fn(async () => {
+			ps.archived = true;
+			return true;
+		});
+
+		const roleStartSeen = deferred<void>();
+		const releaseRoleStart = deferred<void>();
+		const roleBridge = recordingBridge(() => {}, {
+			modelProvider: tupleB.provider,
+			modelId: tupleB.id,
+			thinkingLevel: tupleB.thinkingLevel,
+		});
+		roleBridge.start = vi.fn(async () => {
+			roleStartSeen.resolve();
+			await releaseRoleStart.promise;
+		});
+		roleBridge.stop = vi.fn(async () => { roleBridge.running = false; });
+		let recoveryBridge: any;
+		let factoryCalls = 0;
+		registerRpcBridgeFactory((options: Record<string, any>) => {
+			factoryCalls += 1;
+			if (factoryCalls === 1) return roleBridge;
+			recoveryBridge = recordingBridge(() => {}, bridgeTuple(options));
+			recoveryBridge.stop = vi.fn(async () => { recoveryBridge.running = false; });
+			return recoveryBridge;
+		});
+
+		const manager: any = new BaseSessionManager({ preferencesStore: racePreferences, roleManager: roleManager as any });
+		manager._testStore = store;
+		managers.push(manager);
+		const restartSpy = vi.spyOn(manager, "restartAgent");
+		let originalReads = 0;
+		const original = recordingBridge(() => {}, {
+			modelProvider: tupleA.provider,
+			modelId: tupleA.id,
+			thinkingLevel: tupleA.thinkingLevel,
+		});
+		original.getState = vi.fn(async () => {
+			originalReads += 1;
+			const tuple = originalReads <= 2
+				? tupleA
+				: { provider: tupleA.provider, id: "unverified-partial", thinkingLevel: tupleA.thinkingLevel };
+			return { success: true, data: { model: { provider: tuple.provider, id: tuple.id }, thinkingLevel: tuple.thinkingLevel } };
+		});
+		original.setModel = vi.fn(async () => ({ success: false, error: "fixture rollback failed" }));
+		original.stop = vi.fn(async () => { original.running = false; });
+		const session = liveSession(ps.id, original, {
+			spawnPinnedModel: `${tupleA.provider}/${tupleA.id}`,
+			spawnPinnedThinkingLevel: tupleA.thinkingLevel,
+		});
+		manager.sessions.set(ps.id, session);
+
+		const assignment = manager.assignRole(ps.id, role);
+		await roleStartSeen.promise;
+		const selection = applyRuntimeSessionThinkingSelection(manager, session, "medium");
+		await vi.waitFor(() => {
+			expect(restartSpy).toHaveBeenCalledTimes(1);
+			expect(manager._sessionReplacementCoordinators.get(ps.id)?.pending).toBe(2);
+		});
+		const restartArgs = restartSpy.mock.calls[0] as any[];
+		releaseRoleStart.resolve();
+
+		await expect(assignment).resolves.toBe(true);
+		await expect(selection).rejects.toThrow();
+
+		expect(restartArgs[1]?.session, "STALE_RESPAWN_MISSING_EXPECTED_SESSION_OWNER").toBe(session);
+		expect(restartArgs[1]?.rpcClient, "STALE_RESPAWN_MISSING_EXPECTED_RPC_OWNER").toBe(original);
+		expect(roleBridge.stop, "STALE_RESPAWN_STOPPED_COMMITTED_ROLE_BRIDGE").not.toHaveBeenCalled();
+		expect(factoryCalls, "STALE_RESPAWN_CONSTRUCTED_REPLACEMENT_FOR_UNOWNED_BRIDGE").toBe(1);
+		if (recoveryBridge) {
+			expect(recoveryBridge.stop, "STALE_RESPAWN_QUARANTINED_REPLACEMENT").not.toHaveBeenCalled();
+		}
+		expect(store.archiveAsync, "STALE_RESPAWN_ARCHIVED_COMMITTED_ROLE_BRIDGE").not.toHaveBeenCalled();
+		expect(manager.sessions.get(ps.id)).toBe(session);
+		expect(manager.sessions.get(ps.id)?.rpcClient).toBe(roleBridge);
+		expect({
+			provider: ps.modelProvider,
+			id: ps.modelId,
+			thinkingLevel: ps.effectiveThinkingLevel,
+		}).toEqual(tupleB);
+	});
+
+	it("keeps staged role verification side-effect-free while recovered A remains canonical", async () => {
+		invalidateModelCache();
+		const file = hostTranscript("staged-role-verification-durability");
+		const raceProvider = "staged-role-verification";
+		const tupleA = { provider: raceProvider, id: "tuple-a", thinkingLevel: "off" as const };
+		const tupleB = { provider: raceProvider, id: "tuple-b", thinkingLevel: "off" as const };
+		const racePreferences = new PreferencesStore(
+			path.resolve("/memfs/staged-role-verification-durability"),
+			createMemFs(),
+		);
+		racePreferences.set("customProviders", [{
+			id: raceProvider,
+			name: raceProvider,
+			type: "manual",
+			baseUrl: "http://127.0.0.1:9",
+			apiKey: "test-key",
+			models: [tupleA.id, tupleB.id].map((id) => ({ id, name: id })),
+		}]);
+		const role = {
+			name: "staged-verification-role",
+			label: "Staged verification role",
+			promptTemplate: "Staged verification role",
+			accessory: "replacement-accessory",
+			model: `${tupleB.provider}/${tupleB.id}`,
+			thinkingLevel: tupleB.thinkingLevel,
+		};
+		const roleManager = {
+			getRole: vi.fn((name: string) => name === role.name ? role : undefined),
+			listRoles: vi.fn(() => [role]),
+		};
+		const ps = persisted("staged-role-verification-durability", file, {
+			modelProvider: tupleA.provider,
+			modelId: tupleA.id,
+			effectiveThinkingLevel: tupleA.thinkingLevel,
+		});
+		const store = mutableStore(ps);
+		store.archiveAsync = vi.fn(async () => {
+			ps.archived = true;
+			return true;
+		});
+
+		let restartCompleted = false;
+		let recoveryReadHeld = false;
+		const recoveryReadStarted = deferred<void>();
+		const releaseRecoveryRead = deferred<unknown>();
+		let recoveredBridge: any;
+		let roleBridge: any;
+		let factoryCalls = 0;
+		registerRpcBridgeFactory((options: Record<string, any>) => {
+			factoryCalls += 1;
+			const tuple = bridgeTuple(options);
+			if (factoryCalls === 1) {
+				recoveredBridge = recordingBridge(() => {}, tuple);
+				const normalGetState = recoveredBridge.getState.bind(recoveredBridge);
+				recoveredBridge.getState = vi.fn(async () => {
+					if (restartCompleted && !recoveryReadHeld) {
+						recoveryReadHeld = true;
+						recoveryReadStarted.resolve();
+						return releaseRecoveryRead.promise;
+					}
+					return normalGetState();
+				});
+				recoveredBridge.stop = vi.fn(async () => { recoveredBridge.running = false; });
+				return recoveredBridge;
+			}
+			roleBridge = recordingBridge(() => {}, tuple);
+			roleBridge.stop = vi.fn(async () => { roleBridge.running = false; });
+			return roleBridge;
+		});
+
+		const manager: any = new BaseSessionManager({ preferencesStore: racePreferences, roleManager: roleManager as any });
+		manager._testStore = store;
+		managers.push(manager);
+		const realRestartAgent = manager.restartAgent.bind(manager);
+		manager.restartAgent = vi.fn(async (...args: any[]) => {
+			await realRestartAgent(...args);
+			restartCompleted = true;
+		});
+		const terminateSpy = vi.spyOn(manager, "terminateSession");
+		const modelNameSpy = vi.spyOn(manager, "_writeModelNameFile");
+		const roleTupleVerified = deferred<void>();
+		const releaseRoleVerification = deferred<void>();
+		const realTryApplyThinking = manager.tryApplyDefaultThinkingLevel.bind(manager);
+		manager.tryApplyDefaultThinkingLevel = vi.fn(async (target: any) => {
+			const result = await realTryApplyThinking(target);
+			if (target.rpcClient === roleBridge) {
+				roleTupleVerified.resolve();
+				await releaseRoleVerification.promise;
+			}
+			return result;
+		});
+
+		let originalReads = 0;
+		const original = recordingBridge(() => {}, {
+			modelProvider: tupleA.provider,
+			modelId: tupleA.id,
+			thinkingLevel: tupleA.thinkingLevel,
+		});
+		original.getState = vi.fn(async () => {
+			originalReads += 1;
+			const tuple = originalReads === 1
+				? tupleA
+				: { provider: tupleA.provider, id: "unverified-partial", thinkingLevel: tupleA.thinkingLevel };
+			return { success: true, data: { model: { provider: tuple.provider, id: tuple.id }, thinkingLevel: tuple.thinkingLevel } };
+		});
+		original.setModel = vi.fn(async () => ({ success: false, error: "fixture rollback failed" }));
+		original.stop = vi.fn(async () => { original.running = false; });
+		const session = liveSession(ps.id, original, {
+			spawnPinnedModel: `${tupleA.provider}/${tupleA.id}`,
+			spawnPinnedThinkingLevel: tupleA.thinkingLevel,
+		});
+		manager.sessions.set(ps.id, session);
+
+		const selection = applyRuntimeSessionThinkingSelection(manager, session, "medium");
+		const selectionOutcome = selection.then(
+			(value) => ({ value, error: undefined as unknown }),
+			(error) => ({ value: undefined, error }),
+		);
+		await recoveryReadStarted.promise;
+		modelNameSpy.mockClear();
+		const assignment = manager.assignRole(ps.id, role);
+		const assignmentOutcome = assignment.then(
+			(value: boolean) => ({ value, error: undefined as unknown }),
+			(error: unknown) => ({ value: undefined, error }),
+		);
+		await roleTupleVerified.promise;
+		const durableWhileStaged = {
+			provider: ps.modelProvider,
+			id: ps.modelId,
+			thinkingLevel: ps.effectiveThinkingLevel,
+		};
+		const modelNameWritesWhileStaged = modelNameSpy.mock.calls.length;
+		const provisionalTupleExposed = durableWhileStaged.provider === tupleB.provider
+			&& durableWhileStaged.id === tupleB.id
+			&& durableWhileStaged.thinkingLevel === tupleB.thinkingLevel;
+
+		releaseRecoveryRead.resolve({
+			success: true,
+			data: { model: { provider: tupleA.provider, id: tupleA.id }, thinkingLevel: tupleA.thinkingLevel },
+		});
+		if (provisionalTupleExposed) {
+			await vi.waitFor(() => expect(terminateSpy).toHaveBeenCalledTimes(1));
+		} else {
+			await selectionOutcome;
+		}
+		releaseRoleVerification.resolve();
+		const [settledSelection, settledAssignment] = await Promise.all([selectionOutcome, assignmentOutcome]);
+
+		expect(durableWhileStaged, "STAGED_ROLE_TUPLE_BECAME_DURABLE_BEFORE_LIFECYCLE_COMMIT").toEqual(tupleA);
+		expect(modelNameWritesWhileStaged, "STAGED_ROLE_MODEL_NAME_CHANGED_BEFORE_LIFECYCLE_COMMIT").toBe(0);
+		expect(settledSelection.error).toBeInstanceOf(Error);
+		expect(settledAssignment.error).toBeUndefined();
+		expect(settledAssignment.value).toBe(true);
+		expect(terminateSpy, "STAGED_ROLE_TUPLE_QUARANTINED_HEALTHY_RECOVERY_BRIDGE").not.toHaveBeenCalled();
+		expect(store.archiveAsync, "STAGED_ROLE_TUPLE_ARCHIVED_HEALTHY_SESSION").not.toHaveBeenCalled();
+		expect(recoveredBridge.stop).toHaveBeenCalledTimes(1);
+		expect(roleBridge.stop).not.toHaveBeenCalled();
+		expect(manager.sessions.get(ps.id)?.rpcClient).toBe(roleBridge);
+		expect({
+			provider: ps.modelProvider,
+			id: ps.modelId,
+			thinkingLevel: ps.effectiveThinkingLevel,
+		}).toEqual(tupleB);
 	});
 
 	it("does not let stale runtime recovery quarantine a newer canonical role replacement", async () => {

--- a/tests2/core/runtime-model-recovery-ownership.test.ts
+++ b/tests2/core/runtime-model-recovery-ownership.test.ts
@@ -1,0 +1,255 @@
+import { guardProcessEnv } from "./helpers/env-guard.js";
+guardProcessEnv();
+
+import assert from "node:assert/strict";
+import { describe, it, vi } from "vitest";
+import { applyRuntimeSessionThinkingSelection } from "../../src/server/ws/runtime-model-selection.js";
+
+const SESSION_ID = "runtime-recovery-owner";
+const DURABLE_A = {
+	provider: "anthropic",
+	id: "claude-sonnet-4-20250514",
+	thinkingLevel: "high",
+} as const;
+const DURABLE_B = {
+	provider: "openai",
+	id: "gpt-5",
+	thinkingLevel: "medium",
+} as const;
+const DURABLE_C = {
+	provider: "google",
+	id: "gemini-2.5-pro",
+	thinkingLevel: "high",
+} as const;
+const MARKER = "RUNTIME_RECOVERY_OWNERSHIP";
+
+type Tuple = { provider: string; id: string; thinkingLevel: string };
+type Deferred<T> = {
+	promise: Promise<T>;
+	resolve: (value: T) => void;
+	reject: (reason: unknown) => void;
+};
+
+function deferred<T>(): Deferred<T> {
+	let resolve!: (value: T) => void;
+	let reject!: (reason: unknown) => void;
+	const promise = new Promise<T>((res, rej) => {
+		resolve = res;
+		reject = rej;
+	});
+	return { promise, resolve, reject };
+}
+
+function state(tuple: Tuple): unknown {
+	return {
+		success: true,
+		data: {
+			model: { provider: tuple.provider, id: tuple.id },
+			thinkingLevel: tuple.thinkingLevel,
+		},
+	};
+}
+
+function makeBridge(name: string, getState: () => Promise<unknown>) {
+	const bridge: any = {
+		name,
+		running: true,
+		getState: vi.fn(getState),
+		setModel: vi.fn(async () => ({ success: true })),
+		setThinkingLevel: vi.fn(async () => ({ success: true })),
+		stop: vi.fn(async () => { bridge.running = false; }),
+	};
+	return bridge;
+}
+
+function makeSession(name: string, bridge: any) {
+	return {
+		name,
+		id: SESSION_ID,
+		clients: new Set(),
+		rpcClient: bridge,
+		spawnPinnedModel: `${DURABLE_A.provider}/${DURABLE_A.id}`,
+		spawnPinnedThinkingLevel: DURABLE_A.thinkingLevel,
+	};
+}
+
+function makeHarness(restartBridge: any) {
+	let durable: Tuple = { ...DURABLE_A };
+	let originalReads = 0;
+	const originalBridge = makeBridge("O", async () => {
+		originalReads += 1;
+		// The requested thinking mutation and correction read remain on A/high.
+		// The rollback model read then returns the wrong identity, forcing restart.
+		return originalReads < 4
+			? state(DURABLE_A)
+			: state({ provider: "anthropic", id: "rollback-mismatch", thinkingLevel: "high" });
+	});
+	const original = makeSession("O", originalBridge);
+	const restart = makeSession("R", restartBridge);
+	let canonical: any = original;
+	const terminated: string[] = [];
+	const archived: string[] = [];
+	const broadcasts: string[] = [];
+
+	const manager: any = {
+		getPersistedSession: () => ({
+			modelProvider: durable.provider,
+			modelId: durable.id,
+			effectiveThinkingLevel: durable.thinkingLevel,
+		}),
+		persistSessionModel: (_id: string, provider: string, id: string, thinkingLevel: string) => {
+			durable = { provider, id, thinkingLevel };
+		},
+		updateModelNameFile: vi.fn(),
+		getSession: () => canonical,
+		restartAgent: vi.fn(async () => {
+			await originalBridge.stop();
+			canonical = restart;
+		}),
+		terminateSession: vi.fn(async () => {
+			if (!canonical) return false;
+			terminated.push(canonical.name);
+			await canonical.rpcClient.stop();
+			canonical = undefined;
+			return true;
+		}),
+		storeArchive: vi.fn(async () => {
+			archived.push(canonical?.name ?? "none");
+			return true;
+		}),
+	};
+	const broadcast = (_clients: Set<unknown>, message: any) => {
+		const model = message?.data?.model;
+		broadcasts.push(`${model?.provider}/${model?.id}/${message?.data?.thinkingLevel}`);
+	};
+	const install = (session: any, tuple: Tuple) => {
+		canonical = session;
+		durable = { ...tuple };
+	};
+
+	return {
+		manager,
+		original,
+		restart,
+		originalBridge,
+		broadcast,
+		broadcasts,
+		terminated,
+		archived,
+		install,
+		canonical: () => canonical,
+		durable: () => ({ ...durable }),
+	};
+}
+
+function startFailedSelection(harness: ReturnType<typeof makeHarness>): Promise<unknown> {
+	return applyRuntimeSessionThinkingSelection(
+		harness.manager,
+		harness.original as any,
+		"medium",
+		harness.broadcast,
+	);
+}
+
+describe("runtime recovery bridge ownership", () => {
+	it("retains B when it replaces restart bridge R during R read-back", async () => {
+		const rReadStarted = deferred<void>();
+		const rRead = deferred<unknown>();
+		const rBridge = makeBridge("R", async () => {
+			rReadStarted.resolve();
+			return rRead.promise;
+		});
+		const harness = makeHarness(rBridge);
+		const bBridge = makeBridge("B", async () => state(DURABLE_B));
+		const b = makeSession("B", bBridge);
+
+		const selection = startFailedSelection(harness);
+		await rReadStarted.promise;
+		harness.install(b, DURABLE_B);
+		rRead.resolve({ success: true, data: {} });
+		await assert.rejects(selection);
+
+		assert.deepEqual(harness.terminated, [], `${MARKER}: stale R recovery terminated canonical B`);
+		assert.deepEqual(harness.archived, [], `${MARKER}: stale R recovery archived canonical B`);
+		assert.equal(rBridge.stop.mock.calls.length, 1, `${MARKER}: detached R must be stopped exactly once`);
+		assert.equal(bBridge.stop.mock.calls.length, 0, `${MARKER}: canonical B must not be stopped`);
+		assert.equal(harness.canonical(), b, `${MARKER}: B must remain canonical`);
+		assert.deepEqual(harness.durable(), DURABLE_B, `${MARKER}: B must remain durable`);
+		assert.equal(harness.broadcasts.at(-1), `${DURABLE_B.provider}/${DURABLE_B.id}/${DURABLE_B.thinkingLevel}`);
+	});
+
+	it("retains B when it commits after R failure is released but before quarantine admission", async () => {
+		const rReadStarted = deferred<void>();
+		const releaseRFailure = deferred<void>();
+		const rBridge = makeBridge("R", async () => {
+			rReadStarted.resolve();
+			await releaseRFailure.promise;
+			throw new Error("R read-back failed");
+		});
+		const harness = makeHarness(rBridge);
+		const bBridge = makeBridge("B", async () => state(DURABLE_B));
+		const b = makeSession("B", bBridge);
+
+		const selection = startFailedSelection(harness);
+		await rReadStarted.promise;
+		releaseRFailure.resolve();
+		// This synchronous staged commit runs before the failed read's continuation
+		// can enter quarantine by session id.
+		harness.install(b, DURABLE_B);
+		await assert.rejects(selection);
+
+		assert.deepEqual(harness.terminated, [], `${MARKER}: post-failure R recovery terminated canonical B`);
+		assert.deepEqual(harness.archived, [], `${MARKER}: post-failure R recovery archived canonical B`);
+		assert.equal(rBridge.stop.mock.calls.length, 1, `${MARKER}: failed detached R must be stopped`);
+		assert.equal(bBridge.stop.mock.calls.length, 0, `${MARKER}: canonical B must not be stopped`);
+		assert.equal(harness.canonical(), b, `${MARKER}: B must remain canonical`);
+		assert.deepEqual(harness.durable(), DURABLE_B, `${MARKER}: B must remain durable`);
+	});
+
+	it("does not publish B after C replaces it while B verification is held", async () => {
+		const rReadStarted = deferred<void>();
+		const releaseRFailure = deferred<void>();
+		const rBridge = makeBridge("R", async () => {
+			rReadStarted.resolve();
+			await releaseRFailure.promise;
+			throw new Error("R read-back failed");
+		});
+		const harness = makeHarness(rBridge);
+		const bReadStarted = deferred<void>();
+		const releaseBRead = deferred<unknown>();
+		const bBridge = makeBridge("B", async () => {
+			bReadStarted.resolve();
+			return releaseBRead.promise;
+		});
+		const b = makeSession("B", bBridge);
+		const cBridge = makeBridge("C", async () => state(DURABLE_C));
+		const c = makeSession("C", cBridge);
+
+		const selection = startFailedSelection(harness);
+		await rReadStarted.promise;
+		harness.install(b, DURABLE_B);
+		releaseRFailure.resolve();
+		const admission = await Promise.race([
+			bReadStarted.promise.then(() => "B-read" as const),
+			selection.then(() => "settled" as const, () => "settled" as const),
+		]);
+		assert.equal(admission, "B-read", `${MARKER}: recovery quarantined B instead of verifying the newer canonical bridge`);
+
+		harness.broadcasts.push("C-authoritative");
+		harness.install(c, DURABLE_C);
+		releaseBRead.resolve(state(DURABLE_B));
+		await assert.rejects(selection);
+
+		const cIndex = harness.broadcasts.indexOf("C-authoritative");
+		assert.equal(
+			harness.broadcasts.slice(cIndex + 1).some((entry) => entry === `${DURABLE_B.provider}/${DURABLE_B.id}/${DURABLE_B.thinkingLevel}`),
+			false,
+			`${MARKER}: stale B read-back was published after C became authoritative`,
+		);
+		assert.deepEqual(harness.terminated, [], `${MARKER}: stale B verification terminated canonical C`);
+		assert.deepEqual(harness.archived, [], `${MARKER}: stale B verification archived canonical C`);
+		assert.equal(cBridge.stop.mock.calls.length, 0, `${MARKER}: canonical C must not be stopped`);
+		assert.equal(harness.canonical(), c, `${MARKER}: C must remain canonical`);
+		assert.deepEqual(harness.durable(), DURABLE_C, `${MARKER}: C must remain durable`);
+	});
+});

--- a/tests2/integration/context-bar-reconnect.test.ts
+++ b/tests2/integration/context-bar-reconnect.test.ts
@@ -16,11 +16,33 @@ import {
 	type WsMsg,
 } from "./_e2e/e2e-setup.js";
 import { pollUntil } from "../../tests/e2e/test-utils/cleanup.js";
-import { getAvailableModels, invalidateModelCache, type ApiModel } from "../../src/server/agent/model-registry.js";
+import {
+	getAvailableModels,
+	invalidateModelCache,
+	resolveModelStateMeta,
+	type ApiModel,
+} from "../../src/server/agent/model-registry.js";
 
 const OPUS_5 = { provider: "anthropic", id: "claude-opus-5", thinkingLevel: "xhigh" } as const;
 const STALE_MODEL_IDS = new Set(["claude-opus-4-8", "claude-opus-4-7", "claude-opus-4-6", "claude-opus-4"]);
 const SNAPSHOT_PROVIDER = "tuple-snapshot-custom";
+const INFERRED_DYNAMIC_TUPLE = { provider: "custom", id: "cache-empty-dynamic-a", thinkingLevel: "high" } as const;
+const INFERRED_DYNAMIC_MODEL = {
+	provider: INFERRED_DYNAMIC_TUPLE.provider,
+	id: INFERRED_DYNAMIC_TUPLE.id,
+	contextWindow: 654_319,
+	maxTokens: 23_417,
+	reasoning: true,
+	thinkingLevelMap: { off: null, high: "high", max: "max" },
+} as const;
+const FOREIGN_DYNAMIC_MODEL = {
+	provider: INFERRED_DYNAMIC_TUPLE.provider,
+	id: "cache-empty-dynamic-foreign",
+	contextWindow: 777_731,
+	maxTokens: 31_337,
+	reasoning: true,
+	thinkingLevelMap: { off: "foreign-off", max: "foreign-max" },
+} as const;
 const DURABLE_SNAPSHOT_TUPLE = { provider: SNAPSHOT_PROVIDER, id: "durable-a", thinkingLevel: "high" } as const;
 const TARGET_SNAPSHOT_TUPLE = { provider: SNAPSHOT_PROVIDER, id: "target-b", thinkingLevel: "xhigh" } as const;
 const DURABLE_SNAPSHOT_MODEL = {
@@ -364,6 +386,85 @@ test.describe("model state after reconnect", () => {
 
 	test("a second connection retains the durable custom tuple while thinking mutation is pending", async ({ gateway }) => {
 		await exercisePartialMutationSnapshot(gateway, sessionId, "second-connection");
+	});
+
+	test("cache-empty inferred matching live identity preserves metadata while durable thinking repairs the tuple", async ({ gateway }) => {
+		const session = gateway.sessionManager.getSession(sessionId);
+		expect(session?.status).toBe("idle");
+		gateway.sessionManager.persistSessionModel(
+			sessionId,
+			INFERRED_DYNAMIC_TUPLE.provider,
+			INFERRED_DYNAMIC_TUPLE.id,
+			INFERRED_DYNAMIC_TUPLE.thinkingLevel,
+		);
+		expect(gateway.sessionManager.getPersistedSession(sessionId)).toMatchObject({
+			modelProvider: INFERRED_DYNAMIC_TUPLE.provider,
+			modelId: INFERRED_DYNAMIC_TUPLE.id,
+			effectiveThinkingLevel: INFERRED_DYNAMIC_TUPLE.thinkingLevel,
+		});
+
+		// Force the dynamic custom model through inferMeta: only the matching live
+		// bridge knows its exact limits and thinking map.
+		invalidateModelCache();
+		expect(resolveModelStateMeta(INFERRED_DYNAMIC_TUPLE.provider, INFERRED_DYNAMIC_TUPLE.id).source).toBe("inferred");
+		session.eventBuffer.push({ type: "inferred_dynamic_snapshot_test_seed" });
+
+		const getState = vi.spyOn(session.rpcClient, "getState")
+			.mockResolvedValueOnce({
+				success: true,
+				data: { model: { ...INFERRED_DYNAMIC_MODEL } },
+			})
+			.mockResolvedValueOnce({
+				success: true,
+				data: { model: { ...INFERRED_DYNAMIC_MODEL }, thinkingLevel: "low" },
+			})
+			.mockResolvedValueOnce({
+				success: true,
+				data: { model: { ...FOREIGN_DYNAMIC_MODEL }, thinkingLevel: "low" },
+			});
+		let ws: WsConnection | undefined;
+		try {
+			ws = await connectWs(sessionId);
+			const missingThinking = await ws.waitFor(
+				(message) => stateModelId(message) === INFERRED_DYNAMIC_TUPLE.id,
+				5_000,
+			);
+			expect((missingThinking.data as any).model).toEqual(INFERRED_DYNAMIC_MODEL);
+			expect((missingThinking.data as any).thinkingLevel).toBe(INFERRED_DYNAMIC_TUPLE.thinkingLevel);
+
+			let cursor = ws.messageCount();
+			ws.send({ type: "get_state" });
+			const mismatchedThinking = await ws.waitForFrom(
+				cursor,
+				(message) => stateModelId(message) === INFERRED_DYNAMIC_TUPLE.id,
+				5_000,
+			);
+			expect((mismatchedThinking.data as any).model).toEqual(INFERRED_DYNAMIC_MODEL);
+			expect((mismatchedThinking.data as any).thinkingLevel).toBe(INFERRED_DYNAMIC_TUPLE.thinkingLevel);
+
+			cursor = ws.messageCount();
+			ws.send({ type: "get_state" });
+			const differentIdentity = await ws.waitForFrom(
+				cursor,
+				(message) => stateModelId(message) === INFERRED_DYNAMIC_TUPLE.id,
+				5_000,
+			);
+			const differentIdentityState = differentIdentity.data as any;
+			expect(differentIdentityState.thinkingLevel).toBe(INFERRED_DYNAMIC_TUPLE.thinkingLevel);
+			expect(differentIdentityState.model).toMatchObject({
+				provider: INFERRED_DYNAMIC_TUPLE.provider,
+				id: INFERRED_DYNAMIC_TUPLE.id,
+			});
+			expect(differentIdentityState.model.contextWindow).not.toBe(FOREIGN_DYNAMIC_MODEL.contextWindow);
+			expect(differentIdentityState.model.maxTokens).not.toBe(FOREIGN_DYNAMIC_MODEL.maxTokens);
+			expect(differentIdentityState.model.reasoning).not.toBe(FOREIGN_DYNAMIC_MODEL.reasoning);
+			expect(differentIdentityState.model.thinkingLevelMap).not.toEqual(FOREIGN_DYNAMIC_MODEL.thinkingLevelMap);
+			expect(getState).toHaveBeenCalledTimes(3);
+		} finally {
+			getState.mockRestore();
+			if (ws) await closeWs(ws);
+			invalidateModelCache();
+		}
 	});
 
 	test("matching live model without thinking hydrates one complete durable tuple on reconnect and get_state", async ({ gateway }) => {

--- a/tests2/integration/context-bar-reconnect.test.ts
+++ b/tests2/integration/context-bar-reconnect.test.ts
@@ -16,9 +16,49 @@ import {
 	type WsMsg,
 } from "./_e2e/e2e-setup.js";
 import { pollUntil } from "../../tests/e2e/test-utils/cleanup.js";
+import { getAvailableModels, invalidateModelCache, type ApiModel } from "../../src/server/agent/model-registry.js";
 
 const OPUS_5 = { provider: "anthropic", id: "claude-opus-5", thinkingLevel: "xhigh" } as const;
 const STALE_MODEL_IDS = new Set(["claude-opus-4-8", "claude-opus-4-7", "claude-opus-4-6", "claude-opus-4"]);
+const SNAPSHOT_PROVIDER = "tuple-snapshot-custom";
+const DURABLE_SNAPSHOT_TUPLE = { provider: SNAPSHOT_PROVIDER, id: "durable-a", thinkingLevel: "high" } as const;
+const TARGET_SNAPSHOT_TUPLE = { provider: SNAPSHOT_PROVIDER, id: "target-b", thinkingLevel: "xhigh" } as const;
+const DURABLE_SNAPSHOT_MODEL = {
+	provider: SNAPSHOT_PROVIDER,
+	id: DURABLE_SNAPSHOT_TUPLE.id,
+	contextWindow: 131_071,
+	maxTokens: 8_191,
+	reasoning: true,
+	thinkingLevelMap: { off: "off", high: "high" },
+} as const;
+const TARGET_SNAPSHOT_MODEL = {
+	provider: SNAPSHOT_PROVIDER,
+	id: TARGET_SNAPSHOT_TUPLE.id,
+	contextWindow: 262_139,
+	maxTokens: 32_749,
+	reasoning: true,
+	thinkingLevelMap: { off: null, xhigh: "xhigh", max: "max" },
+} as const;
+
+function snapshotCatalogRow(model: typeof DURABLE_SNAPSHOT_MODEL | typeof TARGET_SNAPSHOT_MODEL): ApiModel {
+	return {
+		...model,
+		name: model.id,
+		api: "openai-completions",
+		input: ["text"],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		authenticated: true,
+	};
+}
+
+async function installSnapshotCatalog(gateway: any): Promise<void> {
+	invalidateModelCache();
+	const preferencesStore = gateway.sessionManager.preferencesStore;
+	expect(preferencesStore, "gateway fixture must expose the current model preferences").toBeTruthy();
+	const models = await getAvailableModels(preferencesStore);
+	expect(models.some((model) => model.provider === SNAPSHOT_PROVIDER)).toBe(false);
+	models.push(snapshotCatalogRow(DURABLE_SNAPSHOT_MODEL), snapshotCatalogRow(TARGET_SNAPSHOT_MODEL));
+}
 
 function stateModelId(message: WsMsg): string | undefined {
 	return message.type === "state" ? (message.data as any)?.model?.id : undefined;
@@ -77,6 +117,171 @@ async function closeWs(ws: WsConnection) {
 	const closed = new Promise<void>(r => ws.ws.once("close", () => r()));
 	ws.close();
 	await closed;
+}
+
+async function waitForPersistedTuple(gateway: any, sessionId: string, tuple: typeof DURABLE_SNAPSHOT_TUPLE | typeof TARGET_SNAPSHOT_TUPLE) {
+	await pollUntil(async () => {
+		const persisted = gateway.sessionManager.getPersistedSession(sessionId);
+		return persisted?.modelProvider === tuple.provider
+			&& persisted.modelId === tuple.id
+			&& persisted.effectiveThinkingLevel === tuple.thinkingLevel;
+	}, { timeoutMs: 5_000, intervalMs: 25, label: `${tuple.id}/${tuple.thinkingLevel} tuple persisted` });
+}
+
+function expectDurablePartialMutationSnapshot(
+	message: WsMsg,
+	expectedStatus: string,
+	expectedStatusVersion: number,
+	expectedCost: Record<string, unknown>,
+): void {
+	expect(message.type).toBe("state");
+	const state = message.data as any;
+	expect(state.model, "an in-flight model must not lend identity or metadata to the durable snapshot").toEqual(DURABLE_SNAPSHOT_MODEL);
+	expect(state.thinkingLevel).toBe(DURABLE_SNAPSHOT_TUPLE.thinkingLevel);
+	expect(state.status).toBe(expectedStatus);
+	expect(state.statusVersion).toBe(expectedStatusVersion);
+	expect(state.preparing).toBe(false);
+	expect(state.serverCost).toEqual(expectedCost);
+}
+
+async function exercisePartialMutationSnapshot(
+	gateway: any,
+	sessionId: string,
+	path: "explicit-get-state" | "second-connection",
+): Promise<void> {
+	await installSnapshotCatalog(gateway);
+	const session = gateway.sessionManager.getSession(sessionId);
+	expect(session?.status).toBe("idle");
+
+	let ws1: WsConnection | undefined;
+	let ws2: WsConnection | undefined;
+	let getStateSpy: ReturnType<typeof vi.spyOn> | undefined;
+	let setThinkingSpy: ReturnType<typeof vi.spyOn> | undefined;
+	let released = false;
+	let releaseThinking!: () => void;
+	const thinkingRelease = new Promise<void>((resolve) => {
+		releaseThinking = () => {
+			if (released) return;
+			released = true;
+			resolve();
+		};
+	});
+
+	try {
+		ws1 = await connectWs(sessionId);
+		const durableCursor = ws1.messageCount();
+		ws1.send({
+			type: "set_model",
+			provider: DURABLE_SNAPSHOT_TUPLE.provider,
+			modelId: DURABLE_SNAPSHOT_TUPLE.id,
+			thinkingLevel: DURABLE_SNAPSHOT_TUPLE.thinkingLevel,
+		});
+		const durableState = await ws1.waitForFrom(
+			durableCursor,
+			(message) => message.type === "state"
+				&& (message.data as any)?.model?.id === DURABLE_SNAPSHOT_TUPLE.id
+				&& (message.data as any)?.thinkingLevel === DURABLE_SNAPSHOT_TUPLE.thinkingLevel,
+			5_000,
+		);
+		expect((durableState.data as any).model).toEqual(DURABLE_SNAPSHOT_MODEL);
+		await waitForPersistedTuple(gateway, sessionId, DURABLE_SNAPSHOT_TUPLE);
+
+		// Proactive hydration is intentionally reserved for sessions with history.
+		// A synthetic buffered event exercises that real attach branch without an
+		// unrelated prompt turn or timing dependency.
+		session.eventBuffer.push({ type: "tuple_snapshot_test_seed" });
+		const expectedCost = gateway.sessionManager.getCostTracker(session.projectId).recordUsage(sessionId, {
+			inputTokens: 321,
+			outputTokens: 45,
+			cacheReadTokens: 67,
+			cacheWriteTokens: 8,
+			cost: 7.25,
+		});
+		const expectedStatus = session.status;
+		const expectedStatusVersion = session.statusVersion;
+
+		const realGetState = session.rpcClient.getState.bind(session.rpcClient);
+		const realSetThinkingLevel = session.rpcClient.setThinkingLevel.bind(session.rpcClient);
+		getStateSpy = vi.spyOn(session.rpcClient, "getState").mockImplementation(async () => {
+			const response = await realGetState();
+			if (!response.success) return response;
+			return {
+				...response,
+				data: {
+					...(response.data as Record<string, unknown> | undefined ?? {}),
+					preparing: false,
+				},
+			};
+		});
+		setThinkingSpy = vi.spyOn(session.rpcClient, "setThinkingLevel").mockImplementation(async (...args: unknown[]) => {
+			await thinkingRelease;
+			return realSetThinkingLevel(args[0] as string);
+		});
+
+		const selectionCursor = ws1.messageCount();
+		ws1.send({
+			type: "set_model",
+			provider: TARGET_SNAPSHOT_TUPLE.provider,
+			modelId: TARGET_SNAPSHOT_TUPLE.id,
+			thinkingLevel: TARGET_SNAPSHOT_TUPLE.thinkingLevel,
+		});
+		await pollUntil(
+			async () => (setThinkingSpy?.mock.calls.length ?? 0) === 1,
+			{ timeoutMs: 5_000, intervalMs: 10, label: "target model bound while thinking mutation is held" },
+		);
+		const partialLiveState = await realGetState();
+		expect(partialLiveState).toMatchObject({
+			success: true,
+			data: {
+				model: { provider: TARGET_SNAPSHOT_TUPLE.provider, id: TARGET_SNAPSHOT_TUPLE.id },
+				thinkingLevel: DURABLE_SNAPSHOT_TUPLE.thinkingLevel,
+			},
+		});
+		await waitForPersistedTuple(gateway, sessionId, DURABLE_SNAPSHOT_TUPLE);
+
+		let snapshot: WsMsg;
+		if (path === "explicit-get-state") {
+			const stateCursor = ws1.messageCount();
+			ws1.send({ type: "get_state" });
+			snapshot = await ws1.waitForFrom(
+				stateCursor,
+				(message) => message.type === "state"
+					&& (message.data as any)?.preparing === false
+					&& (message.data as any)?.model?.id !== undefined,
+				5_000,
+			);
+		} else {
+			ws2 = await connectWs(sessionId);
+			snapshot = await ws2.waitFor(
+				(message) => message.type === "state"
+					&& (message.data as any)?.preparing === false
+					&& (message.data as any)?.model?.id !== undefined,
+				5_000,
+			);
+		}
+		expectDurablePartialMutationSnapshot(snapshot, expectedStatus, expectedStatusVersion, expectedCost);
+
+		releaseThinking();
+		const committed = await ws1.waitForFrom(
+			selectionCursor,
+			(message) => message.type === "state"
+				&& (message.data as any)?.model?.id === TARGET_SNAPSHOT_TUPLE.id
+				&& (message.data as any)?.thinkingLevel === TARGET_SNAPSHOT_TUPLE.thinkingLevel,
+			5_000,
+		);
+		expect((committed.data as any).model).toEqual(TARGET_SNAPSHOT_MODEL);
+		await waitForPersistedTuple(gateway, sessionId, TARGET_SNAPSHOT_TUPLE);
+	} finally {
+		releaseThinking();
+		if ((setThinkingSpy?.mock.calls.length ?? 0) > 0) {
+			await waitForPersistedTuple(gateway, sessionId, TARGET_SNAPSHOT_TUPLE).catch(() => {});
+		}
+		setThinkingSpy?.mockRestore();
+		getStateSpy?.mockRestore();
+		if (ws2) await closeWs(ws2);
+		if (ws1) await closeWs(ws1);
+		invalidateModelCache();
+	}
 }
 
 async function prepareDurableOpus5Xhigh(gateway: any, sessionId: string): Promise<void> {
@@ -151,6 +356,14 @@ test.describe("model state after reconnect", () => {
 		).toBe(true);
 
 		ws2.close();
+	});
+
+	test("explicit get_state retains the durable custom tuple while thinking mutation is pending", async ({ gateway }) => {
+		await exercisePartialMutationSnapshot(gateway, sessionId, "explicit-get-state");
+	});
+
+	test("a second connection retains the durable custom tuple while thinking mutation is pending", async ({ gateway }) => {
+		await exercisePartialMutationSnapshot(gateway, sessionId, "second-connection");
 	});
 
 	test("matching live model without thinking hydrates one complete durable tuple on reconnect and get_state", async ({ gateway }) => {

--- a/tests2/tests-map.json
+++ b/tests2/tests-map.json
@@ -39,6 +39,15 @@
       }
     },
     {
+      "path": "tests2/core/runtime-model-recovery-ownership.test.ts",
+      "reason": "Deterministic failing-first runtime recovery ownership races proving a superseded restart bridge cannot quarantine a newer canonical replacement or publish a stale candidate after ownership and durability move again during verification.",
+      "execution": {
+        "runner": "vitest",
+        "tier": "unit",
+        "project": "core"
+      }
+    },
+    {
       "path": "tests2/core/session-manager-bare-delegate-model-boundary.test.ts",
       "reason": "Focused failing-first actual-SessionManager regression proving bare createDelegateSession rejects the exact deferred kimi-coding provider before RpcBridge construction, process start, or child persistence, while a selectable custom/local provider preserves a slash-containing Kimi-named model ID.",
       "execution": {


### PR DESCRIPTION
## Summary
- preserve complete durable model/thinking tuples across cold restore, force-abort, controlled fallback, and inherited setup
- fence runtime recovery, staged role replacement, zombie archival, rollback, quarantine, and publication to the exact owned bridge
- keep reconnect and explicit state requests on the previous verified tuple during in-flight mutation
- add deterministic regressions for confirmed lifecycle races and document the follow-up disposition

## Verification
- npm run check
- npm run build
- npm run test:unit
- npm run test:browser
- npm run test:e2e
- focused tuple inheritance, recovery ownership, fallback, reconnect, host/sandbox, and argv canaries

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)