### PR TITLE
Consolidate review workflows

### DIFF
--- a/.bobbit/config/project.yaml
+++ b/.bobbit/config/project.yaml
@@ -123,6 +123,7 @@ workflows:
         verify:
           - name: Build
             type: command
+            phase: 0
             timeout: 600
             component: bobbit
             command: build
@@ -138,158 +139,56 @@ workflows:
             command: unit
           - name: Browser tests
             type: command
-            phase: 2
+            phase: 1
             timeout: 900
             component: bobbit
             command: browser
           - name: E2E tests
             type: command
-            phase: 3
+            phase: 1
             timeout: 900
             component: bobbit
             command: e2e
-          - name: Gap analysis
+          - name: Spec and regression conformance
             type: llm-review
             role: spec-auditor
-            phase: 4
+            phase: 2
             prompt: >-
-              Compare the goal specification and design document to the actual
-              implementation on this branch.
-
-
-              The goal spec is:
-
+              Compare the goal specification below, available upstream design or
+              issue analysis, implementation, and tests on branch {{branch}}
+              against origin/{{baseBranch}}.
 
               {{goal_spec}}
 
-
-              Run `git diff origin/{{baseBranch}}...{{branch}} -- .
-              ':!package-lock.json'` to see the implementation diff.
-
-
-              Read the design document content from upstream gates.
-
-
-              Identify:
-
-
-              1. Features described in the goal/design but not implemented
-
-
-              2. Acceptance criteria not met by the code changes
-
-
-              3. Implemented behavior that contradicts the specification
-
-
-              IMPORTANT: Ignore documentation gaps. This gap analysis runs
-              during the implementation phase, BEFORE the documentation gate. Do
-              NOT flag missing or outdated documentation, README updates,
-              design-doc updates, code comments, or other docs-only artifacts as
-              gaps — those are addressed by the dedicated documentation gate
-              later in the workflow. Focus exclusively on code/behavior gaps
-              relative to the spec and design.
-          - name: Code quality review
+              Ignore documentation-only gaps. Identify unmet behavior,
+              acceptance criteria, regressions, contradictions, and missing
+              regression coverage. Every blocker must include implementation-ready
+              remediation and focused tests that prove the fix.
+          - name: Integrated implementation review
             type: llm-review
             role: code-reviewer
-            phase: 4
+            phase: 2
             prompt: >-
-              Review the code changes on branch {{branch}} vs
-              origin/{{baseBranch}} for quality.
+              Review the implementation on branch {{branch}} versus
+              origin/{{baseBranch}}. Cover correctness, error handling,
+              edge and mixed states, concurrency and lifecycle, cross-layer
+              interactions, maintainability, regression coverage, and
+              independently verifiable bugs.
 
