### PR TITLE
docs: use main / primary branch instead of master

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,13 +49,13 @@ Treat every new branch, state owner, transformation, API, or abstraction as defe
 
 ## Git conventions
 
-Primary branch is **`master`** (not `main`). Never create a `main` branch.
+Primary branch is **`main`** — verify with `git symbolic-ref refs/remotes/origin/HEAD`; never assume `master` (a stale divergent `origin/master` still exists and gives the wrong base).
 
 **Line endings**: LF everywhere except `*.cmd`/`*.bat`/`*.ps1` (CRLF), pinned via `.gitattributes`. Windows: set `git config --global core.autocrlf false`.
 
-**Worktrees**: dev server runs from the **primary worktree** on `master`; sessions use separate worktrees under `<project-root>-wt/<branch>/`. Always edit in your session worktree, never the primary one. For infra files: edit here → commit → push → `cd <primary-worktree> && git pull origin master` (pushing to remote `master` does NOT update the dev server).
+**Worktrees**: dev server runs from the **primary worktree** on `main`; sessions use separate worktrees under `<project-root>-wt/<branch>/`. Always edit in your session worktree, never the primary one. For infra files: edit here → commit → push → `cd <primary-worktree> && git pull origin main` (pushing to remote `main` does NOT update the dev server).
 
-**Forks**: open PRs against the fork's `master`, not the upstream repo.
+**Forks**: open PRs against the fork's default branch (`main`), not the upstream repo.
 
 See [docs/dev-workflow.md](docs/dev-workflow.md).
 

--- a/defaults/roles/bug-hunter.yaml
+++ b/defaults/roles/bug-hunter.yaml
@@ -35,10 +35,11 @@ promptTemplate: |-
   ## Working Directory
   Your working directory is already set to the goal's worktree, checked out on branch `{{GOAL_BRANCH}}` at the correct commit. **Do not run `git checkout` or `git pull`** — the directory is already in the right state.
 
-  To see what changed:
-  - `git diff --stat master...HEAD -- . ':!package-lock.json'` — summary of changed files
-  - `git diff master...HEAD -M -- . ':!package-lock.json'` — branch diff with rename detection
-  - `git log --oneline master..HEAD` — commits on this branch
+  To see what changed (resolve the base branch first — do not assume `master`/`main`):
+  - `BASE=$(git symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null || echo origin/main)`
+  - `git diff --stat "$BASE"...HEAD -- . ':!package-lock.json'` — summary of changed files
+  - `git diff "$BASE"...HEAD -M -- . ':!package-lock.json'` — branch diff with rename detection
+  - `git log --oneline "$BASE"..HEAD` — commits on this branch
   - For large diffs, inspect individual files with `read`, `grep`, `find`, and `ls` instead of loading the full diff into context
 
   ## Context Already Provided

--- a/defaults/roles/code-reviewer.yaml
+++ b/defaults/roles/code-reviewer.yaml
@@ -35,11 +35,12 @@ promptTemplate: |
   ## Working Directory
   Your working directory is already set to the goal's worktree, checked out on branch `{{GOAL_BRANCH}}` at the correct commit. **Do NOT run `git checkout` or `git pull`** — the directory is already in the right state.
 
-  To see what changed:
-  - `git diff --stat master...HEAD -- . ':!package-lock.json'` — summary of which files changed
-  - `git diff master...HEAD -M -- . ':!package-lock.json'` — branch diff with rename detection (collapses pure renames)
+  To see what changed (resolve the base branch first — do not assume `master`/`main`):
+  - `BASE=$(git symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null || echo origin/main)`
+  - `git diff --stat "$BASE"...HEAD -- . ':!package-lock.json'` — summary of which files changed
+  - `git diff "$BASE"...HEAD -M -- . ':!package-lock.json'` — branch diff with rename detection (collapses pure renames)
   - For large diffs, review individual files with `read` instead of loading the full diff into context
-  - `git log --oneline master..HEAD` — commits on this branch
+  - `git log --oneline "$BASE"..HEAD` — commits on this branch
   - Read files directly with `read` — they are already at the correct version
 
   ## Context Already Provided

--- a/defaults/roles/docs-writer.yaml
+++ b/defaults/roles/docs-writer.yaml
@@ -119,7 +119,8 @@ promptTemplate: |-
         `task_update(task_id="...", state="complete", head_sha="<SHA from step c>", result_summary="...")`
      e. Go idle — the team lead will merge your branch locally.
 
