### PR TITLE
Isolate maintenance command runners

### DIFF
--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -16,6 +16,12 @@ The card shows the active path, startup source, default path, persisted/pending 
 
 The scanner builds one inventory from Bobbit state, git metadata, filesystem worktree-root directories, and the in-memory worktree pool. It covers live and archived sessions, goals, teams, delegates/child sessions, staff worktrees, pool entries, `git worktree list --porcelain`, and directories under each visible project's resolved worktree root. Multi-repo projects are evaluated per component repo, and configured `worktree_root` values are resolved through the same helper used for worktree creation.
 
+### Command-runner isolation
+
+Maintenance worktree scans and cleanup use the gateway/request-scoped `CommandRunner` resolved when the gateway is constructed. This keeps concurrent in-process gateways isolated: each gateway's injected command fixture supplies only its own Git-probe results, so one gateway cannot affect another's worktree classification or cleanup decisions.
+
+The module default runner is an outer-construction fallback only. Request handling must use its resolved runner rather than shared module state, preserving the gateway's dependency boundary for both production and injected environments.
+
 ### Actionable-first scan
 
 Click **Scan** or **Rescan** to call `GET /api/maintenance/worktrees`. The default response includes safe candidates plus troubleshooting rows; the UI shows safe candidates first and hides protected or diagnostic rows behind a disclosure.

--- a/scripts/testing-v2/test-map-execution.mjs
+++ b/scripts/testing-v2/test-map-execution.mjs
@@ -27,6 +27,7 @@ export const ISOLATED_VITEST_FILES = Object.freeze({
 	"tests2/core/extension-host-session-event-bus.test.ts": "Exercises a module-global EventTarget that must not retain sibling listeners.",
 	"tests2/core/goal-metadata-edges.test.ts": "Reads BOBBIT_DIR-backed goal metadata state during module initialization.",
 	"tests2/core/lifecycle-hub.test.ts": "Exercises module-global lifecycle listeners that must not leak across files.",
+	"tests2/integration/maintenance-request-runner-isolation.test.ts": "It intentionally constructs multiple gateways that mutate module-global serverCommandRunner, so it needs a dedicated isolated fork.",
 });
 
 const UNIT_PROJECTS = new Set(["core", "dom", "integration", "isolated"]);
