### PR TITLE
Require comparative design exploration

### DIFF
--- a/.bobbit/config/project.yaml
+++ b/.bobbit/config/project.yaml
@@ -33,35 +33,51 @@ workflows:
         content: true
         inject_downstream: true
         verify:
-          - name: Design review
+          - name: Comparative design review
             type: llm-review
             role: architect
             prompt: >-
-              Review this design document for structure, clarity, and
-              completeness. Verify:
+              Review this design document for structure, clarity, comparative
+              reasoning, and completeness.
 
 
-              1. Approach is clearly described with rationale
+              For every non-trivial change, FAIL unless the design:
 
 
-              2. File changes are listed with specific descriptions
+              1. Compares two materially different approaches that preserve the
+              same scope and acceptance criteria
 
 
-              3. Acceptance criteria are specific and testable
+              2. Includes a minimal-composition option that names exact
+              well-tested existing code and its protecting tests
 
 
-              4. Edge cases and error handling are considered
+              3. Inventories and justifies every new branch, state owner,
+              transformation, API, abstraction, and dependency as added defect
+              surface
 
 
-              5. **E2E test plan** — the design MUST include a section
-              describing the browser-based E2E tests that will validate the user
-              journey end-to-end. For UI features, this means fullstack tests
-              (in tests/e2e/ui/) that exercise the complete workflow through
-              real browser interactions: navigate to the feature, interact with
-              it, verify state persists across reload, verify cleanup/removal
-              works. For API-only features, E2E tests (in tests/e2e/) covering
-              the request/response lifecycle are sufficient. If no E2E test plan
-              section is present, FAIL this review.
+              4. Compares data/control flow, expected files, failure modes, and
+              test seams
+
+
+              5. Selects the smallest robust solution and explains why the
+              rejected option lost
+
+
+              A quick-fix exemption is acceptable only for one local behavior
+              following an obvious established pattern with no new public API,
+              state owner, persistence, auth, dependency, or cross-layer flow;
+              the design must state why comparison is unnecessary. Do not force
+              reuse where contracts, ownership, or lifecycle differ, and do not
+              demand speculative generalization or adjacent features.
+
+
+              Regardless of comparative-design exemption, every design must list
+              file changes with specific descriptions, define specific and
+              testable acceptance criteria, cover edge/error handling, and
+              include an E2E test plan that validates the user journey
+              end-to-end.
           - name: Gap analysis
             type: llm-review
             role: spec-auditor
@@ -88,6 +104,14 @@ workflows:
 
 
               4. Any contradictions between the goal and the design
+
+
+              5. Compared approaches that do not target the same acceptance
+              criteria and constraints
+
+
+              6. Scope expansion added to justify an abstraction or possible
+              future reuse
 
 
               Use your tools to read the design document content from the
@@ -440,12 +464,51 @@ workflows:
         content: true
         inject_downstream: true
         verify:
-          - name: Design review
+          - name: Comparative design review
             type: llm-review
             role: architect
-            prompt: Review this design document for structure, clarity, and completeness.
-              Verify architecture/API surface, file-change rationale, testable
-              acceptance criteria, and edge/error handling.
+            prompt: >-
+              Review this design document for structure, clarity, comparative
+              reasoning, and completeness.
+
+
+              For every non-trivial change, FAIL unless the design:
+
+
+              1. Compares two materially different approaches that preserve the
+              same scope and acceptance criteria
+
+
+              2. Includes a minimal-composition option that names exact
+              well-tested existing code and its protecting tests
+
+
+              3. Inventories and justifies every new branch, state owner,
+              transformation, API, abstraction, and dependency as added defect
+              surface
+
+
+              4. Compares data/control flow, expected files, failure modes, and
+              test seams
+
+
+              5. Selects the smallest robust solution and explains why the
+              rejected option lost
+
+
+              A quick-fix exemption is acceptable only for one local behavior
+              following an obvious established pattern with no new public API,
+              state owner, persistence, auth, dependency, or cross-layer flow;
+              the design must state why comparison is unnecessary. Do not force
+              reuse where contracts, ownership, or lifecycle differ, and do not
+              demand speculative generalization or adjacent features.
+
+
+              Regardless of comparative-design exemption, every design must list
+              file changes with specific descriptions, define specific and
+              testable acceptance criteria, cover edge/error handling, and
+              include an E2E test plan that validates the user journey
+              end-to-end.
           - name: Gap analysis
             type: llm-review
             role: spec-auditor
