### PR TITLE
Fix workflow and session races

### DIFF
--- a/docs/goals-workflows-tasks.md
+++ b/docs/goals-workflows-tasks.md
@@ -284,6 +284,12 @@ Timeout authoring is type-aware and leaving the field empty does not serialize a
 
 The editor validates the same user-facing constraints before save: `human-signoff` steps require a card title and prompt; named `command` steps require a component; review-agent timeouts are positive whole seconds with a minimum of one second; and stale hidden fields are stripped when a step changes type so saved workflows use the canonical YAML shape.
 
+##### Save ownership
+
+A save response owns only the editor draft that issued it. Mutable fields changed while a create or update is pending remain in the editor instead of being replaced by the older server snapshot. If navigation installs another workflow draft before the request resolves, the late response may refresh the workflow collection but must not select, replace, or clear the newer draft.
+
+A successful create makes the returned server ID authoritative: the editor switches from new to persisted state with that ID shown as immutable, while retaining only post-submit mutable edits. The next save therefore updates the returned workflow rather than issuing another create or targeting an ID typed after submission. This separates durable identity from editable content and prevents delayed responses from reverting work or redirecting a later save.
+
 #### Dependency DAG
 
 Each gate's `dependsOn` lists sibling gate IDs that must pass before it can be signaled. An empty list is explicit and valid: it makes the gate an independent root/parallel gate. The workflow editor preserves `dependsOn: []` instead of silently converting it into a dependency on the previous gate.

--- a/docs/prompt-queue.md
+++ b/docs/prompt-queue.md
@@ -170,8 +170,8 @@ When the user clicks Stop (or presses Escape), the server attempts a graceful ab
 
 **Force-kill recovery flow** (exactly-once at the transcript level):
 
-1. User clicks Stop. `SessionManager.forceAbort()` enters abort handling. The shadow ledger (`session.inFlightSteerTexts`) holds every steer text recorded by `_dispatchSteer()` but not yet echoed as `message_end(role:user)`.
-2. If the graceful abort does not settle, the agent process is stopped and `_reconcileAfterAbort()` re-enqueues each ledger entry at the front of `promptQueue` with `isSteered: true` (via `enqueueAtFront()`), then clears the ledger.
+1. User clicks Stop. `SessionManager.forceAbort()` enters abort handling. The shadow ledger (`session.inFlightSteerTexts`) holds every dispatched steer that has not reached a proven user-role `message_end` echo.
+2. If the graceful abort does not settle, the agent process is stopped and `_reconcileAfterAbort()` re-enqueues only the unresolved ledger entries at the front of `promptQueue` with `isSteered: true` (via `enqueueAtFront()`), then clears the ledger. Reverse traversal preserves their original dispatch order and keeps recovered steers ahead of ordinary queued work.
 3. A synthetic `agent_end` is emitted and a fresh subprocess is spawned.
 4. `drainQueue()` runs. The re-enqueued steered rows are popped via `dequeueAllSteered()`, joined into a single prompt, and dispatched once.
 
@@ -179,13 +179,13 @@ The same reconciliation runs on the graceful path: when `handleAgentLifecycle` s
 
 ### The shadow ledger
 