-
-              Start with `git diff --stat origin/{{baseBranch}}...{{branch}} --
-              . ':!package-lock.json'` to see which files changed.
-
-
-              Then use `git diff origin/{{baseBranch}}...{{branch}} -M -- .
-              ':!package-lock.json'` (with rename detection) to see actual
-              content changes — this collapses pure renames into one-line
-              summaries.
-
-
-              For large diffs, review files individually with `read` rather than
-              dumping the entire diff into context.
-
-
-              Check:
-
-
-              1. Correctness — logic errors, off-by-one, race conditions
-
-
-              2. Error handling — missing try/catch, unhandled promise
-              rejections
-
-
-              3. Edge cases — null/undefined, empty arrays, boundary values
-
-
-              4. Code style — consistent naming, no dead code, clear intent
-
-
-              5. Test coverage — are new behaviors tested?
-          - name: E2E user journey coverage
-            type: llm-review
-            phase: 4
-            prompt: >-
-              Verify that the implementation includes browser-based E2E tests
-              covering the user journey for this feature.
-
-
-              The goal spec is:
-
-
-              {{goal_spec}}
-
-
-              Run `git diff origin/{{baseBranch}}...{{branch}} -- .
-              ':!package-lock.json'` to see all changes.
-
-
-              Check navigation, happy path, persistence, cleanup, and
-              integration coverage in tests/e2e/ui/*.spec.ts or
-              tests/e2e/*.spec.ts. FAIL if no new E2E tests were added for
-              user-facing behavior, or if persistence/cleanup are skipped.
-          - name: Bug hunt
-            type: llm-review
-            role: bug-hunter
-            phase: 4
-            prompt: Review the implementation on branch {{branch}} vs origin/{{baseBranch}}
-              for actionable bugs. Focus on correctness, edge cases, error
-              paths, cross-system interactions, concurrency/lifecycle, and
-              dangerous behavior. Fail only for critical/high actionable bugs;
-              include file:line, reproduction conditions, consequence, and why
-              it is a bug.
-          - name: Verifiable bug hunt
-            type: llm-review
-            role: verifiable-bug-hunter
-            phase: 4
-            prompt: Look for verifiable bugs in the implementation diff.
+              Deduplicate findings by root cause. For each blocker, provide an
+              exact minimal fix and focused tests that independently verify it.
           - name: Security review
             type: llm-review
             role: security-reviewer
-            phase: 4
+            phase: 2
             prompt: >-
-              Security review of changes on branch {{branch}} vs
-              origin/{{baseBranch}}.
+              Review changed trust boundaries, authentication and authorization,
+              validation and injection, secrets, destructive or resource
+              ownership, dependency risk, and security-relevant races on branch
+              {{branch}} versus origin/{{baseBranch}}.
 
-
-              Run `git diff origin/{{baseBranch}}...{{branch}} -- .
-              ':!package-lock.json'` to see changes.
-
-
-              Check injection risks, auth/authz, data validation, secrets
-              handling, and dependency risks.
-          - name: Systems interaction review
-            type: llm-review
-            role: systems-reviewer
-            phase: 4
-            prompt: >-
-              Perform the complete Systems Interaction Review defined by the
-              systems-reviewer role for branch {{branch}} versus {{baseBranch}}.
-              Inspect every changed cross-layer state and action path, continue
-              after the first finding, and submit the verification result.
+              For each blocker, provide minimal remediation plus abuse and
+              regression tests that verify the fix.
       - id: documentation
         name: Documentation
         depends_on:
@@ -534,6 +433,7 @@ workflows:
         verify:
           - name: Build
             type: command
+            phase: 0
             timeout: 600
             component: bobbit
             command: build
@@ -549,72 +449,60 @@ workflows:
             command: unit
           - name: Browser tests
             type: command
-            phase: 2
+            phase: 1
             timeout: 900
             component: bobbit
             command: browser
           - name: E2E tests
             type: command
-            phase: 3
+            phase: 1
             timeout: 900
             component: bobbit
             command: e2e
-          - name: Gap analysis
+          - name: Spec and regression conformance
             type: llm-review
             role: spec-auditor
-            phase: 4
+            phase: 2
             prompt: >-
-              Compare the goal specification and design document to the actual
-              implementation on this branch. Ignore documentation gaps; focus
-              exclusively on code/behavior gaps relative to the spec and design.
-
-
-              The goal spec is:
-
+              Compare the goal specification below, available upstream design or
+              issue analysis, implementation, and tests on branch {{branch}}
+              against origin/{{baseBranch}}.
 
               {{goal_spec}}
-          - name: Code quality review
+
+              Ignore documentation-only gaps. Identify unmet behavior,
+              acceptance criteria, regressions, contradictions, and missing
+              regression coverage. Every blocker must include implementation-ready
+              remediation and focused tests that prove the fix.
+          - name: Integrated implementation review
             type: llm-review
             role: code-reviewer
-            phase: 4
-            prompt: Review the code changes on branch {{branch}} vs origin/{{baseBranch}}
-              for quality. Check correctness, error handling, edge cases, code
-              style, and test coverage.
-          - name: Bug hunt
-            type: llm-review
-            role: bug-hunter
-            phase: 4
-            prompt: Review the implementation on branch {{branch}} vs origin/{{baseBranch}}
-              for actionable bugs. Focus on correctness, edge cases, error
-              paths, cross-system interactions, concurrency/lifecycle, and
-              dangerous behavior. Fail only for critical/high actionable bugs;
-              include file:line, reproduction conditions, consequence, and why
-              it is a bug.
-          - name: Verifiable bug hunt
-            type: llm-review
-            role: verifiable-bug-hunter
-            phase: 4
-            prompt: Look for verifiable bugs in the implementation diff.
+            phase: 2
+            prompt: >-
+              Review the implementation on branch {{branch}} versus
+              origin/{{baseBranch}}. Cover correctness, error handling,
+              edge and mixed states, concurrency and lifecycle, cross-layer
+              interactions, maintainability, regression coverage, and
+              independently verifiable bugs.
+
+              Deduplicate findings by root cause. For each blocker, provide an
+              exact minimal fix and focused tests that independently verify it.
           - name: Security review
             type: llm-review
             role: security-reviewer
-            phase: 4
-            prompt: Security review of changes on branch {{branch}} vs
-              origin/{{baseBranch}}. Check injection, auth/authz, validation,
-              secrets, and dependency risks.
-          - name: Systems interaction review
-            type: llm-review
-            role: systems-reviewer
-            phase: 4
+            phase: 2
             prompt: >-
-              Perform the complete Systems Interaction Review defined by the
-              systems-reviewer role for branch {{branch}} versus {{baseBranch}}.
-              Inspect every changed cross-layer state and action path, continue
-              after the first finding, and submit the verification result.
+              Review changed trust boundaries, authentication and authorization,
+              validation and injection, secrets, destructive or resource
+              ownership, dependency risk, and security-relevant races on branch
+              {{branch}} versus origin/{{baseBranch}}.
+
+              For each blocker, provide minimal remediation plus abuse and
+              regression tests that verify the fix.
           - name: QA testing
             type: agent-qa
             role: qa-tester
-            phase: 5
+            phase: 3
             optional: true
             optionalLabel: Enable QA Testing
             description: Spawn a QA agent that builds the project, starts an ephemeral
@@ -701,6 +589,7 @@ workflows:
         verify:
           - name: Build
             type: command
+            phase: 0
             timeout: 600
             component: bobbit
             command: build
@@ -721,76 +610,60 @@ workflows:
             command: unit
           - name: Browser tests
             type: command
-            phase: 2
+            phase: 1
             timeout: 900
             component: bobbit
             command: browser
           - name: E2E tests
             type: command
-            phase: 3
+            phase: 1
             timeout: 900
             component: bobbit
             command: e2e
-          - name: Gap analysis
+          - name: Spec and regression conformance
             type: llm-review
             role: spec-auditor
-            phase: 4
+            phase: 2
             prompt: >-
-              Compare the goal specification and design document to the actual
-              implementation on this branch. Ignore documentation gaps; focus
-              exclusively on code/behavior gaps relative to the spec and design.
-
-
-              The goal spec is:
+              Compare the goal specification below, available upstream design or
+              issue analysis, implementation, and tests on branch {{branch}}
+              against origin/{{baseBranch}}.
 
               {{goal_spec}}
-          - name: Code quality review
+
+              Ignore documentation-only gaps. Identify unmet behavior,
+              acceptance criteria, regressions, contradictions, and missing
+              regression coverage. Every blocker must include implementation-ready
+              remediation and focused tests that prove the fix.
+          - name: Integrated implementation review
             type: llm-review
             role: code-reviewer
-            phase: 4
-            prompt: Review the code changes on branch {{branch}} vs {{baseBranch}} for
-              quality. Check root-cause fix, minimality, error handling,
-              regression risk, and test coverage.
-          - name: Regression test coverage
-            type: llm-review
-            phase: 4
-            prompt: Verify that the bug fix includes a regression test that would catch
-              reintroduction. PASS if at least one unit, fixture, or E2E test
-              covers the fixed behavior; FAIL if no regression test was added.
-          - name: Bug hunt
-            type: llm-review
-            role: bug-hunter
-            phase: 4
-            prompt: Review the implementation on branch {{branch}} vs {{baseBranch}} for
-              actionable bugs. Focus on correctness, edge cases, error paths,
-              cross-system interactions, concurrency/lifecycle, and dangerous
-              behavior. Fail only for critical/high actionable bugs; include
-              file:line, reproduction conditions, consequence, and why it is a
-              bug.
-          - name: Verifiable bug hunt
-            type: llm-review
-            role: verifiable-bug-hunter
-            phase: 4
-            prompt: Look for verifiable bugs in the implementation diff.
+            phase: 2
+            prompt: >-
+              Review the implementation on branch {{branch}} versus
+              origin/{{baseBranch}}. Cover correctness, error handling,
+              edge and mixed states, concurrency and lifecycle, cross-layer
+              interactions, maintainability, regression coverage, and
+              independently verifiable bugs.
+
+              Deduplicate findings by root cause. For each blocker, provide an
+              exact minimal fix and focused tests that independently verify it.
           - name: Security review
             type: llm-review
             role: security-reviewer
-            phase: 4
-            prompt: Security review of changes on branch {{branch}} vs {{baseBranch}}. Check
-              injection, auth/authz, validation, secrets, and dependency risks.
-          - name: Systems interaction review
-            type: llm-review
-            role: systems-reviewer
-            phase: 4
+            phase: 2
             prompt: >-
-              Perform the complete Systems Interaction Review defined by the
-              systems-reviewer role for branch {{branch}} versus {{baseBranch}}.
-              Inspect every changed cross-layer state and action path, continue
-              after the first finding, and submit the verification result.
+              Review changed trust boundaries, authentication and authorization,
+              validation and injection, secrets, destructive or resource
+              ownership, dependency risk, and security-relevant races on branch
+              {{branch}} versus origin/{{baseBranch}}.
+
+              For each blocker, provide minimal remediation plus abuse and
+              regression tests that verify the fix.
           - name: QA testing
             type: agent-qa
             role: qa-tester
-            phase: 5
+            phase: 3
             optional: true
             optionalLabel: Enable QA Testing
             description: Spawn a QA agent that builds the project, starts an ephemeral
@@ -841,6 +714,7 @@ workflows:
         verify:
           - name: Build
             type: command
+            phase: 0
             timeout: 600
             component: bobbit
             command: build
@@ -856,61 +730,56 @@ workflows:
             command: unit
           - name: Browser tests
             type: command
-            phase: 2
+            phase: 1
             timeout: 900
             component: bobbit
             command: browser
           - name: E2E tests
             type: command
-            phase: 3
+            phase: 1
             timeout: 900
             component: bobbit
             command: e2e
-          - name: Gap analysis
+          - name: Spec and regression conformance
             type: llm-review
             role: spec-auditor
-            phase: 4
+            phase: 2
             prompt: >-
-              Compare the goal specification to the actual implementation on
-              this branch. Ignore documentation gaps; focus exclusively on
-              code/behavior gaps.
-
-
-              The goal spec is:
-
+              Compare the goal specification below, available upstream design or
+              issue analysis, implementation, and tests on branch {{branch}}
+              against origin/{{baseBranch}}.
 
               {{goal_spec}}
-          - name: Code quality review
+
+              Ignore documentation-only gaps. Identify unmet behavior,
+              acceptance criteria, regressions, contradictions, and missing
+              regression coverage. Every blocker must include implementation-ready
+              remediation and focused tests that prove the fix.
+          - name: Integrated implementation review
             type: llm-review
             role: code-reviewer
-            phase: 4
-            prompt: Review the code changes on branch {{branch}} vs {{baseBranch}} for
-              quality. Check correctness, error handling, edge cases,
-              minimality, and test coverage.
-          - name: Bug hunt
-            type: llm-review
-            role: bug-hunter
-            phase: 4
-            prompt: Review the implementation on branch {{branch}} vs {{baseBranch}} for
-              actionable bugs. Focus on correctness, edge cases, error paths,
-              cross-system interactions, concurrency/lifecycle, and dangerous
-              behavior. Fail only for critical/high actionable bugs; include
-              file:line, reproduction conditions, consequence, and why it is a
-              bug.
-          - name: Verifiable bug hunt
-            type: llm-review
-            role: verifiable-bug-hunter
-            phase: 4
-            prompt: Look for verifiable bugs in the implementation diff.
-          - name: Systems interaction review
-            type: llm-review
-            role: systems-reviewer
-            phase: 4
+            phase: 2
             prompt: >-
-              Perform the complete Systems Interaction Review defined by the
-              systems-reviewer role for branch {{branch}} versus {{baseBranch}}.
-              Inspect every changed cross-layer state and action path, continue
-              after the first finding, and submit the verification result.
+              Review the implementation on branch {{branch}} versus
+              origin/{{baseBranch}}. Cover correctness, error handling,
+              edge and mixed states, concurrency and lifecycle, cross-layer
+              interactions, maintainability, regression coverage, and
+              independently verifiable bugs.
+
+              Deduplicate findings by root cause. For each blocker, provide an
+              exact minimal fix and focused tests that independently verify it.
+          - name: Security review
+            type: llm-review
+            role: security-reviewer
+            phase: 2
+            prompt: >-
+              Review changed trust boundaries, authentication and authorization,
+              validation and injection, secrets, destructive or resource
+              ownership, dependency risk, and security-relevant races on branch
+              {{branch}} versus origin/{{baseBranch}}.
+
+              For each blocker, provide minimal remediation plus abuse and
+              regression tests that verify the fix.
       - id: ready-to-merge
         name: Ready to Merge
         depends_on:

--- a/.bobbit/config/project.yaml
+++ b/.bobbit/config/project.yaml
@@ -78,6 +78,20 @@ workflows:
               testable acceptance criteria, cover edge/error handling, and
               include an E2E test plan that validates the user journey
               end-to-end.
+
+              Treat this as a revision-ready content review. A FAIL is valid only
+              for an explicit unmet goal requirement or concrete regression and
+              is invalid without a complete author-ready revision packet for
+              every blocker. For each blocker, identify the exact artifact
+              location; explain the goal-linked gap and practical consequence;
+              provide concrete replacement wording, an outline, contract,
+              data-flow/state sequence, acceptance criterion, example, or
+              test-plan case; state consistency edits and constraints; include
+              credible alternatives with tradeoffs only when they exist; and
+              separate required edits from bounded improvements. Require
+              implementable contracts and testable acceptance criteria only to
+              the level needed by the approved goal, not exhaustive pseudocode,
+              formal proof, or speculative hardening.
           - name: Gap analysis
             type: llm-review
             role: spec-auditor
@@ -116,6 +130,20 @@ workflows:
 
               Use your tools to read the design document content from the
               signal.
+
+              Treat this as a revision-ready content review. A FAIL is valid only
+              for an explicit unmet goal requirement or concrete regression and
+              is invalid without a complete author-ready revision packet for
+              every blocker. For each blocker, identify the exact artifact
+              location; explain the goal-linked gap and practical consequence;
+              provide concrete replacement wording, an outline, contract,
+              data-flow/state sequence, acceptance criterion, example, or
+              test-plan case; state consistency edits and constraints; include
+              credible alternatives with tradeoffs only when they exist; and
+              separate required edits from bounded improvements. Require
+              implementable contracts and testable acceptance criteria only to
+              the level needed by the approved goal, not exhaustive pseudocode,
+              formal proof, or speculative hardening.
       - id: implementation
         name: Implementation
         depends_on:
@@ -210,6 +238,18 @@ workflows:
               documented; stale docs are updated; documentation placement is
               appropriate; and new docs have good hierarchy, resilience, WHY,
               and big-picture context.
+
+              Treat this as a revision-ready documentation review. A FAIL is
+              valid only for an explicit unmet goal requirement or concrete
+              change-introduced regression and is invalid without an author-ready
+              revision packet for every blocker. For each blocker, name exact
+              documentation paths and sections; identify the stale or missing
+              claim and its goal-linked consequence; give proposed replacement
+              wording or outline with relevant examples or links; state related
+              cross-section edits and constraints; include credible alternatives
+              with tradeoffs only when they exist; separate required edits from
+              bounded improvements; and explain how to verify the documented
+              behavior against the implementation.
       - id: ready-to-merge
         name: Ready to Merge
         depends_on:
@@ -408,6 +448,20 @@ workflows:
               testable acceptance criteria, cover edge/error handling, and
               include an E2E test plan that validates the user journey
               end-to-end.
+
+              Treat this as a revision-ready content review. A FAIL is valid only
+              for an explicit unmet goal requirement or concrete regression and
+              is invalid without a complete author-ready revision packet for
+              every blocker. For each blocker, identify the exact artifact
+              location; explain the goal-linked gap and practical consequence;
+              provide concrete replacement wording, an outline, contract,
+              data-flow/state sequence, acceptance criterion, example, or
+              test-plan case; state consistency edits and constraints; include
+              credible alternatives with tradeoffs only when they exist; and
+              separate required edits from bounded improvements. Require
+              implementable contracts and testable acceptance criteria only to
+              the level needed by the approved goal, not exhaustive pseudocode,
+              formal proof, or speculative hardening.
           - name: Gap analysis
             type: llm-review
             role: spec-auditor
@@ -426,6 +480,20 @@ workflows:
               not target the same acceptance criteria, and scope expansion added
               to justify an abstraction or possible future reuse. Use your tools
               to read the design document content from the signal.
+
+              Treat this as a revision-ready content review. A FAIL is valid only
+              for an explicit unmet goal requirement or concrete regression and
+              is invalid without a complete author-ready revision packet for
+              every blocker. For each blocker, identify the exact artifact
+              location; explain the goal-linked gap and practical consequence;
+              provide concrete replacement wording, an outline, contract,
+              data-flow/state sequence, acceptance criterion, example, or
+              test-plan case; state consistency edits and constraints; include
+              credible alternatives with tradeoffs only when they exist; and
+              separate required edits from bounded improvements. Require
+              implementable contracts and testable acceptance criteria only to
+              the level needed by the approved goal, not exhaustive pseudocode,
+              formal proof, or speculative hardening.
       - id: implementation
         name: Implementation
         depends_on:
@@ -525,6 +593,18 @@ workflows:
               features/API/config/behavior changes are documented, existing docs
               are updated, placement is appropriate, and documentation quality
               standards are met.
+
+              Treat this as a revision-ready documentation review. A FAIL is
+              valid only for an explicit unmet goal requirement or concrete
+              change-introduced regression and is invalid without an author-ready
+              revision packet for every blocker. For each blocker, name exact
+              documentation paths and sections; identify the stale or missing
+              claim and its goal-linked consequence; give proposed replacement
+              wording or outline with relevant examples or links; state related
+              cross-section edits and constraints; include credible alternatives
+              with tradeoffs only when they exist; separate required edits from
+              bounded improvements; and explain how to verify the documented
+              behavior against the implementation.
       - id: ready-to-merge
         name: Ready to Merge
         depends_on:
@@ -554,8 +634,23 @@ workflows:
         verify:
           - name: Analysis quality
             type: llm-review
-            prompt: Review the issue analysis for completeness. Check reproduction steps,
-              root cause, symptom/cause distinction, and test plan.
+            prompt: >-
+              Review the issue analysis for completeness. Check reproduction
+              steps, root cause, symptom/cause distinction, and test plan.
+
+              Treat this as a revision-ready content review. A FAIL is valid
+              only for an explicit unmet goal requirement or concrete regression
+              and is invalid without a complete author-ready revision packet for
+              every blocker. For each blocker, identify the exact artifact
+              location; explain the goal-linked gap and practical consequence;
+              provide a concrete reproduction, root-cause contract, proposed
+              wording or structured revision, and test-plan case; state
+              consistency edits and constraints; include credible alternatives
+              with tradeoffs only when they exist; and separate required edits
+              from bounded improvements. Require implementable contracts and
+              testable acceptance criteria only to the level needed by the
+              approved goal, not exhaustive pseudocode, formal proof, or
+              speculative hardening.
           - name: Gap analysis
             type: llm-review
             role: spec-auditor
@@ -570,6 +665,17 @@ workflows:
 
               Identify bug symptoms not analyzed, missing reproduction steps,
               and root cause gaps.
+
+              Treat every blocker as a revision-ready content finding. A FAIL is
+              invalid without an author-ready revision packet identifying the
+              exact artifact location, goal-linked gap and consequence, concrete
+              revision (including reproduction/root-cause contract and test-plan
+              case), consistency edits and constraints, credible alternatives
+              with tradeoffs when they exist, and required edits versus bounded
+              improvements. Keep contracts and acceptance criteria implementable
+              and testable only to the approved goal's needed level; do not
+              demand exhaustive pseudocode, formal proof, or speculative
+              hardening.
       - id: reproducing-test
         name: Reproducing Test
         depends_on:
@@ -686,6 +792,18 @@ workflows:
               {{baseBranch}}. Verify user-facing features/API/config/behavior
               changes are documented, existing docs are updated, placement is
               appropriate, and documentation quality standards are met.
+
+              Treat this as a revision-ready documentation review. A FAIL is
+              valid only for an explicit unmet goal requirement or concrete
+              change-introduced regression and is invalid without an author-ready
+              revision packet for every blocker. For each blocker, name exact
+              documentation paths and sections; identify the stale or missing
+              claim and its goal-linked consequence; give proposed replacement
+              wording or outline with relevant examples or links; state related
+              cross-section edits and constraints; include credible alternatives
+              with tradeoffs only when they exist; separate required edits from
+              bounded improvements; and explain how to verify the documented
+              behavior against the implementation.
       - id: ready-to-merge
         name: Ready to Merge
         depends_on:

--- a/defaults/roles/architect.yaml
+++ b/defaults/roles/architect.yaml
@@ -24,8 +24,31 @@ promptTemplate: |
 
   You review code and design artifacts from an architectural perspective. You evaluate design decisions, system structure, extensibility, and long-term maintainability. You read and analyze — you do NOT modify production code, and you do NOT call `gate_signal` (the policy forbids it).
 
-  ## Change Scope
-  Only raise findings caused by the reviewed change. A finding is in scope only when the diff or artifact introduces the issue or makes a pre-existing issue materially worse. Do not report pre-existing issues that are unchanged by the reviewed change, and do not ask this goal or PR to fix them. You may inspect surrounding code or context to understand impact, but use it only as evidence for in-scope findings.
+  ## Goal Focus and Change Scope
+  Start by restating the goal's objective and acceptance criteria in one or two sentences. The goal specification and explicit user amendments are authoritative; reviewer suggestions never silently become requirements. Evaluate the artifact against that boundary—not against an idealized redesign of the whole system.
+
+  Only raise findings caused by the reviewed change. A finding is in scope only when the diff or artifact introduces the issue, makes a pre-existing issue materially worse, or directly prevents a stated goal requirement from being met. Do not report pre-existing issues that are unchanged by the reviewed change, and do not ask this goal or PR to fix them. Do not invent new requirements, expand the goal spec, or make unrelated cleanup a condition of passing. Inspect surrounding code only to prove impact.
+
+  Classify each observation before reporting it:
+  - **Blocker:** an explicit unmet goal requirement or a concrete regression introduced by this change.
+  - **Bounded improvement:** adjacent, clearly beneficial, low-risk, and small enough to include without broadening the design. Report separately and never fail solely for it.
+  - **Out of scope / pre-existing:** do not raise as a finding; at most add one brief deferred note.
+
+  Prefer the smallest architecture that satisfies the goal. Do not demand speculative extensibility, repository-wide consolidation, or unrelated hardening.
+
+  ## Gate Verdict and Review Convergence
+  A gate review is a bounded verification decision, not an invitation to perfect or comprehensively redesign the system.
+
+  - **Default to PASS when the artifact or change satisfies the explicit goal requirements and acceptance criteria and no proven blocker remains.**
+  - A failing blocker must either quote the explicit goal requirement or acceptance criterion it prevents, or show a concrete regression introduced by the reviewed change. Include the causal path and realistic triggering conditions. Ambiguity, uncertainty, a conceivable risk, missing speculative hardening, or a preferred alternative is not a blocker.
+  - On a design gate, judge whether the design gives a coder enough direction to implement the approved goal safely. Do not require exhaustive pseudocode, complete variable/key inventories, implementation proofs, generalized threat-model closure, or defenses beyond the goal merely because they could be specified.
+  - **Re-review for convergence.** Read the prior signal and prior review findings before reviewing a revision. A repeated review may fail only for an unresolved previously reported blocker or a regression introduced by the revision. Do not introduce a new blocker that was already discoverable in an earlier revision; record it, if useful, as a non-blocking deferred note. The sole exception is a concrete critical data-loss or exploitable-security path; explain both the direct path and why it warrants the exception.
+  - Do not move the goalposts after a previous issue is fixed. Do not transform the remediation itself into a reason to demand adjacent architecture that the original goal did not require.
+  - Report at most three blocker root causes, deduplicated. Medium/low observations and bounded improvements never cause failure.
+  - End with an explicit verdict: `PASS — 0 blockers` or `FAIL — N blockers`. A `FAIL` verdict must contain at least one finding that satisfies the blocker test above. If evidence is insufficient, pass and state the focused implementation-time validation to perform.
+
+  ## Solution-Ready Findings
+  For every finding, provide a concrete, minimal remediation: exact files and symbols to change, the intended control/data-flow adjustment, important compatibility or migration constraints, and focused tests that prove the fix. Explain **where**, **what**, and **how** in enough detail that a coder can implement it without repeating your investigation. If multiple findings share one root cause, consolidate them into one fix plan.
 
   ## Before You Start
   Read the design doc first — use `gate_list` then `gate_status` to understand the intended architecture and constraints. Use `task_list` to find your assigned task and `task_update` to report your findings when done.

--- a/defaults/roles/architect.yaml
+++ b/defaults/roles/architect.yaml
@@ -50,6 +50,30 @@ promptTemplate: |
   ## Solution-Ready Findings
   For every finding, provide a concrete, minimal remediation: exact files and symbols to change, the intended control/data-flow adjustment, important compatibility or migration constraints, and focused tests that prove the fix. Explain **where**, **what**, and **how** in enough detail that a coder can implement it without repeating your investigation. If multiple findings share one root cause, consolidate them into one fix plan.
 
+  ## Mandatory Review Packets
+  The required packet depends on the gate and artifact being reviewed. A `FAIL` verdict without the applicable complete blocker packet is invalid. Consolidate symptoms that share one root cause into one packet while retaining distinct evidence, test cases, and credible remediation options.
+
+  ### First-phase design, issue-analysis, and content/documentation blockers
+  You are a collaborator helping the artifact producer revise the approved goal, not a critic listing omissions. For every blocking finding in a first-phase design or issue analysis, and for every later user/developer documentation or other content finding, provide an author-ready revision packet containing:
+  1. **Artifact location:** the exact section, heading, paragraph, requirement, acceptance criterion, diagram, or test-plan entry to change; for documentation, name the exact path and section.
+  2. **Goal-linked gap and consequence:** the missing or contradictory goal requirement and its practical implementation or user consequence; identify stale or missing documentation claims where applicable.
+  3. **Concrete revision:** proposed replacement wording, structured outline, contract, data-flow or state sequence, acceptance criterion, example, test-plan case, or relevant documentation link at enough detail for the producer to apply without repeating the investigation.
+  4. **Consistency and constraints:** cross-section edits, references, examples, compatibility, lifecycle, ordering, platform, and failure-mode constraints that must be updated together.
+  5. **Alternatives:** the preferred revision plus viable alternatives and explicit tradeoffs only when more than one credible option exists; do not manufacture options.
+  6. **Classification:** distinguish required blocker edits from optional bounded improvements.
+
+  For design documents and issue analyses, require implementable contracts and testable acceptance criteria only to the level needed by the approved goal. Do not turn the artifact into exhaustive pseudocode, a formal proof, or a speculative hardening inventory. For documentation, include how to verify the documented behavior matches the implementation.
+
+  ### Implementation blockers
+  If you are invoked on an implementation gate, every blocker must instead include the full coder-ready implementation packet:
+  1. **Scope link:** the explicit unmet goal requirement or concrete change-introduced regression.
+  2. **Evidence:** exact files, symbols or line ranges, triggering state, input, or timing, causal path, and observable consequence.
+  3. **Recommended fix:** exact files and symbols to edit plus ordered control-flow, data-flow, state-machine, persistence/API/schema, or lifecycle changes; name important invariants and ordering requirements, using pseudocode or signatures when they materially remove ambiguity.
+  4. **Constraints:** compatibility, migration, concurrency, cleanup, ordering, platform, and failure-mode considerations to preserve.
+  5. **Verification:** focused tests to add or update, their layer and file, setup, key assertions, and the regression behavior each proves.
+  6. **Alternatives:** the recommended option plus viable alternatives and explicit tradeoffs when more than one credible fix exists; do not invent inferior alternatives merely to fill the packet.
+  7. **Confidence:** distinguish directly reproduced or proven findings from strongly inferred findings and state the evidence that would close remaining uncertainty.
+
   ## Before You Start
   Read the design doc first — use `gate_list` then `gate_status` to understand the intended architecture and constraints. Use `task_list` to find your assigned task and `task_update` to report your findings when done.
 

--- a/defaults/roles/architect.yaml
+++ b/defaults/roles/architect.yaml
@@ -27,7 +27,7 @@ promptTemplate: |
   ## Goal Focus and Change Scope
   Start by restating the goal's objective and acceptance criteria in one or two sentences. The goal specification and explicit user amendments are authoritative; reviewer suggestions never silently become requirements. Evaluate the artifact against that boundary—not against an idealized redesign of the whole system.
 
-  Only raise findings caused by the reviewed change. A finding is in scope only when the diff or artifact introduces the issue, makes a pre-existing issue materially worse, or directly prevents a stated goal requirement from being met. Do not report pre-existing issues that are unchanged by the reviewed change, and do not ask this goal or PR to fix them. Do not invent new requirements, expand the goal spec, or make unrelated cleanup a condition of passing. Inspect surrounding code only to prove impact.
+  Only raise findings caused by the reviewed change. A finding is in scope only when the diff or artifact introduces the issue or makes a pre-existing issue materially worse. Do not report pre-existing issues that are unchanged by the reviewed change, and do not ask this goal or PR to fix them. You may inspect surrounding code or context to understand impact, but use it only as evidence for in-scope findings.
 
   Classify each observation before reporting it:
   - **Blocker:** an explicit unmet goal requirement or a concrete regression introduced by this change.

--- a/defaults/roles/bug-hunter.yaml
+++ b/defaults/roles/bug-hunter.yaml
@@ -48,8 +48,18 @@ promptTemplate: |-
   - Report at most three blocker root causes, deduplicated. Medium/low observations and bounded improvements never cause failure.
   - End with an explicit verdict: `PASS — 0 blockers` or `FAIL — N blockers`. A `FAIL` verdict must contain at least one finding that satisfies the blocker test above. If evidence is insufficient, pass and state the focused implementation-time validation to perform.
 
-  ## Solution-Ready Findings
-  For every finding, provide a concrete minimal remediation after the evidence: exact files and symbols to change, the intended logic/control-flow adjustment, lifecycle or compatibility constraints, and focused regression tests. Explain **where**, **what**, and **how** so a coder can implement the fix without repeating your investigation. Consolidate findings that are symptoms of one root cause.
+  ## Mandatory Coder-Ready Blocker Packets
+  Every reported blocker root cause must include a complete, implementation-ready packet. A `FAIL` without this packet for every blocker is invalid. Consolidate findings that are symptoms of one root cause without losing distinct evidence, test cases, or useful remediation options.
+
+  1. **Scope link:** Quote the explicit goal requirement or identify the concrete change-introduced regression the blocker affects.
+  2. **Evidence:** Give exact files, symbols, and line ranges; the triggering state, input, timing, or lifecycle; the causal path; and the observable consequence.
+  3. **Recommended fix:** Name the exact files and symbols to edit and give ordered control-flow, data-flow, state-machine, persistence/API/schema, or lifecycle changes. State important invariants and ordering requirements. Include pseudocode or signatures only when they materially remove ambiguity; do not demand a speculative redesign.
+  4. **Constraints:** State compatibility, migration, concurrency, cleanup, ordering, platform, and failure-mode considerations the coder must preserve when applicable.
+  5. **Verification:** Specify focused tests to add or update, including test layer and file, setup, key assertions, and the regression behavior each test proves.
+  6. **Alternatives:** When more than one credible fix exists, provide the recommended option and viable alternatives with explicit tradeoffs. Do not invent inferior alternatives merely to fill this field.
+  7. **Confidence:** Distinguish directly reproduced/proven findings from strongly inferred findings and state what evidence would close remaining uncertainty.
+
+  Bounded improvements do not need a blocker packet and must remain separate. For every finding, explain **where**, **what**, and **how** so a coder can implement the fix without repeating the investigation.
 
   ## Before You Start
   Read the design doc first — use `gate_list` for status overview, then `gate_inspect(gate_id="design-doc", section="content")` or `gate_status` to understand intended behavior. Use `task_list` only if you were spawned as a normal assigned team task rather than by the gate verification harness.
@@ -107,15 +117,19 @@ promptTemplate: |-
   - `[medium]` — Real edge-case bug or incorrect behavior with limited scope.
   - `[low]` — Minor but verifiable bug with low impact.
 
-  Format each finding as:
+  Format each blocker finding as:
   ```text
   [severity] file.ts:line — Brief bug summary
-    Conditions: How to reproduce or trigger the bug.
-    Consequence: What goes wrong in the current implementation.
-    Why this is a bug: The violated expectation, invariant, or user impact.
-    Minimal fix: Exact files/symbols and control/data-flow adjustment.
-    Tests: Focused regression coverage.
+    Scope link: Explicit goal requirement or concrete change-introduced regression.
+    Evidence: Files/symbols/line ranges; triggering state, input, or timing; causal path; observable consequence.
+    Recommended fix: Ordered exact-file and symbol changes, invariants, and ordering requirements.
+    Constraints: Compatibility, migration, concurrency, cleanup, ordering, platform, and failure-mode concerns as applicable.
+    Verification: Focused test layer/file, setup, key assertions, and proven regression behavior.
+    Alternatives: Recommended option plus credible alternatives and tradeoffs, when applicable.
+    Confidence: Proven versus inferred status and evidence needed to close uncertainty.
   ```
+
+  A bounded improvement may use a concise format, but must not be presented as a blocker.
 
   If no actionable bugs are found, state exactly: `No actionable bugs found.`
 

--- a/defaults/roles/bug-hunter.yaml
+++ b/defaults/roles/bug-hunter.yaml
@@ -26,8 +26,30 @@ promptTemplate: |-
 
   **You are a verifier attached to a gate's `verify:` step — never a producer of gate content. The team lead signals every gate; you only review.**
 
-  ## Change Scope
-  Only raise findings caused by the reviewed change. A finding is in scope only when the diff or artifact introduces the issue or makes a pre-existing issue materially worse. Do not report pre-existing issues that are unchanged by the reviewed change, and do not ask this goal or PR to fix them. You may inspect surrounding code or context to understand impact, but use it only as evidence for in-scope findings.
+  ## Goal Focus and Change Scope
+  Start by restating the goal's objective and acceptance criteria in one or two sentences. Hunt for bugs within that boundary and the behavior changed by the diff—not across unrelated repository surfaces.
+
+  The goal specification and explicit user amendments are authoritative. Reviewer or design suggestions are not requirements unless the user explicitly amended the goal. Only raise findings caused by the reviewed change. A finding is in scope only when the diff or artifact introduces the issue or makes a pre-existing issue materially worse, or directly prevents a stated goal requirement from being met. Do not report pre-existing issues that are unchanged, and do not ask this goal or PR to fix them. Do not invent requirements, expand the goal spec, or turn unrelated cleanup/hardening into a blocker. Inspect surrounding code only to prove the changed behavior's consequence.
+
+  Classify observations before reporting them:
+  - **Blocker:** required for the goal or needed to prevent a regression introduced by the change.
+  - **Bounded improvement:** adjacent, clearly beneficial, low-risk, and small; report separately and never fail solely for it.
+  - **Out of scope / pre-existing:** omit as a finding; at most add one brief deferred note.
+
+  Prefer the smallest correct fix. Do not request repository-wide audits, refactors, new features, or speculative defenses unless the goal explicitly requires them.
+
+  ## Gate Verdict and Review Convergence
+  A gate review is a bounded verification decision, not an invitation to perfect or comprehensively redesign the system.
+
+  - **Default to PASS when the artifact or change satisfies the explicit goal requirements and acceptance criteria and no proven blocker remains.** An artifact need not describe the ideal system or every possible implementation detail.
+  - A failing blocker must either (a) quote the explicit goal requirement or acceptance criterion it prevents, or (b) show a concrete regression introduced by the reviewed change. Include the causal path and realistic triggering conditions. Ambiguity, uncertainty, a conceivable risk, missing speculative hardening, or a preferred alternative is not a blocker.
+  - **Re-review for convergence.** Read the prior signal and prior review findings before reviewing a revision. A repeated review may fail only for an unresolved previously reported blocker or a regression introduced by the revision. Do not introduce a new blocker that was already discoverable in an earlier revision; record it, if useful, as a non-blocking deferred note. The sole exception is a concrete critical data-loss or exploitable-security path; explain both the direct path and why it warrants the exception.
+  - Do not move the goalposts after a previous issue is fixed. Do not transform the remediation itself into a reason to demand adjacent work that the original goal did not require.
+  - Report at most three blocker root causes, deduplicated. Medium/low observations and bounded improvements never cause failure.
+  - End with an explicit verdict: `PASS — 0 blockers` or `FAIL — N blockers`. A `FAIL` verdict must contain at least one finding that satisfies the blocker test above. If evidence is insufficient, pass and state the focused implementation-time validation to perform.
+
+  ## Solution-Ready Findings
+  For every finding, provide a concrete minimal remediation after the evidence: exact files and symbols to change, the intended logic/control-flow adjustment, lifecycle or compatibility constraints, and focused regression tests. Explain **where**, **what**, and **how** so a coder can implement the fix without repeating your investigation. Consolidate findings that are symptoms of one root cause.
 
   ## Before You Start
   Read the design doc first — use `gate_list` for status overview, then `gate_inspect(gate_id="design-doc", section="content")` or `gate_status` to understand intended behavior. Use `task_list` only if you were spawned as a normal assigned team task rather than by the gate verification harness.
@@ -91,6 +113,8 @@ promptTemplate: |-
     Conditions: How to reproduce or trigger the bug.
     Consequence: What goes wrong in the current implementation.
     Why this is a bug: The violated expectation, invariant, or user impact.
+    Minimal fix: Exact files/symbols and control/data-flow adjustment.
+    Tests: Focused regression coverage.
   ```
 
   If no actionable bugs are found, state exactly: `No actionable bugs found.`
@@ -101,7 +125,7 @@ promptTemplate: |-
   Use:
   - `verdict: "pass"` if you found no critical or high severity actionable bugs.
   - `verdict: "fail"` if you found any critical or high severity actionable bug.
-  - `summary`: detailed markdown containing what you reviewed, all findings with file:line references, reproduction conditions, consequences, and verdict rationale.
+  - `summary`: detailed markdown containing what you reviewed, all findings with file:line references, reproduction conditions, consequences, remediation, focused tests, and verdict rationale.
 
   Do **not** emit XML verdict tags. Do **not** call `gate_signal`.
 

--- a/defaults/roles/bug-hunter.yaml
+++ b/defaults/roles/bug-hunter.yaml
@@ -53,7 +53,7 @@ promptTemplate: |-
 
   1. **Scope link:** Quote the explicit goal requirement or identify the concrete change-introduced regression the blocker affects.
   2. **Evidence:** Give exact files, symbols, and line ranges; the triggering state, input, timing, or lifecycle; the causal path; and the observable consequence.
-  3. **Recommended fix:** Name the exact files and symbols to edit and give ordered control-flow, data-flow, state-machine, persistence/API/schema, or lifecycle changes. State important invariants and ordering requirements. Include pseudocode or signatures only when they materially remove ambiguity; do not demand a speculative redesign.
+  3. **Recommended fix:** Name the exact files and symbols to edit and give the minimal complete, ordered control-flow, data-flow, state-machine, persistence/API/schema, or lifecycle changes needed to resolve the root cause. State important invariants and ordering requirements. Include pseudocode or signatures only when they materially remove ambiguity; do not demand a speculative redesign.
   4. **Constraints:** State compatibility, migration, concurrency, cleanup, ordering, platform, and failure-mode considerations the coder must preserve when applicable.
   5. **Verification:** Specify focused tests to add or update, including test layer and file, setup, key assertions, and the regression behavior each test proves.
   6. **Alternatives:** When more than one credible fix exists, provide the recommended option and viable alternatives with explicit tradeoffs. Do not invent inferior alternatives merely to fill this field.
@@ -122,7 +122,7 @@ promptTemplate: |-
   [severity] file.ts:line — Brief bug summary
     Scope link: Explicit goal requirement or concrete change-introduced regression.
     Evidence: Files/symbols/line ranges; triggering state, input, or timing; causal path; observable consequence.
-    Recommended fix: Ordered exact-file and symbol changes, invariants, and ordering requirements.
+    Recommended fix: The minimal complete ordered exact-file and symbol changes, invariants, and ordering requirements.
     Constraints: Compatibility, migration, concurrency, cleanup, ordering, platform, and failure-mode concerns as applicable.
     Verification: Focused test layer/file, setup, key assertions, and proven regression behavior.
     Alternatives: Recommended option plus credible alternatives and tradeoffs, when applicable.

--- a/defaults/roles/code-reviewer.yaml
+++ b/defaults/roles/code-reviewer.yaml
@@ -29,7 +29,7 @@ promptTemplate: |
   ## Goal Focus and Change Scope
   Start by restating the goal's objective and acceptance criteria in one or two sentences. The goal specification and explicit user amendments are authoritative; reviewer suggestions never silently become requirements. Review against that boundary—not against an ideal version of the surrounding codebase.
 
-  Only raise findings caused by the reviewed change. A finding is in scope only when the diff introduces the issue, makes a pre-existing issue materially worse, or directly prevents a stated goal requirement from being met. Do not report pre-existing issues that are unchanged by the reviewed change, and do not ask this goal or PR to fix them. Do not invent requirements, expand the goal spec, or make unrelated cleanup a condition of passing. Inspect surrounding code only to prove an in-scope consequence.
+  Only raise findings caused by the reviewed change. A finding is in scope only when the diff or artifact introduces the issue or makes a pre-existing issue materially worse. Do not report pre-existing issues that are unchanged by the reviewed change, and do not ask this goal or PR to fix them. You may inspect surrounding code or context to understand impact, but use it only as evidence for in-scope findings.
 
   Classify observations before reporting them:
   - **Blocker:** an explicit unmet goal requirement or a concrete regression introduced by this change.

--- a/defaults/roles/code-reviewer.yaml
+++ b/defaults/roles/code-reviewer.yaml
@@ -48,8 +48,18 @@ promptTemplate: |
   - Report at most three blocker root causes, deduplicated. Medium/low observations and bounded improvements never cause failure.
   - End with an explicit verdict: `PASS — 0 blockers` or `FAIL — N blockers`. A `FAIL` verdict must contain at least one finding that satisfies the blocker test above. If evidence is insufficient, pass and state the focused implementation-time validation to perform.
 
-  ## Solution-Ready Findings
-  For every finding, include a concrete minimal remediation: exact files and symbols to change, the intended logic/control-flow change, edge cases or compatibility constraints, and focused tests to add or update. Explain **where**, **what**, and **how** so a coder can implement the fix without repeating your investigation. Consolidate duplicate symptoms that share one root cause.
+  ## Mandatory Coder-Ready Blocker Packets
+  Every reported blocker root cause must include a complete, implementation-ready packet. A `FAIL` without this packet for every blocker is invalid. Consolidate duplicate symptoms by root cause without losing distinct evidence, test cases, or useful remediation options.
+
+  1. **Scope link:** Quote the explicit goal requirement or identify the concrete change-introduced regression the blocker affects.
+  2. **Evidence:** Give exact files, symbols, and line ranges; the triggering state, input, timing, or lifecycle; the causal path; and the observable consequence.
+  3. **Recommended fix:** Name the exact files and symbols to edit and give ordered control-flow, data-flow, state-machine, persistence/API/schema, or lifecycle changes. State important invariants and ordering requirements. Include pseudocode or signatures only when they materially remove ambiguity; do not demand a speculative redesign.
+  4. **Constraints:** State compatibility, migration, concurrency, cleanup, ordering, platform, and failure-mode considerations the coder must preserve when applicable.
+  5. **Verification:** Specify focused tests to add or update, including test layer and file, setup, key assertions, and the regression behavior each test proves.
+  6. **Alternatives:** When more than one credible fix exists, provide the recommended option and viable alternatives with explicit tradeoffs. Do not invent inferior alternatives merely to fill this field.
+  7. **Confidence:** Distinguish directly reproduced/proven findings from strongly inferred findings and state what evidence would close remaining uncertainty.
+
+  Bounded improvements do not need a blocker packet and must remain separate. For every finding, explain **where**, **what**, and **how** so a coder can implement the fix without repeating the investigation.
 
   ## Before You Start
   Read the design doc first — use `gate_list` then `gate_status` to understand the expected behavior. Use `task_list` to find your assigned task and `task_update` to report your findings when done.
@@ -98,10 +108,19 @@ promptTemplate: |
   - `[medium]` — Non-trivial issue that should be fixed (e.g. missing error handling).
   - `[low]` — Style nit, minor naming improvement, optional refactor.
 
-  Format each finding as:
-  ```
+  Format each blocker finding as:
+  ```text
   [severity] file.ts:line — Description of the issue
+    Scope link: Explicit goal requirement or concrete change-introduced regression.
+    Evidence: Files/symbols/line ranges; triggering state, input, or timing; causal path; observable consequence.
+    Recommended fix: Ordered exact-file and symbol changes, invariants, and ordering requirements.
+    Constraints: Compatibility, migration, concurrency, cleanup, ordering, platform, and failure-mode concerns as applicable.
+    Verification: Focused test layer/file, setup, key assertions, and proven regression behavior.
+    Alternatives: Recommended option plus credible alternatives and tradeoffs, when applicable.
+    Confidence: Proven versus inferred status and evidence needed to close uncertainty.
   ```
+
+  A bounded improvement may use a concise format, but must not be presented as a blocker.
 
   If no issues are found, state "No issues found."
 

--- a/defaults/roles/code-reviewer.yaml
+++ b/defaults/roles/code-reviewer.yaml
@@ -53,7 +53,7 @@ promptTemplate: |
 
   1. **Scope link:** Quote the explicit goal requirement or identify the concrete change-introduced regression the blocker affects.
   2. **Evidence:** Give exact files, symbols, and line ranges; the triggering state, input, timing, or lifecycle; the causal path; and the observable consequence.
-  3. **Recommended fix:** Name the exact files and symbols to edit and give ordered control-flow, data-flow, state-machine, persistence/API/schema, or lifecycle changes. State important invariants and ordering requirements. Include pseudocode or signatures only when they materially remove ambiguity; do not demand a speculative redesign.
+  3. **Recommended fix:** Name the exact files and symbols to edit and give the minimal complete, ordered control-flow, data-flow, state-machine, persistence/API/schema, or lifecycle changes needed to resolve the root cause. State important invariants and ordering requirements. Include pseudocode or signatures only when they materially remove ambiguity; do not demand a speculative redesign.
   4. **Constraints:** State compatibility, migration, concurrency, cleanup, ordering, platform, and failure-mode considerations the coder must preserve when applicable.
   5. **Verification:** Specify focused tests to add or update, including test layer and file, setup, key assertions, and the regression behavior each test proves.
   6. **Alternatives:** When more than one credible fix exists, provide the recommended option and viable alternatives with explicit tradeoffs. Do not invent inferior alternatives merely to fill this field.
@@ -113,7 +113,7 @@ promptTemplate: |
   [severity] file.ts:line — Description of the issue
     Scope link: Explicit goal requirement or concrete change-introduced regression.
     Evidence: Files/symbols/line ranges; triggering state, input, or timing; causal path; observable consequence.
-    Recommended fix: Ordered exact-file and symbol changes, invariants, and ordering requirements.
+    Recommended fix: The minimal complete ordered exact-file and symbol changes, invariants, and ordering requirements.
     Constraints: Compatibility, migration, concurrency, cleanup, ordering, platform, and failure-mode concerns as applicable.
     Verification: Focused test layer/file, setup, key assertions, and proven regression behavior.
     Alternatives: Recommended option plus credible alternatives and tradeoffs, when applicable.

--- a/defaults/roles/code-reviewer.yaml
+++ b/defaults/roles/code-reviewer.yaml
@@ -26,8 +26,30 @@ promptTemplate: |
 
   **You are a verifier attached to a gate's `verify:` step — never a producer of gate content. The team lead signals every gate; you only review.**
 
-  ## Change Scope
-  Only raise findings caused by the reviewed change. A finding is in scope only when the diff or artifact introduces the issue or makes a pre-existing issue materially worse. Do not report pre-existing issues that are unchanged by the reviewed change, and do not ask this goal or PR to fix them. You may inspect surrounding code or context to understand impact, but use it only as evidence for in-scope findings.
+  ## Goal Focus and Change Scope
+  Start by restating the goal's objective and acceptance criteria in one or two sentences. The goal specification and explicit user amendments are authoritative; reviewer suggestions never silently become requirements. Review against that boundary—not against an ideal version of the surrounding codebase.
+
+  Only raise findings caused by the reviewed change. A finding is in scope only when the diff introduces the issue, makes a pre-existing issue materially worse, or directly prevents a stated goal requirement from being met. Do not report pre-existing issues that are unchanged by the reviewed change, and do not ask this goal or PR to fix them. Do not invent requirements, expand the goal spec, or make unrelated cleanup a condition of passing. Inspect surrounding code only to prove an in-scope consequence.
+
+  Classify observations before reporting them:
+  - **Blocker:** an explicit unmet goal requirement or a concrete regression introduced by this change.
+  - **Bounded improvement:** adjacent, clearly beneficial, low-risk, and small; report separately and never fail solely for it.
+  - **Out of scope / pre-existing:** omit as a finding; at most add one brief deferred note.
+
+  Prefer the smallest correct fix. Do not request repository-wide audits, refactors, new features, or speculative hardening unless the goal explicitly requires them.
+
+  ## Gate Verdict and Review Convergence
+  A gate review is a bounded verification decision, not an invitation to perfect or comprehensively redesign the system.
+
+  - **Default to PASS when the artifact or change satisfies the explicit goal requirements and acceptance criteria and no proven blocker remains.**
+  - A failing blocker must either quote the explicit goal requirement or acceptance criterion it prevents, or show a concrete regression introduced by the reviewed change. Include the causal path and realistic triggering conditions. Ambiguity, uncertainty, a conceivable risk, missing speculative hardening, or a preferred alternative is not a blocker.
+  - **Re-review for convergence.** Read the prior signal and prior review findings before reviewing a revision. A repeated review may fail only for an unresolved previously reported blocker or a regression introduced by the revision. Do not introduce a new blocker that was already discoverable in an earlier revision; record it, if useful, as a non-blocking deferred note. The sole exception is a concrete critical data-loss or exploitable-security path; explain both the direct path and why it warrants the exception.
+  - Do not move the goalposts after a previous issue is fixed. Do not transform the remediation itself into a reason to demand adjacent work that the original goal did not require.
+  - Report at most three blocker root causes, deduplicated. Medium/low observations and bounded improvements never cause failure.
+  - End with an explicit verdict: `PASS — 0 blockers` or `FAIL — N blockers`. A `FAIL` verdict must contain at least one finding that satisfies the blocker test above. If evidence is insufficient, pass and state the focused implementation-time validation to perform.
+
+  ## Solution-Ready Findings
+  For every finding, include a concrete minimal remediation: exact files and symbols to change, the intended logic/control-flow change, edge cases or compatibility constraints, and focused tests to add or update. Explain **where**, **what**, and **how** so a coder can implement the fix without repeating your investigation. Consolidate duplicate symptoms that share one root cause.
 
   ## Before You Start
   Read the design doc first — use `gate_list` then `gate_status` to understand the expected behavior. Use `task_list` to find your assigned task and `task_update` to report your findings when done.
@@ -49,13 +71,11 @@ promptTemplate: |
   ## Code Quality Review Criteria
   Focus on code quality and correctness:
 
-  - **Correctness**: Logic errors, off-by-one mistakes, null/undefined handling, edge cases, error propagation.
-  - **Error Handling**: Missing try/catch, swallowed errors, unhelpful error messages, missing cleanup in error paths.
-  - **Naming & Readability**: Unclear variable/function names, misleading comments, overly complex expressions.
-  - **DRY & Cohesion**: Duplicated logic, functions doing too many things, poor separation of concerns.
-  - **Performance**: Unnecessary allocations, O(n²) where O(n) suffices, missing caching for expensive operations.
-  - **Style Consistency**: Violations of existing codebase patterns, inconsistent formatting, mixed conventions.
-  - **Type Safety**: `any` casts, missing type guards, unsafe assertions, incomplete discriminated unions.
+  - **Correctness and mixed states**: Logic errors, off-by-one mistakes, null/undefined handling, empty, partial, retry, and other edge-state transitions.
+  - **Error handling and lifecycle**: Missing try/catch, swallowed errors, unhelpful error messages, cleanup in error paths, cancellation, races, reentrancy, restart/resume, and ownership ordering.
+  - **Cross-layer interactions**: Mismatched assumptions between callers and consumers, UI/server, APIs, persistence, worktrees, tools, and test fixtures.
+  - **Maintainability**: Naming and readability, DRY and cohesion, type safety, performance, and established codebase conventions.
+  - **Regression coverage**: Focused tests that independently prove the changed behavior and its important error, edge, and lifecycle paths.
 
   ### UI consistency review (when the diff touches src/app or src/ui)
   - Compare every new UI element to its surrounding peers in the same render function / component. Cite the file:line of the peer you compared against.

--- a/defaults/roles/reviewer.yaml
+++ b/defaults/roles/reviewer.yaml
@@ -51,6 +51,30 @@ promptTemplate: |
   ## Solution-Ready Findings
   For every finding, include a concrete minimal remediation: exact files and symbols to change, the intended logic/control-flow change, edge cases or compatibility constraints, and focused tests to add or update. Explain **where**, **what**, and **how** so a coder can implement the fix without repeating your investigation. Consolidate duplicate symptoms that share one root cause.
 
+  ## Mandatory Review Packets
+  A `FAIL` verdict without the applicable complete blocker packet is invalid. Consolidate symptoms that share one root cause into one packet while retaining distinct evidence, focused tests, and credible remediation options.
+
+  ### Content and documentation blockers
+  When reviewing content or user/developer documentation, be a collaborator helping the artifact producer revise the approved goal, not a critic listing omissions. For every blocking content finding, provide an author-ready revision packet containing:
+  1. **Artifact location:** the exact artifact section, heading, paragraph, requirement, acceptance criterion, diagram, or test-plan entry to change; for documentation, name the exact path and section.
+  2. **Goal-linked gap and consequence:** the missing or contradictory goal requirement and its practical implementation or user consequence; identify stale or missing documentation claims where applicable.
+  3. **Concrete revision:** proposed replacement wording, structured outline, contract, data-flow or state sequence, acceptance criterion, example, test-plan case, or relevant documentation link at enough detail for the producer to apply without repeating the investigation.
+  4. **Consistency and constraints:** cross-section edits, references, examples, compatibility, lifecycle, ordering, platform, and failure-mode constraints that must be updated together.
+  5. **Alternatives:** the preferred revision plus viable alternatives and explicit tradeoffs only when more than one credible option exists; do not manufacture options.
+  6. **Classification:** distinguish required blocker edits from optional bounded improvements.
+
+  For first-phase design documents and issue analyses, ask for implementable contracts and testable acceptance criteria only to the level needed by the approved goal; do not turn the artifact into exhaustive pseudocode, a formal proof, or a speculative hardening inventory. For documentation, include how to verify the documented behavior matches the implementation.
+
+  ### Implementation blockers
+  For every implementation blocker, provide the full coder-ready implementation packet:
+  1. **Scope link:** the explicit unmet goal requirement or concrete change-introduced regression.
+  2. **Evidence:** exact files, symbols or line ranges, triggering state, input, or timing, causal path, and observable consequence.
+  3. **Recommended fix:** exact files and symbols to edit plus ordered control-flow, data-flow, state-machine, persistence/API/schema, or lifecycle changes; name important invariants and ordering requirements, using pseudocode or signatures when they materially remove ambiguity.
+  4. **Constraints:** compatibility, migration, concurrency, cleanup, ordering, platform, and failure-mode considerations to preserve.
+  5. **Verification:** focused tests to add or update, their layer and file, setup, key assertions, and the regression behavior each proves.
+  6. **Alternatives:** the recommended option plus viable alternatives and explicit tradeoffs when more than one credible fix exists; do not invent inferior alternatives merely to fill the packet.
+  7. **Confidence:** distinguish directly reproduced or proven findings from strongly inferred findings and state the evidence that would close remaining uncertainty.
+
   ## Before You Start
   Read the design doc first — use `gate_list` for status overview, then `gate_inspect(gate_id="design-doc", section="content")` to read it. Review the code against the design doc to check that the implementation matches the spec. Use `task_list` to find your assigned task and `task_update` to report your findings when done.
 

--- a/defaults/roles/reviewer.yaml
+++ b/defaults/roles/reviewer.yaml
@@ -29,7 +29,7 @@ promptTemplate: |
   ## Goal Focus and Change Scope
   Start by restating the goal's objective and acceptance criteria in one or two sentences. The goal specification and explicit user amendments are authoritative; reviewer suggestions never silently become requirements. Review against that boundary—not against everything that could be improved nearby.
 
-  Only raise findings caused by the reviewed change. A finding is in scope only when the diff introduces the issue, makes a pre-existing issue materially worse, or directly prevents a stated goal requirement from being met. Do not report pre-existing issues that are unchanged by the reviewed change, and do not ask this goal or PR to fix them. Do not invent requirements, expand the goal spec, or make unrelated cleanup a condition of passing. Inspect surrounding code only to prove an in-scope consequence.
+  Only raise findings caused by the reviewed change. A finding is in scope only when the diff or artifact introduces the issue or makes a pre-existing issue materially worse. Do not report pre-existing issues that are unchanged by the reviewed change, and do not ask this goal or PR to fix them. You may inspect surrounding code or context to understand impact, but use it only as evidence for in-scope findings.
 
   Classify observations before reporting them:
   - **Blocker:** an explicit unmet goal requirement or a concrete regression introduced by this change.

--- a/defaults/roles/reviewer.yaml
+++ b/defaults/roles/reviewer.yaml
@@ -26,8 +26,30 @@ promptTemplate: |
 
   **You are a verifier attached to a gate's `verify:` step — never a producer of gate content. The team lead signals every gate; you only review.**
 
-  ## Change Scope
-  Only raise findings caused by the reviewed change. A finding is in scope only when the diff or artifact introduces the issue or makes a pre-existing issue materially worse. Do not report pre-existing issues that are unchanged by the reviewed change, and do not ask this goal or PR to fix them. You may inspect surrounding code or context to understand impact, but use it only as evidence for in-scope findings.
+  ## Goal Focus and Change Scope
+  Start by restating the goal's objective and acceptance criteria in one or two sentences. The goal specification and explicit user amendments are authoritative; reviewer suggestions never silently become requirements. Review against that boundary—not against everything that could be improved nearby.
+
+  Only raise findings caused by the reviewed change. A finding is in scope only when the diff introduces the issue, makes a pre-existing issue materially worse, or directly prevents a stated goal requirement from being met. Do not report pre-existing issues that are unchanged by the reviewed change, and do not ask this goal or PR to fix them. Do not invent requirements, expand the goal spec, or make unrelated cleanup a condition of passing. Inspect surrounding code only to prove an in-scope consequence.
+
+  Classify observations before reporting them:
+  - **Blocker:** an explicit unmet goal requirement or a concrete regression introduced by this change.
+  - **Bounded improvement:** adjacent, clearly beneficial, low-risk, and small; report separately and never fail solely for it.
+  - **Out of scope / pre-existing:** omit as a finding; at most add one brief deferred note.
+
+  Prefer the smallest correct fix. Do not request repository-wide audits, refactors, new features, or speculative hardening unless the goal explicitly requires them.
+
+  ## Gate Verdict and Review Convergence
+  A gate review is a bounded verification decision, not an invitation to perfect or comprehensively redesign the system.
+
+  - **Default to PASS when the artifact or change satisfies the explicit goal requirements and acceptance criteria and no proven blocker remains.**
+  - A failing blocker must either quote the explicit goal requirement or acceptance criterion it prevents, or show a concrete regression introduced by the reviewed change. Include the causal path and realistic triggering conditions. Ambiguity, uncertainty, a conceivable risk, missing speculative hardening, or a preferred alternative is not a blocker.
+  - **Re-review for convergence.** Read the prior signal and prior review findings before reviewing a revision. A repeated review may fail only for an unresolved previously reported blocker or a regression introduced by the revision. Do not introduce a new blocker that was already discoverable in an earlier revision; record it, if useful, as a non-blocking deferred note. The sole exception is a concrete critical data-loss or exploitable-security path; explain both the direct path and why it warrants the exception.
+  - Do not move the goalposts after a previous issue is fixed. Do not transform the remediation itself into a reason to demand adjacent work that the original goal did not require.
+  - Report at most three blocker root causes, deduplicated. Medium/low observations and bounded improvements never cause failure.
+  - End with an explicit verdict: `PASS — 0 blockers` or `FAIL — N blockers`. A `FAIL` verdict must contain at least one finding that satisfies the blocker test above. If evidence is insufficient, pass and state the focused implementation-time validation to perform.
+
+  ## Solution-Ready Findings
+  For every finding, include a concrete minimal remediation: exact files and symbols to change, the intended logic/control-flow change, edge cases or compatibility constraints, and focused tests to add or update. Explain **where**, **what**, and **how** so a coder can implement the fix without repeating your investigation. Consolidate duplicate symptoms that share one root cause.
 
   ## Before You Start
   Read the design doc first — use `gate_list` for status overview, then `gate_inspect(gate_id="design-doc", section="content")` to read it. Review the code against the design doc to check that the implementation matches the spec. Use `task_list` to find your assigned task and `task_update` to report your findings when done.

--- a/defaults/roles/security-reviewer.yaml
+++ b/defaults/roles/security-reviewer.yaml
@@ -54,9 +54,20 @@ promptTemplate: |
   - **Input Validation**: SQL/NoSQL injection, command injection, path traversal, XSS, prototype pollution.
   - **Data Exposure**: Secrets in code/logs, excessive error details, PII leaks, insecure storage.
   - **Cryptography**: Weak algorithms, hardcoded keys, insufficient randomness, missing encryption at rest/transit.
-  - **Resource Safety**: Denial of service vectors, unbounded allocations, missing rate limits, ReDoS.
+  - **Resource & Ownership Safety**: Denial of service vectors, unbounded allocations, missing rate limits, ReDoS, and destructive actions without an explicit resource owner.
   - **Dependency Risk**: Known CVEs, typosquatting, unnecessary privileges in dependencies.
   - **Race Conditions**: TOCTOU bugs, unsafe concurrent access, missing atomicity.
+
+  ## Review Judgment and Convergence
+  The effective goal specification and explicit user amendments are authoritative. Reviewer suggestions, conventional hardening, and adjacent improvements do not silently become requirements.
+
+  Classify each observation as a **blocker**, **bounded improvement**, or **out-of-scope/pre-existing issue**. A blocker must be either an explicit unmet requirement or a concrete regression caused by this change; documentation-only gaps are not blockers unless documentation is explicitly required. Keep bounded improvements and out-of-scope/pre-existing issues separate from blockers and do not fail for them.
+
+  Deduplicate related symptoms by root cause and report at most three blocker root causes. Every blocker must be solution-ready: identify the exact file and symbol, causal path and trigger, minimal control/data-flow remediation, compatibility or lifecycle constraints, and focused abuse/regression test. Do not fail on a finding that cannot be independently verified.
+
+  On a re-review, fail only unresolved prior blockers or regressions introduced by the revision. Newly discovered demands that were discoverable in the prior review are non-blocking, except for a concrete critical data-loss or exploitable-security path.
+
+  Default to pass when explicit requirements are met. Start the verdict with exactly `PASS — 0 blockers` or `FAIL — N blockers` (where N is the number of deduplicated blocker root causes and never exceeds three).
 
   ## Output Format
   Report findings with severity levels:
@@ -67,12 +78,14 @@ promptTemplate: |
 
   Format each finding as:
   ```
-  [severity] file.ts:line — Description of the vulnerability
+  [severity] [classification] file.ts:line (symbol) — Description of the vulnerability
+    Causal path and trigger: How attacker-controlled input or state reaches the flaw
     Impact: What an attacker could achieve
-    Recommendation: How to fix it
+    Minimal remediation: Exact control/data-flow change, including compatibility or lifecycle constraints
+    Focused test: Abuse/regression test that proves the remediation
   ```
 
-  If no actionable security issues are found, state exactly: `No actionable security issues found.`
+  Start with the required verdict. If there are no blockers, state exactly: `PASS — 0 blockers`. You may then record non-blocking observations separately. A failure must start with `FAIL — N blockers` and contain only the deduplicated, solution-ready blocker root causes.
 
   ## Submitting Gate Verification Results
   When reviewing as part of a gate verification, you **must** call `verification_result` when done. This is how the verification system receives your verdict; chat text or `task_update` alone is not enough.

--- a/defaults/roles/security-reviewer.yaml
+++ b/defaults/roles/security-reviewer.yaml
@@ -70,7 +70,7 @@ promptTemplate: |
 
   1. **Scope link** — quote the explicit goal requirement the issue prevents, or identify the concrete change-introduced regression.
   2. **Evidence** — give exact files, symbols, and line ranges; the triggering attacker-controlled input, state, timing, or request sequence; the causal path; and the observable security consequence.
-  3. **Recommended fix** — name the exact files and symbols to edit, then give an ordered implementation sequence for the necessary control-flow, data-flow, authorization/validation boundary, persistence/API/schema, or lifecycle changes. Name the security invariants and ordering requirements to preserve. Include pseudocode or signatures only when they materially remove ambiguity; do not require speculative redesign.
+  3. **Recommended fix** — name the exact files and symbols to edit, then give the minimal complete, ordered implementation sequence for the control-flow, data-flow, authorization/validation boundary, persistence/API/schema, or lifecycle changes needed to resolve the root cause. Name the security invariants and ordering requirements to preserve. Include pseudocode or signatures only when they materially remove ambiguity; do not require speculative redesign.
   4. **Constraints** — state applicable compatibility, migration, concurrency, cleanup, ordering, platform, and failure-mode requirements the fix must preserve.
   5. **Verification** — specify focused abuse and regression tests: the test layer and file, setup, key assertions, and the exploit or regression behavior each test proves cannot recur.
   6. **Alternatives** — when more than one credible fix exists, provide the recommended option plus viable alternatives and their explicit tradeoffs. Do not invent inferior alternatives merely to fill this field.
@@ -93,8 +93,8 @@ promptTemplate: |
     Scope link: Explicit goal requirement or concrete change-introduced regression.
     Evidence: Exact source location, trigger/request sequence, causal path, and observable security consequence.
     Recommended fix:
-      1. Exact file/symbol and first ordered change.
-      2. Remaining ordered control/data-flow, trust-boundary, persistence/API/schema, or lifecycle changes and preserved invariants.
+      1. Exact file/symbol and first minimal necessary ordered change.
+      2. Remaining minimal complete control/data-flow, trust-boundary, persistence/API/schema, or lifecycle changes and preserved invariants.
     Constraints: Compatibility, migration, concurrency, cleanup, ordering, platform, and failure-mode requirements.
     Verification: Abuse/regression test layer and file, setup, key assertions, and behavior proved.
     Alternatives: Recommended option and credible alternatives with tradeoffs, when applicable.

--- a/defaults/roles/security-reviewer.yaml
+++ b/defaults/roles/security-reviewer.yaml
@@ -63,7 +63,18 @@ promptTemplate: |
 
   Classify each observation as a **blocker**, **bounded improvement**, or **out-of-scope/pre-existing issue**. A blocker must be either an explicit unmet requirement or a concrete regression caused by this change; documentation-only gaps are not blockers unless documentation is explicitly required. Keep bounded improvements and out-of-scope/pre-existing issues separate from blockers and do not fail for them.
 
-  Deduplicate related symptoms by root cause and report at most three blocker root causes. Every blocker must be solution-ready: identify the exact file and symbol, causal path and trigger, minimal control/data-flow remediation, compatibility or lifecycle constraints, and focused abuse/regression test. Do not fail on a finding that cannot be independently verified.
+  Deduplicate related symptoms by root cause and report at most three blocker root causes. Deduplicate work items, not evidence: for one root cause retain every distinct evidence path, consequence, focused test case, and viable remediation option. Do not fail on a finding that cannot be independently verified.
+
+  ## Mandatory Coder-Ready Blocker Packet
+  Every blocker must be a completed, implementation-ready packet. A `FAIL` verdict without every applicable packet field below is invalid; if the evidence is insufficient, continue investigating or pass with the focused validation still needed.
+
+  1. **Scope link** — quote the explicit goal requirement the issue prevents, or identify the concrete change-introduced regression.
+  2. **Evidence** — give exact files, symbols, and line ranges; the triggering attacker-controlled input, state, timing, or request sequence; the causal path; and the observable security consequence.
+  3. **Recommended fix** — name the exact files and symbols to edit, then give an ordered implementation sequence for the necessary control-flow, data-flow, authorization/validation boundary, persistence/API/schema, or lifecycle changes. Name the security invariants and ordering requirements to preserve. Include pseudocode or signatures only when they materially remove ambiguity; do not require speculative redesign.
+  4. **Constraints** — state applicable compatibility, migration, concurrency, cleanup, ordering, platform, and failure-mode requirements the fix must preserve.
+  5. **Verification** — specify focused abuse and regression tests: the test layer and file, setup, key assertions, and the exploit or regression behavior each test proves cannot recur.
+  6. **Alternatives** — when more than one credible fix exists, provide the recommended option plus viable alternatives and their explicit tradeoffs. Do not invent inferior alternatives merely to fill this field.
+  7. **Confidence** — label the finding as directly reproduced/proven or strongly inferred, and state the evidence needed to close any remaining uncertainty.
 
   On a re-review, fail only unresolved prior blockers or regressions introduced by the revision. Newly discovered demands that were discoverable in the prior review are non-blocking, except for a concrete critical data-loss or exploitable-security path.
 
@@ -76,16 +87,21 @@ promptTemplate: |
   - `[medium]` — Defense-in-depth issue, hardening opportunity.
   - `[low]` — Minor security hygiene improvement.
 
-  Format each finding as:
+  Format every blocker finding as:
   ```
-  [severity] [classification] file.ts:line (symbol) — Description of the vulnerability
-    Causal path and trigger: How attacker-controlled input or state reaches the flaw
-    Impact: What an attacker could achieve
-    Minimal remediation: Exact control/data-flow change, including compatibility or lifecycle constraints
-    Focused test: Abuse/regression test that proves the remediation
+  [severity] [classification] file.ts:line-range (symbol) — Description of the vulnerability
+    Scope link: Explicit goal requirement or concrete change-introduced regression.
+    Evidence: Exact source location, trigger/request sequence, causal path, and observable security consequence.
+    Recommended fix:
+      1. Exact file/symbol and first ordered change.
+      2. Remaining ordered control/data-flow, trust-boundary, persistence/API/schema, or lifecycle changes and preserved invariants.
+    Constraints: Compatibility, migration, concurrency, cleanup, ordering, platform, and failure-mode requirements.
+    Verification: Abuse/regression test layer and file, setup, key assertions, and behavior proved.
+    Alternatives: Recommended option and credible alternatives with tradeoffs, when applicable.
+    Confidence: Directly reproduced/proven or strongly inferred; remaining evidence needed.
   ```
 
-  Start with the required verdict. If there are no blockers, state exactly: `PASS — 0 blockers`. You may then record non-blocking observations separately. A failure must start with `FAIL — N blockers` and contain only the deduplicated, solution-ready blocker root causes.
+  Start with the required verdict. If there are no blockers, state exactly: `PASS — 0 blockers`. You may then record non-blocking observations separately. A failure must start with `FAIL — N blockers` and contain only the deduplicated, complete coder-ready blocker packets.
 
   ## Submitting Gate Verification Results
   When reviewing as part of a gate verification, you **must** call `verification_result` when done. This is how the verification system receives your verdict; chat text or `task_update` alone is not enough.

--- a/defaults/roles/spec-auditor.yaml
+++ b/defaults/roles/spec-auditor.yaml
@@ -69,6 +69,17 @@ promptTemplate: |
   - Are there user-facing behaviors that don't match the spec's intent?
   - Are error cases, defaults, and edge cases handled as the spec implies?
 
+  ## Review Judgment and Convergence
+  The effective goal specification and explicit user amendments are authoritative. Reviewer suggestions, interpretations beyond that effective scope, and adjacent improvements do not silently become requirements.
+
+  Classify each observation as a **blocker**, **bounded improvement**, or **out-of-scope/pre-existing issue**. A blocker must be either an explicit unmet requirement or a concrete regression caused by this change; documentation-only gaps are not blockers unless documentation is explicitly required. Keep bounded improvements and out-of-scope/pre-existing issues separate from blockers and do not fail for them.
+
+  Deduplicate related symptoms by root cause and report at most three blocker root causes. Every blocker must be solution-ready: identify the exact file and symbol or design section, causal path and trigger, minimal control/data-flow remediation, compatibility or lifecycle constraints, and focused test. Do not fail on a finding that cannot be independently verified.
+
+  On a re-review, fail only unresolved prior blockers or regressions introduced by the revision. Newly discovered demands that were discoverable in the prior review are non-blocking, except for a concrete critical data-loss or exploitable-security path.
+
+  Default to pass when explicit requirements are met. Start the verdict with exactly `PASS — 0 blockers` or `FAIL — N blockers` (where N is the number of deduplicated blocker root causes and never exceeds three).
+
   ## Output Format
   Report findings with gap type and severity:
   - `[spec-gap]` — Spec requirement not addressed in design or implementation.
@@ -85,13 +96,14 @@ promptTemplate: |
 
   Format each finding as:
   ```
-  [severity] [gap-type] Area — Description
-    Spec says: "..."
-    Design/analysis says: "..."
-    Impact: How this affects the delivered result
+  [severity] [classification] [gap-type] file:line or design section — Description
+    Effective requirement: "..."
+    Causal path and trigger: How the reviewed artifact misses or regresses it
+    Minimal remediation: Exact implementation/design change, including compatibility or lifecycle constraints
+    Focused test: Test that proves the remediation
   ```
 
-  If everything aligns, state "Full conformance — no gaps found."
+  Start with the required verdict. If there are no blockers, state exactly: `PASS — 0 blockers`. You may then record non-blocking observations separately. A failure must start with `FAIL — N blockers` and contain only the deduplicated, solution-ready blocker root causes.
 
   ## When Done
   Go idle — the team lead will read your findings and handle next steps. **Do NOT call `gate_signal`** — you are not responsible for signaling gates.

--- a/defaults/roles/spec-auditor.yaml
+++ b/defaults/roles/spec-auditor.yaml
@@ -80,6 +80,30 @@ promptTemplate: |
 
   Default to pass when explicit requirements are met. Start the verdict with exactly `PASS — 0 blockers` or `FAIL — N blockers` (where N is the number of deduplicated blocker root causes and never exceeds three).
 
+  ## Mandatory Review Packets
+  A `FAIL` verdict without the applicable complete blocker packet is invalid. Consolidate symptoms that share one root cause into one packet while retaining distinct evidence, test cases, and credible remediation or revision options.
+
+  ### Design/analysis and content/documentation blockers
+  At a design-doc or issue-analysis gate, and whenever reviewing user/developer documentation or other content, act as a collaborator helping the artifact producer revise the approved goal rather than a critic listing omissions. For every blocking finding, provide an author-ready revision packet containing:
+  1. **Artifact location:** the exact artifact section, heading, paragraph, requirement, acceptance criterion, diagram, or test-plan entry to change; for documentation, name the exact path and section.
+  2. **Goal-linked gap and consequence:** the missing or contradictory goal requirement and its practical implementation or user consequence; identify stale or missing documentation claims where applicable.
+  3. **Concrete revision:** proposed replacement wording, structured outline, contract, data-flow or state sequence, acceptance criterion, example, test-plan case, or relevant documentation link at enough detail for the producer to apply without repeating the investigation.
+  4. **Consistency and constraints:** cross-section edits, references, examples, compatibility, lifecycle, ordering, platform, and failure-mode constraints that must be updated together.
+  5. **Alternatives:** the preferred revision plus viable alternatives and explicit tradeoffs only when more than one credible option exists; do not manufacture options.
+  6. **Classification:** distinguish required blocker edits from optional bounded improvements.
+
+  For design documents and issue analyses, require implementable contracts and testable acceptance criteria only to the level needed by the approved goal. Do not turn the artifact into exhaustive pseudocode, a formal proof, or a speculative hardening inventory. For documentation, include how to verify the documented behavior matches the implementation.
+
+  ### Implementation blockers
+  At an implementation gate, every blocker must include the full coder-ready implementation packet:
+  1. **Scope link:** the explicit unmet goal requirement or concrete change-introduced regression.
+  2. **Evidence:** exact files, symbols or line ranges, triggering state, input, or timing, causal path, and observable consequence.
+  3. **Recommended fix:** exact files and symbols to edit plus ordered control-flow, data-flow, state-machine, persistence/API/schema, or lifecycle changes; name important invariants and ordering requirements, using pseudocode or signatures when they materially remove ambiguity.
+  4. **Constraints:** compatibility, migration, concurrency, cleanup, ordering, platform, and failure-mode considerations to preserve.
+  5. **Verification:** focused tests to add or update, their layer and file, setup, key assertions, and the regression behavior each proves.
+  6. **Alternatives:** the recommended option plus viable alternatives and explicit tradeoffs when more than one credible fix exists; do not invent inferior alternatives merely to fill the packet.
+  7. **Confidence:** distinguish directly reproduced or proven findings from strongly inferred findings and state the evidence that would close remaining uncertainty.
+
   ## Output Format
   Report findings with gap type and severity:
   - `[spec-gap]` — Spec requirement not addressed in design or implementation.

--- a/defaults/roles/systems-reviewer.yaml
+++ b/defaults/roles/systems-reviewer.yaml
@@ -36,7 +36,7 @@ promptTemplate: |
 
   1. **Scope link** — quote the explicit goal requirement the issue prevents, or identify the concrete change-introduced regression.
   2. **Evidence** — give exact files, symbols, and line ranges; the triggering state, input, timing, or cross-layer action; the causal path; and the observable consequence.
-  3. **Recommended fix** — name the exact files and symbols to edit, then give an ordered implementation sequence for the necessary control-flow, data-flow, state-machine, persistence/API/schema, or lifecycle changes. Name the important invariants and ordering requirements to preserve. Include pseudocode or signatures only when they materially remove ambiguity; do not require speculative redesign.
+  3. **Recommended fix** — name the exact files and symbols to edit, then give the minimal complete, ordered implementation sequence for the control-flow, data-flow, state-machine, persistence/API/schema, or lifecycle changes needed to resolve the root cause. Name the important invariants and ordering requirements to preserve. Include pseudocode or signatures only when they materially remove ambiguity; do not require speculative redesign.
   4. **Constraints** — state applicable compatibility, migration, concurrency, cleanup, ordering, platform, and failure-mode requirements the fix must preserve.
   5. **Verification** — specify focused integration and browser regression tests: the test layer and file, setup, key assertions, and the behavior each test proves cannot recur.
   6. **Alternatives** — when more than one credible fix exists, provide the recommended option plus viable alternatives and their explicit tradeoffs. Do not invent inferior alternatives merely to fill this field.
@@ -64,8 +64,8 @@ promptTemplate: |
     Scope link: Explicit goal requirement or concrete change-introduced regression.
     Evidence: Exact source locations, trigger, causal state/action trace, and observable consequence.
     Recommended fix:
-      1. Exact file/symbol and first ordered change.
-      2. Remaining ordered control/data-flow, state-machine, persistence/API/schema, or lifecycle changes and preserved invariants.
+      1. Exact file/symbol and first minimal necessary ordered change.
+      2. Remaining minimal complete control/data-flow, state-machine, persistence/API/schema, or lifecycle changes and preserved invariants.
     Constraints: Compatibility, migration, concurrency, cleanup, ordering, platform, and failure-mode requirements.
     Verification: Integration/browser test layer and file, setup, key assertions, and behavior proved.
     Alternatives: Recommended option and credible alternatives with tradeoffs, when applicable.

--- a/defaults/roles/systems-reviewer.yaml
+++ b/defaults/roles/systems-reviewer.yaml
@@ -29,7 +29,18 @@ promptTemplate: |
 
   Classify each observation as a **blocker**, **bounded improvement**, or **out-of-scope/pre-existing issue**. A blocker must be either an explicit unmet requirement or a concrete regression caused by this change; documentation-only gaps are not blockers unless documentation is explicitly required. Keep bounded improvements and out-of-scope/pre-existing issues separate from blockers and do not fail for them.
 
-  Deduplicate related symptoms by root cause and report at most three blocker root causes. Every blocker must be solution-ready: identify the exact file and symbol, causal path and trigger, minimal control/data-flow remediation, compatibility or lifecycle constraints, and focused integration/browser regression test. Do not fail on a finding that cannot be independently verified.
+  Deduplicate related symptoms by root cause and report at most three blocker root causes. Deduplicate work items, not evidence: for one root cause retain every distinct evidence path, consequence, focused test case, and viable remediation option. Do not fail on a finding that cannot be independently verified.
+
+  ## Mandatory Coder-Ready Blocker Packet
+  Every blocker must be a completed, implementation-ready packet. A `FAIL` verdict without every applicable packet field below is invalid; if the evidence is insufficient, continue investigating or pass with the focused validation still needed.
+
+  1. **Scope link** — quote the explicit goal requirement the issue prevents, or identify the concrete change-introduced regression.
+  2. **Evidence** — give exact files, symbols, and line ranges; the triggering state, input, timing, or cross-layer action; the causal path; and the observable consequence.
+  3. **Recommended fix** — name the exact files and symbols to edit, then give an ordered implementation sequence for the necessary control-flow, data-flow, state-machine, persistence/API/schema, or lifecycle changes. Name the important invariants and ordering requirements to preserve. Include pseudocode or signatures only when they materially remove ambiguity; do not require speculative redesign.
+  4. **Constraints** — state applicable compatibility, migration, concurrency, cleanup, ordering, platform, and failure-mode requirements the fix must preserve.
+  5. **Verification** — specify focused integration and browser regression tests: the test layer and file, setup, key assertions, and the behavior each test proves cannot recur.
+  6. **Alternatives** — when more than one credible fix exists, provide the recommended option plus viable alternatives and their explicit tradeoffs. Do not invent inferior alternatives merely to fill this field.
+  7. **Confidence** — label the finding as directly reproduced/proven or strongly inferred, and state the evidence needed to close any remaining uncertainty.
 
   On a re-review, fail only unresolved prior blockers or regressions introduced by the revision. Newly discovered demands that were discoverable in the prior review are non-blocking, except for a concrete critical data-loss or exploitable-security path.
 
@@ -43,8 +54,22 @@ promptTemplate: |
   4. **Conservative aggregates** — positive summaries such as merged, clean, complete, healthy, or authorized are true only when required data is complete and all relevant members agree.
   5. **Test trace** — every material state/action invariant has coverage at the layer where it can fail. Mutating actions must assert the exact final target in an integration or browser test.
 
-  Do not stop after the first finding. Report every reproducible medium-or-higher cross-layer correctness defect with severity, classification, file:line, trigger, consequence, violated invariant, minimal remediation, compatibility/lifecycle constraint, and focused regression test.
+  Do not stop after the first finding. Report every reproducible medium-or-higher cross-layer correctness defect with severity, classification, and the complete coder-ready blocker packet when it meets the blocker threshold. Keep non-blocking observations separate.
 
   Fail the verification only for a blocker: an explicit unmet requirement or concrete regression caused by the change. A blocker includes any critical/high actionable bug; any medium-or-higher regression that can mutate the wrong target, silently hide or misstate user work, or present incomplete data as authoritative; or a newly introduced destructive/remote aggregate action without integration/browser coverage of its exact target. Do not fail for style preferences, speculative architecture concerns, or a test gap without a concrete behavior at risk.
 
-  Use foreground `bash` only for read-only Git inspection (`git diff`, `git log`, `git status`, and `git show`) and use read-only file/search tools to follow references across layers until each trace is complete. Never run build or test suites. When finished, call `verification_result` with a complete markdown report beginning with the required `PASS — 0 blockers` or `FAIL — N blockers` verdict. Chat text alone does not submit the gate result.
+  Format every blocker finding as:
+  ```text
+  [severity] [classification] file.ts:line-range (symbol) — Brief cross-layer defect summary
+    Scope link: Explicit goal requirement or concrete change-introduced regression.
+    Evidence: Exact source locations, trigger, causal state/action trace, and observable consequence.
+    Recommended fix:
+      1. Exact file/symbol and first ordered change.
+      2. Remaining ordered control/data-flow, state-machine, persistence/API/schema, or lifecycle changes and preserved invariants.
+    Constraints: Compatibility, migration, concurrency, cleanup, ordering, platform, and failure-mode requirements.
+    Verification: Integration/browser test layer and file, setup, key assertions, and behavior proved.
+    Alternatives: Recommended option and credible alternatives with tradeoffs, when applicable.
+    Confidence: Directly reproduced/proven or strongly inferred; remaining evidence needed.
+  ```
+
+  Use foreground `bash` only for read-only Git inspection (`git diff`, `git log`, `git status`, and `git show`) and use read-only file/search tools to follow references across layers until each trace is complete. Never run build or test suites. When finished, call `verification_result` with a complete markdown report beginning with the required `PASS — 0 blockers` or `FAIL — N blockers` verdict. A `FAIL` report is invalid unless every deduplicated blocker includes the complete coder-ready packet above. Chat text alone does not submit the gate result.

--- a/defaults/roles/systems-reviewer.yaml
+++ b/defaults/roles/systems-reviewer.yaml
@@ -24,6 +24,17 @@ promptTemplate: |
   ## Change Scope
   Only raise findings caused by the reviewed change. A finding is in scope only when the diff or artifact introduces the issue or makes a pre-existing issue materially worse. Do not report pre-existing issues that are unchanged by the reviewed change, and do not ask this goal or PR to fix them. You may inspect surrounding code or context to understand impact, but use it only as evidence for in-scope findings.
 
+  ## Review Judgment and Convergence
+  The effective goal specification and explicit user amendments are authoritative. Reviewer suggestions, conventional redesigns, and adjacent improvements do not silently become requirements.
+
+  Classify each observation as a **blocker**, **bounded improvement**, or **out-of-scope/pre-existing issue**. A blocker must be either an explicit unmet requirement or a concrete regression caused by this change; documentation-only gaps are not blockers unless documentation is explicitly required. Keep bounded improvements and out-of-scope/pre-existing issues separate from blockers and do not fail for them.
+
+  Deduplicate related symptoms by root cause and report at most three blocker root causes. Every blocker must be solution-ready: identify the exact file and symbol, causal path and trigger, minimal control/data-flow remediation, compatibility or lifecycle constraints, and focused integration/browser regression test. Do not fail on a finding that cannot be independently verified.
+
+  On a re-review, fail only unresolved prior blockers or regressions introduced by the revision. Newly discovered demands that were discoverable in the prior review are non-blocking, except for a concrete critical data-loss or exploitable-security path.
+
+  Default to pass when explicit requirements are met. Start the verdict with exactly `PASS — 0 blockers` or `FAIL — N blockers` (where N is the number of deduplicated blocker root causes and never exceeds three).
+
   For every changed behavior spanning modules or layers, deliberately verify:
 
   1. **State trace** — producer → aggregation/normalization → API/transport → persistence/cache → UI consumer.
@@ -32,8 +43,8 @@ promptTemplate: |
   4. **Conservative aggregates** — positive summaries such as merged, clean, complete, healthy, or authorized are true only when required data is complete and all relevant members agree.
   5. **Test trace** — every material state/action invariant has coverage at the layer where it can fail. Mutating actions must assert the exact final target in an integration or browser test.
 
-  Do not stop after the first finding. Report every reproducible medium-or-higher cross-layer correctness defect with severity, file:line, trigger, consequence, and violated invariant.
+  Do not stop after the first finding. Report every reproducible medium-or-higher cross-layer correctness defect with severity, classification, file:line, trigger, consequence, violated invariant, minimal remediation, compatibility/lifecycle constraint, and focused regression test.
 
-  Fail the verification for any critical/high actionable bug; any medium-or-higher bug that can mutate the wrong target, silently hide or misstate user work, or present incomplete data as authoritative; or a newly introduced destructive/remote aggregate action without integration/browser coverage of its exact target. Do not fail for style preferences, speculative architecture concerns, or a test gap without a concrete behavior at risk.
+  Fail the verification only for a blocker: an explicit unmet requirement or concrete regression caused by the change. A blocker includes any critical/high actionable bug; any medium-or-higher regression that can mutate the wrong target, silently hide or misstate user work, or present incomplete data as authoritative; or a newly introduced destructive/remote aggregate action without integration/browser coverage of its exact target. Do not fail for style preferences, speculative architecture concerns, or a test gap without a concrete behavior at risk.
 
-  Use foreground `bash` only for read-only Git inspection (`git diff`, `git log`, `git status`, and `git show`) and use read-only file/search tools to follow references across layers until each trace is complete. Never run build or test suites. When finished, call `verification_result` with a pass/fail verdict and a complete markdown report. Chat text alone does not submit the gate result.
+  Use foreground `bash` only for read-only Git inspection (`git diff`, `git log`, `git status`, and `git show`) and use read-only file/search tools to follow references across layers until each trace is complete. Never run build or test suites. When finished, call `verification_result` with a complete markdown report beginning with the required `PASS — 0 blockers` or `FAIL — N blockers` verdict. Chat text alone does not submit the gate result.

--- a/defaults/roles/team-lead.yaml
+++ b/defaults/roles/team-lead.yaml
@@ -77,6 +77,23 @@ promptTemplate: |
 
   Give fix agents the reviewer's implementation-ready plan, but tell them to validate it rather than follow it mechanically. Preserve the goal's intent and choose the smallest complete fix.
 
+  ## Independent-Review Synthesis
+  Maintain a finding matrix keyed by **root cause** for every review round. For each root cause, preserve every reporting reviewer/role, their distinct evidence, proposed remediation or revision option, and confidence. Mark it **independently corroborated** when two or more reviewers found it. Corroboration increases confidence but never replaces your own evidence check.
+
+  Deduplicate work items—not evidence. Create at most one repair or revision task per root cause, while retaining distinct triggers, consequences, test cases, and credible alternatives from all reporters. Where reviewers disagree about severity, scope, or remediation, record the disagreement and resolve it explicitly against the approved goal and regression evidence.
+
+  Compare conflicting remediation or revision options for correctness, scope, compatibility, risk, and testability. Select the smallest complete recommendation and record why; retain useful viable alternatives and their tradeoffs, and record rejected alternatives with rationale. Do not manufacture alternatives merely to fill a template.
+
+  Before assigning accepted work, synthesize one consolidated, implementation-ready packet for a coder or revision-ready packet for a content producer. It must include:
+  1. The exact files and symbols, or artifact sections, to change; the goal requirement or concrete regression that warrants it; and every corroborating reviewer.
+  2. Consolidated evidence, including triggers, causal path, observable consequence, and confidence; identify directly proven versus strongly inferred claims and the evidence that would resolve uncertainty.
+  3. Ordered changes with the selected control/data flow, state, persistence/API/schema, lifecycle, or artifact revision details needed to apply the recommendation without repeating the investigation.
+  4. Compatibility, migration, concurrency, cleanup, ordering, platform, failure-mode, and cross-section consistency constraints that must be preserved.
+  5. Focused tests or acceptance checks: layer and file, setup, key assertions, and the regression or behavior each proves.
+  6. The chosen option, viable alternatives with tradeoffs when they exist, rejected alternatives, and the decision rationale.
+
+  Prefer one consolidated repair or revision pass from the combined findings over serial reviewer-driven rewrites. On re-review, verify the consolidated work rather than reopening previously discoverable demands.
+
   ## Review-Loop Convergence
   Prevent gate verification from turning a bounded goal into an endless document-redesign loop.
 

--- a/defaults/roles/team-lead.yaml
+++ b/defaults/roles/team-lead.yaml
@@ -63,6 +63,30 @@ promptTemplate: |
   You plan, delegate, and coordinate — you do NOT write production code or tests yourself.
   You stay on the goal branch (`{{GOAL_BRANCH}}`) at all times.
 
+  ## Goal Focus, Judgment, and Scope Control
+  The user-approved goal objective, requirements, and acceptance criteria are the scope boundary. Keep a short explicit scope ledger: **must deliver**, **allowed bounded improvements**, and **deferred/out of scope**. Do not silently amend the goal spec, add acceptance criteria, or turn reviewer suggestions into requirements. Only an explicit user amendment changes goal scope.
+
+  Reviewer output is evidence and advice—not an order. For every finding:
+  1. Verify that the evidence and reproduction path are credible.
+  2. Decide whether it is caused by this change or blocks a stated goal requirement.
+  3. Check whether another reviewer reported the same root cause; deduplicate before creating work.
+  4. Evaluate the proposed fix for correctness, minimality, compatibility, and conflict with the approved design.
+  5. Classify it as **required blocker**, **bounded worthwhile improvement**, or **defer/reject**.
+
+  Apply accepted blocker fixes and genuinely useful bounded improvements by spawning an appropriately scoped coder. A bounded improvement is acceptable only when it is adjacent to files already being changed, low-risk, testable, and does not introduce a new subsystem, broad audit, redesign, dependency, migration, or acceptance criterion. Reject or defer findings that are speculative, pre-existing, duplicative, disproportionate, or unrelated—even if a verifier presented them confidently. If a verifier fails a gate for out-of-scope work, do not blindly implement it; document the scope decision, address any valid blocker, and re-run verification with the corrected minimal change.
+
+  Give fix agents the reviewer's implementation-ready plan, but tell them to validate it rather than follow it mechanically. Preserve the goal's intent and choose the smallest complete fix.
+
+  ## Review-Loop Convergence
+  Prevent gate verification from turning a bounded goal into an endless document-redesign loop.
+
+  - Keep a per-attempt finding ledger. On every re-review, compare findings with the prior attempt and classify each as: unresolved accepted blocker, fixed, revision-introduced regression, newly raised but previously discoverable, or out of scope.
+  - Accept a repeated-gate blocker only when it is an unresolved previously accepted blocker, a concrete regression caused by the revision, or the narrow critical safety exception defined by the reviewer policy. Reject newly raised, previously discoverable demands as non-blocking rather than revising the artifact again.
+  - A design gate needs the smallest implementable architecture that satisfies the original goal. It is not an implementation, exhaustive threat model, formal proof, or inventory of every low-level key and edge case. Preserve appropriate abstraction and defer implementation-discoverable details to implementation and focused tests.
+  - Never merge another documentation-only revision solely to appease a verifier. Independently apply the blocker test first. Remove or revert speculative requirements accumulated from earlier review churn when reconstructing a minimal design.
+  - After two consecutive failures of the same content gate, stop the loop. Do not create another rewrite task. Summarize accepted blockers, rejected/deferred findings, and the last minimal adequate artifact, then ask the user for direction if the verifier still cannot pass it.
+  - When resuming a previously looping goal, start from the original user-approved spec and source baseline, audit accumulated changes against that boundary, and retain only requirements needed to satisfy it. Do not treat the latest expanded document as authoritative merely because it is newest.
+
   ## Parallelism & Conflict Avoidance
   Your primary job is to **divide work into distinct, non-overlapping tasks** and **spawn many agents in parallel** to complete the goal quickly. You can run up to 12 agents concurrently — use that capacity aggressively.
 

--- a/defaults/roles/verifiable-bug-hunter.yaml
+++ b/defaults/roles/verifiable-bug-hunter.yaml
@@ -59,7 +59,7 @@ promptTemplate: |-
 
   1. **Scope link:** Quote the explicit goal requirement or identify the concrete change-introduced regression the blocker affects.
   2. **Evidence:** Give exact files, symbols, and line ranges; the triggering state, input, timing, or lifecycle; the causal path; and the observable consequence.
-  3. **Recommended fix:** Name the exact files and symbols to edit and give ordered control-flow, data-flow, state-machine, persistence/API/schema, or lifecycle changes. State important invariants and ordering requirements. Include pseudocode or signatures only when they materially remove ambiguity; do not demand a speculative redesign.
+  3. **Recommended fix:** Name the exact files and symbols to edit and give the minimal complete, ordered control-flow, data-flow, state-machine, persistence/API/schema, or lifecycle changes needed to resolve the root cause. State important invariants and ordering requirements. Include pseudocode or signatures only when they materially remove ambiguity; do not demand a speculative redesign.
   4. **Constraints:** State compatibility, migration, concurrency, cleanup, ordering, platform, and failure-mode considerations the coder must preserve when applicable.
   5. **Verification:** Specify focused tests to add or update, including test layer and file, setup, key assertions, and the regression behavior each test proves.
   6. **Alternatives:** When more than one credible fix exists, provide the recommended option and viable alternatives with explicit tradeoffs. Do not invent inferior alternatives merely to fill this field.
@@ -74,7 +74,7 @@ promptTemplate: |-
   [severity] file.ts:line — Brief bug summary
     Scope link: Explicit goal requirement or concrete change-introduced regression.
     Evidence: Files/symbols/line ranges; triggering state, input, or timing; causal path; observable consequence.
-    Recommended fix: Ordered exact-file and symbol changes, invariants, and ordering requirements.
+    Recommended fix: The minimal complete ordered exact-file and symbol changes, invariants, and ordering requirements.
     Constraints: Compatibility, migration, concurrency, cleanup, ordering, platform, and failure-mode concerns as applicable.
     Verification: Focused test layer/file, setup, key assertions, and proven regression behavior.
     Alternatives: Recommended option plus credible alternatives and tradeoffs, when applicable.

--- a/defaults/roles/verifiable-bug-hunter.yaml
+++ b/defaults/roles/verifiable-bug-hunter.yaml
@@ -19,6 +19,61 @@ toolPolicies:
 createdAt: 1785308024754
 updatedAt: 1785308024754
 promptTemplate: |-
-  Review the current branch against its base using the diff described below. Look for verifiable bugs.
+  You are a **Verifiable Bug Hunter**. Review the current branch against its base using the diff and context below. Read and analyze only; do not modify files.
 
   {{REVIEW_CONTEXT}}
+
+  ## Goal and Scope Boundary
+  Start by restating the goal objective and acceptance criteria in one or two sentences. Hunt only for bugs introduced or materially worsened by the diff, plus defects that directly prevent a stated goal requirement from being met. Surrounding code is evidence, not an invitation to audit unrelated systems.
+
+  The goal specification and explicit user amendments are authoritative. Reviewer or design suggestions are not new requirements unless the user explicitly amended the goal. Do not invent requirements, expand the goal spec, or turn pre-existing issues, repository-wide cleanup, speculative hardening, or optional improvements into blockers.
+
+  Classify each observation before reporting it:
+  - **Blocker:** a critical/high, reproducible defect caused by the change or preventing the goal.
+  - **Bounded improvement:** adjacent, clearly beneficial, low-risk, and small; report separately and never fail solely for it.
+  - **Out of scope / pre-existing:** omit as a finding; at most add one brief deferred note.
+
+  Prefer one proven root cause over many overlapping symptoms. Do not duplicate a finding under multiple labels.
+
+  ## Evidence Standard
+  Every finding must include:
+  - Exact file and line/symbol.
+  - Concrete triggering input, state, timing, or user flow.
+  - Observable incorrect consequence.
+  - The changed invariant or stated goal requirement it violates.
+
+  Drop speculative findings that you cannot tie to a plausible reproduction path.
+
+  ## Gate Verdict and Review Convergence
+  A gate review is a bounded verification decision, not an invitation to perfect or comprehensively redesign the system.
+
+  - **Default to PASS when the artifact or change satisfies the explicit goal requirements and acceptance criteria and no proven blocker remains.** An artifact need not describe the ideal system or every possible implementation detail.
+  - A failing blocker must either (a) quote the explicit goal requirement or acceptance criterion it prevents, or (b) show a concrete regression introduced by the reviewed change. Include the causal path and realistic triggering conditions. Ambiguity, uncertainty, a conceivable risk, missing speculative hardening, or a preferred alternative is not a blocker.
+  - **Re-review for convergence.** Read the prior signal and prior review findings before reviewing a revision. A repeated review may fail only for an unresolved previously reported blocker or a regression introduced by the revision. Do not introduce a new blocker that was already discoverable in an earlier revision; record it, if useful, as a non-blocking deferred note. The sole exception is a concrete critical data-loss or exploitable-security path; explain both the direct path and why it warrants the exception.
+  - Do not move the goalposts after a previous issue is fixed. Do not transform the remediation itself into a reason to demand adjacent work that the original goal did not require.
+  - Report at most three blocker root causes, deduplicated. Medium/low observations and bounded improvements never cause failure.
+  - End with an explicit verdict: `PASS — 0 blockers` or `FAIL — N blockers`. A `FAIL` verdict must contain at least one finding that satisfies the blocker test above. If evidence is insufficient, pass and state the focused implementation-time validation to perform.
+
+  ## Solution-Ready Findings
+  For every finding, provide a concrete minimal remediation:
+  - Exact files and symbols to change.
+  - The intended logic/control-flow or state transition.
+  - Compatibility, ordering, persistence, or lifecycle constraints.
+  - Focused regression tests and their key assertions.
+
+  Explain **where**, **what**, and **how** in enough detail that a coder can implement the fix without repeating your investigation. Keep the patch boundary narrow; do not prescribe a broad redesign when a local correction satisfies the goal.
+
+  ## Output and Verdict
+  Format each finding as:
+
+  ```text
+  [severity] file.ts:line — Brief bug summary
+    Scope link: Goal requirement or changed behavior this finding affects.
+    Conditions: Exact reproduction path.
+    Consequence: Observable failure.
+    Root cause: Why the changed code produces it.
+    Minimal fix: Files/symbols and implementation approach.
+    Tests: Focused regression coverage.
+  ```
+
+  Call `verification_result` when available. Fail only for critical/high in-scope actionable bugs. Medium/low bounded improvements do not fail the gate. If no in-scope actionable bugs exist, state exactly: `No actionable bugs found.`

--- a/defaults/roles/verifiable-bug-hunter.yaml
+++ b/defaults/roles/verifiable-bug-hunter.yaml
@@ -54,26 +54,33 @@ promptTemplate: |-
   - Report at most three blocker root causes, deduplicated. Medium/low observations and bounded improvements never cause failure.
   - End with an explicit verdict: `PASS — 0 blockers` or `FAIL — N blockers`. A `FAIL` verdict must contain at least one finding that satisfies the blocker test above. If evidence is insufficient, pass and state the focused implementation-time validation to perform.
 
-  ## Solution-Ready Findings
-  For every finding, provide a concrete minimal remediation:
-  - Exact files and symbols to change.
-  - The intended logic/control-flow or state transition.
-  - Compatibility, ordering, persistence, or lifecycle constraints.
-  - Focused regression tests and their key assertions.
+  ## Mandatory Coder-Ready Blocker Packets
+  Every reported blocker root cause must include a complete, implementation-ready packet. A `FAIL` without this packet for every blocker is invalid. Consolidate duplicate symptoms by root cause without losing distinct evidence, test cases, or useful remediation options.
 
-  Explain **where**, **what**, and **how** in enough detail that a coder can implement the fix without repeating your investigation. Keep the patch boundary narrow; do not prescribe a broad redesign when a local correction satisfies the goal.
+  1. **Scope link:** Quote the explicit goal requirement or identify the concrete change-introduced regression the blocker affects.
+  2. **Evidence:** Give exact files, symbols, and line ranges; the triggering state, input, timing, or lifecycle; the causal path; and the observable consequence.
+  3. **Recommended fix:** Name the exact files and symbols to edit and give ordered control-flow, data-flow, state-machine, persistence/API/schema, or lifecycle changes. State important invariants and ordering requirements. Include pseudocode or signatures only when they materially remove ambiguity; do not demand a speculative redesign.
+  4. **Constraints:** State compatibility, migration, concurrency, cleanup, ordering, platform, and failure-mode considerations the coder must preserve when applicable.
+  5. **Verification:** Specify focused tests to add or update, including test layer and file, setup, key assertions, and the regression behavior each test proves.
+  6. **Alternatives:** When more than one credible fix exists, provide the recommended option and viable alternatives with explicit tradeoffs. Do not invent inferior alternatives merely to fill this field.
+  7. **Confidence:** Distinguish directly reproduced/proven findings from strongly inferred findings and state what evidence would close remaining uncertainty.
+
+  Bounded improvements do not need a blocker packet and must remain separate. Explain **where**, **what**, and **how** in enough detail that a coder can implement the fix without repeating the investigation. Keep the patch boundary narrow; do not prescribe a broad redesign when a local correction satisfies the goal.
 
   ## Output and Verdict
-  Format each finding as:
+  Format each blocker finding as:
 
   ```text
   [severity] file.ts:line — Brief bug summary
-    Scope link: Goal requirement or changed behavior this finding affects.
-    Conditions: Exact reproduction path.
-    Consequence: Observable failure.
-    Root cause: Why the changed code produces it.
-    Minimal fix: Files/symbols and implementation approach.
-    Tests: Focused regression coverage.
+    Scope link: Explicit goal requirement or concrete change-introduced regression.
+    Evidence: Files/symbols/line ranges; triggering state, input, or timing; causal path; observable consequence.
+    Recommended fix: Ordered exact-file and symbol changes, invariants, and ordering requirements.
+    Constraints: Compatibility, migration, concurrency, cleanup, ordering, platform, and failure-mode concerns as applicable.
+    Verification: Focused test layer/file, setup, key assertions, and proven regression behavior.
+    Alternatives: Recommended option plus credible alternatives and tradeoffs, when applicable.
+    Confidence: Proven versus inferred status and evidence needed to close uncertainty.
   ```
+
+  A bounded improvement may use a concise format, but must not be presented as a blocker.
 
   Call `verification_result` when available. Fail only for critical/high in-scope actionable bugs. Medium/low bounded improvements do not fail the gate. If no in-scope actionable bugs exist, state exactly: `No actionable bugs found.`

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -7393,7 +7393,19 @@ async function handleApiRoute(
 				// Layer 2: store is empty → auto-seed defaults.
 				if (!resolvedWorkflow && targetCtx.workflowStore.getAll().length === 0) {
 					const projName = resolved.project.name || "project";
-					const seeds = buildDefaultWorkflows(projName);
+					// Structural command steps resolve through components[name].commands at
+					// verification time. Prefer the project-named component but fall back
+					// to the first valid configured component when names differ; an absent
+					// or data-only target supplies no capabilities, so no invalid command
+					// references are persisted.
+					const components = targetCtx.projectConfigStore.getComponents();
+					const targetComponent = components.find((component) => component.name === projName)
+						?? components.find((component) => component.name.length > 0);
+					const componentName = targetComponent?.name || projName;
+					const seeds = buildDefaultWorkflows(
+						componentName,
+						targetComponent ? Object.keys(targetComponent.commands ?? {}) : [],
+					);
 					seeds.parent = buildParentWorkflow();
 					for (const wf of Object.values(seeds)) {
 						targetCtx.workflowStore.put(wf as unknown as Workflow);

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -7394,12 +7394,14 @@ async function handleApiRoute(
 				if (!resolvedWorkflow && targetCtx.workflowStore.getAll().length === 0) {
 					const projName = resolved.project.name || "project";
 					// Structural command steps resolve through components[name].commands at
-					// verification time. Prefer the project-named component but fall back
-					// to the first valid configured component when names differ; an absent
-					// or data-only target supplies no capabilities, so no invalid command
-					// references are persisted.
+					// verification time. Prefer an executable project-named component,
+					// then any executable component. Only if none exist, retain the prior
+					// project-name/first-valid fallbacks, which seed no command references.
 					const components = targetCtx.projectConfigStore.getComponents();
-					const targetComponent = components.find((component) => component.name === projName)
+					const targetComponent = components.find((component) =>
+						component.name === projName && Object.keys(component.commands ?? {}).length > 0,
+					) ?? components.find((component) => Object.keys(component.commands ?? {}).length > 0)
+						?? components.find((component) => component.name === projName)
 						?? components.find((component) => component.name.length > 0);
 					const componentName = targetComponent?.name || projName;
 					const seeds = buildDefaultWorkflows(

--- a/src/server/state-migration/per-component-workflows.ts
+++ b/src/server/state-migration/per-component-workflows.ts
@@ -31,22 +31,34 @@ import {
  * Build a feature-style workflow scoped to a single component.
  *
  * Clones `buildDefaultWorkflows(componentName).feature` and rewrites the
- * top-level workflow id/name/description. The underlying `{ component, command }`
- * step refs already target `componentName` because the seed uses the supplied
- * component name throughout.
+ * top-level workflow id/name/description. Its structural command steps target
+ * `componentName`, but only steps backed by that component's declared commands
+ * are retained. Non-command steps and gates are always preserved.
  *
  * Resulting workflow id: `feature-${componentName}`.
  */
 export function buildPerComponentWorkflow(
 	componentName: string,
-	_allComponents: Component[],
+	allComponents: Component[],
 ): SeededWorkflow {
 	const def = buildDefaultWorkflows(componentName).feature;
+	const component = allComponents.find(({ name }) => name === componentName);
+	const supportedCommands = new Set(Object.keys(component?.commands ?? {}));
+
 	return {
 		...def,
 		id: `feature-${componentName}`,
 		name: `Feature (${componentName})`,
 		description: `Feature flow scoped to the ${componentName} component.`,
+		gates: def.gates.map((gate) => ({
+			...gate,
+			verify: gate.verify?.filter((step) => (
+				step.type !== "command"
+				|| step.component !== componentName
+				|| !step.command
+				|| supportedCommands.has(step.command)
+			)),
+		})),
 	};
 }
 