@@ -460,8 +523,10 @@ workflows:
 
 
               Identify unaddressed requirements, uncovered acceptance criteria,
-              missing edge cases, and contradictions. Use your tools to read the
-              design document content from the signal.
+              missing edge cases, contradictions, compared approaches that do
+              not target the same acceptance criteria, and scope expansion added
+              to justify an abstraction or possible future reuse. Use your tools
+              to read the design document content from the signal.
       - id: implementation
         name: Implementation
         depends_on:

--- a/.bobbit/config/roles/spec-auditor.yaml
+++ b/.bobbit/config/roles/spec-auditor.yaml
@@ -42,6 +42,8 @@ promptTemplate: |
   ## Review Method
   For implementation gates, compare the effective goal requirements, upstream design/context, and the actual code changes. Focus on user-visible behavior and acceptance criteria. Ignore documentation gaps during implementation gates unless the prompt specifically asks for documentation review.
 
+  At design/analysis gates, confirm every compared approach satisfies the same acceptance criteria and constraints. Flag options that add behavior to justify a preferred abstraction, weaken an existing requirement, or turn possible future reuse into current scope. Accept explicitly rejected adjacent improvements as non-goals rather than asking this goal to implement them.
+
   ## Output Format
   Report findings with gap type and severity:
   - `[spec-gap]` — Spec requirement not addressed in design or implementation.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,10 @@ Orient here, then `rg` for the symbol.
 3. **Search for "never reintroduce" / "single source of truth" / "pinned by"** in source comments around what you're touching.
 4. **`docs/debugging.md`** has full diagnostic walkthroughs indexed by symptom — search there before guessing.
 
+## Engineering principle
+
+Treat every new branch, state owner, transformation, API, or abstraction as defect surface: prefer composing existing well-tested code when its contract, ownership, and lifecycle fit, but do not force reuse or mechanical DRY across unrelated semantics.
+
 ## Testing (Test Suite v2)
 
 - **New tests land in `tests2/`** (or the guard fails). `*.test.ts`⇒Vitest (`core`/`dom`/`integration`, with explicit isolated exceptions); `*.spec.ts`⇒Playwright (`tests2/browser`). Register in `tests2/tests-map.json`. Three sequential gate phases: `test:unit` → `test:browser` → `test:e2e`; worktree/Docker/MCP/restart coverage belongs to E2E or `test:manual`.

--- a/defaults/roles/architect.yaml
+++ b/defaults/roles/architect.yaml
@@ -47,6 +47,17 @@ promptTemplate: |
   - **Complexity Budget**: Is the added complexity proportional to the value delivered? Are there simpler alternatives?
   - **Data Flow**: Is the data model clean? Are there unnecessary transformations, redundant state, or unclear ownership?
 
+  ### Comparative Design Decisions
+  For a non-trivial `design-doc`, require evidence that the team compared **two materially different approaches** before implementation:
+
+  - At least one approach must compose existing well-tested logic, naming the exact reusable symbols and their protecting tests.
+  - Both approaches must preserve the same goal scope and acceptance criteria.
+  - Compare the new branches, state owners, transformations, APIs, abstractions, dependencies, failure modes, and test seams each approach introduces. Treat these as defect surface, not as free flexibility.
+  - The selected approach must be justified as the **smallest robust solution**, including why the rejected option lost.
+  - Raise a `[high]` finding when this evidence is absent, a simpler well-composed option was rejected without reason, or a new abstraction is justified only by speculative future reuse.
+
+  A quick-fix exemption is acceptable only for one local behavior following an obvious established pattern with no new public API, state owner, persistence, auth, dependency, or cross-layer flow. Do not force reuse when contracts, ownership, or lifecycle differ, and do not demand speculative generalization or adjacent features.
+
   ## Output Format
   Report findings with severity levels:
   - `[critical]` — Fundamental design flaw that will cause serious problems at scale or block future work.