-`SessionInfo.inFlightSteerTexts: string[]` is a per-session array of steer texts whose lifecycle is bounded between **dispatch start** (recorded by `_dispatchSteer()` before the row-removal store update) and **echo** (`message_end` whose user-role body matches an entry, mirroring the SDK's `_steeringMessages` text-match splice).
+`SessionInfo.inFlightSteerTexts` is a per-session array of durable steer records. A record's lifecycle is bounded between **dispatch start** (recorded by `_dispatchSteer()` before the row-removal store update) and a proven user-role echo. The record carries a stable prompt ID as well as the original text so settlement can distinguish repeated identical steers.
 
-- **Record + persist**: `_dispatchSteer()` appends the batch text before removing queue rows, then persists `messageQueue` and `inFlightSteerTexts` in the same store update. A gateway restart after row removal but before transcript echo can therefore recover the text exactly once.
-- **Splice**: in `_consumeSteerEcho()`, called from `handleAgentLifecycle` for every event. Silent no-op for non-matching messages (regular prompts, follow-ups, skill-expansion echoes whose body has been rewritten).
-- **Drain**: in `_reconcileAfterAbort()` and during `restoreSession()` after `switch_session` has replayed durable echoes. Any ledger entry still un-echoed is re-enqueued at the front with `isSteered: true`, then the ledger is cleared.
+- **Record + persist**: `_dispatchSteer()` appends the batch record before removing queue rows, then persists `messageQueue` and `inFlightSteerTexts` in the same store update. A gateway restart after row removal but before transcript echo can therefore recover the text exactly once.
+- **Settle**: `_consumeSteerEcho()` accepts only a user or user-with-attachments `message_end`. When a prompt-author binding is available, it matches by prompt ID; only legacy/unbound echoes fall back to the first matching text. A replayed terminal frame that is already settled is ignored, so it cannot consume a later same-text steer.
+- **Drain**: `_reconcileAfterAbort()` and `restoreSession()` run after durable echoes have been replayed. They re-enqueue only records that remain unresolved, in dispatch order, with `isSteered: true`, then clear the ledger.
 
-The ledger exists because the SDK's in-process steering mirror is not a durable restart/abort recovery surface. Mirroring the SDK's text-match removal logic at Bobbit's persisted-session layer gives Bobbit a single, bounded reconciliation point without an upstream PR. Bounded growth is enforced by construction: every push has a paired echo or abort-drain; neither path is silently dropped.
+The ledger exists because the SDK's in-process steering mirror is not a durable restart/abort recovery surface. The proven user-role echo is Bobbit's durable settlement boundary: it shows the steer reached Pi, so it must never be replayed after Stop or a restart. Entries without that proof are recovered exactly once from the ledger. Bounded growth is enforced by construction: every push has a paired settlement or recovery drain; neither path is silently dropped.
 
 Late RPC rejection is also guarded: `_dispatchSteer()` only rolls a failed steer back into the queue if its ledger entry is still present. If abort/restart reconciliation already drained that entry, the catch path persists the cleared ledger and does **not** enqueue a duplicate.
 

--- a/src/app/workflow-page.ts
+++ b/src/app/workflow-page.ts
@@ -55,6 +55,11 @@ interface EditorInstance {
 	selectedWorkflow: Workflow | null;
 	isNew: boolean;
 	saving: boolean;
+	// Replaced whenever the page installs a different draft. Save responses
+	// only own the draft generation that dispatched them.
+	draftOwnerGeneration: number;
+	// Incremented for every controlled draft mutation.
+	editRevision: number;
 	// Expansion / drag state
 	expandedGateIndices: Set<number>;
 	expandedVStepKeys: Set<string>;
@@ -83,6 +88,8 @@ function makeInstance(id: string): EditorInstance {
 		selectedWorkflow: null,
 		isNew: false,
 		saving: false,
+		draftOwnerGeneration: 0,
+		editRevision: 0,
 		expandedGateIndices: new Set(),
 		expandedVStepKeys: new Set(),
 		dragIndex: null,
@@ -101,6 +108,10 @@ function makeInstance(id: string): EditorInstance {
 
 // Canonical page-level editor instance. Owned by the Workflows page shell.
 const pageInstance: EditorInstance = makeInstance("__page__");
+
+// Never reset this counter: an in-flight save must not mistake a later draft
+// for the one that dispatched it, even if both happen to have the same fields.
+let nextPageDraftOwnerGeneration = 0;
 
 // Embed instances keyed by `workflowKey` (e.g. `__inspector__:bug-fix`,
 // `__editor__:bug-fix`). Embeds keep their own state across re-renders so
@@ -229,6 +240,8 @@ async function fetchWorkflowsScoped(): Promise<Workflow[]> {
 }
 
 function resetPageInstance(): void {
+	pageInstance.draftOwnerGeneration = ++nextPageDraftOwnerGeneration;
+	pageInstance.editRevision = 0;
 	pageInstance.controller = null;
 	pageInstance.editId = "";
 	pageInstance.editName = "";
@@ -282,6 +295,8 @@ function showList(): void {
 
 function showEdit(workflow: Workflow): void {
 	currentView = "edit";
+	pageInstance.draftOwnerGeneration = ++nextPageDraftOwnerGeneration;
+	pageInstance.editRevision = 0;
 	pageInstance.controller = null;
 	pageInstance.selectedWorkflow = workflow;
 	pageInstance.isNew = false;
@@ -301,6 +316,8 @@ function showEdit(workflow: Workflow): void {
 
 function showNewEdit(): void {
 	currentView = "edit";
+	pageInstance.draftOwnerGeneration = ++nextPageDraftOwnerGeneration;
+	pageInstance.editRevision = 0;
 	pageInstance.controller = null;
 	pageInstance.selectedWorkflow = null;
 	pageInstance.isNew = true;
@@ -323,8 +340,7 @@ export function navigateToWorkflowEdit(workflowId: string): void {
 	if (wf) {
 		showEdit(wf);
 	} else {
-		currentView = "list";
-		pageInstance.selectedWorkflow = null;
+		showList();
 	}
 	renderApp();
 }
@@ -548,6 +564,9 @@ async function handleSave(): Promise<void> {
 		return;
 	}
 
+	const submittedOwnerGeneration = pageInstance.draftOwnerGeneration;
+	const submittedRevision = pageInstance.editRevision;
+	const submittedWorkflow = pageInstance.selectedWorkflow;
 	pageInstance.saving = true;
 	renderApp();
 
@@ -568,25 +587,56 @@ async function handleSave(): Promise<void> {
 		}, getConfigProjectId({ preserveHeadquarters: true }) || undefined);
 		if (result) {
 			workflows = await fetchWorkflowsScoped();
-			showEdit(result);
+			if (pageInstance.draftOwnerGeneration !== submittedOwnerGeneration) return;
+			if (pageInstance.editRevision === submittedRevision) {
+				showEdit(result);
+			} else {
+				// A create makes the server's identity authoritative, but must not
+				// replace mutable edits made after the request was dispatched.
+				pageInstance.editId = result.id;
+				pageInstance.selectedWorkflow = result;
+				pageInstance.isNew = false;
+				pageInstance.saving = false;
+				saveAttempted = false;
+				saveBlockedReason = null;
+				renderApp();
+			}
 			return;
 		}
-	} else if (pageInstance.selectedWorkflow) {
-		const ok = await updateWorkflow(pageInstance.selectedWorkflow.id, {
+	} else if (submittedWorkflow) {
+		const submittedWorkflowId = submittedWorkflow.id;
+		const ok = await updateWorkflow(submittedWorkflowId, {
 			name: pageInstance.editName,
 			description: pageInstance.editDescription,
 			gates: gatesWithDeps,
 		}, getConfigProjectId({ preserveHeadquarters: true }) || undefined);
 		if (ok) {
 			workflows = await fetchWorkflowsScoped();
-			const updated = workflows.find((w) => w.id === pageInstance.selectedWorkflow!.id);
+			if (pageInstance.draftOwnerGeneration !== submittedOwnerGeneration) return;
+			if (pageInstance.editRevision !== submittedRevision) {
+				// A successful PUT makes the submitted identity durable even if its
+				// subsequent list refresh is stale, incomplete, or unavailable. Keep
+				// the newer mutable draft rather than letting a missing refresh target
+				// navigate it away.
+				pageInstance.editId = submittedWorkflowId;
+				pageInstance.selectedWorkflow = submittedWorkflow;
+				pageInstance.isNew = false;
+				pageInstance.saving = false;
+				saveAttempted = false;
+				saveBlockedReason = null;
+				renderApp();
+				return;
+			}
+			const updated = workflows.find((w) => w.id === submittedWorkflowId);
 			if (updated) showEdit(updated);
 			else showList();
 			return;
 		}
 	}
-	pageInstance.saving = false;
-	renderApp();
+	if (pageInstance.draftOwnerGeneration === submittedOwnerGeneration) {
+		pageInstance.saving = false;
+		renderApp();
+	}
 }
 
 async function handleDelete(workflow: Workflow): Promise<void> {
@@ -651,6 +701,7 @@ function updateGateField(inst: EditorInstance, index: number, field: string, val
 
 // Build the current draft and notify the controller (if any).
 function notifyControlledChange(inst: EditorInstance): void {
+	inst.editRevision++;
 	if (!inst.controller) return;
 	const draft: Workflow = {
 		id: inst.editId,

--- a/src/server/agent/session-manager.ts
+++ b/src/server/agent/session-manager.ts
@@ -4819,11 +4819,9 @@ export class SessionManager {
 	}
 
 	/**
-	 * Splice an entry from the shadow ledger when its echo arrives.
-	 * Matches the SDK's text-match removal at agent-session.js:265-280:
-	 * find the first index whose text equals the user-message body, splice it.
-	 * Silent no-op for non-matching messages (regular prompts, follow-ups,
-	 * skill-expansion echoes whose body has been rewritten).
+	 * Splice an entry from the shadow ledger when its user-role echo arrives.
+	 * The echo is the durable settlement boundary: it proves Pi accepted and
+	 * executed the steer, so Stop must never redispatch it.
 	 */
 	private _consumeSteerEcho(session: SessionInfo, event: any): void {
 		const ledger = session.inFlightSteerTexts;
@@ -4868,6 +4866,9 @@ export class SessionManager {
 	}
 
 	private _reconcileAfterAbort(session: SessionInfo): void {
+		// A user-role echo consumes its steer record, so only unresolved durable
+		// entries remain to be requeued chronologically. Replaying an echoed steer
+		// would duplicate an instruction Pi already executed in the cancelled turn.
 		this._reconcileInFlightSteers(session);
 	}
 
@@ -5331,10 +5332,8 @@ export class SessionManager {
 			}
 		}
 
-		// Splice this echoed user message off the shadow ledger if it was a
-		// dispatched steer. Mirrors the SDK's _steeringMessages text-match
-		// removal (agent-session.js:265–280); harmless no-op for non-steer
-		// user messages (regular prompts, follow-ups, ask responses).
+		// Every proven user echo settles the durable ledger. Stop only recovers
+		// entries still unresolved after this boundary.
 		this._consumeSteerEcho(session, event);
 
 		// Tool boundary: defensively flush any steered rows that remain queued
@@ -5425,20 +5424,10 @@ export class SessionManager {
 				session.oneTimeGrantedTools = [];
 			}
 
-			// Safety net: if steers arrived after the last tool call or during a
-			// non-tool turn (no tool_execution_end fired), dispatch them now.
-			if (session.status !== "aborting") {
-				const steered = session.promptQueue.dequeueAllSteered();
-				if (steered.length > 0) void this._dispatchSteer(session, steered).catch(() => {});
-			}
-
 			const wasAborting = session.status === "aborting";
 			if (wasAborting) {
-				// Reconcile in-flight steers that the SDK accepted but never
-				// echoed because the turn was aborted. Re-enqueueing at front
-				// as steered means drainQueue → _dispatchSteer redispatches
-				// the batch on the next turn. Plus a defensive rebroadcast in
-				// case the queue was mutated mid-abort.
+				// Requeue only durable entries that did not reach the user-role echo
+				// settlement boundary before the aborted turn ended.
 				this._reconcileAfterAbort(session);
 				this.broadcastQueue(session);
 
@@ -5455,6 +5444,11 @@ export class SessionManager {
 				session.lastTurnErrored = false;
 				session.lastTurnErrorMessage = undefined;
 				session.consecutiveErrorTurns = 0;
+			} else {
+				// Safety net: if steers arrived after the last tool call or during a
+				// non-tool turn (no tool_execution_end fired), dispatch them now.
+				const steered = session.promptQueue.dequeueAllSteered();
+				if (steered.length > 0) void this._dispatchSteer(session, steered).catch(() => {});
 			}
 
 			session.streamingStartedAt = undefined;

--- a/tests/ui-fixtures/goal-workflow-editor-entry.ts
+++ b/tests/ui-fixtures/goal-workflow-editor-entry.ts
@@ -24,6 +24,20 @@ type FetchLogEntry = { url: string; method: string; body: any };
 let workflows: FixtureWorkflow[] = [];
 let fetchLog: FetchLogEntry[] = [];
 
+type HeldWorkflowRequest = {
+	release: Promise<void>;
+	releaseRequest: () => void;
+	reportRequest: (request: FetchLogEntry) => void;
+};
+
+type HeldWorkflowCreate = HeldWorkflowRequest & { resultId: string };
+
+let heldWorkflowCreate: HeldWorkflowCreate | null = null;
+let heldWorkflowUpdate: HeldWorkflowRequest | null = null;
+let nextWorkflowUpdate: ((request: FetchLogEntry) => void) | null = null;
+let nextWorkflowListFetch: ((request: FetchLogEntry) => void) | null = null;
+let omitNextWorkflowList = false;
+
 class FixtureWebSocket {
 	static CONNECTING = 0;
 	static OPEN = 1;
@@ -77,10 +91,30 @@ window.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
 	fetchLog.push({ url, method, body: clone(body) });
 
 	if (url.startsWith("/api/workflows") && !workflowIdFromPath(url)) {
-		if (method === "GET") return response({ workflows: clone(workflows) });
+		if (method === "GET") {
+			const reportListFetch = nextWorkflowListFetch;
+			nextWorkflowListFetch = null;
+			reportListFetch?.({ url, method, body: clone(body) });
+			if (omitNextWorkflowList) {
+				omitNextWorkflowList = false;
+				return response({});
+			}
+			return response({ workflows: clone(workflows) });
+		}
 		if (method === "POST") {
-			const workflow = { ...body, createdAt: Date.now(), updatedAt: Date.now() };
+			const held = heldWorkflowCreate;
+			const workflow = {
+				...body,
+				id: held?.resultId ?? body.id,
+				createdAt: Date.now(),
+				updatedAt: Date.now(),
+			};
 			workflows = [...workflows, workflow];
+			if (held) {
+				held.reportRequest({ url, method, body: clone(body) });
+				await held.release;
+				heldWorkflowCreate = null;
+			}
 			return response(clone(workflow), 201);
 		}
 	}
@@ -93,6 +127,15 @@ window.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
 		}
 		if (method === "PUT") {
 			if (idx < 0) return response({ error: "not found" }, 404);
+			const held = heldWorkflowUpdate;
+			if (held) {
+				held.reportRequest({ url, method, body: clone(body) });
+				await held.release;
+				heldWorkflowUpdate = null;
+			}
+			const reportUpdate = nextWorkflowUpdate;
+			nextWorkflowUpdate = null;
+			reportUpdate?.({ url, method, body: clone(body) });
 			workflows[idx] = { ...workflows[idx], ...body, id, updatedAt: Date.now() };
 			return response(clone(workflows[idx]));
 		}
@@ -116,12 +159,20 @@ function nextFrame(): Promise<void> {
 }
 
 setRenderApp(doRender);
+// The production app's route shell redraws after hash navigation. This focused
+// page fixture owns no shell, so mirror that redraw for Back/list navigation.
+window.addEventListener("hashchange", doRender);
 localStorage.setItem("gateway.url", "http://fixture");
 localStorage.setItem("gateway.token", "fixture-token");
 
-(window as any).__loadGoalWorkflowFixture = async (workflow: FixtureWorkflow) => {
-	workflows = [clone(workflow)];
+(window as any).__loadGoalWorkflowFixture = async (workflow: FixtureWorkflow | FixtureWorkflow[] | null) => {
+	workflows = workflow === null ? [] : Array.isArray(workflow) ? clone(workflow) : [clone(workflow)];
 	fetchLog = [];
+	heldWorkflowCreate = null;
+	heldWorkflowUpdate = null;
+	nextWorkflowUpdate = null;
+	nextWorkflowListFetch = null;
+	omitNextWorkflowList = false;
 	state.projects = [{
 		id: PROJECT_ID,
 		name: "Fixture Project",
@@ -134,9 +185,51 @@ localStorage.setItem("gateway.token", "fixture-token");
 	clearWorkflowPageState();
 	window.location.hash = "#/workflows";
 	await loadWorkflowPageData();
-	navigateToWorkflowEdit(workflow.id);
+	if (workflows[0]) navigateToWorkflowEdit(workflows[0].id);
 	doRender();
 	await nextFrame();
+};
+
+(window as any).__holdNextWorkflowCreate = (resultId: string): Promise<FetchLogEntry> => {
+	if (heldWorkflowCreate) throw new Error("A workflow create is already held");
+	return new Promise((reportRequest) => {
+		let releaseRequest!: () => void;
+		const release = new Promise<void>((resolve) => { releaseRequest = resolve; });
+		heldWorkflowCreate = { resultId, release, releaseRequest, reportRequest };
+	});
+};
+
+(window as any).__releaseHeldWorkflowCreate = () => {
+	if (!heldWorkflowCreate) throw new Error("No workflow create is held");
+	heldWorkflowCreate.releaseRequest();
+};
+
+(window as any).__holdNextWorkflowUpdate = (): Promise<FetchLogEntry> => {
+	if (heldWorkflowUpdate) throw new Error("A workflow update is already held");
+	return new Promise((reportRequest) => {
+		let releaseRequest!: () => void;
+		const release = new Promise<void>((resolve) => { releaseRequest = resolve; });
+		heldWorkflowUpdate = { release, releaseRequest, reportRequest };
+	});
+};
+
+(window as any).__releaseHeldWorkflowUpdate = () => {
+	if (!heldWorkflowUpdate) throw new Error("No workflow update is held");
+	heldWorkflowUpdate.releaseRequest();
+};
+
+(window as any).__waitForNextWorkflowUpdate = (): Promise<FetchLogEntry> => {
+	if (nextWorkflowUpdate) throw new Error("A workflow update is already awaited");
+	return new Promise((resolve) => { nextWorkflowUpdate = resolve; });
+};
+
+(window as any).__waitForNextWorkflowListFetch = (): Promise<FetchLogEntry> => {
+	if (nextWorkflowListFetch) throw new Error("A workflow list fetch is already awaited");
+	return new Promise((resolve) => { nextWorkflowListFetch = resolve; });
+};
+
+(window as any).__omitNextWorkflowList = () => {
+	omitNextWorkflowList = true;
 };
 
 (window as any).__goalWorkflowFetchLog = () => clone(fetchLog);

--- a/tests2/browser/fixtures/goal-workflow-editor.spec.ts
+++ b/tests2/browser/fixtures/goal-workflow-editor.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, type Page } from "@playwright/test";
+import { test, expect, type Locator, type Page } from "@playwright/test";
 import fs from "node:fs";
 import path from "node:path";
 import { buildBundle } from "../fixtures/build-bundle.js";
@@ -42,12 +42,26 @@ test.beforeAll(() => {
 	});
 });
 
-async function loadWorkflow(page: Page, workflow: FixtureWorkflow): Promise<void> {
+async function loadWorkflow(page: Page, workflow: FixtureWorkflow | FixtureWorkflow[]): Promise<void> {
 	await page.goto(`file://${SHELL.replace(/\\/g, "/")}`);
 	await page.addScriptTag({ path: BUNDLE });
 	await page.waitForFunction(() => (window as any).__goalWorkflowEditorReady === true, null, { timeout: 10_000 });
 	await page.evaluate((wf) => (window as any).__loadGoalWorkflowFixture(wf), workflow);
-	await expect(page.locator("input[placeholder='Workflow name']").first()).toHaveValue(workflow.name, { timeout: 10_000 });
+	const firstWorkflow = Array.isArray(workflow) ? workflow[0] : workflow;
+	await expect(page.locator("input[placeholder='Workflow name']").first()).toHaveValue(firstWorkflow.name, { timeout: 10_000 });
+}
+
+async function loadNewWorkflowEditor(page: Page): Promise<void> {
+	await page.goto(`file://${SHELL.replace(/\\/g, "/")}`);
+	await page.addScriptTag({ path: BUNDLE });
+	await page.waitForFunction(() => (window as any).__goalWorkflowEditorReady === true, null, { timeout: 10_000 });
+	await page.evaluate(() => (window as any).__loadGoalWorkflowFixture(null));
+	await page.getByRole("button", { name: "create one by hand" }).click();
+	await expect(page.locator("input[placeholder='e.g. bug-fix']")).toBeVisible();
+}
+
+function saveButton(page: Page): Locator {
+	return page.locator(".wf-nav-right button").last();
 }
 
 async function expandFirstGate(page: Page): Promise<void> {
@@ -182,5 +196,103 @@ test.describe("Goal/workflow editor fixture", () => {
 
 		const body = await lastPutBody(page);
 		expect(body.gates[0].verify.map((step: any) => step.phase ?? 0)).toEqual([0, 1]);
+	});
+
+	test("preserves mutable edits after a held create while saving the server-created ID", async ({ page }) => {
+		await loadNewWorkflowEditor(page);
+		const workflowId = page.locator("input[placeholder='e.g. bug-fix']");
+		const workflowName = page.locator("input[placeholder='Workflow name']");
+		await workflowId.fill("submitted-workflow-id");
+		await workflowName.fill("Submitted workflow name");
+
+		const createRequest = page.evaluate(() =>
+			(window as any).__holdNextWorkflowCreate("server-created-workflow-id"),
+		);
+		await saveButton(page).click();
+		const capturedCreate = await createRequest;
+		expect(capturedCreate).toMatchObject({
+			url: "/api/workflows?projectId=fixture-project",
+			method: "POST",
+			body: { id: "submitted-workflow-id", name: "Submitted workflow name" },
+		});
+		await expect(saveButton(page)).toHaveText("Saving…");
+
+		await workflowId.fill("post-submit-id-must-not-persist");
+		await workflowName.fill("Mutable name after create submit");
+		await page.evaluate(() => (window as any).__releaseHeldWorkflowCreate());
+
+		const persistedWorkflowId = page.locator(".wf-identity-row").first().locator("input[disabled]");
+		await expect(persistedWorkflowId).toBeDisabled();
+		await expect(persistedWorkflowId).toHaveValue("server-created-workflow-id");
+		await expect(workflowName).toHaveValue("Mutable name after create submit");
+		await expect(saveButton(page)).toHaveText("Save");
+		await expect(saveButton(page)).toBeEnabled();
+
+		const updateRequest = page.evaluate(() => (window as any).__waitForNextWorkflowUpdate());
+		await saveButton(page).click();
+		const capturedUpdate = await updateRequest;
+		expect(capturedUpdate).toMatchObject({
+			url: "/api/workflows/server-created-workflow-id?projectId=fixture-project",
+			method: "PUT",
+			body: { name: "Mutable name after create submit" },
+		});
+		const requests = await page.evaluate(() => (window as any).__goalWorkflowFetchLog());
+		expect(requests.filter((request: any) => request.method === "POST")).toHaveLength(1);
+	});
+
+	test("preserves a newer draft when a held PUT refresh omits its target", async ({ page }) => {
+		await loadWorkflow(page, workflowWithSteps([]));
+		const workflowName = page.locator("input[placeholder='Workflow name']");
+		const updateRequest = page.evaluate(() => (window as any).__holdNextWorkflowUpdate());
+
+		await saveButton(page).click();
+		const capturedUpdate = await updateRequest;
+		expect(capturedUpdate).toMatchObject({
+			url: "/api/workflows/fixture-workflow?projectId=fixture-project",
+			method: "PUT",
+			body: { name: "Fixture Workflow" },
+		});
+		await expect(saveButton(page)).toHaveText("Saving…");
+
+		await workflowName.fill("Mutable name after update submit");
+		await page.evaluate(() => (window as any).__omitNextWorkflowList());
+		await page.evaluate(() => (window as any).__releaseHeldWorkflowUpdate());
+
+		await expect(page.locator(".wf-identity-row").first().locator("input[disabled]")).toHaveValue("fixture-workflow");
+		await expect(workflowName).toHaveValue("Mutable name after update submit");
+		await expect(saveButton(page)).toHaveText("Save");
+		await expect(saveButton(page)).toBeEnabled();
+
+		const nextUpdate = page.evaluate(() => (window as any).__waitForNextWorkflowUpdate());
+		await saveButton(page).click();
+		await expect(nextUpdate).resolves.toMatchObject({
+			url: "/api/workflows/fixture-workflow?projectId=fixture-project",
+			method: "PUT",
+			body: { name: "Mutable name after update submit" },
+		});
+	});
+
+	test("ignores a held response after navigation installs another workflow draft", async ({ page }) => {
+		const workflowA = { ...workflowWithSteps([]), id: "workflow-a", name: "Workflow A" };
+		const workflowB = { ...workflowWithSteps([]), id: "workflow-b", name: "Workflow B" };
+		await loadWorkflow(page, [workflowA, workflowB]);
+		const updateRequest = page.evaluate(() => (window as any).__holdNextWorkflowUpdate());
+
+		await saveButton(page).click();
+		const capturedUpdate = await updateRequest;
+		expect(capturedUpdate).toMatchObject({ url: "/api/workflows/workflow-a?projectId=fixture-project" });
+		await page.locator(".wf-back").click();
+		await page.locator(".wf-row[data-workflow-id='workflow-b']").click();
+		const workflowName = page.locator("input[placeholder='Workflow name']");
+		await expect(workflowName).toHaveValue("Workflow B");
+
+		const listFetch = page.evaluate(() => (window as any).__waitForNextWorkflowListFetch());
+		await page.evaluate(() => (window as any).__releaseHeldWorkflowUpdate());
+		await listFetch;
+		await page.evaluate(() => new Promise<void>((resolve) => requestAnimationFrame(() => resolve())));
+
+		await expect(page.locator(".wf-identity-row").first().locator("input[disabled]")).toHaveValue("workflow-b");
+		await expect(workflowName).toHaveValue("Workflow B");
+		await expect(saveButton(page)).toHaveText("Save");
 	});
 });

--- a/tests2/core/session-manager-direct-prompt-lifecycle.test.ts
+++ b/tests2/core/session-manager-direct-prompt-lifecycle.test.ts
@@ -849,6 +849,92 @@ describe("SessionManager direct idle prompt lifecycle", () => {
 		await steerPromise;
 	});
 
+	it("does not replay an echoed live steer after Stop", async () => {
+		const manager = makeManager();
+		const steer = vi.fn(async () => ({ success: true }));
+		const { session } = putSession(manager, {
+			status: "streaming",
+			rpcClient: { prompt: vi.fn(async () => ({ success: true })), steer },
+		});
+
+		await manager.deliverLiveSteer(session.id, "A echoed");
+		const echo = manager.prepareVisibleAgentEvent(session, {
+			type: "message_end",
+			message: { role: "user", content: "A echoed" },
+		});
+		manager.handleAgentLifecycle(session, echo);
+		manager._reconcileAfterAbort(session);
+
+		assert.deepEqual(session.inFlightSteerTexts, []);
+		assert.deepEqual(
+			session.promptQueue.toArray().map((row: any) => row.text),
+			[],
+			"a proven user echo is settled work, not abort recovery work",
+		);
+	});
+
+	it("recovers only an unechoed later steer after Stop", async () => {
+		const manager = makeManager();
+		const steer = vi.fn(async () => ({ success: true }));
+		const { session } = putSession(manager, {
+			status: "streaming",
+			rpcClient: { prompt: vi.fn(async () => ({ success: true })), steer },
+		});
+
+		await manager.deliverLiveSteer(session.id, "A echoed");
+		await manager.deliverLiveSteer(session.id, "B unechoed");
+		const echo = manager.prepareVisibleAgentEvent(session, {
+			type: "message_end",
+			message: { role: "user", content: "A echoed" },
+		});
+		manager.handleAgentLifecycle(session, echo);
+		manager._reconcileAfterAbort(session);
+
+		assert.deepEqual(
+			session.promptQueue.toArray().map((row: any) => row.text),
+			["B unechoed"],
+			"Stop recovers the unresolved B intent without duplicating settled A",
+		);
+	});
+
+	it("recovers multiple unechoed steers in dispatch order", async () => {
+		const manager = makeManager();
+		const steer = vi.fn(async () => ({ success: true }));
+		const { session } = putSession(manager, {
+			status: "streaming",
+			rpcClient: { prompt: vi.fn(async () => ({ success: true })), steer },
+		});
+
+		await manager.deliverLiveSteer(session.id, "A first");
+		await manager.deliverLiveSteer(session.id, "B second");
+		manager._reconcileAfterAbort(session);
+
+		assert.deepEqual(
+			session.promptQueue.toArray().map((row: any) => row.text),
+			["A first", "B second"],
+			"front insertion reverses the ledger traversal, preserving chronological dispatch order",
+		);
+	});
+
+	it("places recovered steers before an ordinary queued prompt without reordering either", async () => {
+		const manager = makeManager();
+		const steer = vi.fn(async () => ({ success: true }));
+		const { session } = putSession(manager, {
+			status: "streaming",
+			rpcClient: { prompt: vi.fn(async () => ({ success: true })), steer },
+		});
+
+		await manager.deliverLiveSteer(session.id, "A recover");
+		session.promptQueue.enqueue("ordinary queued prompt");
+		manager._reconcileAfterAbort(session);
+
+		assert.deepEqual(
+			session.promptQueue.toArray().map((row: any) => row.text),
+			["A recover", "ordinary queued prompt"],
+			"recovered steer retains priority while ordinary queued work remains FIFO behind it",
+		);
+	});
+
 	it("correlates duplicate multi-block update/end streams to stable prompt bindings", () => {
 		const manager = makeManager();
 		const systemAuthor = { kind: "system", id: "system:bobbit", label: "Bobbit" } as const;

--- a/tests2/integration/abort-status-e2e.test.ts
+++ b/tests2/integration/abort-status-e2e.test.ts
@@ -140,7 +140,7 @@ test.describe("Abort status E2E", () => {
 		}
 	});
 
-	test("PI-25b: live-steer (direct) survives abort and is delivered as next user turn", async () => {
+	test("PI-25b: an unechoed direct live-steer survives abort and is delivered as next user turn", async ({ gateway }) => {
 		// Bug: `deliverLiveSteer()` in session-manager.ts calls rpcClient.steer()
 		// WITHOUT writing to promptQueue. The SDK parks the steer until the next
 		// tool boundary; forceAbort tears the turn down and the parked steer is
@@ -163,6 +163,14 @@ test.describe("Abort status E2E", () => {
 
 			await startAbortableBusyTurn(conn, "long running task");
 
+			// Pin the actual recovery seam: accept the steer RPC but suppress its
+			// user-role echo. An echoed steer is settled work and must not replay;
+			// only this explicitly unechoed state is recovered after Stop.
+			const live = gateway.sessionManager.getSession(sessionId);
+			const mockAgent = live?.rpcClient?._agent;
+			expect(mockAgent, "PI-25b requires the in-process mock bridge").toBeTruthy();
+			mockAgent.env.MOCK_STEER_QUEUE_DROP = "always";
+
 			// Snapshot cursor so we look only at events AFTER steer+abort.
 			const cursor = conn.messageCount();
 
@@ -171,57 +179,71 @@ test.describe("Abort status E2E", () => {
 			conn.send({ type: "steer", text: "S_DIRECT" });
 			conn.send({ type: "abort" });
 
-			// Wait for session to settle after abort. The abort-induced agent_end
-			// drops us back to idle; with the fix, drainQueue then delivers the
-			// steered text as a fresh user turn (which transitions us back to
-			// streaming and then idle again).
-			await conn.waitForFrom(cursor, statusPredicate("idle"), 10_000);
-
-			// Give drain a brief window to dispatch the re-armed steer and for
-			// the mock agent to emit the resulting user message_end.
-			const userMsgIdx = await conn.waitForFrom(
+			// Establish the abort terminal boundary before looking for delivery.
+			// This fixture suppresses the original echo, so the subsequent user
+			// event proves one recovered delivery after the cancelled turn.
+			await conn.waitForFrom(
 				cursor,
+				(m) => m.type === "event" && m.data?.type === "agent_end",
+				10_000,
+			);
+			const postAbortEnd = conn.messages.slice(cursor);
+			const firstAgentEndIdx = postAbortEnd.findIndex(
+				(m) => m.type === "event" && m.data?.type === "agent_end",
+			);
+			expect(firstAgentEndIdx, "PI-25b: expected an agent_end event from the abort before the redelivered user turn").toBeGreaterThanOrEqual(0);
+
+			await conn.waitForFrom(
+				cursor + firstAgentEndIdx + 1,
 				(m) =>
 					m.type === "event" &&
 					m.data?.type === "message_end" &&
 					m.data?.message?.role === "user" &&
 					m.data?.message?.content?.[0]?.text === "S_DIRECT",
 				8_000,
-			).then(() => conn.messageCount()).catch(() => -1);
+			).catch(() => { /* handled by the assertion below */ });
 
-			// Wait for the agent to complete its turn in response to the redelivered
-			// steer (the assertion below keys on this follow-up agent_end).
-			if (userMsgIdx > 0) {
+			// Find the redelivered user turn, then wait from that exact event
+			// boundary for the turn it starts to finish.
+			let post = conn.messages.slice(cursor);
+			let userDirectIdx = post.findIndex(
+				(m, index) =>
+					index > firstAgentEndIdx &&
+					m.type === "event" &&
+					m.data?.type === "message_end" &&
+					m.data?.message?.role === "user" &&
+					m.data?.message?.content?.[0]?.text === "S_DIRECT",
+			);
+			if (userDirectIdx >= 0) {
 				await conn.waitForFrom(
-					userMsgIdx,
+					cursor + userDirectIdx + 1,
 					(m) => m.type === "event" && m.data?.type === "agent_end",
 					8_000,
-				).catch(() => { /* handled below */ });
+				).catch(() => { /* handled by the assertion below */ });
+				post = conn.messages.slice(cursor);
+				userDirectIdx = post.findIndex(
+					(m, index) =>
+						index > firstAgentEndIdx &&
+						m.type === "event" &&
+						m.data?.type === "message_end" &&
+						m.data?.message?.role === "user" &&
+						m.data?.message?.content?.[0]?.text === "S_DIRECT",
+				);
 			}
 
-			// Collect the event stream post-cursor and find the abort-induced
-			// agent_end + any subsequent user message_end carrying "S_DIRECT".
-			const post = conn.messages.slice(cursor);
-			const firstAgentEndIdx = post.findIndex(
-				(m) => m.type === "event" && m.data?.type === "agent_end",
-			);
-			const userDirectIdx = post.findIndex(
+			const recoveredSteers = post.filter(
 				(m) =>
 					m.type === "event" &&
 					m.data?.type === "message_end" &&
 					m.data?.message?.role === "user" &&
 					m.data?.message?.content?.[0]?.text === "S_DIRECT",
 			);
+			expect(recoveredSteers, "PI-25b must recover an unechoed steer exactly once").toHaveLength(1);
 
 			// Specific, identifiable error message for the harness to key on.
 			expect(
 				userDirectIdx,
 				"PI-25b: live-steer text 'S_DIRECT' was never delivered as a user turn after abort — deliverLiveSteer did not persist the steer and drainQueue had nothing to re-dispatch",
-			).toBeGreaterThanOrEqual(0);
-
-			expect(
-				firstAgentEndIdx,
-				"PI-25b: expected an agent_end event from the abort before the redelivered user turn",
 			).toBeGreaterThanOrEqual(0);
 
 			// The redelivered user message_end must come AFTER the abort's agent_end.

--- a/tests2/integration/helpers/local-mock-agent-clock.ts
+++ b/tests2/integration/helpers/local-mock-agent-clock.ts
@@ -8,6 +8,38 @@ export interface LocalMockAgentClock {
 }
 
 /**
+ * Restore a session with its per-bridge virtual clock installed at the exact
+ * queue-drain boundary. `restoreSessions()` re-enqueues durable steers, then
+ * releases its replacement coordinator which drains that queue synchronously.
+ * Attaching after restore returns races the mock's first sleep: that sleep can
+ * already have captured the real-time implementation, while the caller only
+ * advances the local clock. Installing immediately before the drain makes the
+ * entire recovered turn belong to one deterministic clock.
+ */
+export async function restoreWithLocalMockAgentClock(gateway: any, sessionId: string): Promise<LocalMockAgentClock> {
+	const manager = gateway.sessionManager;
+	const originalDrainQueue = manager.drainQueue;
+	let localClock: LocalMockAgentClock | undefined;
+
+	const patchedDrainQueue = (session: { id?: string }) => {
+		if (session?.id === sessionId && !localClock) {
+			localClock = attachLocalMockAgentClock(gateway, sessionId);
+		}
+		return originalDrainQueue.call(manager, session);
+	};
+	manager.drainQueue = patchedDrainQueue;
+	try {
+		await manager.restoreSessions();
+	} finally {
+		if (manager.drainQueue === patchedDrainQueue) manager.drainQueue = originalDrainQueue;
+	}
+	if (!localClock) {
+		throw new Error(`session ${sessionId} did not drain a recovered mock-agent prompt`);
+	}
+	return localClock;
+}
+
+/**
  * Give one in-process mock agent its own virtual clock.
  *
  * The gateway clock is fork-scoped, so advancing it from a test also fires

--- a/tests2/integration/steer-gateway-restart.test.ts
+++ b/tests2/integration/steer-gateway-restart.test.ts
@@ -20,7 +20,7 @@ import {
 	promptAuthorBindingMatchesText,
 	readAuthorSidecar,
 } from "../../src/server/agent/author-sidecar.js";
-import { attachLocalMockAgentClock } from "./helpers/local-mock-agent-clock.js";
+import { restoreWithLocalMockAgentClock } from "./helpers/local-mock-agent-clock.js";
 
 const STEER_TEXT = "RESTART_M1\nRESTART_M2";
 const AGENT_STEER_TEXT = "RESTART_AGENT_ACCOUNTABLE_STEER";
@@ -103,9 +103,7 @@ test.describe("Steer + gateway restart (AC §3)", () => {
 			live.unsubscribe();
 			await live.rpcClient.stop();
 			sm.sessions.delete(sessionId);
-			await sm.restoreSessions();
-
-			const restoredClock = attachLocalMockAgentClock(gateway, sessionId);
+			const restoredClock = await restoreWithLocalMockAgentClock(gateway, sessionId);
 			await restoredClock.settleCurrentPrompt();
 
 			conn = await connectWs(sessionId);
@@ -179,9 +177,7 @@ test.describe("Steer + gateway restart (AC §3)", () => {
 			live.unsubscribe();
 			await live.rpcClient.stop();
 			sm.sessions.delete(sessionId);
-			await sm.restoreSessions();
-
-			const restoredClock = attachLocalMockAgentClock(gateway, sessionId);
+			const restoredClock = await restoreWithLocalMockAgentClock(gateway, sessionId);
 			await restoredClock.settleCurrentPrompt();
 			expect(rawUserMessages(gateway, sessionId).filter(message => messageText(message) === piText),
 				"only the healthy post-restart bridge observes the decorated steer").toHaveLength(1);


### PR DESCRIPTION
## Summary
- preserve workflow drafts and authoritative server-created IDs across delayed create/update responses
- settle echoed steers exactly once and recover only unresolved durable entries after abort/restart
- replace wall-clock restart assumptions with the local manual lifecycle clock
- add focused browser, core, and integration race regressions plus contract documentation

## Verification
- `npm run check`
- full unit, browser, and E2E workflow gates
- focused workflow, direct-prompt, abort, and restart races repeated without retries

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)