@@ -143,7 +144,7 @@ export function loadVitestExecutionMap({
 	for (const [path, owners] of materializedOwnership) {
 		if (owners.length > 1) errors.push(`${path}: duplicate materialized execution ownership (${owners.join(", ")})`);
 	}
-	if (projects.isolated.length > 10) errors.push(`isolated execution has ${projects.isolated.length} files; maximum is 10`);
+	if (projects.isolated.length > 11) errors.push(`isolated execution has ${projects.isolated.length} files; maximum is 11`);
 
 	const physicalVitest = collectVitestFiles(repoRoot);
 	for (const path of physicalVitest) {

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -16839,7 +16839,7 @@ async function handleApiRoute(
 	// ─── Maintenance endpoints ──────────────────────────────────────────
 	// These replace the old automatic cleanup-on-startup behavior.
 	// Users can preview orphaned resources and choose to clean them up.
-	const worktreeInventory = () => new WorktreeInventoryService({ projectContextManager, sessionManager, commandRunner: serverCommandRunner, remotePolicy: serverRemoteGitPolicy });
+	const worktreeInventory = () => new WorktreeInventoryService({ projectContextManager, sessionManager, commandRunner: commandRunner!, remotePolicy: serverRemoteGitPolicy });
 
 	// GET /api/maintenance/worktrees
 	if (url.pathname === "/api/maintenance/worktrees" && req.method === "GET") {

--- a/tests2/integration/maintenance-request-runner-isolation.test.ts
+++ b/tests2/integration/maintenance-request-runner-isolation.test.ts
@@ -116,6 +116,7 @@ async function bootGatewayFixture(label: string): Promise<GatewayFixture> {
 	const branch = `session/${label}-archived-worktree`;
 	const sessionId = `${label}-archived-session`;
 	const model = new MaintenanceGitModel(`maintenance-request-runner-${label}`);
+	let gateway: ReturnType<typeof createGateway> | undefined;
 	try {
 		activateFixtureRoot(root);
 		mkdirSync(join(root, "state", "session-prompts"), { recursive: true });
@@ -136,7 +137,7 @@ async function bootGatewayFixture(label: string): Promise<GatewayFixture> {
 			agentBridgeFactory: () => null,
 			fsImpl: realFs,
 		};
-		const gateway = createGateway({
+		gateway = createGateway({
 			host: "127.0.0.1",
 			port: 0,
 			portExplicit: true,
@@ -174,6 +175,7 @@ async function bootGatewayFixture(label: string): Promise<GatewayFixture> {
 		} as any);
 		return { label, root, repoPath, worktreePath, branch, sessionId, model, runner, gateway, baseUrl };
 	} catch (error) {
+		try { await gateway?.shutdown(); } catch { /* preserve the setup error */ }
 		model.reset();
 		rmSync(root, { recursive: true, force: true });
 		throw error;

--- a/tests2/integration/maintenance-request-runner-isolation.test.ts
+++ b/tests2/integration/maintenance-request-runner-isolation.test.ts
@@ -1,0 +1,242 @@
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterAll, describe, expect, it } from "vitest";
+
+import {
+	bobbitStateDir,
+	getAgentDirState,
+	getProjectRoot,
+	initializeAgentDirRuntime,
+	resetAgentDirStateForTests,
+	setProjectRoot,
+	type AgentDirRuntimeState,
+} from "../../src/server/bobbit-dir.js";
+import type { CommandRunner, ExecFileOptions, GatewayDeps } from "../../src/server/gateway-deps.js";
+import { realClock, realFs } from "../../src/server/gateway-deps.js";
+import { scaffoldBobbitDir } from "../../src/server/scaffold.js";
+import { createGateway } from "../../src/server/server.js";
+import { MaintenanceGitModel } from "./helpers/maintenance-git-model.js";
+
+const REPO_ROOT = resolve(fileURLToPath(new URL("../..", import.meta.url)));
+const TOKEN = "maintenance-request-runner-isolation-token";
+const ENV_KEYS = [
+	"BOBBIT_DIR",
+	"BOBBIT_SECRETS_DIR",
+	"BOBBIT_AGENT_DIR",
+	"BOBBIT_SKIP_AIGW_DISCOVERY",
+	"BOBBIT_TEST_NO_EXTERNAL",
+	"NODE_ENV",
+] as const;
+
+type ProcessState = {
+	env: Record<(typeof ENV_KEYS)[number], string | undefined>;
+	projectRoot: string;
+	agentDirState?: AgentDirRuntimeState;
+};
+
+type RunnerCall = { file: string; args: readonly string[]; cwd?: string };
+type GatewayFixture = {
+	label: string;
+	root: string;
+	repoPath: string;
+	worktreePath: string;
+	branch: string;
+	sessionId: string;
+	model: MaintenanceGitModel;
+	runner: CommandRunner & { calls: RunnerCall[] };
+	gateway: ReturnType<typeof createGateway>;
+	baseUrl: string;
+};
+
+function snapshotProcessState(): ProcessState {
+	let agentDirState: AgentDirRuntimeState | undefined;
+	try { agentDirState = getAgentDirState(); } catch { /* no active runtime */ }
+	return {
+		env: Object.fromEntries(ENV_KEYS.map(key => [key, process.env[key]])) as ProcessState["env"],
+		projectRoot: getProjectRoot(),
+		...(agentDirState ? { agentDirState } : {}),
+	};
+}
+
+function activateFixtureRoot(root: string): void {
+	process.env.BOBBIT_DIR = root;
+	process.env.BOBBIT_SECRETS_DIR = join(root, "secrets");
+	process.env.BOBBIT_AGENT_DIR = join(root, "agent");
+	process.env.BOBBIT_SKIP_AIGW_DISCOVERY = "1";
+	process.env.BOBBIT_TEST_NO_EXTERNAL = "1";
+	process.env.NODE_ENV = "test";
+	setProjectRoot(root);
+	resetAgentDirStateForTests();
+}
+
+function restoreProcessState(state: ProcessState): void {
+	for (const key of ENV_KEYS) {
+		const value = state.env[key];
+		if (value === undefined) delete process.env[key];
+		else process.env[key] = value;
+	}
+	setProjectRoot(state.projectRoot);
+	resetAgentDirStateForTests();
+	if (state.agentDirState) {
+		initializeAgentDirRuntime({
+			env: process.env,
+			projectRoot: state.agentDirState.startup.projectRoot,
+			stateDir: bobbitStateDir(state.agentDirState.startup.projectRoot),
+			persisted: state.agentDirState.persisted,
+		});
+	}
+}
+
+function ownsPath(root: string, cwd: string | undefined): boolean {
+	return !!cwd && (cwd === root || cwd.startsWith(`${root}/`) || cwd.startsWith(`${root}\\`));
+}
+
+function createRunner(root: string, model: MaintenanceGitModel): CommandRunner & { calls: RunnerCall[] } {
+	const calls: RunnerCall[] = [];
+	return {
+		calls,
+		async execFile(file: string, args: readonly string[], options?: ExecFileOptions) {
+			const cwd = typeof options?.cwd === "string" ? options.cwd : undefined;
+			calls.push({ file, args, cwd });
+			if (file !== "git") throw new Error(`unexpected ${root} fixture executable: ${file}`);
+			if (!ownsPath(root, cwd)) {
+				throw new Error(`MAINTENANCE_REQUEST_RUNNER_ISOLATION_REGRESSION: ${root} runner received foreign cwd ${cwd ?? "<none>"}`);
+			}
+			return { stdout: model.run(cwd!, args), stderr: "" };
+		},
+	};
+}
+
+async function bootGatewayFixture(label: string): Promise<GatewayFixture> {
+	const root = mkdtempSync(join(tmpdir(), `bobbit-maintenance-runner-${label}-`));
+	const repoPath = join(root, "project-repo");
+	const worktreePath = join(root, "archived-worktree");
+	const branch = `session/${label}-archived-worktree`;
+	const sessionId = `${label}-archived-session`;
+	const model = new MaintenanceGitModel(`maintenance-request-runner-${label}`);
+	try {
+		activateFixtureRoot(root);
+		mkdirSync(join(root, "state", "session-prompts"), { recursive: true });
+		mkdirSync(join(root, "secrets"), { recursive: true });
+		mkdirSync(join(root, "agent"), { recursive: true });
+		mkdirSync(join(repoPath, ".git"), { recursive: true });
+		writeFileSync(join(root, "state", "projects.json"), "[]");
+		writeFileSync(join(root, "state", "setup-complete"), "test\n");
+		writeFileSync(join(repoPath, "README.md"), `# ${label} maintenance runner fixture\n`);
+		scaffoldBobbitDir(root);
+		model.registerRepo(repoPath);
+		model.addWorktree(repoPath, worktreePath, branch);
+		const runner = createRunner(root, model);
+		const deps: GatewayDeps = {
+			clock: realClock,
+			commandRunner: runner,
+			fetchImpl: async () => new Response("network fenced", { status: 503 }),
+			agentBridgeFactory: () => null,
+			fsImpl: realFs,
+		};
+		const gateway = createGateway({
+			host: "127.0.0.1",
+			port: 0,
+			portExplicit: true,
+			authToken: TOKEN,
+			defaultCwd: root,
+			forceAuth: true,
+			skipMcp: true,
+			skipWorktreePool: true,
+			skipTitleGeneration: true,
+			skipRemotePush: true,
+			skipNonLocalRemoteGit: true,
+			builtinsDir: join(REPO_ROOT, "defaults"),
+			builtinPacksDir: join(REPO_ROOT, "market-packs"),
+		}, deps);
+		const baseUrl = `http://127.0.0.1:${await gateway.start()}`;
+		const projectResponse = await fetch(`${baseUrl}/api/projects`, {
+			method: "POST",
+			headers: { Authorization: `Bearer ${TOKEN}`, "Content-Type": "application/json" },
+			body: JSON.stringify({ name: `${label} maintenance project`, rootPath: repoPath, upsert: true, acceptCanonical: true }),
+		});
+		if (!projectResponse.ok) throw new Error(`fixture ${label} project registration returned ${projectResponse.status}: ${await projectResponse.text()}`);
+		const project = await projectResponse.json() as { id: string };
+		gateway.sessionManager.getSessionStore(project.id).put({
+			id: sessionId,
+			projectId: project.id,
+			title: `${label} archived worktree`,
+			cwd: worktreePath,
+			createdAt: 1,
+			lastActivity: 2,
+			archived: true,
+			archivedAt: 3,
+			repoPath,
+			worktreePath,
+			branch,
+		} as any);
+		return { label, root, repoPath, worktreePath, branch, sessionId, model, runner, gateway, baseUrl };
+	} catch (error) {
+		model.reset();
+		rmSync(root, { recursive: true, force: true });
+		throw error;
+	}
+}
+
+async function shutdownFixture(fixture: GatewayFixture | undefined): Promise<void> {
+	if (!fixture) return;
+	try { await fixture.gateway.shutdown(); }
+	finally {
+		fixture.model.reset();
+		rmSync(fixture.root, { recursive: true, force: true });
+	}
+}
+
+function archivedItem(body: any, fixture: GatewayFixture): any {
+	return body.items.find((item: any) => item.sessionId === fixture.sessionId);
+}
+
+describe.sequential("maintenance request command-runner isolation", () => {
+	const processState = snapshotProcessState();
+	let gatewayA: GatewayFixture | undefined;
+	let gatewayB: GatewayFixture | undefined;
+
+	afterAll(async () => {
+		try {
+			await shutdownFixture(gatewayB);
+			await shutdownFixture(gatewayA);
+		} finally {
+			restoreProcessState(processState);
+		}
+	});
+
+	it("keeps archived-worktree scans on the runner captured by each live gateway", async () => {
+		// Construction order is the regression trigger: current production code stores
+		// B's runner globally, then A's request incorrectly resolves through B.
+		gatewayA = await bootGatewayFixture("gateway-a");
+		gatewayB = await bootGatewayFixture("gateway-b");
+
+		const [responseA, responseB] = await Promise.all([
+			fetch(`${gatewayA.baseUrl}/api/maintenance/archived-session-worktrees`, { headers: { Authorization: `Bearer ${TOKEN}` } }),
+			fetch(`${gatewayB.baseUrl}/api/maintenance/archived-session-worktrees`, { headers: { Authorization: `Bearer ${TOKEN}` } }),
+		]);
+		expect(responseA.status).toBe(200);
+		expect(responseB.status).toBe(200);
+		const [bodyA, bodyB] = await Promise.all([responseA.json(), responseB.json()]);
+
+		expect(archivedItem(bodyA, gatewayA), "MAINTENANCE_REQUEST_RUNNER_ISOLATION_REGRESSION: gateway A must classify only its archived worktree as removable").toMatchObject({
+			status: "removable",
+			reason: "safe-archived-session-worktree",
+			repoPath: gatewayA.repoPath,
+			path: gatewayA.worktreePath,
+		});
+		expect(archivedItem(bodyB, gatewayB), "MAINTENANCE_REQUEST_RUNNER_ISOLATION_REGRESSION: gateway B must classify only its archived worktree as removable").toMatchObject({
+			status: "removable",
+			reason: "safe-archived-session-worktree",
+			repoPath: gatewayB.repoPath,
+			path: gatewayB.worktreePath,
+		});
+
+		for (const fixture of [gatewayA, gatewayB]) {
+			expect(fixture.runner.calls.length, `MAINTENANCE_REQUEST_RUNNER_ISOLATION_REGRESSION: ${fixture.label} runner must receive its scan probes`).toBeGreaterThan(0);
+			expect(fixture.runner.calls.every(call => ownsPath(fixture.root, call.cwd)), `MAINTENANCE_REQUEST_RUNNER_ISOLATION_REGRESSION: ${fixture.label} runner must never receive a foreign fixture path`).toBe(true);
+		}
+	});
+});

--- a/tests2/tests-map.json
+++ b/tests2/tests-map.json
@@ -1732,6 +1732,15 @@
       }
     },
     {
+      "path": "tests2/integration/maintenance-request-runner-isolation.test.ts",
+      "reason": "Deterministic two-live-gateway regression proving maintenance worktree scans use the command runner captured by their request gateway rather than a later gateway's module-global runner.",
+      "execution": {
+        "runner": "vitest",
+        "tier": "unit",
+        "project": "integration"
+      }
+    },
+    {
       "path": "tests2/core/spawn-with-retry-policy.test.ts",
       "reason": "Subprocess-free policy coverage for bounded fixture command retry, timeout, redaction, literal argv, and safe process options through an injectable backend.",
       "execution": {

--- a/tests2/tests-map.json
+++ b/tests2/tests-map.json
@@ -1737,7 +1737,8 @@
       "execution": {
         "runner": "vitest",
         "tier": "unit",
-        "project": "integration"
+        "project": "isolated",
+        "reason": "It intentionally constructs multiple gateways that mutate module-global serverCommandRunner, so it needs a dedicated isolated fork."
       }
     },
     {


### PR DESCRIPTION
## Summary

- route maintenance worktree Git probes through each request's gateway-scoped command runner
- add a deterministic concurrent in-process gateway regression that fails on the former global-runner cross-talk
- document the maintenance command-runner isolation boundary

## Verification

- deterministic expect-failure regression on the unfixed implementation
- focused isolation regression repeated 3 times without retries
- focused maintenance API integration tests
- build and type check
- full unit, browser, and E2E workflow verification
- integrated conformance, code, and security reviews

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)