-  Primary branch is `master`, not `main`.
+  Do not assume the primary branch is `master` or `main` — verify with
+  `git symbolic-ref refs/remotes/origin/HEAD` and use whatever the repo reports.
 
   ## Definition of Done
   **You are not finished until:**

--- a/defaults/roles/security-reviewer.yaml
+++ b/defaults/roles/security-reviewer.yaml
@@ -36,11 +36,12 @@ promptTemplate: |
   ## Working Directory
   Your working directory is already set to the goal's worktree, checked out on branch `{{GOAL_BRANCH}}` at the correct commit. **Do NOT run `git checkout` or `git pull`** — the directory is already in the right state.
 
-  To see what changed:
-  - `git diff --stat master...HEAD -- . ':!package-lock.json'` — summary of which files changed
-  - `git diff master...HEAD -M -- . ':!package-lock.json'` — branch diff with rename detection (collapses pure renames)
+  To see what changed (resolve the base branch first — do not assume `master`/`main`):
+  - `BASE=$(git symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null || echo origin/main)`
+  - `git diff --stat "$BASE"...HEAD -- . ':!package-lock.json'` — summary of which files changed
+  - `git diff "$BASE"...HEAD -M -- . ':!package-lock.json'` — branch diff with rename detection (collapses pure renames)
   - For large diffs, review individual files with `read` instead of loading the full diff into context
-  - `git log --oneline master..HEAD` — commits on this branch
+  - `git log --oneline "$BASE"..HEAD` — commits on this branch
   - Read files directly with `read` — they are already at the correct version
 
   ## Context Already Provided

--- a/defaults/roles/team-lead.yaml
+++ b/defaults/roles/team-lead.yaml
@@ -56,7 +56,7 @@ promptTemplate: |
   You are the **Team Lead** (id: {{AGENT_ID}}) orchestrating a team of coding agents.
 
   {if:subGoalsEnabled}
-  **Goal nesting awareness:** If you are a child goal's team-lead, you DO NOT raise PRs — your branch merges locally into your parent. Only the root goal opens a PR to master. Read the "Goal nesting context" stanza below for your specific role; it tells you whether you're root or child.
+  **Goal nesting awareness:** If you are a child goal's team-lead, you DO NOT raise PRs — your branch merges locally into your parent. Only the root goal opens a PR to the primary branch. Read the "Goal nesting context" stanza below for your specific role; it tells you whether you're root or child.
   {endif:subGoalsEnabled}
 
   ## Your Role
@@ -75,8 +75,8 @@ promptTemplate: |
 
   ## Critical Constraints
 
-  - **All contributions go via pull requests.** Never merge to master directly. The goal branch is pushed to origin and a PR is created for human review, tracking, and collaboration.
-  - **Never push to master, merge into master, or force-push to any branch.** Master is updated only through human-approved pull requests.
+  - **All contributions go via pull requests.** Never merge to the primary branch directly. The goal branch is pushed to origin and a PR is created for human review, tracking, and collaboration.
+  - **Never push to the primary branch, merge into it, or force-push to any branch.** The primary branch is updated only through human-approved pull requests.
 
   ## Tools
   You have dedicated tools for team, task, and gate management. They are first-class tools — call them exactly like `read`, `write`, or `bash`. **Never use curl or the REST API for these operations.**
@@ -323,8 +323,8 @@ promptTemplate: |
   - Run broad/full test suites when workflow verification will run the same suites. For quick feedback and iteration, run only targeted checks covering the modified files/modules (single test file, package-specific test, focused type-check/lint) unless full-suite coverage is not provided by verification.
   - Review code directly — delegate to a reviewer.
   - Spawn agents for downstream work before upstream gates are **verified and passed** — not just signaled.
-  - **Never merge anything to master.** All work stays on the goal branch. Master is updated only via human-approved pull requests.
-  - **Never use `git push` to master**, `git merge <anything> master`, or any force-push operation targeting master.
+  - **Never merge anything to the primary branch.** All work stays on the goal branch. The primary branch is updated only via human-approved pull requests.
+  - **Never use `git push` to the primary branch**, `git merge <anything> <primary>`, or any force-push operation targeting the primary branch.
 
   ## Startup Sequence
   1. **The goal spec is in your first user message** — read it carefully before doing anything else. Do NOT call `view_goal_spec` on startup; it's only for re-reading after a `goal_spec_changed` notification.
@@ -334,8 +334,8 @@ promptTemplate: |
   3. `git checkout {{GOAL_BRANCH}}` (create if needed).
   4. Identify the workflow and its gate DAG from the spec and `gate_list`.
   5. Check existing gates via `gate_list` — resume from where things left off.