--- a/defaults/roles/coder.yaml
+++ b/defaults/roles/coder.yaml
@@ -23,6 +23,18 @@ promptTemplate: |
   ## Before You Start
   Check gates before coding — use `gate_list` for status overview, then `gate_inspect(gate_id="design-doc", section="content")` to read the design doc and understand the architecture, file changes, and requirements. Use `task_list` to find your assigned task and `task_update` to report progress and completion.
 
+  ## Design Exploration Mode
+  If your task explicitly assigns **design exploration mode**, investigate one candidate approach without implementing it:
+
+  - Do not edit production code, tests, or configuration, and do not create an empty commit.
+  - Inspect existing implementations, call sites, and exact existing symbols before proposing anything new. Name the symbols you would reuse and their protecting tests.
+  - Keep the goal scope and acceptance criteria unchanged. Do not add adjacent behavior to make an abstraction appear worthwhile.
+  - Report the approach's data/control flow, expected files, new branches/state/transformations/APIs/abstractions, failure modes, test seams, and unresolved assumptions.
+  - Update the task to `complete` with the current HEAD as `head_sha` and put the full proposal in `result_summary`, then go idle. Do not continue into the normal implementation workflow.
+
+  ## Engineering Principle
+  Treat every new branch, state owner, transformation, API, and abstraction as additional defect surface that must be justified. Prefer composing existing well-tested code when its contract, ownership, and lifecycle fit the requirement cleanly. Minimize the number of independent concepts needed to explain the system and keep unavoidable new logic small, explicit, and testable; identify the focused coverage the test engineer must add. Do not force reuse or apply mechanical DRY when it couples unrelated semantics or hides meaningful differences.
+
   ## Git Workflow
   You are already on your own branch in your own worktree — do NOT checkout `{{GOAL_BRANCH}}` or create sub-branches.
 

--- a/defaults/roles/spec-auditor.yaml
+++ b/defaults/roles/spec-auditor.yaml
@@ -51,6 +51,8 @@ promptTemplate: |
   - Does the design/analysis address every requirement in the goal spec?
   - Are there spec requirements that the design silently omits or reinterprets?
   - Does the design introduce scope that wasn't in the spec (scope creep)?
+  - Do all compared approaches satisfy the same acceptance criteria, without adding behavior to justify a preferred abstraction?
+  - Does the design incorrectly turn possible future reuse into current scope?
   - Are edge cases from the spec reflected in the design?
   - Is the test plan adequate for the scope of changes?
 

--- a/defaults/roles/team-lead.yaml
+++ b/defaults/roles/team-lead.yaml
@@ -194,9 +194,23 @@ promptTemplate: |
   8. **Handle failures** — if verification fails a gate, inspect persisted gate diagnostics first (`gate_status`, then step-scoped `gate_inspect` with `grep`/`slice`/`tail`). Re-run tests only to validate new changes or when retained diagnostics are insufficient or stale, then fix and re-signal via `gate_signal`.
   9. **Avoid duplicate validation** — workflow verification is the authoritative place for broad/full suites. Do not run full suites yourself when the workflow's verify steps will run the same suites; use targeted checks for fast feedback, then let gate verification do the comprehensive pass.
 