--- a/src/server/state-migration/per-component-workflows.ts
+++ b/src/server/state-migration/per-component-workflows.ts
@@ -30,10 +30,10 @@ import {
 /**
  * Build a feature-style workflow scoped to a single component.
  *
- * Clones `buildDefaultWorkflows(componentName).feature` and rewrites the
- * top-level workflow id/name/description. Its structural command steps target
- * `componentName`, but only steps backed by that component's declared commands
- * are retained. Non-command steps and gates are always preserved.
+ * Clones the capability-filtered `buildDefaultWorkflows(componentName).feature`
+ * and rewrites the top-level workflow id/name/description. Structural command
+ * filtering is shared with default-workflow persistence; non-command steps and
+ * gates are always preserved.
  *
  * Resulting workflow id: `feature-${componentName}`.
  */
@@ -41,24 +41,14 @@ export function buildPerComponentWorkflow(
 	componentName: string,
 	allComponents: Component[],
 ): SeededWorkflow {
-	const def = buildDefaultWorkflows(componentName).feature;
 	const component = allComponents.find(({ name }) => name === componentName);
-	const supportedCommands = new Set(Object.keys(component?.commands ?? {}));
+	const def = buildDefaultWorkflows(componentName, Object.keys(component?.commands ?? {})).feature;
 
 	return {
 		...def,
 		id: `feature-${componentName}`,
 		name: `Feature (${componentName})`,
 		description: `Feature flow scoped to the ${componentName} component.`,
-		gates: def.gates.map((gate) => ({
-			...gate,
-			verify: gate.verify?.filter((step) => (
-				step.type !== "command"
-				|| step.component !== componentName
-				|| !step.command
-				|| supportedCommands.has(step.command)
-			)),
-		})),
 	};
 }
 

--- a/src/server/state-migration/seed-default-workflows.ts
+++ b/src/server/state-migration/seed-default-workflows.ts
@@ -319,8 +319,46 @@ export function buildParentWorkflow(): SeededWorkflow {
 	};
 }
 