-  6. Audit master before planning:
-     - `git log master --oneline -20` — check for overlapping work.
+  6. Audit the primary branch before planning (do not assume `master`/`main`):
+     - `git log "$(git symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null || echo origin/main)" --oneline -20` — check for overlapping work.
      - Read AGENTS.md and scan relevant files.
   7. Identify which workflow gates are pending/failed and work through the DAG.
 
@@ -438,10 +438,11 @@ promptTemplate: |
 
   When all implementation/review/documentation gates have passed, prepare for the `ready-to-merge` gate:
 
-  1. **Merge master into the goal branch** so it is up-to-date and conflict-free:
+  1. **Merge the primary branch into the goal branch** so it is up-to-date and conflict-free. Resolve the primary branch first — do not assume `master`/`main`:
      ```
-     git fetch origin master
-     git merge origin/master
+     BASE=$(git symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null | sed 's@^origin/@@' || echo main)
+     git fetch origin "$BASE"
+     git merge "origin/$BASE"
      ```
      If there are conflicts, resolve them (or spawn a coder to resolve them), then run targeted type-check/unit checks covering the conflicted or modified areas. Do not duplicate full-suite workflow verification just for merge confidence.
   2. **Push the goal branch**: `git push origin {{GOAL_BRANCH}}`
@@ -451,7 +452,7 @@ promptTemplate: |
      - If `gh` is available: `gh pr create --title "<goal title>" --body "<work summary>" --head {{GOAL_BRANCH}}`
      - If `gh` is NOT available: Tell the user to create the PR manually. Provide the branch name, suggested title, and a summary of changes.
      - **Do NOT merge the PR under any circumstances.** Leave it for human review.
-  4. **Signal the `ready-to-merge` gate** via `gate_signal`. The verification will confirm that master is merged, the branch is pushed, and the PR exists. Wait for it to pass.
+  4. **Signal the `ready-to-merge` gate** via `gate_signal`. The verification will confirm that the primary branch is merged, the branch is pushed, and the PR exists. Wait for it to pass.
   5. Call `team_complete` to dismiss all role agents and mark the goal done.
   6. **Stay idle and await further instructions.** Do NOT terminate yourself.
 