+  ## Comparative Design Before Implementation
+  For a `design-doc` gate, first decide whether the change is a quick fix. A quick fix is one local behavior following an obvious established pattern, with no new public API, state owner, persistence, auth, dependency, or cross-layer flow. Record why comparison is unnecessary; do not add ceremony.
+
+  For every other design, run **two independent design explorations** before signaling the gate:
+
+  1. Create two design tasks and spawn two `coder` producers in design exploration mode. Give them the same goal scope and acceptance criteria, prohibit production edits, and keep their investigations independent until both report.
+  2. Require one option to be the minimal composition of existing well-tested code. Require the other to use a materially different implementation approach without adding behavior.
+  3. Compare the exact reused symbols and protecting tests, data/control flow, expected files, and every new branch, state owner, transformation, API, abstraction, and dependency. Treat each new logic unit as added defect surface.
+  4. Use a bounded unmerged spike only when one named uncertainty could change the decision. A spike is evidence, not production code.
+  5. Choose the **smallest robust solution** that satisfies the goal. Do not blend options, force reuse across mismatched semantics, or add speculative future scope.
+  6. Write the selected approach and why the alternative lost into the design document, then signal it for Architect and Spec Auditor verification. Do not spawn implementation work until it passes.
+
+  Consume read-only exploration from task `result_summary`; there is no branch content to merge. If neither option meets the goal without excessive new logic, shrink or split the goal instead of relaxing the comparison.
+
   ## Gate Content Quality
   Gate content must be substantive:
-  - **design-doc**: Actual file paths, function signatures, data flow, architectural reasoning. A coder should implement from this alone.
+  - **design-doc**: For non-quick-fixes, two independently researched approaches, exact reused symbols and protecting tests, a defect-surface comparison, rejected-option rationale, plus actual file paths, function signatures, data flow, architectural reasoning, and testable acceptance criteria. A coder should implement the selected approach from this alone.
   - **test-plan**: Specific commands, expected outputs, edge cases, pass/fail criteria.
   - **review-findings / code-review**: File:line references, severity ratings, whether issues were fixed.
 
@@ -213,7 +227,7 @@ promptTemplate: |
   ## Producing Content for Content Gates
   For content gates — `design-doc`, `issue-analysis`, `documentation`, `review-findings` — you are responsible for producing the markdown content that goes into `gate_signal(content=...)`. Two patterns:
 
-  - **Direct draft.** You draft the content yourself in chat, using the upstream context already injected into your prompt (the goal spec, passed upstream gates), and call `gate_signal(gate_id="design-doc", content="...")` directly. Best for small/medium docs where you already have everything you need.
+  - **Direct draft.** You draft the content yourself in chat, using the upstream context already injected into your prompt, and call `gate_signal` directly. Use this for quick-fix design exemptions and content gates that do not require comparative codebase exploration; it does not bypass the comparative-design rule for non-trivial `design-doc` gates.
   - **Delegated artifact.** Spawn a *producer* role — typically `coder` for design docs that need codebase research, or `docs-writer` for the `documentation` gate — to write a markdown file on its own branch. After it commits, marks its task complete, and goes idle, merge its branch into `{{GOAL_BRANCH}}`, read the merged file, then call `gate_signal` with that content (or a summary of it) yourself.
 
   Explicitly: **architect, spec-auditor, code-reviewer, bug-hunter, security-reviewer, and reviewer never author content gates.** They only appear under `verify:`. If a content gate needs an artifact written, choose `coder` or `docs-writer`, not a reviewer role.

--- a/defaults/workflow-authoring-guide.md
+++ b/defaults/workflow-authoring-guide.md
@@ -172,7 +172,15 @@ Roles listed under a gate's `verify:` block (e.g. `role: architect`, `role: code
 
 The team lead is the producer for content gates: it either drafts the markdown directly and signals, or delegates artifact-writing to a `coder` / `docs-writer`, merges the resulting branch, and signals from the merged content. Every contributor role carries `gate_signal: never` in its tool-policy; only the `team-lead` role's policy permits the call. Workflow authors should therefore not staff content-producing tasks with reviewer roles, and should expect the team lead — never the reviewer named under `verify:` — to be the one calling `gate_signal`.
 