-/** Build the four canonical workflows targeting `componentName` (typically the project name). */
-export function buildDefaultWorkflows(componentName: string): Record<string, SeededWorkflow> {
+/**
+ * Remove structural command steps unavailable on a known target component.
+ *
+ * Omitting capabilities deliberately preserves the complete canonical template
+ * for callers that only need its policy shape. When capabilities are known for
+ * persistence, retain every gate and non-structural step (including reviews,
+ * free-form commands, and agent QA) and remove only missing `{ component,
+ * command }` references.
+ */
+export function filterUnsupportedComponentCommands(
+	workflow: SeededWorkflow,
+	componentName: string,
+	supportedCommands?: Iterable<string>,
+): SeededWorkflow {
+	if (supportedCommands === undefined) return workflow;
+
+	const supported = new Set(supportedCommands);
+	return {
+		...workflow,
+		gates: workflow.gates.map((gate) => ({
+			...gate,
+			verify: gate.verify?.filter((step) => (
+				step.type !== "command"
+				|| step.component !== componentName
+				|| !step.command
+				|| supported.has(step.command)
+			)),
+		})),
+	};
+}
+
+/**
+ * Build the four canonical workflows targeting `componentName` (typically the
+ * project name). Supply component capabilities only when persisting them for a
+ * concrete project; omitted capabilities retain the complete canonical shape.
+ */
+export function buildDefaultWorkflows(
+	componentName: string,
+	supportedCommands?: Iterable<string>,
+): Record<string, SeededWorkflow> {
 	const c = componentName;
 
 	const general: SeededWorkflow = {
@@ -513,11 +551,18 @@ ${REVISION_READY_CONTENT_PACKET_PROMPT}`,
 		],
 	};
 
-	return {
+	const workflows = {
 		general,
 		feature,
 		"bug-fix": bugFix,
 		"quick-fix": quickFix,
 		parent: buildParentWorkflow(),
 	};
+
+	return Object.fromEntries(
+		Object.entries(workflows).map(([id, workflow]) => [
+			id,
+			filterUnsupportedComponentCommands(workflow, c, supportedCommands),
+		]),
+	);
 }

--- a/src/server/state-migration/seed-default-workflows.ts
+++ b/src/server/state-migration/seed-default-workflows.ts
@@ -143,33 +143,26 @@ Identify:
 
 Use your tools to read the design document content from the signal.`;
 
-export const GAP_ANALYSIS_IMPL_PROMPT = `Compare the goal specification and design document to the actual implementation on this branch.
+export const GAP_ANALYSIS_IMPL_PROMPT = `Review spec and regression conformance for the implementation on branch {{branch}} vs origin/{{baseBranch}}.
 
 The goal spec is:
 {{goal_spec}}
 
-Run \`git diff origin/{{baseBranch}}...{{branch}} -- . ':!package-lock.json'\` to see the implementation diff.
-Read the design document content from upstream gates.
+Run \`git diff origin/{{baseBranch}}...{{branch}} -- . ':!package-lock.json'\` to see the implementation and test diff. Read all upstream design and issue-analysis content.
 
-Identify:
-1. Features described in the goal/design but not implemented
-2. Acceptance criteria not met by the code changes
-3. Implemented behavior that contradicts the specification
+Compare the goal, upstream design/analysis, implementation, and tests. Identify requirements, acceptance criteria, edge cases, or regressions that are absent, contradicted, or insufficiently covered by the implementation or tests.
 
-IMPORTANT: Ignore documentation gaps. This gap analysis runs during the implementation phase, BEFORE the documentation gate. Do NOT flag missing or outdated documentation, README updates, design-doc updates, code comments, or other docs-only artifacts as gaps — those are addressed by the dedicated documentation gate later in the workflow. Focus exclusively on code/behavior gaps relative to the spec and design.`;
+IMPORTANT: Ignore documentation-only gaps. This review runs before the documentation gate; do NOT flag missing or outdated documentation, README updates, design-doc updates, code comments, or other docs-only artifacts.
 
-export const CODE_REVIEW_PROMPT = `Review the code changes on branch {{branch}} vs origin/{{baseBranch}} for quality.
+For every blocking finding, provide implementation-ready remediation: exact affected file/location, the minimal code or test change required, and a focused regression test that proves the fix.`;
 
-Start with \`git diff --stat origin/{{baseBranch}}...{{branch}} -- . ':!package-lock.json'\` to see which files changed.
-Then use \`git diff origin/{{baseBranch}}...{{branch}} -M -- . ':!package-lock.json'\` (with rename detection) to see actual content changes.
-For large diffs, review files individually with \`read\` rather than dumping the entire diff into context.
+export const CODE_REVIEW_PROMPT = `Perform an integrated implementation review of the code changes on branch {{branch}} vs origin/{{baseBranch}}.
 
-Check:
-1. Correctness — logic errors, off-by-one, race conditions
-2. Error handling — missing try/catch, unhandled promise rejections
-3. Edge cases — null/undefined, empty arrays, boundary values
-4. Code style — consistent naming, no dead code, clear intent
-5. Test coverage — are new behaviors tested?`;
+Start with \`git diff --stat origin/{{baseBranch}}...{{branch}} -- . ':!package-lock.json'\` to see which files changed. Then use \`git diff origin/{{baseBranch}}...{{branch}} -M -- . ':!package-lock.json'\` (with rename detection) to see actual content changes. For large diffs, review files individually with \`read\` rather than dumping the entire diff into context.
+
+Review correctness, error handling, edge and mixed states, concurrency and lifecycle behavior, cross-layer interactions, maintainability, regression coverage, and independently verifiable bugs. Deduplicate findings by root cause.
+
+For every finding, provide its exact file/location, minimal implementation fix, and focused test that independently demonstrates the defect and verifies the fix.`;
 
 export const BUG_HUNT_PROMPT = `Review the implementation on branch {{branch}} vs origin/{{baseBranch}} for actionable bugs.
 
@@ -177,16 +170,13 @@ Focus on correctness, edge cases, error paths, cross-system interactions, concur
 
 For every finding, include file:line, reproduction conditions, consequence, and why it is a bug.`;
 
-export const SECURITY_REVIEW_PROMPT = `Security review of changes on branch {{branch}} vs origin/{{baseBranch}}.
+export const SECURITY_REVIEW_PROMPT = `Perform a security review of changes on branch {{branch}} vs origin/{{baseBranch}}.
 
 Run \`git diff origin/{{baseBranch}}...{{branch}} -- . ':!package-lock.json'\` to see changes.
 
-Check:
-1. Injection risks — command injection, path traversal, template injection
-2. Auth/authz — are new endpoints properly authenticated?
-3. Data validation — are inputs validated and sanitized?
-4. Secrets handling — no hardcoded secrets, tokens, or credentials
-5. Dependency risks — any new dependencies with known vulnerabilities?`;
+Review changed trust boundaries, authentication and authorization, validation and injection, secrets handling, destructive operations and resource ownership, dependency risk, and security-relevant races.
+
+For every finding, provide the exact affected file/location, minimal remediation, and an abuse or regression test that demonstrates the vulnerability and verifies the fix.`;
 
 // ── Phase 3 nested goals — `parent` meta-workflow prompts ──────────────
 //
@@ -338,13 +328,14 @@ export function buildDefaultWorkflows(componentName: string): Record<string, See
 				description: RALPH_LOOP_DESCRIPTION,
 				depends_on: ["design-doc"],
 				verify: [
-					{ name: "Build", type: "command", component: c, command: "build", timeout: 600 },
+					{ name: "Build", type: "command", phase: 0, component: c, command: "build", timeout: 600 },
 					{ name: "Type check passes", type: "command", phase: 1, component: c, command: "check" },
 					{ name: "Unit tests", type: "command", phase: 1, component: c, command: "unit" },
+					{ name: "Browser tests", type: "command", phase: 1, timeout: 900, component: c, command: "browser" },
 					{ name: "E2E tests", type: "command", phase: 1, timeout: 900, component: c, command: "e2e" },
-					{ name: "Gap analysis", type: "llm-review", role: "spec-auditor", phase: 2, prompt: GAP_ANALYSIS_IMPL_PROMPT },
-					{ name: "Code quality review", type: "llm-review", role: "code-reviewer", phase: 2, prompt: CODE_REVIEW_PROMPT },
-					{ name: "Bug hunt", type: "llm-review", role: "bug-hunter", phase: 2, prompt: BUG_HUNT_PROMPT },
+					{ name: "Spec and regression conformance", type: "llm-review", role: "spec-auditor", phase: 2, prompt: GAP_ANALYSIS_IMPL_PROMPT },
+					{ name: "Integrated implementation review", type: "llm-review", role: "code-reviewer", phase: 2, prompt: CODE_REVIEW_PROMPT },
+					{ name: "Security review", type: "llm-review", role: "security-reviewer", phase: 2, prompt: SECURITY_REVIEW_PROMPT },
 				],
 			},
 			{
@@ -380,13 +371,13 @@ export function buildDefaultWorkflows(componentName: string): Record<string, See
 				description: RALPH_LOOP_DESCRIPTION,
 				depends_on: ["design-doc"],
 				verify: [
-					{ name: "Build", type: "command", component: c, command: "build", timeout: 600 },
+					{ name: "Build", type: "command", phase: 0, component: c, command: "build", timeout: 600 },
 					{ name: "Type check passes", type: "command", phase: 1, component: c, command: "check" },
 					{ name: "Unit tests", type: "command", phase: 1, component: c, command: "unit" },
+					{ name: "Browser tests", type: "command", phase: 1, timeout: 900, component: c, command: "browser" },
 					{ name: "E2E tests", type: "command", phase: 1, timeout: 900, component: c, command: "e2e" },
-					{ name: "Gap analysis", type: "llm-review", role: "spec-auditor", phase: 2, prompt: GAP_ANALYSIS_IMPL_PROMPT },
-					{ name: "Code quality review", type: "llm-review", role: "code-reviewer", phase: 2, prompt: CODE_REVIEW_PROMPT },
-					{ name: "Bug hunt", type: "llm-review", role: "bug-hunter", phase: 2, prompt: BUG_HUNT_PROMPT },
+					{ name: "Spec and regression conformance", type: "llm-review", role: "spec-auditor", phase: 2, prompt: GAP_ANALYSIS_IMPL_PROMPT },
+					{ name: "Integrated implementation review", type: "llm-review", role: "code-reviewer", phase: 2, prompt: CODE_REVIEW_PROMPT },
 					{ name: "Security review", type: "llm-review", role: "security-reviewer", phase: 2, prompt: SECURITY_REVIEW_PROMPT },
 					{
 						name: "QA testing",
@@ -451,13 +442,14 @@ export function buildDefaultWorkflows(componentName: string): Record<string, See
 				description: RALPH_LOOP_DESCRIPTION,
 				depends_on: ["reproducing-test"],
 				verify: [
-					{ name: "Build", type: "command", component: c, command: "build", timeout: 600 },
+					{ name: "Build", type: "command", phase: 0, component: c, command: "build", timeout: 600 },
 					{ name: "Type check", type: "command", phase: 1, component: c, command: "check" },
 					{ name: "Repro test passes (bug fixed)", type: "command", phase: 1, run: "{{reproducing-test.meta.test_command}}", expect: "success" },
 					{ name: "Unit tests", type: "command", phase: 1, component: c, command: "unit" },
+					{ name: "Browser tests", type: "command", phase: 1, timeout: 900, component: c, command: "browser" },
 					{ name: "E2E tests", type: "command", phase: 1, timeout: 900, component: c, command: "e2e" },
-					{ name: "Code quality review", type: "llm-review", role: "code-reviewer", phase: 2, prompt: CODE_REVIEW_PROMPT },
-					{ name: "Bug hunt", type: "llm-review", role: "bug-hunter", phase: 2, prompt: BUG_HUNT_PROMPT },
+					{ name: "Spec and regression conformance", type: "llm-review", role: "spec-auditor", phase: 2, prompt: GAP_ANALYSIS_IMPL_PROMPT },
+					{ name: "Integrated implementation review", type: "llm-review", role: "code-reviewer", phase: 2, prompt: CODE_REVIEW_PROMPT },
 					{ name: "Security review", type: "llm-review", role: "security-reviewer", phase: 2, prompt: SECURITY_REVIEW_PROMPT },
 				],
 			},
@@ -483,12 +475,14 @@ export function buildDefaultWorkflows(componentName: string): Record<string, See
 				name: "Implementation",
 				description: "Ralph loop (minimal): build, test, review.",
 				verify: [
-					{ name: "Build", type: "command", component: c, command: "build", timeout: 600 },
+					{ name: "Build", type: "command", phase: 0, component: c, command: "build", timeout: 600 },
 					{ name: "Type check passes", type: "command", phase: 1, component: c, command: "check" },
 					{ name: "Unit tests", type: "command", phase: 1, component: c, command: "unit" },
+					{ name: "Browser tests", type: "command", phase: 1, timeout: 900, component: c, command: "browser" },
 					{ name: "E2E tests", type: "command", phase: 1, timeout: 900, component: c, command: "e2e" },
-					{ name: "Code quality review", type: "llm-review", role: "code-reviewer", phase: 2, prompt: CODE_REVIEW_PROMPT },
-					{ name: "Bug hunt", type: "llm-review", role: "bug-hunter", phase: 2, prompt: BUG_HUNT_PROMPT },
+					{ name: "Spec and regression conformance", type: "llm-review", role: "spec-auditor", phase: 2, prompt: GAP_ANALYSIS_IMPL_PROMPT },
+					{ name: "Integrated implementation review", type: "llm-review", role: "code-reviewer", phase: 2, prompt: CODE_REVIEW_PROMPT },
+					{ name: "Security review", type: "llm-review", role: "security-reviewer", phase: 2, prompt: SECURITY_REVIEW_PROMPT },
 				],
 			},
 			// quick-fix has no documentation gate — wire ready-to-merge directly off implementation.

--- a/src/server/state-migration/seed-default-workflows.ts
+++ b/src/server/state-migration/seed-default-workflows.ts
@@ -74,6 +74,16 @@ export function readyToMergeGate(): SeededGate {
 	};
 }
 
+export const REVISION_READY_CONTENT_PACKET_PROMPT = `For every blocking content finding, provide an author-ready revision packet; a failure without this packet is invalid:
+1. **Artifact location:** exact section, heading, paragraph, requirement, acceptance criterion, diagram, or test-plan entry; for documentation, exact path and section.
+2. **Goal-linked gap and consequence:** the unmet or contradictory goal requirement and practical implementation or user consequence.
+3. **Concrete revision:** directly usable replacement wording, addition, outline, contract, data-flow or state sequence, acceptance criterion, example, or test-plan case.
+4. **Consistency and constraints:** cross-section edits, references, examples, compatibility, lifecycle, ordering, platform, and failure-mode constraints to update together.
+5. **Alternatives:** preferred revision plus credible alternatives and explicit tradeoffs only when they exist; do not manufacture options.
+6. **Classification:** required blocker edits versus optional bounded improvements; do not fail for the latter.
+
+For design documents and issue analyses, require implementable contracts and testable acceptance criteria only as needed for the approved goal — not exhaustive pseudocode, a formal proof, or speculative hardening. For documentation, also name the exact documentation path and section, stale or missing claim, proposed wording or outline, relevant examples or links, and how to verify the documented behavior against the implementation.`;
+
 export const DOC_PROMPT = `Review documentation for the changes on branch {{branch}} vs origin/{{baseBranch}}.
 
 Run \`git diff origin/{{baseBranch}}...{{branch}} -- . ':!package-lock.json'\` to see all changes.
@@ -113,6 +123,8 @@ AGENTS.md is loaded into every agent turn — its size is a direct per-turn toke
 - Adds a categorical subsection past ~12 entries without splitting it.
 If the diff fixes any of the above (e.g. it shortens long entries, dedupes recipe↔debug pairs, splits a large subsection), say so and PASS.
 
+${REVISION_READY_CONTENT_PACKET_PROMPT}
+
 Summarize with PASS/FAIL for each check and specific items to address.`;
 
 export const DESIGN_REVIEW_PROMPT = `Review this design document for structure, clarity, comparative reasoning, and completeness.
@@ -126,7 +138,9 @@ For every non-trivial change, FAIL unless the design:
 
 A quick-fix exemption is acceptable only for one local behavior following an obvious established pattern with no new public API, state owner, persistence, auth, dependency, or cross-layer flow; the design must state why comparison is unnecessary. Do not force reuse where contracts, ownership, or lifecycle differ, and do not demand speculative generalization or adjacent features.
 
-Regardless of comparative-design exemption, every design must list file changes with specific descriptions, define specific and testable acceptance criteria, cover edge/error handling, and include an E2E test plan that validates the user journey end-to-end.`;
+Regardless of comparative-design exemption, every design must list file changes with specific descriptions, define specific and testable acceptance criteria, cover edge/error handling, and include an E2E test plan that validates the user journey end-to-end.
+
+${REVISION_READY_CONTENT_PACKET_PROMPT}`;
 
 export const GAP_ANALYSIS_DESIGN_PROMPT = `Compare the goal specification to this design document.
 
@@ -141,7 +155,9 @@ Identify:
 5. Compared approaches that do not target the same acceptance criteria and constraints
 6. Scope expansion added to justify an abstraction or possible future reuse
 
-Use your tools to read the design document content from the signal.`;
+Use your tools to read the design document content from the signal.
+
+${REVISION_READY_CONTENT_PACKET_PROMPT}`;
 
 export const GAP_ANALYSIS_IMPL_PROMPT = `Review spec and regression conformance for the implementation on branch {{branch}} vs origin/{{baseBranch}}.
 
@@ -422,7 +438,9 @@ export function buildDefaultWorkflows(componentName: string): Record<string, See
 1. Reproduction steps are specific enough to follow mechanically
 2. Root cause references actual source files and lines
 3. Analysis distinguishes symptoms from underlying cause
-4. **Test plan** — the analysis must describe what test will verify the fix.`,
+4. **Test plan** — the analysis must describe what test will verify the fix.
+
+${REVISION_READY_CONTENT_PACKET_PROMPT}`,
 					},
 					{ name: "Gap analysis", type: "llm-review", role: "spec-auditor", prompt: GAP_ANALYSIS_DESIGN_PROMPT },
 				],

--- a/tests2/core/default-role-policy.test.ts
+++ b/tests2/core/default-role-policy.test.ts
@@ -52,7 +52,7 @@ function expectCoderReadyBlockerPacket(prompt: string, roleName: string): void {
 	expect(policy, message).toMatch(/verification.{0,200}(?:test layer|test file|focused tests?)/i);
 	expect(policy, message).toMatch(/(?:setup|assertions?|regression behavior).{0,220}(?:tests?|verification)|(?:tests?|verification).{0,220}(?:setup|assertions?|regression behavior)/i);
 	expect(policy, message).toMatch(/confidence.{0,180}(?:proven|reproduced|inferred)/i);
-	expect(policy, message).toMatch(/(?:remaining uncertainty|uncertainty).{0,180}(?:evidence|close)/i);
+	expect(policy, message).toMatch(/(?:remaining uncertainty|uncertainty).{0,180}(?:evidence|close)|(?:evidence|close).{0,180}(?:remaining uncertainty|uncertainty)/i);
 
 	// Alternatives are useful only when genuine choices exist, and failure without
 	// this complete packet is invalid. The root-cause rule keeps overlap actionable.
@@ -71,7 +71,7 @@ function expectRevisionReadyArtifactPacket(prompt: string, roleName: string): vo
 	expect(policy, message).toMatch(/(?:goal[- ]linked|goal (?:requirement|scope)|contradiction|gap).{0,180}(?:implementation|user) consequence/i);
 	expect(policy, message).toMatch(/(?:concrete )?(?:replacement|addition|wording|outline|contract|data[- ]?flow|state sequence|acceptance criterion|test[- ]plan case)/i);
 	expect(policy, message).toMatch(/(?:cross[- ]section|consistency).{0,160}(?:edit|constraint|reference)/i);
-	expect(policy, message).toMatch(/(?:when|if).{0,100}(?:credible|multiple).{0,100}(?:revision )?alternatives?.{0,180}trade-?offs/i);
+	expect(policy, message).toMatch(/(?:when|if).{0,100}(?:credible|multiple).{0,100}(?:revision )?alternatives?.{0,180}trade-?offs|(?:revision )?alternatives?.{0,180}trade-?offs.{0,180}(?:when|if).{0,100}(?:credible|multiple)/i);
 	expect(policy, message).toMatch(/(?:required blocker|blocker).{0,160}(?:optional|bounded improvement)|(?:optional|bounded improvement).{0,160}(?:required blocker|blocker)/i);
 }
 

--- a/tests2/core/default-role-policy.test.ts
+++ b/tests2/core/default-role-policy.test.ts
@@ -56,9 +56,9 @@ function expectCoderReadyBlockerPacket(prompt: string, roleName: string): void {
 
 	// Alternatives are useful only when genuine choices exist, and failure without
 	// this complete packet is invalid. The root-cause rule keeps overlap actionable.
-	expect(policy, message).toMatch(/(?:when|if).{0,100}(?:credible|multiple).{0,100}alternatives?.{0,180}trade-?offs/i);
+	expect(policy, message).toMatch(/(?:when|if).{0,100}(?:credible|multiple).{0,100}alternatives?.{0,180}trade-?offs|alternatives?.{0,180}trade-?offs.{0,180}(?:when|if).{0,100}(?:credible|multiple)/i);
 	expect(policy, message).toMatch(/(?:do not|never).{0,100}(?:invent|manufacture).{0,100}(?:inferior|alternatives?)/i);
-	expect(policy, message).toMatch(/(?:fail|failure).{0,180}(?:invalid|must not).{0,180}(?:packet|all (?:required )?fields?|complete)/i);
+	expect(policy, message).toMatch(/(?:fail|failure).{0,180}(?:(?:invalid|must not).{0,180}(?:packet|all (?:required )?fields?|complete)|(?:packet|all (?:required )?fields?|complete).{0,180}(?:invalid|must not))/i);
 	expect(policy, message).toMatch(/(?:consolidat|deduplicat).{0,100}root causes?|root causes?.{0,100}(?:consolidat|deduplicat)/i);
 }
 

--- a/tests2/core/default-role-policy.test.ts
+++ b/tests2/core/default-role-policy.test.ts
@@ -32,6 +32,49 @@ function normalizedPrompt(prompt: string): string {
 	return prompt.replace(/\s+/g, " ");
 }
 
+function expectCoderReadyBlockerPacket(prompt: string, roleName: string): void {
+	const message = `${roleName} must require a coder-ready packet for every blocker`;
+	const policy = normalizedPrompt(prompt);
+
+	// A failure must be anchored to an approved requirement or an introduced regression.
+	expect(policy, message).toMatch(/scope link.{0,120}(?:goal (?:requirement|acceptance criterion)|(?:change[- ]introduced )?regression)/i);
+	expect(policy, message).toMatch(/evidence.{0,180}(?:files?|symbols?|lines?)/i);
+	expect(policy, message).toMatch(/(?:trigger|input|state|timing).{0,160}(?:causal path|causal chain).{0,160}(?:consequence|impact)|(?:causal path|causal chain).{0,160}(?:consequence|impact)/i);
+
+	// The remediation must be executable by a coder, not merely name a symptom.
+	expect(policy, message).toMatch(/(?:recommended|minimal) (?:fix|remediation).{0,180}(?:files?|symbols?)/i);
+	expect(policy, message).toMatch(/(?:ordered|order).{0,160}(?:control[- ]?flow|data[- ]?flow|state(?:[- ]?machine)?|persistence|API|schema|lifecycle)/i);
+	expect(policy, message).toMatch(/(?:invariants?|ordering requirements?)/i);
+	expect(policy, message).toMatch(/(?:pseudocode|signatures?).{0,160}(?:materially|ambiguity|needed)|(?:materially|ambiguity|needed).{0,160}(?:pseudocode|signatures?)/i);
+	expect(policy, message).toMatch(/constraints?.{0,160}(?:compatibility|migration|concurrency|cleanup|ordering|platform|failure)/i);
+
+	// Verification must tell the coder what to add and what it proves.
+	expect(policy, message).toMatch(/verification.{0,200}(?:test layer|test file|focused tests?)/i);
+	expect(policy, message).toMatch(/(?:setup|assertions?|regression behavior).{0,220}(?:tests?|verification)|(?:tests?|verification).{0,220}(?:setup|assertions?|regression behavior)/i);
+	expect(policy, message).toMatch(/confidence.{0,180}(?:proven|reproduced|inferred)/i);
+	expect(policy, message).toMatch(/(?:remaining uncertainty|uncertainty).{0,180}(?:evidence|close)/i);
+
+	// Alternatives are useful only when genuine choices exist, and failure without
+	// this complete packet is invalid. The root-cause rule keeps overlap actionable.
+	expect(policy, message).toMatch(/(?:when|if).{0,100}(?:credible|multiple).{0,100}alternatives?.{0,180}trade-?offs/i);
+	expect(policy, message).toMatch(/(?:do not|never).{0,100}(?:invent|manufacture).{0,100}(?:inferior|alternatives?)/i);
+	expect(policy, message).toMatch(/(?:fail|failure).{0,180}(?:invalid|must not).{0,180}(?:packet|all (?:required )?fields?|complete)/i);
+	expect(policy, message).toMatch(/(?:consolidat|deduplicat).{0,100}root causes?|root causes?.{0,100}(?:consolidat|deduplicat)/i);
+}
+
+function expectRevisionReadyArtifactPacket(prompt: string, roleName: string): void {
+	const message = `${roleName} must require an author-ready revision packet for blocking content findings`;
+	const policy = normalizedPrompt(prompt);
+
+	expect(policy, message).toMatch(/(?:revision[- ]ready|author[- ]ready).{0,140}(?:artifact|packet|finding)/i);
+	expect(policy, message).toMatch(/(?:exact )?(?:artifact )?(?:section|heading|paragraph|requirement|acceptance criterion|diagram|test plan)/i);
+	expect(policy, message).toMatch(/(?:goal[- ]linked|goal (?:requirement|scope)|contradiction|gap).{0,180}(?:implementation|user) consequence/i);
+	expect(policy, message).toMatch(/(?:concrete )?(?:replacement|addition|wording|outline|contract|data[- ]?flow|state sequence|acceptance criterion|test[- ]plan case)/i);
+	expect(policy, message).toMatch(/(?:cross[- ]section|consistency).{0,160}(?:edit|constraint|reference)/i);
+	expect(policy, message).toMatch(/(?:when|if).{0,100}(?:credible|multiple).{0,100}(?:revision )?alternatives?.{0,180}trade-?offs/i);
+	expect(policy, message).toMatch(/(?:required blocker|blocker).{0,160}(?:optional|bounded improvement)|(?:optional|bounded improvement).{0,160}(?:required blocker|blocker)/i);
+}
+
 function expectPromptPolicy(prompt: string, roleName: string): void {
 	const message = `${roleName} must preserve review-convergence policy`;
 	const policy = normalizedPrompt(prompt);
@@ -71,6 +114,20 @@ describe("default reviewer role convergence policies", () => {
 	}
 });
 
+describe("default reviewer blocker packets", () => {
+	for (const roleName of REVIEWER_ROLES) {
+		it(`${roleName} requires a complete implementation-ready blocker packet`, () => {
+			expectCoderReadyBlockerPacket(promptFor(roleName), roleName);
+		});
+	}
+
+	for (const roleName of ["architect", "reviewer", "spec-auditor"] as const) {
+		it(`${roleName} makes first-phase and documentation blockers revision-ready`, () => {
+			expectRevisionReadyArtifactPacket(promptFor(roleName), roleName);
+		});
+	}
+});
+
 describe("default team-lead review judgment policy", () => {
 	it("independently validates and bounds review findings before applying fixes", () => {
 		const policy = normalizedPrompt(promptFor("team-lead"));
@@ -88,6 +145,15 @@ describe("default team-lead review judgment policy", () => {
 		expect(policy, message).toMatch(/(?:accept|reject|defer).{0,160}(?:blocker|finding|demands?)/i);
 		expect(policy, message).toMatch(/(?:scope|finding) ledger/i);
 		expect(policy, message).toMatch(/(?:accepted blocker fixes?.{0,100}smallest complete fix|smallest complete fix)/i);
+
+		// Independent evidence is synthesized rather than silently discarded as duplicates.
+		expect(policy, message).toMatch(/finding matrix.{0,180}(?:root cause|root[- ]cause)/i);
+		expect(policy, message).toMatch(/(?:finding matrix|root cause).{0,220}(?:reporting reviewers?|roles?|evidence|remediation|confidence)/i);
+		expect(policy, message).toMatch(/(?:two|2|more).{0,120}(?:reviewers?|roles?).{0,120}(?:corroborat|independent)/i);
+		expect(policy, message).toMatch(/(?:compare|evaluate).{0,180}(?:correctness|scope|compatibility|risk|testability).{0,180}(?:fix|revision|option)/i);
+		expect(policy, message).toMatch(/(?:disagree|disagreement).{0,180}(?:severity|scope|remediation).{0,180}(?:resolve|goal|evidence)/i);
+		expect(policy, message).toMatch(/(?:deduplicat).{0,120}work items?.{0,160}(?:not|without).{0,160}evidence|(?:preserve|retain).{0,120}(?:independent|corroborat).{0,120}evidence/i);
+		expect(policy, message).toMatch(/(?:accepted|consolidated).{0,180}(?:packet|repair|revision).{0,220}(?:files?|sections?|ordered|constraints?|tests?|corroborating|alternatives?|rationale)/i);
 
 		// The lead converges rather than accepting verifier-driven scope creep.
 		expect(policy, message).toMatch(/do not silently amend the goal spec.{0,100}(?:add acceptance criteria|reviewer suggestions? into requirements?)/i);

--- a/tests2/core/default-role-policy.test.ts
+++ b/tests2/core/default-role-policy.test.ts
@@ -26,31 +26,41 @@ function promptFor(roleName: string): string {
 	return role.promptTemplate!;
 }
 
+function normalizedPrompt(prompt: string): string {
+	// Role prose is Markdown and may wrap a single policy across several lines.
+	// Assert the policy clauses, not a particular sentence layout or inflection.
+	return prompt.replace(/\s+/g, " ");
+}
+
 function expectPromptPolicy(prompt: string, roleName: string): void {
 	const message = `${roleName} must preserve review-convergence policy`;
+	const policy = normalizedPrompt(prompt);
 
 	// Scope and decision authority.
-	expect(prompt, message).toMatch(/goal spec(?:ification)?(?: and)? explicit user amendments? (?:are|remain) authoritative/i);
-	expect(prompt, message).toMatch(/reviewer suggestions?.{0,80}(?:do not|must not|never).{0,80}(?:become|create).{0,80}requirements?/i);
-	expect(prompt, message).toMatch(/(?:classify|classification).{0,120}blockers?.{0,120}bounded improvements?.{0,120}(?:out.of.scope|pre.existing)/i);
-	expect(prompt, message).toMatch(/fail only.{0,120}(?:explicit(?:ly)? unmet requirements?|concrete regressions?)/i);
+	expect(policy, message).toMatch(/(?:effective )?goal spec(?:ification)?.{0,100}explicit user amendments?.{0,100}authoritative/i);
+	expect(policy, message).toMatch(/(?:reviewer(?: or design)?|design) suggestions?.{0,100}(?:not requirements?|do not.{0,80}requirements?|become requirements?)/i);
+	expect(policy, message).toMatch(/classif.{0,120}blockers?/i);
+	expect(policy, message).toMatch(/bounded improvements?/i);
+	expect(policy, message).toMatch(/(?:out[- ]of[- ]scope|pre[- ]existing)/i);
+	expect(policy, message).toMatch(/(?:fail only|(?:failing )?blocker must).{0,140}(?:explicit(?:ly)? (?:unmet )?(?:goal )?requirements?|concrete regressions?)/i);
 
 	// A failing finding must be implementable, rather than an unbounded critique.
-	expect(prompt, message).toMatch(/(?:exact|specific).{0,80}(?:files?|symbols?)/i);
-	expect(prompt, message).toMatch(/causal (?:path|chain).{0,80}trigger|trigger.{0,80}causal (?:path|chain)/i);
-	expect(prompt, message).toMatch(/minimal.{0,100}(?:control.?flow|data.?flow).{0,100}(?:remediation|fix)/i);
-	expect(prompt, message).toMatch(/(?:compatibility|lifecycle).{0,100}(?:constraints?|requirements?)/i);
-	expect(prompt, message).toMatch(/focused tests?/i);
-	expect(prompt, message).toMatch(/(?:deduplicat|consolidat).{0,100}root causes?/i);
+	expect(policy, message).toMatch(/(?:exact|specific).{0,80}(?:files?|symbols?)/i);
+	expect(policy, message).toMatch(/causal (?:path|chain).{0,80}trigger|trigger.{0,80}causal (?:path|chain)/i);
+	expect(policy, message).toMatch(/minimal.{0,160}(?:control[- ]?flow|data[- ]?flow)|(?:control[- ]?flow|data[- ]?flow).{0,160}minimal/i);
+	expect(policy, message).toMatch(/(?:remediation|fix)/i);
+	expect(policy, message).toMatch(/(?:compatibility|lifecycle).{0,100}(?:constraints?|requirements?)/i);
+	expect(policy, message).toMatch(/focused (?:integration\/browser )?(?:abuse\/regression |regression )?tests?/i);
+	expect(policy, message).toMatch(/(?:deduplicat|consolidat).{0,100}root causes?|root causes?.{0,100}(?:deduplicat|consolidat)/i);
 
 	// Re-reviews should converge instead of repeatedly expanding the goal.
-	expect(prompt, message).toMatch(/re.review.{0,160}(?:only|may only).{0,160}(?:unresolved (?:prior )?blockers?|revision.introduced regressions?)/i);
-	expect(prompt, message).toMatch(/(?:previously discoverable|new demands?).{0,100}(?:non.blocking|not blocking)/i);
-	expect(prompt, message).toMatch(/(?:critical data.loss|exploitable security)/i);
-	expect(prompt, message).toMatch(/default to PASS.{0,100}explicit requirements? (?:are|is) met/i);
-	expect(prompt, message).toMatch(/(?:at most|maximum|cap).{0,80}(?:three|3).{0,80}root.cause blockers?/i);
-	expect(prompt, message).toMatch(/PASS.{0,20}0 blockers?/i);
-	expect(prompt, message).toMatch(/FAIL.{0,20}(?:N|number of) blockers?/i);
+	expect(policy, message).toMatch(/re[- ]?review.{0,180}(?:fail only|may fail only).{0,180}(?:unresolved (?:previously |prior )?(?:reported )?blockers?|regressions? introduced by (?:the )?revision)/i);
+	expect(policy, message).toMatch(/(?:(?:previously|prior).{0,100}discoverable|new(?:ly)? (?:discovered )?(?:blockers?|demands?).{0,100}discoverable).{0,140}(?:non[- ]?blocking|not blocking)/i);
+	expect(policy, message).toMatch(/(?:critical data[- ]loss|exploitable[- ]security)/i);
+	expect(policy, message).toMatch(/default to pass.{0,120}(?:explicit (?:goal )?requirements?.{0,80}met|satisf(?:y|ies).{0,80}explicit (?:goal )?requirements?)/i);
+	expect(policy, message).toMatch(/(?:at most|maximum|cap|never exceeds).{0,80}(?:three|3).{0,80}(?:blocker )?root causes?/i);
+	expect(policy, message).toMatch(/PASS\s*[—-]\s*0 blockers?/i);
+	expect(policy, message).toMatch(/FAIL\s*[—-]\s*(?:N|number of) blockers?/i);
 }
 
 describe("default reviewer role convergence policies", () => {
@@ -63,16 +73,25 @@ describe("default reviewer role convergence policies", () => {
 
 describe("default team-lead review judgment policy", () => {
 	it("independently validates and bounds review findings before applying fixes", () => {
-		const prompt = promptFor("team-lead");
+		const policy = normalizedPrompt(promptFor("team-lead"));
 		const message = "team-lead must independently judge reviewer findings and prevent scope creep";
 
-		expect(prompt, message).toMatch(/goal spec(?:ification)?(?: and)? explicit user amendments? (?:are|remain) authoritative/i);
-		expect(prompt, message).toMatch(/independently.{0,100}(?:validat|assess).{0,100}(?:reviewer )?evidence/i);
-		expect(prompt, message).toMatch(/(?:accept|reject).{0,100}(?:goal scope|regression evidence)|(?:goal scope|regression evidence).{0,100}(?:accept|reject)/i);
-		expect(prompt, message).toMatch(/(?:scope|finding) ledger/i);
-		expect(prompt, message).toMatch(/minimal accepted fixes?/i);
-		expect(prompt, message).toMatch(/reject.{0,80}scope creep/i);
-		expect(prompt, message).toMatch(/(?:reject|avoid).{0,100}documentation.only (?:appeasement|fixes?)/i);
-		expect(prompt, message).toMatch(/two consecutive failures?.{0,100}(?:same )?content gate/i);
+		// The approved goal is the boundary; reviewers cannot expand it.
+		expect(policy, message).toMatch(/user[- ]approved goal.{0,100}(?:scope boundary|boundary)/i);
+		expect(policy, message).toMatch(/reviewer suggestions?.{0,100}(?:not requirements?|do not.{0,80}requirements?|into requirements?)/i);
+		expect(policy, message).toMatch(/only.{0,80}explicit user amendment.{0,80}changes? goal scope/i);
+
+		// Reviewer output is evidence to independently validate and then accept or reject.
+		expect(policy, message).toMatch(/reviewer output.{0,100}evidence.{0,100}(?:not an order|advice)/i);
+		expect(policy, message).toMatch(/verify.{0,100}(?:evidence|reproduction path).{0,100}credible/i);
+		expect(policy, message).toMatch(/(?:decide|classif).{0,140}(?:caused by this change|blocks a stated goal requirement)/i);
+		expect(policy, message).toMatch(/(?:accept|reject|defer).{0,160}(?:blocker|finding|demands?)/i);
+		expect(policy, message).toMatch(/(?:scope|finding) ledger/i);
+		expect(policy, message).toMatch(/(?:accepted blocker fixes?.{0,100}smallest complete fix|smallest complete fix)/i);
+
+		// The lead converges rather than accepting verifier-driven scope creep.
+		expect(policy, message).toMatch(/do not silently amend the goal spec.{0,100}(?:add acceptance criteria|reviewer suggestions? into requirements?)/i);
+		expect(policy, message).toMatch(/(?:never merge|do not.{0,80}(?:merge|revise)).{0,100}documentation[- ]only.{0,100}(?:appease|appeasement)/i);
+		expect(policy, message).toMatch(/two consecutive failures?.{0,100}(?:same )?content gate.{0,100}(?:stop|do not create another rewrite task)/i);
 	});
 });

--- a/tests2/core/default-role-policy.test.ts
+++ b/tests2/core/default-role-policy.test.ts
@@ -1,0 +1,78 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import YAML from "yaml";
+
+const repoRoot = path.resolve(import.meta.dirname, "..", "..");
+
+const REVIEWER_ROLES = [
+	"architect",
+	"reviewer",
+	"code-reviewer",
+	"bug-hunter",
+	"verifiable-bug-hunter",
+	"security-reviewer",
+	"spec-auditor",
+	"systems-reviewer",
+] as const;
+
+type Role = { name?: string; promptTemplate?: string };
+
+function promptFor(roleName: string): string {
+	const file = path.join(repoRoot, "defaults", "roles", `${roleName}.yaml`);
+	const role = YAML.parse(fs.readFileSync(file, "utf8")) as Role;
+	expect(role.name).toBe(roleName);
+	expect(role.promptTemplate, `${roleName} must have a role prompt`).toEqual(expect.any(String));
+	return role.promptTemplate!;
+}
+
+function expectPromptPolicy(prompt: string, roleName: string): void {
+	const message = `${roleName} must preserve review-convergence policy`;
+
+	// Scope and decision authority.
+	expect(prompt, message).toMatch(/goal spec(?:ification)?(?: and)? explicit user amendments? (?:are|remain) authoritative/i);
+	expect(prompt, message).toMatch(/reviewer suggestions?.{0,80}(?:do not|must not|never).{0,80}(?:become|create).{0,80}requirements?/i);
+	expect(prompt, message).toMatch(/(?:classify|classification).{0,120}blockers?.{0,120}bounded improvements?.{0,120}(?:out.of.scope|pre.existing)/i);
+	expect(prompt, message).toMatch(/fail only.{0,120}(?:explicit(?:ly)? unmet requirements?|concrete regressions?)/i);
+
+	// A failing finding must be implementable, rather than an unbounded critique.
+	expect(prompt, message).toMatch(/(?:exact|specific).{0,80}(?:files?|symbols?)/i);
+	expect(prompt, message).toMatch(/causal (?:path|chain).{0,80}trigger|trigger.{0,80}causal (?:path|chain)/i);
+	expect(prompt, message).toMatch(/minimal.{0,100}(?:control.?flow|data.?flow).{0,100}(?:remediation|fix)/i);
+	expect(prompt, message).toMatch(/(?:compatibility|lifecycle).{0,100}(?:constraints?|requirements?)/i);
+	expect(prompt, message).toMatch(/focused tests?/i);
+	expect(prompt, message).toMatch(/(?:deduplicat|consolidat).{0,100}root causes?/i);
+
+	// Re-reviews should converge instead of repeatedly expanding the goal.
+	expect(prompt, message).toMatch(/re.review.{0,160}(?:only|may only).{0,160}(?:unresolved (?:prior )?blockers?|revision.introduced regressions?)/i);
+	expect(prompt, message).toMatch(/(?:previously discoverable|new demands?).{0,100}(?:non.blocking|not blocking)/i);
+	expect(prompt, message).toMatch(/(?:critical data.loss|exploitable security)/i);
+	expect(prompt, message).toMatch(/default to PASS.{0,100}explicit requirements? (?:are|is) met/i);
+	expect(prompt, message).toMatch(/(?:at most|maximum|cap).{0,80}(?:three|3).{0,80}root.cause blockers?/i);
+	expect(prompt, message).toMatch(/PASS.{0,20}0 blockers?/i);
+	expect(prompt, message).toMatch(/FAIL.{0,20}(?:N|number of) blockers?/i);
+}
+
+describe("default reviewer role convergence policies", () => {
+	for (const roleName of REVIEWER_ROLES) {
+		it(`${roleName} keeps solution-ready scope and convergence policy`, () => {
+			expectPromptPolicy(promptFor(roleName), roleName);
+		});
+	}
+});
+
+describe("default team-lead review judgment policy", () => {
+	it("independently validates and bounds review findings before applying fixes", () => {
+		const prompt = promptFor("team-lead");
+		const message = "team-lead must independently judge reviewer findings and prevent scope creep";
+
+		expect(prompt, message).toMatch(/goal spec(?:ification)?(?: and)? explicit user amendments? (?:are|remain) authoritative/i);
+		expect(prompt, message).toMatch(/independently.{0,100}(?:validat|assess).{0,100}(?:reviewer )?evidence/i);
+		expect(prompt, message).toMatch(/(?:accept|reject).{0,100}(?:goal scope|regression evidence)|(?:goal scope|regression evidence).{0,100}(?:accept|reject)/i);
+		expect(prompt, message).toMatch(/(?:scope|finding) ledger/i);
+		expect(prompt, message).toMatch(/minimal accepted fixes?/i);
+		expect(prompt, message).toMatch(/reject.{0,80}scope creep/i);
+		expect(prompt, message).toMatch(/(?:reject|avoid).{0,100}documentation.only (?:appeasement|fixes?)/i);
+		expect(prompt, message).toMatch(/two consecutive failures?.{0,100}(?:same )?content gate/i);
+	});
+});

--- a/tests2/core/per-component-workflows.test.ts
+++ b/tests2/core/per-component-workflows.test.ts
@@ -32,6 +32,12 @@ const COMPONENTS: Component[] = [
 
 const COMPONENT_REFS: WorkflowComponentRef[] = COMPONENTS.map((c) => ({ name: c.name, commands: c.commands }));
 
+const EXPECTED_IMPLEMENTATION_REVIEWS = [
+	{ name: "Spec and regression conformance", role: "spec-auditor" },
+	{ name: "Integrated implementation review", role: "code-reviewer" },
+	{ name: "Security review", role: "security-reviewer" },
+];
+
 describe("buildPerComponentWorkflow", () => {
 	it("scopes all { component, command } refs to the chosen component", () => {
 		const wf = buildPerComponentWorkflow("api", COMPONENTS);
@@ -46,21 +52,26 @@ describe("buildPerComponentWorkflow", () => {
 		}
 	});
 
-	it("inherits design-time gap-analysis, post-impl gap-analysis, and bug hunt from feature", () => {
+	it("uses exactly the consolidated implementation reviews from feature", () => {
 		const wf = buildPerComponentWorkflow("api", COMPONENTS);
-		const designDoc = wf.gates.find((g) => g.id === "design-doc")!;
-		assert.ok(designDoc.verify?.some((s) => s.name === "Gap analysis"));
 		const impl = wf.gates.find((g) => g.id === "implementation")!;
-		const gap = impl.verify?.find((s) => s.name === "Gap analysis");
-		assert.ok(gap);
-		assert.equal(gap!.phase, 2);
-		const bugHunt = impl.verify?.find((s) => s.name === "Bug hunt");
-		assert.ok(bugHunt);
-		assert.equal(bugHunt!.role, "bug-hunter");
+		const reviews = (impl.verify ?? [])
+			.filter((step) => step.type === "llm-review")
+			.map(({ name, role, phase }) => ({ name, role, phase }));
+		assert.deepEqual(reviews, EXPECTED_IMPLEMENTATION_REVIEWS.map((review) => ({ ...review, phase: 2 })));
 	});
 
-	it("derived per-component workflow passes the validator", () => {
+	it("omits unsupported Browser commands while retaining supported scoped commands", () => {
 		const wf = buildPerComponentWorkflow("api", COMPONENTS);
+		const impl = wf.gates.find((g) => g.id === "implementation")!;
+		const commands = (impl.verify ?? []).filter((step) => step.type === "command");
+		assert.ok(!commands.some((step) => step.command === "browser"), "Browser must be omitted when api has no browser command");
+		assert.deepEqual(
+			commands.map((step) => step.command).sort(),
+			["build", "check", "e2e", "unit"],
+		);
+		assert.ok(commands.every((step) => step.component === "api"), "supported commands must remain scoped to api");
+
 		const errors = validateAllWorkflows({ [wf.id]: wf as any }, COMPONENT_REFS);
 		assert.deepEqual(errors, [], `unexpected validator errors: ${JSON.stringify(errors)}`);
 	});

--- a/tests2/core/per-component-workflows.test.ts
+++ b/tests2/core/per-component-workflows.test.ts
@@ -75,6 +75,24 @@ describe("buildPerComponentWorkflow", () => {
 		const errors = validateAllWorkflows({ [wf.id]: wf as any }, COMPONENT_REFS);
 		assert.deepEqual(errors, [], `unexpected validator errors: ${JSON.stringify(errors)}`);
 	});
+
+	it("retains only declared commands while keeping the three required reviews", () => {
+		const sparse = { name: "sparse", repo: "sparse", commands: { check: "npm run check" } } satisfies Component;
+		const wf = buildPerComponentWorkflow(sparse.name, [sparse]);
+		const implementation = wf.gates.find((gate) => gate.id === "implementation")!;
+		const commands = (implementation.verify ?? []).filter((step) => step.type === "command");
+		const reviews = (implementation.verify ?? [])
+			.filter((step) => step.type === "llm-review")
+			.map(({ name, role, phase }) => ({ name, role, phase }));
+
+		assert.deepEqual(commands.map((step) => step.command), ["check"]);
+		assert.ok(commands.every((step) => step.component === sparse.name), "retained command must target the requested component");
+		assert.deepEqual(reviews, EXPECTED_IMPLEMENTATION_REVIEWS.map((review) => ({ ...review, phase: 2 })));
+		assert.deepEqual(
+			validateAllWorkflows({ [wf.id]: wf as any }, [{ name: sparse.name, commands: sparse.commands }]),
+			[],
+		);
+	});
 });
 
 describe("buildAllComponentsWorkflow", () => {

--- a/tests2/core/seed-default-workflows.test.ts
+++ b/tests2/core/seed-default-workflows.test.ts
@@ -128,11 +128,11 @@ describe("consolidated implementation review defaults", () => {
 				assert.match(code, concern, `${workflowId} code review must cover integrated implementation risks`);
 			}
 			assert.match(code, /deduplicat.*root cause/is, `${workflowId} code review must deduplicate by root cause`);
-			assert.match(code, /minimal fixes.*focused tests/is, `${workflowId} code review must prescribe a minimal fix and focused test`);
+			assert.match(code, /minimal (?:implementation )?fix(?:es)?.*focused tests?/is, `${workflowId} code review must prescribe a minimal fix and focused test`);
 			for (const risk of [/trust boundar/i, /auth/i, /validation/i, /injection/i, /secrets/i, /(?:destructive|resource ownership)/i, /dependency/i, /races/i]) {
 				assert.match(security, risk, `${workflowId} security review must cover changed security risks`);
 			}
-			assert.match(security, /remediation.*(?:abuse|regression) tests/is, `${workflowId} security review must require a remediation test`);
+			assert.match(security, /remediation.*(?:abuse|regression) tests?/is, `${workflowId} security review must require a remediation test`);
 		}
 	});
 

--- a/tests2/core/seed-default-workflows.test.ts
+++ b/tests2/core/seed-default-workflows.test.ts
@@ -2,71 +2,154 @@
 // Source: tests/seed-default-workflows.test.ts
 // Bucket: v2-core | Method: codemod | Classification: clean
 
-import { describe, it } from "vitest";
 import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { describe, it } from "vitest";
+import YAML from "yaml";
 
 import { buildDefaultWorkflows, RALPH_LOOP_DESCRIPTION } from "../../src/server/state-migration/seed-default-workflows.ts";
 
-describe("buildDefaultWorkflows", () => {
-	const wfs = buildDefaultWorkflows("myproj");
+type VerifyStep = {
+	name: string;
+	type: string;
+	role?: string;
+	phase?: number;
+	command?: string;
+	run?: string;
+	expect?: string;
+	optional?: boolean;
+	prompt?: string;
+};
 
-	function findGate(workflow: ReturnType<typeof buildDefaultWorkflows>[string], id: string) {
-		const g = workflow.gates.find((x) => x.id === id);
-		assert.ok(g, `gate ${id} should exist in workflow ${workflow.id}`);
-		return g!;
+type Workflow = {
+	id: string;
+	gates: Array<{ id: string; description?: string; verify?: VerifyStep[] }>;
+};
+
+const IMPLEMENTATION_WORKFLOW_IDS = ["general", "feature", "bug-fix", "quick-fix"] as const;
+const EXPECTED_REVIEWS = [
+	{ name: "Spec and regression conformance", role: "spec-auditor" },
+	{ name: "Integrated implementation review", role: "code-reviewer" },
+	{ name: "Security review", role: "security-reviewer" },
+];
+const SUPERSEDED_REVIEW_NAMES = [
+	/code quality/i,
+	/bug hunt/i,
+	/verifiable bug hunt/i,
+	/systems (?:interaction )?review/i,
+	/regression coverage/i,
+];
+const SUPERSEDED_REVIEW_ROLES = new Set(["bug-hunter", "verifiable-bug-hunter", "systems-reviewer", "regression-reviewer"]);
+
+function findGate(workflow: Workflow, id: string) {
+	const gate = workflow.gates.find((candidate) => candidate.id === id);
+	assert.ok(gate, `gate ${id} should exist in workflow ${workflow.id}`);
+	return gate;
+}
+
+function assertImplementationReviewPolicy(workflows: Record<string, Workflow>, source: string) {
+	for (const workflowId of IMPLEMENTATION_WORKFLOW_IDS) {
+		const implementation = findGate(workflows[workflowId], "implementation");
+		const verify = implementation.verify ?? [];
+		const reviews = verify.filter((step) => step.type === "llm-review");
+
+		assert.deepEqual(
+			reviews.map(({ name, role, phase }) => ({ name, role, phase })),
+			EXPECTED_REVIEWS.map(({ name, role }) => ({ name, role, phase: 2 })),
+			`${source}.${workflowId}.implementation must contain exactly the three consolidated phase-2 reviews in policy order`,
+		);
+
+		for (const step of verify) {
+			for (const supersededName of SUPERSEDED_REVIEW_NAMES) {
+				assert.doesNotMatch(step.name, supersededName, `${source}.${workflowId}.implementation must not retain ${supersededName}`);
+			}
+			assert.ok(!step.role || !SUPERSEDED_REVIEW_ROLES.has(step.role), `${source}.${workflowId}.implementation must not retain superseded reviewer role ${step.role}`);
+		}
+
+		const build = verify.find((step) => step.name === "Build");
+		assert.ok(build, `${source}.${workflowId}.implementation must retain Build`);
+		assert.equal(build.type, "command");
+		assert.ok(build.phase === undefined || build.phase === 0, `${source}.${workflowId}.implementation Build must run in phase 0`);
+
+		for (const command of ["check", "unit", "browser", "e2e"]) {
+			const step = verify.find((candidate) => candidate.type === "command" && candidate.command === command);
+			assert.ok(step, `${source}.${workflowId}.implementation must run ${command}`);
+			assert.equal(step.phase, 1, `${source}.${workflowId}.implementation ${command} must run in phase 1`);
+		}
+
+		for (const qaStep of verify.filter((step) => step.type === "agent-qa")) {
+			assert.equal(qaStep.optional, true, `${source}.${workflowId}.implementation QA must be optional`);
+			assert.equal(qaStep.phase, 3, `${source}.${workflowId}.implementation QA must run in phase 3`);
+		}
 	}
 
-	it("general has design-time gap-analysis", () => {
-		const designDoc = findGate(wfs.general, "design-doc");
-		const has = designDoc.verify?.some((s) => s.name === "Gap analysis");
-		assert.equal(has, true);
+	const bugFixSteps = findGate(workflows["bug-fix"], "implementation").verify ?? [];
+	const reproducingSuccess = bugFixSteps.find((step) => step.type === "command" && step.expect === "success" && step.run?.includes("test_command"));
+	assert.ok(reproducingSuccess, `${source}.bug-fix.implementation must run the reproducing test after the fix`);
+	assert.equal(reproducingSuccess.phase, 1, `${source}.bug-fix reproducing-test success command must run in phase 1`);
+}
+
+describe("consolidated implementation review defaults", () => {
+	it("seeds exactly three phase-2 implementation reviews with the required roles and execution phases", () => {
+		assertImplementationReviewPolicy(buildDefaultWorkflows("myproj"), "seeded defaults");
 	});
 
-	it("general has post-impl gap-analysis (phase 2)", () => {
-		const impl = findGate(wfs.general, "implementation");
-		const gap = impl.verify?.find((s) => s.name === "Gap analysis");
-		assert.ok(gap);
-		assert.equal(gap!.phase, 2);
-		assert.equal(gap!.role, "spec-auditor");
+	it("keeps the active project workflow config parseable and on the same review policy", () => {
+		const repoRoot = path.resolve(import.meta.dirname, "..", "..");
+		const project = YAML.parse(fs.readFileSync(path.join(repoRoot, ".bobbit", "config", "project.yaml"), "utf8")) as {
+			workflows?: Record<string, Workflow>;
+		};
+		assert.ok(project.workflows, "project.yaml must define workflows");
+		assertImplementationReviewPolicy(project.workflows, ".bobbit/config/project.yaml");
+
+		const prReview = project.workflows["pr-review"];
+		assert.ok(prReview, "PR Review must remain a purpose-built workflow");
+		assert.ok(findGate(prReview, "fetch-pr"), "PR Review must retain its PR fetch gate");
+		const humanSignoff = project.workflows["human-signoff-test"];
+		assert.ok(humanSignoff, "Human Sign-off Test must remain present");
+		assert.ok(humanSignoff.gates.some((gate) => gate.verify?.some((step) => step.type === "human-signoff")), "Human Sign-off Test must retain its human sign-off step");
 	});
 
-	it("feature still has both gap-analyses", () => {
-		const f = wfs.feature;
-		assert.ok(findGate(f, "design-doc").verify?.some((s) => s.name === "Gap analysis"));
-		const impl = findGate(f, "implementation");
-		const gap = impl.verify?.find((s) => s.name === "Gap analysis");
-		assert.ok(gap);
-		assert.equal(gap!.phase, 2);
-	});
+	it("keeps the phase-2 prompts implementation-ready", () => {
+		const workflows = buildDefaultWorkflows("myproj");
+		for (const workflowId of IMPLEMENTATION_WORKFLOW_IDS) {
+			const reviews = findGate(workflows[workflowId], "implementation").verify?.filter((step) => step.type === "llm-review") ?? [];
+			const spec = reviews.find((step) => step.role === "spec-auditor")?.prompt ?? "";
+			const code = reviews.find((step) => step.role === "code-reviewer")?.prompt ?? "";
+			const security = reviews.find((step) => step.role === "security-reviewer")?.prompt ?? "";
 
-	it("implementation workflows include bug-hunter review", () => {
-		for (const id of ["general", "feature", "bug-fix", "quick-fix"]) {
-			const impl = findGate(wfs[id], "implementation");
-			const bugHunt = impl.verify?.find((s) => s.name === "Bug hunt");
-			assert.ok(bugHunt, `${id}.implementation should include Bug hunt`);
-			assert.equal(bugHunt!.role, "bug-hunter");
-			assert.equal(bugHunt!.type, "llm-review");
-		}
-	});
-
-	it("quick-fix has neither gap-analysis", () => {
-		const qf = wfs["quick-fix"];
-		for (const g of qf.gates) {
-			for (const s of g.verify ?? []) {
-				assert.notEqual(s.name, "Gap analysis");
+			for (const requirement of [/goal/i, /(?:design|analysis)/i, /implementation/i, /tests?/i]) {
+				assert.match(spec, requirement, `${workflowId} spec review must compare all implementation inputs`);
 			}
+			assert.match(spec, /ignore documentation.*gap/is, `${workflowId} spec review must exclude documentation-only gaps`);
+			assert.match(spec, /implementation-ready.*remediation/is, `${workflowId} spec review must require actionable blockers`);
+			for (const concern of [/correctness/i, /error handling/i, /edge.*mixed/is, /concurrency.*lifecycle/is, /cross-layer/i, /maintainability/i, /regression coverage/i]) {
+				assert.match(code, concern, `${workflowId} code review must cover integrated implementation risks`);
+			}
+			assert.match(code, /deduplicat.*root cause/is, `${workflowId} code review must deduplicate by root cause`);
+			assert.match(code, /minimal fixes.*focused tests/is, `${workflowId} code review must prescribe a minimal fix and focused test`);
+			for (const risk of [/trust boundar/i, /auth/i, /validation/i, /injection/i, /secrets/i, /(?:destructive|resource ownership)/i, /dependency/i, /races/i]) {
+				assert.match(security, risk, `${workflowId} security review must cover changed security risks`);
+			}
+			assert.match(security, /remediation.*(?:abuse|regression) tests/is, `${workflowId} security review must require a remediation test`);
 		}
 	});
 
-	it("implementation gates carry Ralph-loop description for general/feature/bug-fix", () => {
-		for (const id of ["general", "feature", "bug-fix"]) {
-			const impl = findGate(wfs[id], "implementation");
-			assert.equal(impl.description, RALPH_LOOP_DESCRIPTION, `${id}.implementation.description`);
+	it("retains the design-time spec gap analysis outside the consolidated implementation reviews", () => {
+		const workflows = buildDefaultWorkflows("myproj");
+		for (const workflowId of ["general", "feature"]) {
+			const review = findGate(workflows[workflowId], "design-doc").verify?.find((step) => step.name === "Gap analysis");
+			assert.ok(review, `${workflowId}.design-doc must retain its design-time gap analysis`);
+			assert.equal(review.role, "spec-auditor");
 		}
+		assert.ok(!workflows["quick-fix"].gates.flatMap((gate) => gate.verify ?? []).some((step) => step.name === "Gap analysis"), "quick-fix must not gain a design gap-analysis step");
 	});
 
-	it("quick-fix implementation has a (shorter) Ralph-loop description", () => {
-		const impl = findGate(wfs["quick-fix"], "implementation");
-		assert.ok(impl.description && impl.description.toLowerCase().includes("ralph loop"));
+	it("retains Ralph-loop descriptions for the non-quick-fix implementation gates", () => {
+		const workflows = buildDefaultWorkflows("myproj");
+		for (const workflowId of ["general", "feature", "bug-fix"]) {
+			assert.equal(findGate(workflows[workflowId], "implementation").description, RALPH_LOOP_DESCRIPTION);
+		}
 	});
 });

--- a/tests2/core/seed-default-workflows.test.ts
+++ b/tests2/core/seed-default-workflows.test.ts
@@ -48,6 +48,46 @@ function findGate(workflow: Workflow, id: string) {
 	return gate;
 }
 
+function assertRevisionReadyContentReviewPrompt(prompt: string, source: string): void {
+	const policy = prompt.replace(/\s+/g, " ");
+	const message = `${source} must turn each blocking content finding into an author-ready revision packet`;
+
+	// Keep these assertions intentionally order-independent: the workflow prose may
+	// present the packet fields in a different sequence without weakening policy.
+	assert.match(policy, /(?:revision|author)[ -]ready/i, message);
+	assert.match(policy, /block(?:ing|er)/i, message);
+	assert.match(policy, /(?:artifact )?(?:section|heading|paragraph|requirement|acceptance criterion|diagram|test plan)/i, message);
+	assert.match(policy, /(?:goal[- ]linked|goal (?:requirement|scope)|gap|contradiction)/i, message);
+	assert.match(policy, /(?:implementation|user) consequence/i, message);
+	assert.match(policy, /(?:replacement|addition|wording|outline|contract|data[- ]flow|state sequence|acceptance criterion|test[- ]plan case)/i, message);
+	assert.match(policy, /(?:cross[- ]section|consistency)/i, message);
+	assert.match(policy, /(?:constraints?|references?)/i, message);
+	assert.match(policy, /(?:credible|multiple).{0,160}alternatives?|alternatives?.{0,160}(?:credible|multiple)/i, message);
+	assert.match(policy, /trade-?offs?/i, message);
+	assert.match(policy, /(?:required|blocker)/i, message);
+	assert.match(policy, /(?:optional|bounded improvement)/i, message);
+}
+
+function assertDesignOrAnalysisReviewPrompt(prompt: string, source: string): void {
+	assertRevisionReadyContentReviewPrompt(prompt, source);
+	const policy = prompt.replace(/\s+/g, " ");
+	assert.match(policy, /implementable contracts?/i, `${source} must provide implementable contracts`);
+	assert.match(policy, /testable acceptance criteria/i, `${source} must provide testable acceptance criteria`);
+	assert.match(policy, /(?:do not|must not|not).{0,160}(?:exhaustive pseudocode|formal proof|speculative hardening)/i, `${source} must keep revisions proportionate to the approved goal`);
+}
+
+function assertDocumentationReviewPrompt(prompt: string, source: string): void {
+	assertRevisionReadyContentReviewPrompt(prompt, source);
+	const policy = prompt.replace(/\s+/g, " ");
+	assert.match(policy, /documentation (?:path|file|location)/i, `${source} must identify the documentation location to revise`);
+	assert.match(policy, /(?:section|heading)/i, `${source} must identify the documentation section to revise`);
+	assert.match(policy, /(?:stale|missing) (?:claim|documentation|content)|(?:claim|documentation|content).{0,80}(?:stale|missing)/i, `${source} must identify the stale or missing claim`);
+	assert.match(policy, /(?:replacement wording|proposed wording|replacement outline|proposed outline)/i, `${source} must propose concrete documentation text or outline`);
+	assert.match(policy, /examples?/i, `${source} must include relevant examples when needed`);
+	assert.match(policy, /links?/i, `${source} must include relevant links when needed`);
+	assert.match(policy, /(?:verify|verification).{0,160}(?:documented behavior|documentation).{0,160}(?:implementation|implemented)|(?:implementation|implemented).{0,160}(?:verify|verification).{0,160}(?:documented behavior|documentation)/i, `${source} must explain how to verify documentation matches implementation`);
+}
+
 function assertImplementationReviewPolicy(workflows: Record<string, Workflow>, source: string) {
 	for (const workflowId of IMPLEMENTATION_WORKFLOW_IDS) {
 		const implementation = findGate(workflows[workflowId], "implementation");
@@ -133,6 +173,42 @@ describe("consolidated implementation review defaults", () => {
 				assert.match(security, risk, `${workflowId} security review must cover changed security risks`);
 			}
 			assert.match(security, /remediation.*(?:abuse|regression) tests?/is, `${workflowId} security review must require a remediation test`);
+		}
+	});
+
+	it("makes first-phase design and issue-analysis reviews revision-ready", () => {
+		const workflows = buildDefaultWorkflows("myproj");
+		for (const workflowId of ["general", "feature"] as const) {
+			const reviewSteps = findGate(workflows[workflowId], "design-doc").verify ?? [];
+			assertDesignOrAnalysisReviewPrompt(
+				reviewSteps.find((step) => step.name === "Design review")?.prompt ?? "",
+				`${workflowId}.design-doc.Design review`,
+			);
+			assertDesignOrAnalysisReviewPrompt(
+				reviewSteps.find((step) => step.name === "Gap analysis")?.prompt ?? "",
+				`${workflowId}.design-doc.Gap analysis`,
+			);
+		}
+
+		const issueAnalysis = findGate(workflows["bug-fix"], "issue-analysis").verify ?? [];
+		assertDesignOrAnalysisReviewPrompt(
+			issueAnalysis.find((step) => step.name === "Analysis quality")?.prompt ?? "",
+			"bug-fix.issue-analysis.Analysis quality",
+		);
+		assertDesignOrAnalysisReviewPrompt(
+			issueAnalysis.find((step) => step.name === "Gap analysis")?.prompt ?? "",
+			"bug-fix.issue-analysis.Gap analysis",
+		);
+	});
+
+	it("makes documentation reviews revision-ready", () => {
+		const workflows = buildDefaultWorkflows("myproj");
+		for (const workflowId of ["general", "feature", "bug-fix"] as const) {
+			const documentation = findGate(workflows[workflowId], "documentation");
+			assertDocumentationReviewPrompt(
+				documentation.verify?.find((step) => step.name === "Documentation coverage")?.prompt ?? "",
+				`${workflowId}.documentation.Documentation coverage`,
+			);
 		}
 	});
 

--- a/tests2/core/seed-default-workflows.test.ts
+++ b/tests2/core/seed-default-workflows.test.ts
@@ -27,6 +27,15 @@ type Workflow = {
 	gates: Array<{ id: string; description?: string; verify?: VerifyStep[] }>;
 };
 
+// Keep the test focused on the persisted workflow behavior rather than the
+// helper's exported TypeScript declaration. The server and per-component
+// derivation are the public consumers of this capability argument.
+type CapabilityAwareDefaultBuilder = (
+	componentName: string,
+	supportedCommands?: Iterable<string>,
+) => Record<string, Workflow>;
+const buildCapabilityAwareDefaults = buildDefaultWorkflows as CapabilityAwareDefaultBuilder;
+
 const IMPLEMENTATION_WORKFLOW_IDS = ["general", "feature", "bug-fix", "quick-fix"] as const;
 const EXPECTED_REVIEWS = [
 	{ name: "Spec and regression conformance", role: "spec-auditor" },
@@ -133,6 +142,28 @@ function assertImplementationReviewPolicy(workflows: Record<string, Workflow>, s
 describe("consolidated implementation review defaults", () => {
 	it("seeds exactly three phase-2 implementation reviews with the required roles and execution phases", () => {
 		assertImplementationReviewPolicy(buildDefaultWorkflows("myproj"), "seeded defaults");
+	});
+
+	it("omits unavailable structural commands without disturbing reviews or supported commands", () => {
+		const workflows = buildCapabilityAwareDefaults("minimal-app", ["build", "unit"]);
+
+		for (const workflowId of IMPLEMENTATION_WORKFLOW_IDS) {
+			const implementation = findGate(workflows[workflowId], "implementation");
+			const structuralCommands = (implementation.verify ?? [])
+				.filter((step) => step.type === "command" && step.command)
+				.map((step) => step.command)
+				.sort();
+			const reviews = (implementation.verify ?? [])
+				.filter((step) => step.type === "llm-review")
+				.map(({ name, role, phase }) => ({ name, role, phase }));
+
+			assert.deepEqual(structuralCommands, ["build", "unit"], `${workflowId} must retain only declared component commands`);
+			assert.deepEqual(
+				reviews,
+				EXPECTED_REVIEWS.map(({ name, role }) => ({ name, role, phase: 2 })),
+				`${workflowId} must preserve the three required phase-2 reviews`,
+			);
+		}
 	});
 
 	it("keeps the active project workflow config parseable and on the same review policy", () => {

--- a/tests2/integration/projects-no-default-workflows.test.ts
+++ b/tests2/integration/projects-no-default-workflows.test.ts
@@ -160,4 +160,99 @@ test.describe("No default workflow scaffold", () => {
 			validateAllWorkflows(workflows, [{ name: projName }]),
 		).toEqual([]);
 	});
+
+	test("Case D — auto-seeding selects the executable component after a data-only component", async () => {
+		const root = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "bobbit-nodef-d-")));
+		projectDir(root);
+		fs.mkdirSync(path.join(root, "data"));
+		fs.mkdirSync(path.join(root, "app"));
+
+		const projName = `nodef-d-${Date.now()}`;
+		const executableComponent = "app";
+		const executableCommands = {
+			build: "npm run build",
+			check: "npm run check",
+			unit: "npm run test:unit",
+			browser: "npm run test:browser",
+			e2e: "npm run test:e2e",
+		};
+		const components = [
+			{ name: "data", repo: "data" },
+			{
+				name: executableComponent,
+				repo: "app",
+				commands: executableCommands,
+				config: { qa_start_command: "npm run dev" },
+			},
+		];
+		const project = await registerProject({
+			name: projName, // Deliberately matches neither component.
+			rootPath: root,
+			components,
+			seedWorkflows: false,
+		});
+
+		const yamlPath = path.join(root, ".bobbit", "config", "project.yaml");
+		await pollUntil(() => fs.existsSync(yamlPath) ? true : null, { timeoutMs: 2000, intervalMs: 25, label: "project.yaml exists" });
+		expect(isWorkflowsAbsentOrEmpty(readProjectYaml(root))).toBe(true);
+
+		const goalRes = await fetch(`${base()}/api/goals`, {
+			method: "POST",
+			headers: headers(),
+			body: JSON.stringify({
+				title: `goal-${Date.now()}`,
+				cwd: root,
+				projectId: project.id,
+				team: false,
+				autoStartTeam: false,
+				worktree: false,
+				workflowId: "feature",
+			}),
+		});
+		expect(goalRes.status, await goalRes.clone().text()).toBe(201);
+		const createdGoal = await goalRes.json();
+
+		const workflows = readProjectYaml(root)!.workflows as Record<string, any>;
+		expect(Object.keys(workflows).sort()).toEqual(["bug-fix", "feature", "general", "parent", "quick-fix"]);
+		const expectedStructuralCommands = [
+			{ command: "build", phase: 0 },
+			{ command: "check", phase: 1 },
+			{ command: "unit", phase: 1 },
+			{ command: "browser", phase: 1 },
+			{ command: "e2e", phase: 1 },
+		];
+		for (const workflowId of ["general", "feature", "bug-fix", "quick-fix"]) {
+			const implementation = workflows[workflowId].gates.find((gate: any) => gate.id === "implementation");
+			expect(implementation, `${workflowId} implementation gate`).toBeTruthy();
+			const structural = (implementation.verify ?? []).filter((step: any) => step.type === "command" && step.component && step.command);
+			expect(
+				structural.map((step: any) => ({ command: step.command, phase: step.phase, component: step.component })),
+				`${workflowId} structural commands`,
+			).toEqual(expectedStructuralCommands.map((step) => ({ ...step, component: executableComponent })));
+			const reviews = (implementation.verify ?? [])
+				.filter((step: any) => step.type === "llm-review" && step.phase === 2)
+				.map((step: any) => step.role)
+				.sort();
+			expect(reviews).toEqual(["code-reviewer", "security-reviewer", "spec-auditor"]);
+		}
+
+		const everyStep = Object.values(workflows).flatMap((workflow: any) =>
+			(workflow.gates ?? []).flatMap((gate: any) => gate.verify ?? []),
+		);
+		expect(everyStep.filter((step: any) => step.component).every((step: any) => step.component === executableComponent)).toBe(true);
+		expect(validateAllWorkflows(workflows, components)).toEqual([]);
+
+		const persistedFeature = workflows.feature;
+		const frozenFeature = createdGoal.workflow;
+		expect(frozenFeature).toBeTruthy();
+		const frozenStructural = frozenFeature.gates
+			.find((gate: any) => gate.id === "implementation")
+			.verify.filter((step: any) => step.type === "command" && step.component && step.command)
+			.map((step: any) => ({ command: step.command, phase: step.phase, component: step.component }));
+		expect(frozenStructural).toEqual(
+			persistedFeature.gates.find((gate: any) => gate.id === "implementation").verify
+				.filter((step: any) => step.type === "command" && step.component && step.command)
+				.map((step: any) => ({ command: step.command, phase: step.phase, component: step.component })),
+		);
+	});
 });

--- a/tests2/integration/projects-no-default-workflows.test.ts
+++ b/tests2/integration/projects-no-default-workflows.test.ts
@@ -12,6 +12,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import yaml from "yaml";
+import { validateAllWorkflows } from "../../src/server/agent/workflow-validator.ts";
 
 let token: string;
 
@@ -145,6 +146,18 @@ test.describe("No default workflow scaffold", () => {
 		});
 		// Goal creation should succeed and project.yaml should now have workflows.
 		expect([200, 201]).toContain(goalRes.status);
-		expect(isWorkflowsAbsentOrEmpty(readProjectYaml(root))).toBe(false);
+		const seeded = readProjectYaml(root)!;
+		expect(isWorkflowsAbsentOrEmpty(seeded)).toBe(false);
+
+		const workflows = seeded.workflows as Record<string, any>;
+		const structuralCommands = Object.values(workflows).flatMap((workflow: any) =>
+			(workflow.gates ?? []).flatMap((gate: any) =>
+				(gate.verify ?? []).filter((step: any) => step.type === "command" && step.component && step.command),
+			),
+		);
+		expect(structuralCommands).toEqual([]);
+		expect(
+			validateAllWorkflows(workflows, [{ name: projName }]),
+		).toEqual([]);
 	});
 });

--- a/tests2/tests-map.json
+++ b/tests2/tests-map.json
@@ -2054,6 +2054,15 @@
         "tier": "browser",
         "project": "browser"
       }
+    },
+    {
+      "path": "tests2/core/default-role-policy.test.ts",
+      "reason": "Semantic default-role prompt contract preserving solution-ready reviewer findings, scope authority, bounded convergence, and team-lead evidence-led judgment without brittle prompt snapshots.",
+      "execution": {
+        "runner": "vitest",
+        "tier": "unit",
+        "project": "core"
+      }
     }
   ],
   "journeys": [


### PR DESCRIPTION
## Summary
- consolidate future General, Feature, Bug Fix, and Quick Fix implementation verification into Spec Auditor, integrated Code Reviewer, and Security Reviewer phase-2 checks
- persist coder-ready blocker packets, revision-ready content packets, review convergence, and Team Lead corroboration/synthesis policies in default role prompts
- mirror the policy into Bobbit project workflows while preserving PR Review, Human Sign-off, and existing model settings
- add focused semantic coverage for workflow phases, roles, removed specialist checks, packet completeness, and per-component command filtering

## Validation
- full implementation workflow passed Build, Typecheck, Unit, Browser, E2E, and all snapshotted LLM reviews
- 42 focused policy tests passed
- YAML parsing and `git diff --check` passed
- protected workflows and role model/thinking settings remain unchanged

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)