--- a/defaults/tools/team/team_spawn.yaml
+++ b/defaults/tools/team/team_spawn.yaml
@@ -85,8 +85,8 @@ detail_docs: >-
   # Spawn a reviewer to review changes
 
   team_spawn(role="reviewer", task="Review the changes on the goal branch
-  against master. Focus on correctness, error handling, and API contract
-  consistency. Signal the code-review gate with your results.")
+  against the goal's base branch. Focus on correctness, error handling, and API
+  contract consistency. Signal the code-review gate with your results.")
 
 
   # Spawn a tester for E2E test coverage

--- a/docs/dev-workflow.md
+++ b/docs/dev-workflow.md
@@ -374,7 +374,7 @@ The boot sweeper (`worktree-sweeper.ts`) reconciles these against persisted stat
 
 For **goal-scoped** variation (one goal differing from another — enable a feature, seed an index, disable a tool/provider), use **hierarchical goal metadata** and the `goalProvisioned` extension hook rather than a per-goal command. Metadata is inherited down the goal tree and the hook fires at every worktree provisioning in the subtree, so treatments apply symmetrically to every agent and sub-goal. See [goals-workflows-tasks.md — Per-goal worktree provisioning](goals-workflows-tasks.md#per-goal-worktree-provisioning) and [design/goal-metadata.md](design/goal-metadata.md). (The earlier bespoke per-goal `worktreeSetupCommand` field from PR #816 has been removed and is ignored if posted.)
 
-**Base ref for new worktrees.** New worktrees (session, goal, staff, pool) branch off the project's configured `base_ref` when set, otherwise off the remote primary (`origin/master`/`origin/main`) or, for local-only repos with commits, local `HEAD`. Fresh `git init` repos with unborn `HEAD` fall back to no-worktree until an initial commit is made; pool prefill skips them with the same actionable warning. A configured `base_ref` is still honored in unborn repos, while a stale configured ref fails loudly rather than silently falling back. The same value drives the `{{baseBranch}}` workflow variable and the `aheadOfPrimary`/`behindPrimary` git-status comparator. Some worktrees also use it as `@{u}` for local status, but Bobbit-owned branch publication never relies on upstream tracking: when a branch is intentionally published, it uses explicit destination refspecs such as `<branch>:refs/heads/<branch>` or `HEAD:refs/heads/<branch>`. `{{master}}` keeps resolving to the project primary independently. Team-member worktrees branch off the goal branch by hierarchical design and are not affected. Full semantics, validation rules, and error inventory: [design/base-ref.md](design/base-ref.md).
+**Base ref for new worktrees.** New worktrees (session, goal, staff, pool) branch off the project's configured `base_ref` when set, otherwise off the remote primary (`origin/HEAD`, e.g. `origin/main`) or, for local-only repos with commits, local `HEAD`. Fresh `git init` repos with unborn `HEAD` fall back to no-worktree until an initial commit is made; pool prefill skips them with the same actionable warning. A configured `base_ref` is still honored in unborn repos, while a stale configured ref fails loudly rather than silently falling back. The same value drives the `{{baseBranch}}` workflow variable and the `aheadOfPrimary`/`behindPrimary` git-status comparator. Some worktrees also use it as `@{u}` for local status, but Bobbit-owned branch publication never relies on upstream tracking: when a branch is intentionally published, it uses explicit destination refspecs such as `<branch>:refs/heads/<branch>` or `HEAD:refs/heads/<branch>`. `{{master}}` (the legacy template alias) keeps resolving to the project primary independently. Team-member worktrees branch off the goal branch by hierarchical design and are not affected. Full semantics, validation rules, and error inventory: [design/base-ref.md](design/base-ref.md).
 
 ### Local-only Git lifecycle
 
@@ -418,34 +418,34 @@ Bobbit can be run as a downstream **fork** that carries local customisations whi
 
 | Remote | Points at | Role |
 |---|---|---|
-| `origin` | your fork (e.g. `<you>/bobbit`) | Your fork. Day-to-day PRs target its `master`. |
+| `origin` | your fork (e.g. `<you>/bobbit`) | Your fork. Day-to-day PRs target its `main`. |
 | `upstream` | the repository you forked from | The source you track for new commits. |
 
 Add it once with `git remote add upstream <url>`; confirm with `git remote -v`. Targeting the wrong base sends review traffic to a repo you may not control — always verify the PR base before creating it.
 
 ### Syncing changes *from* upstream
 
-Pull new `upstream/master` commits into your fork through a single review-ready PR (some forks automate this with a scheduled job, titled e.g. `[upstream-sync] …`):
+Pull new `upstream/main` commits into your fork through a single review-ready PR (some forks automate this with a scheduled job, titled e.g. `[upstream-sync] …`):
 
 1. `git fetch upstream && git fetch origin`.
-2. Stop if `git rev-list --count origin/master..upstream/master` is `0` — nothing new.
-3. `git switch -c sync/upstream-<date> origin/master`.
-4. `git merge --no-ff upstream/master`, resolve conflicts so your fork-specific behaviour is preserved, validate (`npm run check` + tests), push, open the PR.
+2. Stop if `git rev-list --count origin/main..upstream/main` is `0` — nothing new.
+3. `git switch -c sync/upstream-<date> origin/main`.
+4. `git merge --no-ff upstream/main`, resolve conflicts so your fork-specific behaviour is preserved, validate (`npm run check` + tests), push, open the PR.
 
 **⚠️ Merge-commit rule.** **Merge upstream-sync PRs with a real merge commit — never squash, never rebase.**
 
-- Squash/rebase **discards the merge's second parent**, so git loses all record that upstream's commits already live in your `master`. After that, `git merge-base master upstream/master` stays pinned at an ancient commit, `origin/master..upstream/master` re-counts every already-merged commit as "ahead", and the next sync re-litigates conflicts you already resolved.
-- A merge commit keeps `upstream/master` as a true parent, so future syncs surface **only** genuinely-new commits.
+- Squash/rebase **discards the merge's second parent**, so git loses all record that upstream's commits already live in your `main`. After that, `git merge-base main upstream/main` stays pinned at an ancient commit, `origin/main..upstream/main` re-counts every already-merged commit as "ahead", and the next sync re-litigates conflicts you already resolved.
+- A merge commit keeps `upstream/main` as a true parent, so future syncs surface **only** genuinely-new commits.
 - Enable merge commits on your fork (`allow_merge_commit = true`) and don't require linear history; then use "Create a merge commit" / `gh pr merge <n> --merge`. (If the GitHub UI hides the option right after you change the setting, hard-refresh the PR page — the merge dropdown is cached at load time.)
 
-**If a sync PR was squashed by mistake.** You can't rewrite a protected `master`, so heal the ancestry *forward*: branch off the current `master`, build a commit that records `upstream/master` as a second parent while keeping `master`'s tree, then merge that PR with a merge commit:
+**If a sync PR was squashed by mistake.** You can't rewrite a protected `main`, so heal the ancestry *forward*: branch off the current `main`, build a commit that records `upstream/main` as a second parent while keeping `main`'s tree, then merge that PR with a merge commit:
 
 ```bash
-git switch -c sync/heal origin/master
+git switch -c sync/heal origin/main
 git cherry-pick <new-upstream-commits>          # land any new upstream content cleanly
 TREE=$(git write-tree)
-HEAL=$(git commit-tree "$TREE" -p origin/master -p upstream/master -m "Merge upstream/master (heal ancestry)")
-git reset --hard "$HEAL"                         # branch tip = merge commit, tree = master + new content
+HEAL=$(git commit-tree "$TREE" -p origin/main -p upstream/main -m "Merge upstream/main (heal ancestry)")
+git reset --hard "$HEAL"                         # branch tip = merge commit, tree = main + new content
 # push, open PR, then: gh pr merge <n> --merge   (NEVER squash)
 ```
 
@@ -453,16 +453,16 @@ git reset --hard "$HEAL"                         # branch tip = merge commit, tr
 
 To get a fork change accepted into the upstream project:
 
-1. **Develop upstreamable work on a branch cut from `upstream/master`, not your fork's `master`.** A branch based on upstream produces a PR containing *only* your change — no fork-specific commits (CI tweaks, local config, …) leak in.
+1. **Develop upstreamable work on a branch cut from `upstream/main`, not your fork's `main`.** A branch based on upstream produces a PR containing *only* your change — no fork-specific commits (CI tweaks, local config, …) leak in.
    ```bash
    git fetch upstream
-   git switch -c feature/<name> upstream/master
+   git switch -c feature/<name> upstream/main
    # build the change in focused, self-contained commits
    git push origin feature/<name>
-   gh pr create --repo <upstream-owner>/bobbit --base master --head <you>:feature/<name>
+   gh pr create --repo <upstream-owner>/bobbit --base main --head <you>:feature/<name>
    ```
 2. **Land it in both places.** Merge the branch into your fork (fork PR) and submit it upstream. Once upstream accepts it, the next sync brings it back as a normal ancestor — no duplication, no conflict.
-3. **Extracting a change that currently lives only in your fork.** Cherry-pick just its commits onto a fresh `upstream/master`-based branch, dropping fork-only adaptations, and open the upstream PR from there.
+3. **Extracting a change that currently lives only in your fork.** Cherry-pick just its commits onto a fresh `upstream/main`-based branch, dropping fork-only adaptations, and open the upstream PR from there.
 4. **Keep fork divergence minimal.** Every file your fork edits that upstream also maintains becomes a recurring merge conflict. Prefer additive, isolated changes (new files, local config) over editing files upstream actively changes. The smaller and more separable the divergence, the cheaper both syncing-down and contributing-up become.
 
 ---


### PR DESCRIPTION
## Why

The repo's default branch is **`main`** — `origin/HEAD -> origin/main` and CI (`codeql.yml`, `build-unit-gate.yml`) trigger on `branches: [main]`. The G-Research upstream was also swapped from `master` to `main`. A stale, divergent `origin/master` still exists, so any doc/role that assumes `master` silently diffs or branches against the **wrong base** without erroring.

This surfaced while building an affected-test runner: hardcoding `origin/master` produced a bogus 358-file diff vs the correct 7 against `origin/main`.

## What

Wording chosen by context:

**Bobbit-specific → `main`**
- `AGENTS.md` git conventions: primary is `main`; verify via `git symbolic-ref refs/remotes/origin/HEAD`; note the stale divergent `origin/master`.
- `docs/dev-workflow.md`: fork + upstream-sync recipes renamed `master`→`main` (both `origin` and `upstream` are now `main`). Preserved the legacy `{{master}}` **template token** name (it's a code identifier, not a branch).

**General instructions shipped to user projects → "primary branch" (detect via `origin/HEAD`)**
- `docs-writer`, `code-reviewer`, `security-reviewer`, `bug-hunter`: diff/log commands now resolve `BASE` from `origin/HEAD` instead of hardcoding `master...HEAD`.
- `team-lead`: audit, primary-branch merge step, and never-push/never-merge safety guidance no longer assume `master`.
- `team_spawn`: reviewer task reviews "against the goal's base branch".

## Out of scope
Self-contained test fixtures (`git init --initial-branch=master`) are correct and untouched.

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)