-### 3.1 The implementation gate is a Ralph loop
+### 3.1 Comparative design gates
+
+Non-trivial `design-doc` gates should compare **two independent approaches** before implementation. Give both explorations the same acceptance criteria and constraints; require one to minimize new logic by composing existing well-tested code, and require the other to use a materially different implementation approach without adding behavior. The signaled design should name exact reusable symbols and protecting tests, inventory new branches/state owners/transformations/APIs/abstractions/dependencies as defect surface, compare failure modes and test seams, and justify the smallest robust solution.
+
+Do not turn this into mechanical DRY: reuse only when contracts, ownership, and lifecycle align. A quick-fix may state that comparison is unnecessary when it changes one local behavior through an obvious established pattern and adds no public API, state owner, persistence, auth, dependency, or cross-layer flow. A bounded unmerged spike is appropriate only when one named uncertainty could change the decision; spike code is evidence, not production.
+
+The Architect verifies the comparison and rejects unexplained new logic or speculative generalization. The Spec Auditor confirms both approaches preserve the same scope so possible future reuse does not become current work.
+
+### 3.2 The implementation gate is a Ralph loop
 
 The `implementation` gate's `verify` list is the agent's loop body. When verification
 fails, the gate runner reports the failed steps to the implementing agent, which
@@ -341,12 +349,12 @@ These are the typical gate sets per workflow style. Generators MAY extend, prune
 
 > All non-quick-fix flows below include **both** a design-time gap-analysis step
 > (in `design-doc` / `issue-analysis`) and a post-implementation gap-analysis step
-> (in `implementation`, phase 2). See §3.1 — these two checks bracket the Ralph loop.
+> (in `implementation`, phase 2). See §3.2 — these two checks bracket the Ralph loop.
 
 ### 6.1 `general` — lightweight
 
 ```yaml
-- design-doc       (content; design-review + gap-analysis llm-review)
+- design-doc       (content; comparative design-review + gap-analysis llm-review)
 - implementation   (build/check/unit/e2e in phase 1; gap-analysis + code-review + bug-hunt llm-review in phase 2)  # Ralph loop
 - documentation    (llm-review)
 - ready-to-merge   (push, fast-forward, PR exists)
@@ -355,7 +363,7 @@ These are the typical gate sets per workflow style. Generators MAY extend, prune
 ### 6.2 `feature` — full design + impl + multi-review + optional QA
 
 ```yaml
-- design-doc       (content; design-review + gap-analysis llm-review)
+- design-doc       (content; comparative design-review + gap-analysis llm-review)
 - implementation   (build/check/unit/e2e, gap+code+bug-hunt+security llm-review, optional agent-qa)    # Ralph loop
 - documentation    (llm-review)
 - ready-to-merge   (push/fast-forward/PR)
@@ -432,7 +440,7 @@ workflows:
         content: true
         inject_downstream: true
         verify:
-          - { name: "Design review", type: llm-review, role: architect, prompt: "Review this design document for structure, clarity, and completeness." }
+          - { name: "Comparative design review", type: llm-review, role: architect, prompt: "For non-trivial changes, require two materially different approaches, exact well-tested reuse evidence, a defect-surface comparison, and selection of the smallest robust solution. Do not force reuse across mismatched contracts." }
 
       - id: implementation
         name: Implementation

--- a/src/server/state-migration/seed-default-workflows.ts
+++ b/src/server/state-migration/seed-default-workflows.ts
@@ -115,12 +115,18 @@ If the diff fixes any of the above (e.g. it shortens long entries, dedupes recip
 
 Summarize with PASS/FAIL for each check and specific items to address.`;
 
-export const DESIGN_REVIEW_PROMPT = `Review this design document for structure, clarity, and completeness. Verify:
-1. Approach is clearly described with rationale
-2. File changes are listed with specific descriptions
-3. Acceptance criteria are specific and testable
-4. Edge cases and error handling are considered
-5. **E2E test plan** — the design MUST include a section describing browser-based E2E tests that validate the user journey end-to-end. If no E2E test plan section is present, FAIL this review.`;
+export const DESIGN_REVIEW_PROMPT = `Review this design document for structure, clarity, comparative reasoning, and completeness.
+
+For every non-trivial change, FAIL unless the design:
+1. Compares two materially different approaches that preserve the same scope and acceptance criteria
+2. Includes a minimal-composition option that names exact well-tested existing code and its protecting tests
+3. Inventories and justifies every new branch, state owner, transformation, API, abstraction, and dependency as added defect surface
+4. Compares data/control flow, expected files, failure modes, and test seams
+5. Selects the smallest robust solution and explains why the rejected option lost
+
+A quick-fix exemption is acceptable only for one local behavior following an obvious established pattern with no new public API, state owner, persistence, auth, dependency, or cross-layer flow; the design must state why comparison is unnecessary. Do not force reuse where contracts, ownership, or lifecycle differ, and do not demand speculative generalization or adjacent features.
+
+Regardless of comparative-design exemption, every design must list file changes with specific descriptions, define specific and testable acceptance criteria, cover edge/error handling, and include an E2E test plan that validates the user journey end-to-end.`;
 
 export const GAP_ANALYSIS_DESIGN_PROMPT = `Compare the goal specification to this design document.
 
@@ -132,6 +138,8 @@ Identify:
 2. Acceptance criteria not covered by the proposed changes
 3. Edge cases mentioned in the goal but missing from the design
 4. Any contradictions between the goal and the design
+5. Compared approaches that do not target the same acceptance criteria and constraints
+6. Scope expansion added to justify an abstraction or possible future reuse
 
 Use your tools to read the design document content from the signal.`;
 

--- a/tests2/core/comparative-design-prompts.test.ts
+++ b/tests2/core/comparative-design-prompts.test.ts
@@ -1,0 +1,104 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import YAML from "yaml";
+import {
+	buildDefaultWorkflows,
+	DESIGN_REVIEW_PROMPT,
+	GAP_ANALYSIS_DESIGN_PROMPT,
+} from "../../src/server/state-migration/seed-default-workflows.ts";
+
+const repoRoot = path.resolve(import.meta.dirname, "..", "..");
+
+function read(relativePath: string): string {
+	return fs.readFileSync(path.join(repoRoot, relativePath), "utf8");
+}
+
+function rolePrompt(relativePath: string): string {
+	const role = YAML.parse(read(relativePath)) as { promptTemplate?: string };
+	return role.promptTemplate ?? "";
+}
+
+function architectPromptFromProjectWorkflow(workflowId: "general" | "feature"): string {
+	const project = YAML.parse(read(".bobbit/config/project.yaml")) as {
+		workflows: Record<string, { gates: Array<{ id: string; verify?: Array<{ role?: string; prompt?: string }> }> }>;
+	};
+	const gate = project.workflows[workflowId].gates.find((candidate) => candidate.id === "design-doc");
+	const review = gate?.verify?.find((candidate) => candidate.role === "architect");
+	return review?.prompt ?? "";
+}
+
+describe("comparative design prompt contracts", () => {
+	it("instructs every coding agent to prefer simple composition of well-tested code", () => {
+		const agents = read("AGENTS.md");
+		const coder = rolePrompt("defaults/roles/coder.yaml");
+
+		for (const prompt of [agents, coder]) {
+			expect(prompt).toMatch(/defect surface/i);
+			expect(prompt).toMatch(/well-tested/i);
+			expect(prompt).toMatch(/contracts?.*ownership.*lifecycle/is);
+			expect(prompt).toMatch(/do not force reuse|not.*mechanical.*DRY/i);
+		}
+	});
+
+	it("gives the team lead and coder a bounded, independent exploration protocol", () => {
+		const lead = rolePrompt("defaults/roles/team-lead.yaml");
+		const coder = rolePrompt("defaults/roles/coder.yaml");
+
+		expect(lead).toMatch(/two independent design explorations/i);
+		expect(lead).toMatch(/same (?:goal )?scope/i);
+		expect(lead).toMatch(/smallest robust solution/i);
+		expect(lead).toMatch(/quick[- ]fix(?:es)?/i);
+		expect(coder).toMatch(/design exploration mode/i);
+		expect(coder).toMatch(/do not (?:write|edit|modify) production/i);
+		expect(coder).toMatch(/exact.*(?:symbols|implementations)/is);
+		expect(coder).toMatch(/protecting tests/i);
+	});
+
+	it("makes architecture and spec reviewers enforce comparison without expanding scope", () => {
+		const architect = rolePrompt("defaults/roles/architect.yaml");
+		const auditors = [
+			rolePrompt("defaults/roles/spec-auditor.yaml"),
+			rolePrompt(".bobbit/config/roles/spec-auditor.yaml"),
+		];
+
+		expect(architect).toMatch(/two materially different approaches/i);
+		expect(architect).toMatch(/branches?.*state.*transformations?.*APIs/is);
+		expect(architect).toMatch(/smallest robust solution/i);
+		expect(architect).toMatch(/do not (?:demand|force).*reuse/i);
+		for (const auditor of auditors) {
+			expect(auditor).toMatch(/same acceptance criteria/i);
+			expect(auditor).toMatch(/future reuse.*current scope/i);
+		}
+	});
+
+	it("pins comparative design in canonical and current project workflows", () => {
+		for (const prompt of [
+			DESIGN_REVIEW_PROMPT,
+			architectPromptFromProjectWorkflow("general"),
+			architectPromptFromProjectWorkflow("feature"),
+		]) {
+			expect(prompt).toMatch(/two materially different approaches/i);
+			expect(prompt).toMatch(/well-tested existing (?:code|logic)/i);
+			expect(prompt).toMatch(/smallest robust solution/i);
+			expect(prompt).toMatch(/do not force reuse/i);
+		}
+		expect(GAP_ANALYSIS_DESIGN_PROMPT).toMatch(/same acceptance criteria/i);
+		expect(GAP_ANALYSIS_DESIGN_PROMPT).toMatch(/scope expansion/i);
+
+		const seeded = buildDefaultWorkflows("app");
+		for (const workflowId of ["general", "feature"] as const) {
+			const gate = seeded[workflowId].gates.find((candidate) => candidate.id === "design-doc");
+			const review = gate?.verify?.find((candidate) => candidate.role === "architect");
+			expect(review?.prompt).toBe(DESIGN_REVIEW_PROMPT);
+		}
+	});
+
+	it("documents comparative design as the authoring default rather than a project-only exception", () => {
+		const guide = read("defaults/workflow-authoring-guide.md");
+		expect(guide).toMatch(/comparative design gates/i);
+		expect(guide).toMatch(/two independent approaches/i);
+		expect(guide).toMatch(/defect surface/i);
+		expect(guide).toMatch(/quick-fix/i);
+	});
+});

--- a/tests2/tests-map.json
+++ b/tests2/tests-map.json
@@ -21,6 +21,15 @@
   },
   "v2Native": [
     {
+      "path": "tests2/core/comparative-design-prompts.test.ts",
+      "reason": "Prompt-contract coverage proving non-trivial design gates compare independent approaches before implementation, coding agents prefer simple composition of well-tested code without forced DRY, reviewers preserve equal scope, and the canonical/current workflow prompts enforce the same decision standard.",
+      "execution": {
+        "runner": "vitest",
+        "tier": "unit",
+        "project": "core"
+      }
+    },
+    {
       "path": "tests2/core/reviewer-read-session-policy.test.ts",
       "reason": "Resolved tool-policy coverage proving every first-party reviewer role and project override explicitly denies cross-session transcript reads through read_session.",
       "execution": {


### PR DESCRIPTION
## Summary
- require two independent approaches for non-trivial design gates
- favor minimal composition of well-tested code while rejecting forced reuse and scope expansion
- add shared role guidance, canonical workflow prompts, authoring documentation, and prompt-contract tests

## Validation
- `npm run check` passed
- focused prompt contract suite passed: 5 files, 50 tests
- full unit suite was stopped under the shared execution-slot policy and was not restarted

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)