### PR TITLE
Add Claude Agent SDK event translator

### DIFF
--- a/docs/design/claude-sdk-g0-findings.md
+++ b/docs/design/claude-sdk-g0-findings.md
@@ -1,0 +1,65 @@
+# Claude Agent SDK G0 findings
+
+## Purpose and evidence boundary
+
+This is a G0 evidence record for a possible Claude Agent SDK runtime. It is not a runtime integration guide and does not change Bobbit behavior. The accompanying translator is deliberately offline: `src/server/agent/claude-sdk-event-translator.ts` accepts SDK-shaped values and returns Pi-compatible events without importing it from session setup or dispatch.
+
+The SDK evidence below comes from the published declarations for `@anthropic-ai/claude-agent-sdk` 0.3.220 (Claude Code 2.1.220), inspected without installing the package or running a Claude process. The JSON records in `tests2/fixtures/claude-sdk-event-translator/` are hand-authored captured-shape fixtures traceable to those declarations, not live recordings. They make the evidence auditable while keeping this slice offline.
+
+## SessionStore is not an SDK transcript store
+
+Bobbit's `SessionStore` persists gateway session metadata in `sessions.json` so sessions can survive a gateway restart. Its `PersistedSession` contract includes the gateway session identity, working-directory and agent-session-file references, queue and in-flight-steer recovery state, project and goal relationships, model selection, and lifecycle metadata. It does not model an SDK transcript tree.
+
+The SDK alpha session-store declarations describe a different responsibility: a mirror of transcript entries and subkeys, including subagent state. That data has different identity, ownership, retention, and recovery semantics from Bobbit's gateway session metadata and prompt queue.
+
+**Finding:** the two stores are not interchangeable. A future runtime needs a separate, explicitly designed adapter at the transcript/resume boundary; it must not substitute the SDK store for `SessionStore` or write SDK transcript records into Bobbit's gateway metadata store. This PR adds no adapter or store integration.
+
+## Steer ordering remains owned by SessionManager
+
+`SessionManager._dispatchSteer()` establishes the existing recovery ordering:
+
+1. It records the accepted steer in the in-flight shadow ledger.
+2. It persists that ledger with removal of the prompt-queue row, before awaiting `rpcClient.steer()`.
+3. It calls the bridge's `steer()` method.
+4. `_consumeSteerEcho()` removes only the matching user-role terminal echo from the ledger.
+5. Restore and abort reconciliation re-enqueue unresolved entries at the front, preserving their order for exactly-once redispatch.
+
+This protects the dispatch-to-echo crash window: an accepted steer is not silently lost after a reconnect or restart, while a duplicate or already-settled echo cannot consume a later same-text steer. The coverage in `tests2/integration/steer-midturn.test.ts`, `steer-reconnect.test.ts`, `steer-gateway-restart.test.ts`, and `steer-snapshot-continuity.test.ts` exercises immediate dispatch, reconnect continuity, restart recovery, and the visibility gap respectively. `tests2/core/splice-inflight-steer-occurrence.test.ts` protects the matching/occurrence boundary used when snapshotting in-flight steers.
+
+**Finding:** the translator must preserve incoming event order and must not interpret, settle, or reorder user echoes. It has no session, queue, bridge, or store access; future bridge wiring must retain `SessionManager` as the ordering owner.
+
+## Numeric effort is unspecified
+
+The published declarations expose numeric `effort` on agent definitions, while top-level query options accept named effort levels. Neither those declarations nor the published README specifies a numeric range, units, permitted granularity, or a conversion between numeric and named values.
+
+**Decision:** numeric effort support is withheld. Do not pass numeric effort values until a future live SDK spike establishes their valid range, units, semantics, and behavior across the intended models. This PR does not add model or thinking control.
+
+## Subagent stream shape and partitioning
+
+The declarations show `parent_tool_use_id` on assistant, partial-assistant (`stream_event`), and user/tool-result messages. Forwarded subagent traffic also includes task and tool-progress shapes with task, tool, and subagent identities. Tool traffic is available by default; forwarding child text and thinking is option-dependent.
+
+The fixtures record both kinds of child evidence:
+
+- `interleaved-subagents.json` interleaves root traffic with two child streams that deliberately reuse the same UUID. It includes child text, a child tool use, and its matching child result.
+- `root-tool-lifecycle.json` records text, thinking, tool use, and a user tool result in the root partition.
+- `streamed-tool-input.json` records streamed tool JSON and its truncated form.
+- `terminal-and-permission.json` records success, error, abort, permission-denial, and unknown-message shapes.
+
+The translator chooses `parent_tool_use_id` (or an internal root sentinel) before any UUID, message, or tool lookup. Its partition-local state means child output cannot merge with root output or another child's output, even when identities collide. Child events retain `parentToolUseId`; rendering those spans is intentionally deferred.
+
+**Finding:** a future subagent renderer must consume the partition identity already preserved by the translator rather than reconstructing parentage from UUIDs or message text.
+
+## Product recommendations requiring approval
+
+The following are recommendations for a later runtime design. **None is applied by this PR, and each requires explicit user approval before it changes Bobbit behavior.**
+
+| Topic | Recommendation only | Rationale | Status in this PR |
+|---|---|---|---|
+| Native Claude tools | Initially suppress native Claude tool execution. | Bobbit needs one accountable tool, permission, and event lifecycle; allowing a second native executor before that boundary risks duplicate or untracked side effects. | Not applied; no runtime or tool plumbing exists. |
+| Slash commands | Intercept slash commands in Bobbit first. | Bobbit can retain its command semantics, authorization, and UI behavior instead of relying on an SDK command path with different ownership. | Not applied; no dispatch behavior changes. |
+| Bundled skills | Resolve bundled skills through Bobbit's pack resolver. | The existing pack system provides the project-scoped source of truth and avoids diverging skill selection or precedence. | Not applied; no skill adoption or pack changes. |
+| Built-in `Agent` and `Task` | Initially withhold the SDK's built-in subagent tools. | Bobbit must first define supervision, isolation, lifecycle, and rendering for child work; the partitioned stream evidence is necessary but not sufficient for that product behavior. | Not applied; no subagent runtime or rendering exists. |
+
+## Scope confirmation
+
+This G0 slice adds only the pure translator, typed captured-shape fixtures, focused tests, and this findings record. It does not spawn a runtime, register a provider or dependency, change session setup/dispatch, install permissions, execute tools, expose skills, persist transcripts, or render subagents. The recommendations above remain documentation, not implementation.

--- a/src/server/agent/claude-sdk-event-translator.ts
+++ b/src/server/agent/claude-sdk-event-translator.ts
@@ -1,10 +1,30 @@
 import type { AgentEvent } from "@earendil-works/pi-agent-core";
+import type {
+	AssistantMessage,
+	AssistantMessageEvent,
+	StopReason,
+	TextContent,
+	ThinkingContent,
+	ToolCall,
+	ToolResultMessage,
+	Usage,
+} from "@earendil-works/pi-ai";
 
 /** The untyped envelope emitted by the Claude Agent SDK query iterator. */
 export type ClaudeSdkEvent = Readonly<Record<string, unknown>>;
 
+/** SDK terminal information which Pi's AgentEvent vocabulary does not represent. */
+export interface ClaudeSdkEventMetadata {
+	readonly terminal?: Readonly<{ error?: string; terminalReason?: string; subtype?: string }>;
+}
+
 /** A Pi event annotated when it belongs to a forwarded subagent stream. */
-export type ClaudeSdkTranslatedEvent = AgentEvent & { parentToolUseId?: string };
+type ClaudeSdkEventAnnotation = {
+	readonly parentToolUseId?: string;
+	readonly claudeSdk?: ClaudeSdkEventMetadata;
+};
+
+export type ClaudeSdkTranslatedEvent = AgentEvent & ClaudeSdkEventAnnotation;
 
 export interface ClaudeSdkTranslatorDiagnostic {
 	code: "malformed" | "unknown_kind" | "late_event" | "duplicate" | "partition_mismatch";
@@ -18,48 +38,53 @@ export interface ClaudeSdkTranslation {
 	diagnostics: readonly ClaudeSdkTranslatorDiagnostic[];
 }
 
-type ContentBlock = Readonly<Record<string, unknown>>;
+type TranslatorContent = TextContent | ThinkingContent | (ToolCall & { readonly argumentsJson?: string });
+type PartitionKey = string | typeof ROOT;
 
 interface PartialAssistant {
 	readonly id: string;
-	readonly blocks: Readonly<Record<string, ContentBlock>>;
+	readonly blocks: ReadonlyMap<number, TranslatorContent>;
+	readonly stoppedBlocks: ReadonlySet<number>;
+	readonly timestamp: number;
+	readonly usage: Usage;
 }
 
 interface OpenTool {
 	readonly id: string;
 	readonly name: string;
-	readonly input: unknown;
+	readonly input: Record<string, any>;
 }
 
 interface PartitionState {
-	readonly partials: Readonly<Record<string, PartialAssistant>>;
-	readonly openTools: Readonly<Record<string, OpenTool>>;
-	readonly finalized: Readonly<Record<string, true>>;
+	readonly partials: ReadonlyMap<string, PartialAssistant>;
+	readonly openTools: ReadonlyMap<string, OpenTool>;
+	readonly finalized: ReadonlySet<string>;
 	readonly fingerprints: readonly string[];
+	readonly activeStreamId?: string;
 }
 
 /**
- * Immutable state for the offline SDK-message translator.  The root key is an
- * implementation detail: all externally visible child events retain their
- * original parentToolUseId.
+ * Immutable state for the offline SDK-message translator. A symbol makes the
+ * internal root identity structurally disjoint from every SDK parent_tool_use_id.
  */
 export interface ClaudeSdkTranslatorState {
-	readonly partitions: Readonly<Record<string, PartitionState>>;
+	readonly partitions: ReadonlyMap<PartitionKey, PartitionState>;
 	readonly terminated: boolean;
 }
 
-const ROOT = "__claude_sdk_root__";
+const ROOT = Symbol("claude-sdk-root");
+const ROOT_LABEL = "root";
 const MAX_FINGERPRINTS = 256;
 const MAX_DIAGNOSTIC_DETAIL = 240;
-const EMPTY_PARTITION: PartitionState = Object.freeze({
-	partials: Object.freeze({}),
-	openTools: Object.freeze({}),
-	finalized: Object.freeze({}),
-	fingerprints: Object.freeze([]),
-});
+const EMPTY_PARTITION: PartitionState = {
+	partials: new Map(),
+	openTools: new Map(),
+	finalized: new Set(),
+	fingerprints: [],
+};
 
 export function createClaudeSdkTranslatorState(): ClaudeSdkTranslatorState {
-	return Object.freeze({ partitions: Object.freeze({}), terminated: false });
+	return { partitions: new Map(), terminated: false };
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -70,16 +95,20 @@ function nonEmptyString(value: unknown): string | undefined {
 	return typeof value === "string" && value.length > 0 ? value : undefined;
 }
 
-function partitionFor(input: Record<string, unknown>): string {
+function partitionFor(input: Record<string, unknown>): PartitionKey {
 	return nonEmptyString(input.parent_tool_use_id) ?? ROOT;
+}
+
+function partitionLabel(key: PartitionKey): string {
+	return key === ROOT ? ROOT_LABEL : key;
 }
 
 function diagnostic(
 	code: ClaudeSdkTranslatorDiagnostic["code"],
-	partition: string,
+	partition: PartitionKey,
 	detail: string,
 ): ClaudeSdkTranslatorDiagnostic {
-	return { code, partition, detail: detail.slice(0, MAX_DIAGNOSTIC_DETAIL) };
+	return { code, partition: partitionLabel(partition), detail: detail.slice(0, MAX_DIAGNOSTIC_DETAIL) };
 }
 
 /** A deterministic, bounded fingerprint which cannot throw on hostile input. */
@@ -118,12 +147,17 @@ function safeValue(value: unknown, seen = new WeakSet<object>(), depth = 0): unk
 	if (seen.has(value)) return "[circular]";
 	seen.add(value);
 	if (Array.isArray(value)) return value.slice(0, 128).map(item => safeValue(item, seen, depth + 1));
-	const result: Record<string, unknown> = {};
+	const result: Record<string, unknown> = Object.create(null);
 	for (const key of Object.keys(value).slice(0, 128)) {
 		const child = safeValue((value as Record<string, unknown>)[key], seen, depth + 1);
 		if (child !== undefined) result[key] = child;
 	}
 	return result;
+}
+
+function safeRecord(value: unknown): Record<string, any> {
+	const safe = safeValue(value);
+	return isRecord(safe) ? safe : {};
 }
 
 function safeText(value: unknown): string {
@@ -133,87 +167,173 @@ function safeText(value: unknown): string {
 	try { return JSON.stringify(safe); } catch { return "[unserializable]"; }
 }
 
-function contentBlocks(content: unknown): ContentBlock[] {
+function timestampFor(input: Record<string, unknown>): number {
+	const timestamp = input.timestamp_ms ?? input.timestamp;
+	return typeof timestamp === "number" && Number.isFinite(timestamp) ? timestamp : 0;
+}
+
+function usageFor(value: unknown): Usage {
+	const usage = isRecord(value) ? value : {};
+	const number = (name: string): number => typeof usage[name] === "number" && Number.isFinite(usage[name]) ? usage[name] as number : 0;
+	const input = number("input_tokens") || number("input");
+	const output = number("output_tokens") || number("output");
+	const cacheRead = number("cache_read_input_tokens") || number("cacheRead");
+	const cacheWrite = number("cache_creation_input_tokens") || number("cacheWrite");
+	const cost = typeof usage.cost_usd === "number" && Number.isFinite(usage.cost_usd) ? usage.cost_usd : 0;
+	return {
+		input,
+		output,
+		cacheRead,
+		cacheWrite,
+		totalTokens: input + output,
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: cost },
+	};
+}
+
+function stopReasonFor(value: unknown, error = false, aborted = false): StopReason {
+	if (aborted) return "aborted";
+	if (error) return "error";
+	switch (value) {
+		case "end_turn": case "stop_sequence": case "stop": return "stop";
+		case "max_tokens": case "length": return "length";
+		case "tool_use": case "toolUse": return "toolUse";
+		case "error": case "refusal": return "error";
+		case "aborted": case "aborted_streaming": case "aborted_tools": return "aborted";
+		default: return "stop";
+	}
+}
+
+function parsedToolArguments(block: ToolCall & { readonly argumentsJson?: string }): Record<string, any> {
+	if (block.argumentsJson !== undefined) {
+		try {
+			const parsed: unknown = JSON.parse(block.argumentsJson);
+			return isRecord(parsed) ? safeRecord(parsed) : {};
+		} catch { return {}; }
+	}
+	return safeRecord(block.arguments);
+}
+
+function contentBlocks(content: unknown): TranslatorContent[] {
 	if (typeof content === "string") return content.length > 0 ? [{ type: "text", text: content }] : [];
 	if (!Array.isArray(content)) return [];
-	const blocks: ContentBlock[] = [];
+	const blocks: TranslatorContent[] = [];
 	for (const block of content) {
 		if (!isRecord(block)) continue;
 		const type = nonEmptyString(block.type);
 		if (type === "text" && typeof block.text === "string") blocks.push({ type: "text", text: block.text });
-		else if ((type === "thinking" || type === "redacted_thinking") && typeof block.thinking === "string") {
-			blocks.push({ type: "thinking", thinking: block.thinking, ...(nonEmptyString(block.signature) ? { signature: block.signature } : {}) });
-		} else if (type === "tool_use" && nonEmptyString(block.id) && nonEmptyString(block.name)) {
-			blocks.push({ type: "toolCall", id: block.id, name: block.name, arguments: safeValue(block.input) ?? {} });
+		else if (type === "thinking" && typeof block.thinking === "string") {
+			const signature = nonEmptyString(block.signature);
+			blocks.push({ type: "thinking", thinking: block.thinking, ...(signature ? { thinkingSignature: signature } : {}) });
+		} else if (type === "redacted_thinking" && typeof block.data === "string") {
+			blocks.push({ type: "thinking", thinking: "", thinkingSignature: block.data, redacted: true });
+		} else if (type === "tool_use") {
+			const id = nonEmptyString(block.id);
+			const name = nonEmptyString(block.name);
+			if (id && name) blocks.push({ type: "toolCall", id, name, arguments: safeRecord(block.input) });
 		}
 	}
 	return blocks;
 }
 
-function assistantMessage(id: string, blocks: readonly ContentBlock[], source?: Record<string, unknown>): Record<string, unknown> {
+function assistantMessage(
+	blocks: readonly TranslatorContent[],
+	source: Record<string, unknown> | undefined,
+	timestamp: number,
+	usage?: Usage,
+	error = false,
+	aborted = false,
+): AssistantMessage {
 	return {
-		id,
 		role: "assistant",
-		content: blocks,
+		content: blocks.map((block) => block.type === "toolCall" ? { ...block, arguments: parsedToolArguments(block) } : block),
 		api: "anthropic",
 		provider: "anthropic",
 		model: nonEmptyString(source?.model) ?? "claude-code-sdk",
-		...(nonEmptyString(source?.stop_reason) ? { stopReason: nonEmptyString(source?.stop_reason) } : {}),
+		usage: usage ?? usageFor(source?.usage),
+		stopReason: stopReasonFor(source?.stop_reason, error, aborted),
+		timestamp,
+		...(error ? { errorMessage: terminalError(source) } : {}),
 	};
 }
 
-function annotate(event: Record<string, unknown>, partition: string): ClaudeSdkTranslatedEvent {
-	return (partition === ROOT ? event : { ...event, parentToolUseId: partition }) as ClaudeSdkTranslatedEvent;
+function toolsIn(blocks: readonly TranslatorContent[]): OpenTool[] {
+	return blocks.flatMap((block) => block.type === "toolCall"
+		? [{ id: block.id, name: block.name, input: parsedToolArguments(block) }]
+		: []);
 }
 
-function toolsIn(blocks: readonly ContentBlock[]): OpenTool[] {
-	return blocks.flatMap((block) => {
-		const id = nonEmptyString(block.id);
-		const name = nonEmptyString(block.name);
-		return block.type === "toolCall" && id && name
-			? [{ id, name, input: block.arguments ?? {} }]
-			: [];
-	});
-}
-
-function updatePartition(state: ClaudeSdkTranslatorState, key: string, partition: PartitionState): ClaudeSdkTranslatorState {
-	return { ...state, partitions: { ...state.partitions, [key]: partition } };
+function updatePartition(state: ClaudeSdkTranslatorState, key: PartitionKey, partition: PartitionState): ClaudeSdkTranslatorState {
+	const partitions = new Map(state.partitions);
+	partitions.set(key, partition);
+	return { ...state, partitions };
 }
 
 function withFingerprint(partition: PartitionState, value: string): PartitionState {
-	const fingerprints = [...partition.fingerprints, value];
-	return { ...partition, fingerprints: fingerprints.slice(-MAX_FINGERPRINTS) };
+	return { ...partition, fingerprints: [...partition.fingerprints, value].slice(-MAX_FINGERPRINTS) };
 }
 
-function blocksFor(partial: PartialAssistant): ContentBlock[] {
-	return Object.keys(partial.blocks).sort((a, b) => Number(a) - Number(b)).map(index => partial.blocks[index]!);
+function blocksFor(partial: PartialAssistant): TranslatorContent[] {
+	return [...partial.blocks.entries()].sort(([left], [right]) => left - right).map(([, block]) => block);
+}
+
+function annotate<T extends AgentEvent>(event: T, partition: PartitionKey, metadata?: ClaudeSdkEventMetadata): T & ClaudeSdkEventAnnotation {
+	return partition === ROOT
+		? { ...event, ...(metadata ? { claudeSdk: metadata } : {}) }
+		: { ...event, parentToolUseId: partition, ...(metadata ? { claudeSdk: metadata } : {}) };
+}
+
+function partialEvent(
+	partial: PartialAssistant,
+	source: Record<string, unknown> | undefined,
+	type: AssistantMessageEvent["type"],
+	index?: number,
+	delta?: string,
+): ClaudeSdkTranslatedEvent {
+	const message = assistantMessage(blocksFor(partial), source, partial.timestamp, partial.usage);
+	const contentIndex = index ?? 0;
+	let event: AssistantMessageEvent;
+	switch (type) {
+		case "start": event = { type, partial: message }; break;
+		case "text_start": case "thinking_start": case "toolcall_start": event = { type, contentIndex, partial: message }; break;
+		case "text_delta": case "thinking_delta": case "toolcall_delta": event = { type, contentIndex, delta: delta ?? "", partial: message }; break;
+		case "text_end": case "thinking_end": event = { type, contentIndex, content: delta ?? "", partial: message }; break;
+		case "toolcall_end": {
+			const block = partial.blocks.get(contentIndex);
+			if (!block || block.type !== "toolCall") return partialEvent(partial, source, "start");
+			event = { type, contentIndex, toolCall: { ...block, arguments: parsedToolArguments(block) }, partial: message };
+			break;
+		}
+		default: event = { type: "start", partial: message };
+	}
+	const translated: Extract<AgentEvent, { type: "message_update" }> = { type: "message_update", message, assistantMessageEvent: event };
+	return translated;
 }
 
 function emitAssistantEnd(
 	partition: PartitionState,
-	partitionKey: string,
+	partitionKey: PartitionKey,
 	id: string,
-	blocks: readonly ContentBlock[],
+	blocks: readonly TranslatorContent[],
 	source: Record<string, unknown> | undefined,
+	timestamp: number,
 	events: ClaudeSdkTranslatedEvent[],
 ): PartitionState {
-	if (partition.finalized[id]) return partition;
-	events.push(annotate({ type: "message_end", message: assistantMessage(id, blocks, source) }, partitionKey));
-	const openTools = { ...partition.openTools };
+	if (partition.finalized.has(id)) return partition;
+	events.push(annotate({ type: "message_end", message: assistantMessage(blocks, source, timestamp) }, partitionKey));
+	const openTools = new Map(partition.openTools);
 	for (const tool of toolsIn(blocks)) {
-		if (openTools[tool.id]) continue;
-		openTools[tool.id] = tool;
+		if (openTools.has(tool.id)) continue;
+		openTools.set(tool.id, tool);
 		events.push(annotate({ type: "tool_execution_start", toolCallId: tool.id, toolName: tool.name, args: tool.input }, partitionKey));
 	}
-	const partials = { ...partition.partials };
-	delete partials[id];
-	return { ...partition, partials, openTools, finalized: { ...partition.finalized, [id]: true } };
+	const partials = new Map(partition.partials);
+	partials.delete(id);
+	return { ...partition, partials, openTools, finalized: new Set([...partition.finalized, id]), activeStreamId: partition.activeStreamId === id ? undefined : partition.activeStreamId };
 }
 
 function extractToolResult(message: Record<string, unknown>): { id: string; content: unknown; isError: boolean } | undefined {
-	const content = message.content;
-	if (!Array.isArray(content)) return undefined;
-	for (const item of content) {
+	if (!Array.isArray(message.content)) return undefined;
+	for (const item of message.content) {
 		if (!isRecord(item) || item.type !== "tool_result") continue;
 		const id = nonEmptyString(item.tool_use_id);
 		if (id) return { id, content: item.content, isError: item.is_error === true };
@@ -221,39 +341,70 @@ function extractToolResult(message: Record<string, unknown>): { id: string; cont
 	return undefined;
 }
 
-function toolResultMessage(tool: OpenTool, content: unknown, isError: boolean): Record<string, unknown> {
+function toolResultMessage(tool: OpenTool, content: unknown, isError: boolean, timestamp: number): ToolResultMessage {
 	return {
 		role: "toolResult",
 		toolCallId: tool.id,
 		toolName: tool.name,
 		content: [{ type: "text", text: safeText(content) }],
 		isError,
+		timestamp,
 	};
 }
 
+function terminalError(source: Record<string, unknown> | undefined): string {
+	if (!source) return "";
+	if (Array.isArray(source.errors)) return source.errors.map(safeText).filter(Boolean).join("; ").slice(0, 2_000);
+	if (typeof source.error === "string") return source.error.slice(0, 2_000);
+	if (source.aborted === true) return "Request aborted";
+	if (typeof source.terminal_reason === "string") return source.terminal_reason.slice(0, 2_000);
+	return safeText(source.subtype ?? source.result).slice(0, 2_000);
+}
+
 function isTerminalEvent(type: string, input: Record<string, unknown>): boolean {
-	return type === "result" || type === "error" || type === "abort" || (type === "assistant" && input.is_error === true);
+	return type === "result" || (type === "assistant" && (input.aborted === true || typeof input.error === "string"));
+}
+
+function terminalIsError(source: Record<string, unknown>): boolean {
+	return source.is_error === true || source.aborted === true || typeof source.error === "string"
+		|| /^error/.test(String(source.subtype ?? "")) || /^aborted/.test(String(source.terminal_reason ?? ""));
 }
 
 function drain(state: ClaudeSdkTranslatorState, events: ClaudeSdkTranslatedEvent[], source: Record<string, unknown>): ClaudeSdkTranslatorState {
-	let next: ClaudeSdkTranslatorState = { ...state, partitions: { ...state.partitions }, terminated: true };
-	for (const [partitionKey, original] of Object.entries(state.partitions)) {
+	let next: ClaudeSdkTranslatorState = { ...state, partitions: new Map(state.partitions), terminated: true };
+	for (const [partitionKey, original] of state.partitions) {
 		let partition = original;
-		for (const partial of Object.values(partition.partials)) {
-			partition = emitAssistantEnd(partition, partitionKey, partial.id, blocksFor(partial), undefined, events);
+		for (const partial of partition.partials.values()) {
+			partition = emitAssistantEnd(partition, partitionKey, partial.id, blocksFor(partial), undefined, partial.timestamp, events);
 		}
-		const openTools = Object.values(partition.openTools);
-		for (const tool of openTools) {
-			const result = toolResultMessage(tool, "Tool call ended before a result was received.", true);
+		for (const tool of partition.openTools.values()) {
+			const result = toolResultMessage(tool, "Tool call ended before a result was received.", true, timestampFor(source));
 			events.push(annotate({ type: "message_end", message: result }, partitionKey));
 			events.push(annotate({ type: "tool_execution_end", toolCallId: tool.id, toolName: tool.name, result: { content: result.content }, isError: true }, partitionKey));
 		}
-		partition = { ...partition, openTools: {} };
+		partition = { ...partition, openTools: new Map(), activeStreamId: undefined };
 		next = updatePartition(next, partitionKey, partition);
 	}
-	const error = source.is_error === true || source.type === "error" || source.type === "abort" || /^error|abort/.test(String(source.subtype ?? ""));
-	events.push(annotate({ type: "agent_end", messages: [], ...(error ? { error: safeText(source.error ?? source.result ?? source.subtype) } : {}) }, ROOT));
+	const error = terminalIsError(source);
+	const terminalReason = nonEmptyString(source.terminal_reason);
+	const errorText = error ? terminalError(source) : undefined;
+	events.push(annotate(
+		{ type: "agent_end", messages: [] },
+		ROOT,
+		{ terminal: { ...(errorText ? { error: errorText } : {}), ...(terminalReason ? { terminalReason } : {}), ...(nonEmptyString(source.subtype) ? { subtype: nonEmptyString(source.subtype) } : {}) } },
+	));
 	return next;
+}
+
+function streamId(input: Record<string, unknown>, raw: Record<string, unknown>, partition: PartitionState): string | undefined {
+	const rawMessage = isRecord(raw.message) ? raw.message : undefined;
+	return nonEmptyString(rawMessage?.id) ?? partition.activeStreamId ?? nonEmptyString(input.uuid);
+}
+
+function contentStart(block: Record<string, unknown>): TranslatorContent | undefined {
+	return contentBlocks([block])[0] ?? (block.type === "tool_use" && nonEmptyString(block.id) && nonEmptyString(block.name)
+		? { type: "toolCall", id: block.id, name: block.name, arguments: {}, argumentsJson: "" }
+		: undefined);
 }
 
 /**
@@ -265,23 +416,26 @@ export function translateClaudeSdkEvent(state: ClaudeSdkTranslatorState, input: 
 	const events: ClaudeSdkTranslatedEvent[] = [];
 	const diagnostics: ClaudeSdkTranslatorDiagnostic[] = [];
 	if (!isRecord(input)) {
-		return { state: { ...state, partitions: { ...state.partitions } }, events, diagnostics: [diagnostic("malformed", ROOT, "SDK event must be an object")] };
+		return { state: { ...state, partitions: new Map(state.partitions) }, events, diagnostics: [diagnostic("malformed", ROOT, "SDK event must be an object")] };
 	}
 
 	const partitionKey = partitionFor(input);
 	if (state.terminated) {
-		return { state: { ...state, partitions: { ...state.partitions } }, events, diagnostics: [diagnostic("late_event", partitionKey, "event arrived after terminal result")] };
+		return { state: { ...state, partitions: new Map(state.partitions) }, events, diagnostics: [diagnostic("late_event", partitionKey, "event arrived after terminal result")] };
 	}
-	let partition = state.partitions[partitionKey] ?? EMPTY_PARTITION;
-	const frame = fingerprint(input);
-	if (partition.fingerprints.includes(frame)) {
-		return { state: updatePartition(state, partitionKey, partition), events, diagnostics: [diagnostic("duplicate", partitionKey, "duplicate SDK event")] };
-	}
-	partition = withFingerprint(partition, frame);
-	let next = updatePartition(state, partitionKey, partition);
-
+	let partition = state.partitions.get(partitionKey) ?? EMPTY_PARTITION;
 	const type = nonEmptyString(input.type);
-	if (!type) return { state: next, events, diagnostics: [diagnostic("malformed", partitionKey, "SDK event is missing type")] };
+	if (!type) return { state: updatePartition(state, partitionKey, partition), events, diagnostics: [diagnostic("malformed", partitionKey, "SDK event is missing type")] };
+
+	// Streaming deltas are transitions, not replayable snapshots: two equal deltas append twice.
+	if (type !== "stream_event") {
+		const frame = fingerprint(input);
+		if (partition.fingerprints.includes(frame)) {
+			return { state: updatePartition(state, partitionKey, partition), events, diagnostics: [diagnostic("duplicate", partitionKey, "duplicate SDK event")] };
+		}
+		partition = withFingerprint(partition, frame);
+	}
+	let next = updatePartition(state, partitionKey, partition);
 
 	if (isTerminalEvent(type, input)) return { state: drain(next, events, input), events, diagnostics };
 
@@ -289,66 +443,110 @@ export function translateClaudeSdkEvent(state: ClaudeSdkTranslatorState, input: 
 		const message = isRecord(input.message) ? input.message : undefined;
 		const id = nonEmptyString(input.uuid) ?? nonEmptyString(message?.id);
 		if (!message || !id) return { state: next, events, diagnostics: [diagnostic("malformed", partitionKey, "assistant event is missing message identity")] };
-		if (partition.finalized[id]) return { state: next, events, diagnostics: [diagnostic("late_event", partitionKey, "assistant message is already final")] };
-		partition = emitAssistantEnd(partition, partitionKey, id, contentBlocks(message.content), message, events);
+		if (partition.finalized.has(id)) return { state: next, events, diagnostics: [diagnostic("late_event", partitionKey, "assistant message is already final")] };
+		partition = emitAssistantEnd(partition, partitionKey, id, contentBlocks(message.content), message, timestampFor(input), events);
 		return { state: updatePartition(next, partitionKey, partition), events, diagnostics };
 	}
 
 	if (type === "stream_event") {
 		const raw = isRecord(input.event) ? input.event : undefined;
-		const rawMessage = isRecord(raw?.message) ? raw.message : undefined;
 		const rawType = nonEmptyString(raw?.type);
-		const id = nonEmptyString(input.uuid) ?? nonEmptyString(rawMessage?.id);
+		const id = raw && streamId(input, raw, partition);
 		if (!raw || !rawType || !id) return { state: next, events, diagnostics: [diagnostic("malformed", partitionKey, "stream event is missing event type or message identity")] };
-		if (partition.finalized[id]) return { state: next, events, diagnostics: [diagnostic("late_event", partitionKey, "stream event follows final assistant message")] };
+		if (partition.finalized.has(id)) return { state: next, events, diagnostics: [diagnostic("late_event", partitionKey, "stream event follows final assistant message")] };
+		const source = isRecord(raw.message) ? raw.message : undefined;
 		if (rawType === "message_start") {
-			if (!partition.partials[id]) {
-				const partial: PartialAssistant = { id, blocks: {} };
-				partition = { ...partition, partials: { ...partition.partials, [id]: partial } };
-				events.push(annotate({ type: "message_update", message: assistantMessage(id, [], isRecord(raw.message) ? raw.message : undefined) }, partitionKey));
-			}
+			if (!partition.partials.has(id)) {
+				const partial: PartialAssistant = { id, blocks: new Map(), stoppedBlocks: new Set(), timestamp: timestampFor(input), usage: usageFor(source?.usage) };
+				partition = { ...partition, partials: new Map([...partition.partials, [id, partial]]), activeStreamId: id };
+				events.push(annotate(partialEvent(partial, source, "start"), partitionKey));
+			} else partition = { ...partition, activeStreamId: id };
 			return { state: updatePartition(next, partitionKey, partition), events, diagnostics };
 		}
 		if (rawType === "content_block_start" || rawType === "content_block_delta") {
-			const index = typeof raw.index === "number" && Number.isInteger(raw.index) && raw.index >= 0 ? String(raw.index) : undefined;
-			if (!index) return { state: next, events, diagnostics: [diagnostic("malformed", partitionKey, "content block event is missing index")] };
-			const previous = partition.partials[id] ?? { id, blocks: {} };
-			const existing = previous.blocks[index];
+			const index = typeof raw.index === "number" && Number.isInteger(raw.index) && raw.index >= 0 ? raw.index : undefined;
+			if (index === undefined) return { state: next, events, diagnostics: [diagnostic("malformed", partitionKey, "content block event is missing index")] };
+			const previous = partition.partials.get(id) ?? { id, blocks: new Map(), stoppedBlocks: new Set(), timestamp: timestampFor(input), usage: usageFor(undefined) };
+			const existing = previous.blocks.get(index);
 			const block = rawType === "content_block_start" ? raw.content_block : raw.delta;
 			if (!isRecord(block)) return { state: next, events, diagnostics: [diagnostic("malformed", partitionKey, "content block payload must be an object")] };
-			let normalized: ContentBlock | undefined;
-			if (rawType === "content_block_start") normalized = contentBlocks([block])[0];
-			else if (existing?.type === "text" && typeof block.text === "string") normalized = { ...existing, text: `${existing.text ?? ""}${block.text}` };
-			else if (existing?.type === "thinking" && typeof block.thinking === "string") normalized = { ...existing, thinking: `${existing.thinking ?? ""}${block.thinking}` };
-			else if (existing?.type === "toolCall" && typeof block.partial_json === "string") normalized = { ...existing, arguments: `${existing.arguments ?? ""}${block.partial_json}` };
+			let normalized: TranslatorContent | undefined;
+			let messageEvent: AssistantMessageEvent["type"];
+			let delta: string | undefined;
+			if (rawType === "content_block_start") {
+				normalized = contentStart(block);
+				messageEvent = normalized?.type === "text" ? "text_start" : normalized?.type === "thinking" ? "thinking_start" : "toolcall_start";
+			} else if (existing?.type === "text" && typeof block.text === "string") {
+				normalized = { ...existing, text: existing.text + block.text }; messageEvent = "text_delta"; delta = block.text;
+			} else if (existing?.type === "thinking" && typeof block.thinking === "string") {
+				normalized = { ...existing, thinking: existing.thinking + block.thinking }; messageEvent = "thinking_delta"; delta = block.thinking;
+			} else if (existing?.type === "thinking" && typeof block.signature === "string") {
+				normalized = { ...existing, thinkingSignature: block.signature }; messageEvent = "thinking_delta"; delta = "";
+			} else if (existing?.type === "toolCall" && typeof block.partial_json === "string") {
+				normalized = { ...existing, argumentsJson: (existing.argumentsJson ?? "") + block.partial_json }; messageEvent = "toolcall_delta"; delta = block.partial_json;
+			}
 			if (!normalized) return { state: next, events, diagnostics: [diagnostic("unknown_kind", partitionKey, "unrecognized content block")] };
-			const partial: PartialAssistant = { id, blocks: { ...previous.blocks, [index]: normalized } };
-			partition = { ...partition, partials: { ...partition.partials, [id]: partial } };
-			events.push(annotate({ type: "message_update", message: assistantMessage(id, blocksFor(partial)) }, partitionKey));
+			const partial: PartialAssistant = { ...previous, blocks: new Map([...previous.blocks, [index, normalized]]) };
+			partition = { ...partition, partials: new Map([...partition.partials, [id, partial]]), activeStreamId: id };
+			events.push(annotate(partialEvent(partial, source, messageEvent!, index, delta), partitionKey));
 			return { state: updatePartition(next, partitionKey, partition), events, diagnostics };
 		}
-		if (rawType === "message_stop" || rawType === "content_block_stop" || rawType === "message_delta" || rawType === "ping") return { state: next, events, diagnostics };
+		if (rawType === "content_block_stop") {
+			const index = typeof raw.index === "number" && Number.isInteger(raw.index) && raw.index >= 0 ? raw.index : undefined;
+			const partial = index === undefined ? undefined : partition.partials.get(id);
+			if (index === undefined || !partial) return { state: next, events, diagnostics };
+			if (partial.stoppedBlocks.has(index)) return { state: next, events, diagnostics: [diagnostic("duplicate", partitionKey, "content block is already stopped")] };
+			const block = partial.blocks.get(index);
+			if (!block) return { state: next, events, diagnostics: [diagnostic("malformed", partitionKey, "content block stop has no block")] };
+			const stopped = { ...partial, stoppedBlocks: new Set([...partial.stoppedBlocks, index]) };
+			partition = { ...partition, partials: new Map([...partition.partials, [id, stopped]]) };
+			const eventType = block.type === "text" ? "text_end" : block.type === "thinking" ? "thinking_end" : "toolcall_end";
+			events.push(annotate(partialEvent(stopped, source, eventType, index, block.type === "text" ? block.text : block.type === "thinking" ? block.thinking : undefined), partitionKey));
+			return { state: updatePartition(next, partitionKey, partition), events, diagnostics };
+		}
+		if (rawType === "message_delta") {
+			const partial = partition.partials.get(id);
+			const usage = isRecord(raw.usage) ? raw.usage : isRecord(raw.delta) ? raw.delta.usage : undefined;
+			if (partial && usage) {
+				const updated = { ...partial, usage: usageFor(usage) };
+				partition = { ...partition, partials: new Map([...partition.partials, [id, updated]]) };
+				events.push(annotate(partialEvent(updated, source, "start"), partitionKey));
+			}
+			return { state: updatePartition(next, partitionKey, partition), events, diagnostics };
+		}
+		if (rawType === "message_stop") return { state: updatePartition(next, partitionKey, { ...partition, activeStreamId: partition.activeStreamId === id ? undefined : partition.activeStreamId }), events, diagnostics };
+		if (rawType === "ping") return { state: next, events, diagnostics };
 		return { state: next, events, diagnostics: [diagnostic("unknown_kind", partitionKey, `unknown stream event ${rawType}`)] };
 	}
 
 	if (type === "user") {
 		const message = isRecord(input.message) ? input.message : undefined;
 		const result = message && extractToolResult(message);
-		if (!result) return { state: next, events, diagnostics: [diagnostic("malformed", partitionKey, "user event has no tool result")] };
-		const tool = partition.openTools[result.id];
+		if (!result) return { state: next, events, diagnostics };
+		const tool = partition.openTools.get(result.id);
 		if (!tool) return { state: next, events, diagnostics: [diagnostic("late_event", partitionKey, "tool result has no open tool in this partition")] };
-		const messageEnd = toolResultMessage(tool, result.content, result.isError);
+		const messageEnd = toolResultMessage(tool, result.content, result.isError, timestampFor(input));
 		events.push(annotate({ type: "message_end", message: messageEnd }, partitionKey));
 		events.push(annotate({ type: "tool_execution_end", toolCallId: tool.id, toolName: tool.name, result: { content: messageEnd.content }, isError: result.isError }, partitionKey));
-		const openTools = { ...partition.openTools };
-		delete openTools[tool.id];
+		const openTools = new Map(partition.openTools);
+		openTools.delete(tool.id);
 		return { state: updatePartition(next, partitionKey, { ...partition, openTools }), events, diagnostics };
 	}
 
-	if (type === "system" && String(input.subtype ?? "") === "permission_denial") {
-		const text = safeText(input.error ?? input.message ?? "Permission denied");
-		events.push(annotate({ type: "message_end", message: { role: "toolResult", content: [{ type: "text", text }], isError: true } }, partitionKey));
-		return { state: next, events, diagnostics };
+	if (type === "system" && input.subtype === "permission_denied") {
+		const id = nonEmptyString(input.tool_use_id);
+		const name = nonEmptyString(input.tool_name);
+		if (!id || !name) return { state: next, events, diagnostics: [diagnostic("malformed", partitionKey, "permission denial is missing tool identity")] };
+		const tool = partition.openTools.get(id) ?? { id, name, input: {} };
+		const message = toolResultMessage(tool, input.message ?? input.error ?? "Permission denied", true, timestampFor(input));
+		events.push(annotate({ type: "message_end", message }, partitionKey));
+		if (partition.openTools.has(id)) {
+			events.push(annotate({ type: "tool_execution_end", toolCallId: tool.id, toolName: tool.name, result: { content: message.content }, isError: true }, partitionKey));
+			const openTools = new Map(partition.openTools);
+			openTools.delete(id);
+			partition = { ...partition, openTools };
+		}
+		return { state: updatePartition(next, partitionKey, partition), events, diagnostics };
 	}
 
 	return { state: next, events, diagnostics: [diagnostic("unknown_kind", partitionKey, `unknown SDK message type ${type}`)] };

--- a/src/server/agent/claude-sdk-event-translator.ts
+++ b/src/server/agent/claude-sdk-event-translator.ts
@@ -1,0 +1,351 @@
+import type { AgentEvent } from "@earendil-works/pi-agent-core";
+
+/** The untyped envelope emitted by the Claude Agent SDK query iterator. */
+export type ClaudeSdkEvent = Readonly<Record<string, unknown>>;
+
+/** A Pi event annotated when it belongs to a forwarded subagent stream. */
+export type ClaudeSdkTranslatedEvent = AgentEvent & { parentToolUseId?: string };
+
+export interface ClaudeSdkTranslatorDiagnostic {
+	code: "malformed" | "unknown_kind" | "late_event" | "duplicate" | "partition_mismatch";
+	partition: string;
+	detail: string;
+}
+
+export interface ClaudeSdkTranslation {
+	state: ClaudeSdkTranslatorState;
+	events: readonly ClaudeSdkTranslatedEvent[];
+	diagnostics: readonly ClaudeSdkTranslatorDiagnostic[];
+}
+
+type ContentBlock = Readonly<Record<string, unknown>>;
+
+interface PartialAssistant {
+	readonly id: string;
+	readonly blocks: Readonly<Record<string, ContentBlock>>;
+}
+
+interface OpenTool {
+	readonly id: string;
+	readonly name: string;
+	readonly input: unknown;
+}
+
+interface PartitionState {
+	readonly partials: Readonly<Record<string, PartialAssistant>>;
+	readonly openTools: Readonly<Record<string, OpenTool>>;
+	readonly finalized: Readonly<Record<string, true>>;
+	readonly fingerprints: readonly string[];
+}
+
+/**
+ * Immutable state for the offline SDK-message translator.  The root key is an
+ * implementation detail: all externally visible child events retain their
+ * original parentToolUseId.
+ */
+export interface ClaudeSdkTranslatorState {
+	readonly partitions: Readonly<Record<string, PartitionState>>;
+	readonly terminated: boolean;
+}
+
+const ROOT = "__claude_sdk_root__";
+const MAX_FINGERPRINTS = 256;
+const MAX_DIAGNOSTIC_DETAIL = 240;
+const EMPTY_PARTITION: PartitionState = Object.freeze({
+	partials: Object.freeze({}),
+	openTools: Object.freeze({}),
+	finalized: Object.freeze({}),
+	fingerprints: Object.freeze([]),
+});
+
+export function createClaudeSdkTranslatorState(): ClaudeSdkTranslatorState {
+	return Object.freeze({ partitions: Object.freeze({}), terminated: false });
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+function nonEmptyString(value: unknown): string | undefined {
+	return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function partitionFor(input: Record<string, unknown>): string {
+	return nonEmptyString(input.parent_tool_use_id) ?? ROOT;
+}
+
+function diagnostic(
+	code: ClaudeSdkTranslatorDiagnostic["code"],
+	partition: string,
+	detail: string,
+): ClaudeSdkTranslatorDiagnostic {
+	return { code, partition, detail: detail.slice(0, MAX_DIAGNOSTIC_DETAIL) };
+}
+
+/** A deterministic, bounded fingerprint which cannot throw on hostile input. */
+function fingerprint(value: unknown): string {
+	const seen = new WeakSet<object>();
+	const visit = (entry: unknown, depth: number): string => {
+		if (depth > 12) return "[depth]";
+		if (entry === null) return "null";
+		switch (typeof entry) {
+			case "string": return JSON.stringify(entry.length > 2_000 ? entry.slice(0, 2_000) : entry);
+			case "number": return Number.isFinite(entry) ? String(entry) : "[number]";
+			case "boolean": return String(entry);
+			case "undefined": return "undefined";
+			case "bigint": return `[bigint:${entry.toString()}]`;
+			case "symbol": return "[symbol]";
+			case "function": return "[function]";
+			case "object": {
+				if (seen.has(entry)) return "[circular]";
+				seen.add(entry);
+				if (Array.isArray(entry)) return `[${entry.slice(0, 64).map(item => visit(item, depth + 1)).join(",")}]`;
+				const record = entry as Record<string, unknown>;
+				return `{${Object.keys(record).sort().slice(0, 64).map(key => `${JSON.stringify(key)}:${visit(record[key], depth + 1)}`).join(",")}}`;
+			}
+		}
+		return "[unknown]";
+	};
+	return visit(value, 0).slice(0, 8_192);
+}
+
+function safeValue(value: unknown, seen = new WeakSet<object>(), depth = 0): unknown {
+	if (depth > 10) return "[truncated]";
+	if (value === null || typeof value === "string" || typeof value === "boolean") return value;
+	if (typeof value === "number") return Number.isFinite(value) ? value : null;
+	if (typeof value === "bigint") return value.toString();
+	if (typeof value !== "object") return undefined;
+	if (seen.has(value)) return "[circular]";
+	seen.add(value);
+	if (Array.isArray(value)) return value.slice(0, 128).map(item => safeValue(item, seen, depth + 1));
+	const result: Record<string, unknown> = {};
+	for (const key of Object.keys(value).slice(0, 128)) {
+		const child = safeValue((value as Record<string, unknown>)[key], seen, depth + 1);
+		if (child !== undefined) result[key] = child;
+	}
+	return result;
+}
+
+function safeText(value: unknown): string {
+	if (typeof value === "string") return value;
+	const safe = safeValue(value);
+	if (safe === undefined) return "";
+	try { return JSON.stringify(safe); } catch { return "[unserializable]"; }
+}
+
+function contentBlocks(content: unknown): ContentBlock[] {
+	if (typeof content === "string") return content.length > 0 ? [{ type: "text", text: content }] : [];
+	if (!Array.isArray(content)) return [];
+	const blocks: ContentBlock[] = [];
+	for (const block of content) {
+		if (!isRecord(block)) continue;
+		const type = nonEmptyString(block.type);
+		if (type === "text" && typeof block.text === "string") blocks.push({ type: "text", text: block.text });
+		else if ((type === "thinking" || type === "redacted_thinking") && typeof block.thinking === "string") {
+			blocks.push({ type: "thinking", thinking: block.thinking, ...(nonEmptyString(block.signature) ? { signature: block.signature } : {}) });
+		} else if (type === "tool_use" && nonEmptyString(block.id) && nonEmptyString(block.name)) {
+			blocks.push({ type: "toolCall", id: block.id, name: block.name, arguments: safeValue(block.input) ?? {} });
+		}
+	}
+	return blocks;
+}
+
+function assistantMessage(id: string, blocks: readonly ContentBlock[], source?: Record<string, unknown>): Record<string, unknown> {
+	return {
+		id,
+		role: "assistant",
+		content: blocks,
+		api: "anthropic",
+		provider: "anthropic",
+		model: nonEmptyString(source?.model) ?? "claude-code-sdk",
+		...(nonEmptyString(source?.stop_reason) ? { stopReason: nonEmptyString(source?.stop_reason) } : {}),
+	};
+}
+
+function annotate(event: Record<string, unknown>, partition: string): ClaudeSdkTranslatedEvent {
+	return (partition === ROOT ? event : { ...event, parentToolUseId: partition }) as ClaudeSdkTranslatedEvent;
+}
+
+function toolsIn(blocks: readonly ContentBlock[]): OpenTool[] {
+	return blocks.flatMap((block) => {
+		const id = nonEmptyString(block.id);
+		const name = nonEmptyString(block.name);
+		return block.type === "toolCall" && id && name
+			? [{ id, name, input: block.arguments ?? {} }]
+			: [];
+	});
+}
+
+function updatePartition(state: ClaudeSdkTranslatorState, key: string, partition: PartitionState): ClaudeSdkTranslatorState {
+	return { ...state, partitions: { ...state.partitions, [key]: partition } };
+}
+
+function withFingerprint(partition: PartitionState, value: string): PartitionState {
+	const fingerprints = [...partition.fingerprints, value];
+	return { ...partition, fingerprints: fingerprints.slice(-MAX_FINGERPRINTS) };
+}
+
+function blocksFor(partial: PartialAssistant): ContentBlock[] {
+	return Object.keys(partial.blocks).sort((a, b) => Number(a) - Number(b)).map(index => partial.blocks[index]!);
+}
+
+function emitAssistantEnd(
+	partition: PartitionState,
+	partitionKey: string,
+	id: string,
+	blocks: readonly ContentBlock[],
+	source: Record<string, unknown> | undefined,
+	events: ClaudeSdkTranslatedEvent[],
+): PartitionState {
+	if (partition.finalized[id]) return partition;
+	events.push(annotate({ type: "message_end", message: assistantMessage(id, blocks, source) }, partitionKey));
+	const openTools = { ...partition.openTools };
+	for (const tool of toolsIn(blocks)) {
+		if (openTools[tool.id]) continue;
+		openTools[tool.id] = tool;
+		events.push(annotate({ type: "tool_execution_start", toolCallId: tool.id, toolName: tool.name, args: tool.input }, partitionKey));
+	}
+	const partials = { ...partition.partials };
+	delete partials[id];
+	return { ...partition, partials, openTools, finalized: { ...partition.finalized, [id]: true } };
+}
+
+function extractToolResult(message: Record<string, unknown>): { id: string; content: unknown; isError: boolean } | undefined {
+	const content = message.content;
+	if (!Array.isArray(content)) return undefined;
+	for (const item of content) {
+		if (!isRecord(item) || item.type !== "tool_result") continue;
+		const id = nonEmptyString(item.tool_use_id);
+		if (id) return { id, content: item.content, isError: item.is_error === true };
+	}
+	return undefined;
+}
+
+function toolResultMessage(tool: OpenTool, content: unknown, isError: boolean): Record<string, unknown> {
+	return {
+		role: "toolResult",
+		toolCallId: tool.id,
+		toolName: tool.name,
+		content: [{ type: "text", text: safeText(content) }],
+		isError,
+	};
+}
+
+function drain(state: ClaudeSdkTranslatorState, events: ClaudeSdkTranslatedEvent[], source: Record<string, unknown>): ClaudeSdkTranslatorState {
+	let next: ClaudeSdkTranslatorState = { ...state, partitions: { ...state.partitions }, terminated: true };
+	for (const [partitionKey, original] of Object.entries(state.partitions)) {
+		let partition = original;
+		for (const partial of Object.values(partition.partials)) {
+			partition = emitAssistantEnd(partition, partitionKey, partial.id, blocksFor(partial), undefined, events);
+		}
+		const openTools = Object.values(partition.openTools);
+		for (const tool of openTools) {
+			const result = toolResultMessage(tool, "Tool call ended before a result was received.", true);
+			events.push(annotate({ type: "message_end", message: result }, partitionKey));
+			events.push(annotate({ type: "tool_execution_end", toolCallId: tool.id, toolName: tool.name, result: { content: result.content }, isError: true }, partitionKey));
+		}
+		partition = { ...partition, openTools: {} };
+		next = updatePartition(next, partitionKey, partition);
+	}
+	const error = source.is_error === true || source.type === "error" || source.type === "abort" || /^error|abort/.test(String(source.subtype ?? ""));
+	events.push(annotate({ type: "agent_end", messages: [], ...(error ? { error: safeText(source.error ?? source.result ?? source.subtype) } : {}) }, ROOT));
+	return next;
+}
+
+/**
+ * Translate one SDK message without touching a bridge, process, store, clock,
+ * or input/state object. Partition selection happens before any message or tool
+ * identity lookup, preventing forwarded child traffic from entering root state.
+ */
+export function translateClaudeSdkEvent(state: ClaudeSdkTranslatorState, input: unknown): ClaudeSdkTranslation {
+	const events: ClaudeSdkTranslatedEvent[] = [];
+	const diagnostics: ClaudeSdkTranslatorDiagnostic[] = [];
+	if (!isRecord(input)) {
+		return { state: { ...state, partitions: { ...state.partitions } }, events, diagnostics: [diagnostic("malformed", ROOT, "SDK event must be an object")] };
+	}
+
+	const partitionKey = partitionFor(input);
+	if (state.terminated) {
+		return { state: { ...state, partitions: { ...state.partitions } }, events, diagnostics: [diagnostic("late_event", partitionKey, "event arrived after terminal result")] };
+	}
+	let partition = state.partitions[partitionKey] ?? EMPTY_PARTITION;
+	const frame = fingerprint(input);
+	if (partition.fingerprints.includes(frame)) {
+		return { state: updatePartition(state, partitionKey, partition), events, diagnostics: [diagnostic("duplicate", partitionKey, "duplicate SDK event")] };
+	}
+	partition = withFingerprint(partition, frame);
+	let next = updatePartition(state, partitionKey, partition);
+
+	const type = nonEmptyString(input.type);
+	if (!type) return { state: next, events, diagnostics: [diagnostic("malformed", partitionKey, "SDK event is missing type")] };
+
+	if (type === "result" || type === "error" || type === "abort") return { state: drain(next, events, input), events, diagnostics };
+
+	if (type === "assistant") {
+		const message = isRecord(input.message) ? input.message : undefined;
+		const id = nonEmptyString(input.uuid) ?? nonEmptyString(message?.id);
+		if (!message || !id) return { state: next, events, diagnostics: [diagnostic("malformed", partitionKey, "assistant event is missing message identity")] };
+		if (partition.finalized[id]) return { state: next, events, diagnostics: [diagnostic("late_event", partitionKey, "assistant message is already final")] };
+		partition = emitAssistantEnd(partition, partitionKey, id, contentBlocks(message.content), message, events);
+		return { state: updatePartition(next, partitionKey, partition), events, diagnostics };
+	}
+
+	if (type === "stream_event") {
+		const raw = isRecord(input.event) ? input.event : undefined;
+		const rawMessage = isRecord(raw?.message) ? raw.message : undefined;
+		const rawType = nonEmptyString(raw?.type);
+		const id = nonEmptyString(input.uuid) ?? nonEmptyString(rawMessage?.id);
+		if (!raw || !rawType || !id) return { state: next, events, diagnostics: [diagnostic("malformed", partitionKey, "stream event is missing event type or message identity")] };
+		if (partition.finalized[id]) return { state: next, events, diagnostics: [diagnostic("late_event", partitionKey, "stream event follows final assistant message")] };
+		if (rawType === "message_start") {
+			if (!partition.partials[id]) {
+				const partial: PartialAssistant = { id, blocks: {} };
+				partition = { ...partition, partials: { ...partition.partials, [id]: partial } };
+				events.push(annotate({ type: "message_update", message: assistantMessage(id, [], isRecord(raw.message) ? raw.message : undefined) }, partitionKey));
+			}
+			return { state: updatePartition(next, partitionKey, partition), events, diagnostics };
+		}
+		if (rawType === "content_block_start" || rawType === "content_block_delta") {
+			const index = typeof raw.index === "number" && Number.isInteger(raw.index) && raw.index >= 0 ? String(raw.index) : undefined;
+			if (!index) return { state: next, events, diagnostics: [diagnostic("malformed", partitionKey, "content block event is missing index")] };
+			const previous = partition.partials[id] ?? { id, blocks: {} };
+			const existing = previous.blocks[index];
+			const block = rawType === "content_block_start" ? raw.content_block : raw.delta;
+			if (!isRecord(block)) return { state: next, events, diagnostics: [diagnostic("malformed", partitionKey, "content block payload must be an object")] };
+			let normalized: ContentBlock | undefined;
+			if (rawType === "content_block_start") normalized = contentBlocks([block])[0];
+			else if (existing?.type === "text" && typeof block.text === "string") normalized = { ...existing, text: `${existing.text ?? ""}${block.text}` };
+			else if (existing?.type === "thinking" && typeof block.thinking === "string") normalized = { ...existing, thinking: `${existing.thinking ?? ""}${block.thinking}` };
+			else if (existing?.type === "toolCall" && typeof block.partial_json === "string") normalized = { ...existing, arguments: `${existing.arguments ?? ""}${block.partial_json}` };
+			if (!normalized) return { state: next, events, diagnostics: [diagnostic("unknown_kind", partitionKey, "unrecognized content block")] };
+			const partial: PartialAssistant = { id, blocks: { ...previous.blocks, [index]: normalized } };
+			partition = { ...partition, partials: { ...partition.partials, [id]: partial } };
+			events.push(annotate({ type: "message_update", message: assistantMessage(id, blocksFor(partial)) }, partitionKey));
+			return { state: updatePartition(next, partitionKey, partition), events, diagnostics };
+		}
+		if (rawType === "message_stop" || rawType === "content_block_stop" || rawType === "message_delta" || rawType === "ping") return { state: next, events, diagnostics };
+		return { state: next, events, diagnostics: [diagnostic("unknown_kind", partitionKey, `unknown stream event ${rawType}`)] };
+	}
+
+	if (type === "user") {
+		const message = isRecord(input.message) ? input.message : undefined;
+		const result = message && extractToolResult(message);
+		if (!result) return { state: next, events, diagnostics: [diagnostic("malformed", partitionKey, "user event has no tool result")] };
+		const tool = partition.openTools[result.id];
+		if (!tool) return { state: next, events, diagnostics: [diagnostic("late_event", partitionKey, "tool result has no open tool in this partition")] };
+		const messageEnd = toolResultMessage(tool, result.content, result.isError);
+		events.push(annotate({ type: "message_end", message: messageEnd }, partitionKey));
+		events.push(annotate({ type: "tool_execution_end", toolCallId: tool.id, toolName: tool.name, result: { content: messageEnd.content }, isError: result.isError }, partitionKey));
+		const openTools = { ...partition.openTools };
+		delete openTools[tool.id];
+		return { state: updatePartition(next, partitionKey, { ...partition, openTools }), events, diagnostics };
+	}
+
+	if (type === "system" && String(input.subtype ?? "") === "permission_denial") {
+		const text = safeText(input.error ?? input.message ?? "Permission denied");
+		events.push(annotate({ type: "message_end", message: { role: "toolResult", content: [{ type: "text", text }], isError: true } }, partitionKey));
+		return { state: next, events, diagnostics };
+	}
+
+	return { state: next, events, diagnostics: [diagnostic("unknown_kind", partitionKey, `unknown SDK message type ${type}`)] };
+}

--- a/src/server/agent/claude-sdk-event-translator.ts
+++ b/src/server/agent/claude-sdk-event-translator.ts
@@ -245,7 +245,11 @@ function assistantMessage(
 ): AssistantMessage {
 	return {
 		role: "assistant",
-		content: blocks.map((block) => block.type === "toolCall" ? { ...block, arguments: parsedToolArguments(block) } : block),
+		content: blocks.map((block) => {
+			if (block.type !== "toolCall") return block;
+			const { argumentsJson: _internalArgumentsJson, ...toolCall } = block;
+			return { ...toolCall, arguments: parsedToolArguments(block) };
+		}),
 		api: "anthropic",
 		provider: "anthropic",
 		model: nonEmptyString(source?.model) ?? "claude-code-sdk",
@@ -276,6 +280,11 @@ function blocksFor(partial: PartialAssistant): TranslatorContent[] {
 	return [...partial.blocks.entries()].sort(([left], [right]) => left - right).map(([, block]) => block);
 }
 
+/** Pi content indexes address the normalized content array, not raw SDK indexes. */
+function contentIndexFor(partial: PartialAssistant, rawIndex: number): number | undefined {
+	return [...partial.blocks.keys()].sort((left, right) => left - right).indexOf(rawIndex);
+}
+
 function annotate<T extends AgentEvent>(event: T, partition: PartitionKey, metadata?: ClaudeSdkEventMetadata): T & ClaudeSdkEventAnnotation {
 	return partition === ROOT
 		? { ...event, ...(metadata ? { claudeSdk: metadata } : {}) }
@@ -286,39 +295,43 @@ function partialEvent(
 	partial: PartialAssistant,
 	source: Record<string, unknown> | undefined,
 	type: AssistantMessageEvent["type"],
-	index?: number,
+	rawIndex?: number,
 	delta?: string,
-): ClaudeSdkTranslatedEvent {
+): ClaudeSdkTranslatedEvent | undefined {
 	const message = assistantMessage(blocksFor(partial), source, partial.timestamp, partial.usage);
-	const contentIndex = index ?? 0;
+	if (type === "start") {
+		return { type: "message_update", message, assistantMessageEvent: { type, partial: message } };
+	}
+	if (rawIndex === undefined) return undefined;
+	const contentIndex = contentIndexFor(partial, rawIndex);
+	if (contentIndex === undefined || contentIndex < 0) return undefined;
 	let event: AssistantMessageEvent;
 	switch (type) {
-		case "start": event = { type, partial: message }; break;
 		case "text_start": case "thinking_start": case "toolcall_start": event = { type, contentIndex, partial: message }; break;
 		case "text_delta": case "thinking_delta": case "toolcall_delta": event = { type, contentIndex, delta: delta ?? "", partial: message }; break;
 		case "text_end": case "thinking_end": event = { type, contentIndex, content: delta ?? "", partial: message }; break;
 		case "toolcall_end": {
-			const block = partial.blocks.get(contentIndex);
-			if (!block || block.type !== "toolCall") return partialEvent(partial, source, "start");
-			event = { type, contentIndex, toolCall: { ...block, arguments: parsedToolArguments(block) }, partial: message };
+			const block = partial.blocks.get(rawIndex);
+			if (!block || block.type !== "toolCall") return undefined;
+			const { argumentsJson: _internalArgumentsJson, ...toolCall } = block;
+			event = { type, contentIndex, toolCall: { ...toolCall, arguments: parsedToolArguments(block) }, partial: message };
 			break;
 		}
-		default: event = { type: "start", partial: message };
+		default: return undefined;
 	}
-	const translated: Extract<AgentEvent, { type: "message_update" }> = { type: "message_update", message, assistantMessageEvent: event };
-	return translated;
+	return { type: "message_update", message, assistantMessageEvent: event };
 }
 
 function emitAssistantEnd(
 	partition: PartitionState,
 	partitionKey: PartitionKey,
-	id: string,
+	identities: readonly string[],
 	blocks: readonly TranslatorContent[],
 	source: Record<string, unknown> | undefined,
 	timestamp: number,
 	events: ClaudeSdkTranslatedEvent[],
 ): PartitionState {
-	if (partition.finalized.has(id)) return partition;
+	if (identities.some((id) => partition.finalized.has(id))) return partition;
 	events.push(annotate({ type: "message_end", message: assistantMessage(blocks, source, timestamp) }, partitionKey));
 	const openTools = new Map(partition.openTools);
 	for (const tool of toolsIn(blocks)) {
@@ -327,18 +340,25 @@ function emitAssistantEnd(
 		events.push(annotate({ type: "tool_execution_start", toolCallId: tool.id, toolName: tool.name, args: tool.input }, partitionKey));
 	}
 	const partials = new Map(partition.partials);
-	partials.delete(id);
-	return { ...partition, partials, openTools, finalized: new Set([...partition.finalized, id]), activeStreamId: partition.activeStreamId === id ? undefined : partition.activeStreamId };
+	for (const id of identities) partials.delete(id);
+	return {
+		...partition,
+		partials,
+		openTools,
+		finalized: new Set([...partition.finalized, ...identities]),
+		activeStreamId: identities.includes(partition.activeStreamId ?? "") ? undefined : partition.activeStreamId,
+	};
 }
 
-function extractToolResult(message: Record<string, unknown>): { id: string; content: unknown; isError: boolean } | undefined {
-	if (!Array.isArray(message.content)) return undefined;
+function extractToolResults(message: Record<string, unknown>): { id: string; content: unknown; isError: boolean }[] {
+	if (!Array.isArray(message.content)) return [];
+	const results: { id: string; content: unknown; isError: boolean }[] = [];
 	for (const item of message.content) {
 		if (!isRecord(item) || item.type !== "tool_result") continue;
 		const id = nonEmptyString(item.tool_use_id);
-		if (id) return { id, content: item.content, isError: item.is_error === true };
+		if (id) results.push({ id, content: item.content, isError: item.is_error === true });
 	}
-	return undefined;
+	return results;
 }
 
 function toolResultMessage(tool: OpenTool, content: unknown, isError: boolean, timestamp: number): ToolResultMessage {
@@ -375,7 +395,7 @@ function drain(state: ClaudeSdkTranslatorState, events: ClaudeSdkTranslatedEvent
 	for (const [partitionKey, original] of state.partitions) {
 		let partition = original;
 		for (const partial of partition.partials.values()) {
-			partition = emitAssistantEnd(partition, partitionKey, partial.id, blocksFor(partial), undefined, partial.timestamp, events);
+			partition = emitAssistantEnd(partition, partitionKey, [partial.id], blocksFor(partial), undefined, partial.timestamp, events);
 		}
 		for (const tool of partition.openTools.values()) {
 			const result = toolResultMessage(tool, "Tool call ended before a result was received.", true, timestampFor(source));
@@ -441,10 +461,15 @@ export function translateClaudeSdkEvent(state: ClaudeSdkTranslatorState, input: 
 
 	if (type === "assistant") {
 		const message = isRecord(input.message) ? input.message : undefined;
-		const id = nonEmptyString(input.uuid) ?? nonEmptyString(message?.id);
-		if (!message || !id) return { state: next, events, diagnostics: [diagnostic("malformed", partitionKey, "assistant event is missing message identity")] };
-		if (partition.finalized.has(id)) return { state: next, events, diagnostics: [diagnostic("late_event", partitionKey, "assistant message is already final")] };
-		partition = emitAssistantEnd(partition, partitionKey, id, contentBlocks(message.content), message, timestampFor(input), events);
+		const envelopeId = nonEmptyString(input.uuid);
+		const messageId = nonEmptyString(message?.id);
+		const primaryId = envelopeId ?? messageId;
+		if (!message || !primaryId) return { state: next, events, diagnostics: [diagnostic("malformed", partitionKey, "assistant event is missing message identity")] };
+		const identities = [...new Set([primaryId, envelopeId, messageId, partition.activeStreamId].filter((id): id is string => !!id))];
+		if (identities.some((id) => partition.finalized.has(id))) {
+			return { state: next, events, diagnostics: [diagnostic("late_event", partitionKey, "assistant message is already final")] };
+		}
+		partition = emitAssistantEnd(partition, partitionKey, identities, contentBlocks(message.content), message, timestampFor(input), events);
 		return { state: updatePartition(next, partitionKey, partition), events, diagnostics };
 	}
 
@@ -459,7 +484,8 @@ export function translateClaudeSdkEvent(state: ClaudeSdkTranslatorState, input: 
 			if (!partition.partials.has(id)) {
 				const partial: PartialAssistant = { id, blocks: new Map(), stoppedBlocks: new Set(), timestamp: timestampFor(input), usage: usageFor(source?.usage) };
 				partition = { ...partition, partials: new Map([...partition.partials, [id, partial]]), activeStreamId: id };
-				events.push(annotate(partialEvent(partial, source, "start"), partitionKey));
+				const event = partialEvent(partial, source, "start");
+				if (event) events.push(annotate(event, partitionKey));
 			} else partition = { ...partition, activeStreamId: id };
 			return { state: updatePartition(next, partitionKey, partition), events, diagnostics };
 		}
@@ -468,6 +494,12 @@ export function translateClaudeSdkEvent(state: ClaudeSdkTranslatorState, input: 
 			if (index === undefined) return { state: next, events, diagnostics: [diagnostic("malformed", partitionKey, "content block event is missing index")] };
 			const previous = partition.partials.get(id) ?? { id, blocks: new Map(), stoppedBlocks: new Set(), timestamp: timestampFor(input), usage: usageFor(undefined) };
 			const existing = previous.blocks.get(index);
+			if (rawType === "content_block_start" && existing) {
+				return { state: next, events, diagnostics: [diagnostic("duplicate", partitionKey, "content block start already exists")] };
+			}
+			if (previous.stoppedBlocks.has(index)) {
+				return { state: next, events, diagnostics: [diagnostic("duplicate", partitionKey, "content block is already stopped")] };
+			}
 			const block = rawType === "content_block_start" ? raw.content_block : raw.delta;
 			if (!isRecord(block)) return { state: next, events, diagnostics: [diagnostic("malformed", partitionKey, "content block payload must be an object")] };
 			let normalized: TranslatorContent | undefined;
@@ -488,7 +520,8 @@ export function translateClaudeSdkEvent(state: ClaudeSdkTranslatorState, input: 
 			if (!normalized) return { state: next, events, diagnostics: [diagnostic("unknown_kind", partitionKey, "unrecognized content block")] };
 			const partial: PartialAssistant = { ...previous, blocks: new Map([...previous.blocks, [index, normalized]]) };
 			partition = { ...partition, partials: new Map([...partition.partials, [id, partial]]), activeStreamId: id };
-			events.push(annotate(partialEvent(partial, source, messageEvent!, index, delta), partitionKey));
+			const event = partialEvent(partial, source, messageEvent!, index, delta);
+			if (event) events.push(annotate(event, partitionKey));
 			return { state: updatePartition(next, partitionKey, partition), events, diagnostics };
 		}
 		if (rawType === "content_block_stop") {
@@ -501,7 +534,8 @@ export function translateClaudeSdkEvent(state: ClaudeSdkTranslatorState, input: 
 			const stopped = { ...partial, stoppedBlocks: new Set([...partial.stoppedBlocks, index]) };
 			partition = { ...partition, partials: new Map([...partition.partials, [id, stopped]]) };
 			const eventType = block.type === "text" ? "text_end" : block.type === "thinking" ? "thinking_end" : "toolcall_end";
-			events.push(annotate(partialEvent(stopped, source, eventType, index, block.type === "text" ? block.text : block.type === "thinking" ? block.thinking : undefined), partitionKey));
+			const event = partialEvent(stopped, source, eventType, index, block.type === "text" ? block.text : block.type === "thinking" ? block.thinking : undefined);
+			if (event) events.push(annotate(event, partitionKey));
 			return { state: updatePartition(next, partitionKey, partition), events, diagnostics };
 		}
 		if (rawType === "message_delta") {
@@ -510,7 +544,6 @@ export function translateClaudeSdkEvent(state: ClaudeSdkTranslatorState, input: 
 			if (partial && usage) {
 				const updated = { ...partial, usage: usageFor(usage) };
 				partition = { ...partition, partials: new Map([...partition.partials, [id, updated]]) };
-				events.push(annotate(partialEvent(updated, source, "start"), partitionKey));
 			}
 			return { state: updatePartition(next, partitionKey, partition), events, diagnostics };
 		}
@@ -521,15 +554,20 @@ export function translateClaudeSdkEvent(state: ClaudeSdkTranslatorState, input: 
 
 	if (type === "user") {
 		const message = isRecord(input.message) ? input.message : undefined;
-		const result = message && extractToolResult(message);
-		if (!result) return { state: next, events, diagnostics };
-		const tool = partition.openTools.get(result.id);
-		if (!tool) return { state: next, events, diagnostics: [diagnostic("late_event", partitionKey, "tool result has no open tool in this partition")] };
-		const messageEnd = toolResultMessage(tool, result.content, result.isError, timestampFor(input));
-		events.push(annotate({ type: "message_end", message: messageEnd }, partitionKey));
-		events.push(annotate({ type: "tool_execution_end", toolCallId: tool.id, toolName: tool.name, result: { content: messageEnd.content }, isError: result.isError }, partitionKey));
+		const results = message ? extractToolResults(message) : [];
+		if (results.length === 0) return { state: next, events, diagnostics };
 		const openTools = new Map(partition.openTools);
-		openTools.delete(tool.id);
+		for (const result of results) {
+			const tool = openTools.get(result.id);
+			if (!tool) {
+				diagnostics.push(diagnostic("late_event", partitionKey, "tool result has no open tool in this partition"));
+				continue;
+			}
+			const messageEnd = toolResultMessage(tool, result.content, result.isError, timestampFor(input));
+			events.push(annotate({ type: "message_end", message: messageEnd }, partitionKey));
+			events.push(annotate({ type: "tool_execution_end", toolCallId: tool.id, toolName: tool.name, result: { content: messageEnd.content }, isError: result.isError }, partitionKey));
+			openTools.delete(tool.id);
+		}
 		return { state: updatePartition(next, partitionKey, { ...partition, openTools }), events, diagnostics };
 	}
 

--- a/src/server/agent/claude-sdk-event-translator.ts
+++ b/src/server/agent/claude-sdk-event-translator.ts
@@ -231,6 +231,10 @@ function toolResultMessage(tool: OpenTool, content: unknown, isError: boolean): 
 	};
 }
 
+function isTerminalEvent(type: string, input: Record<string, unknown>): boolean {
+	return type === "result" || type === "error" || type === "abort" || (type === "assistant" && input.is_error === true);
+}
+
 function drain(state: ClaudeSdkTranslatorState, events: ClaudeSdkTranslatedEvent[], source: Record<string, unknown>): ClaudeSdkTranslatorState {
 	let next: ClaudeSdkTranslatorState = { ...state, partitions: { ...state.partitions }, terminated: true };
 	for (const [partitionKey, original] of Object.entries(state.partitions)) {
@@ -279,7 +283,7 @@ export function translateClaudeSdkEvent(state: ClaudeSdkTranslatorState, input: 
 	const type = nonEmptyString(input.type);
 	if (!type) return { state: next, events, diagnostics: [diagnostic("malformed", partitionKey, "SDK event is missing type")] };
 
-	if (type === "result" || type === "error" || type === "abort") return { state: drain(next, events, input), events, diagnostics };
+	if (isTerminalEvent(type, input)) return { state: drain(next, events, input), events, diagnostics };
 
 	if (type === "assistant") {
 		const message = isRecord(input.message) ? input.message : undefined;

--- a/src/server/agent/claude-sdk-event-translator.ts
+++ b/src/server/agent/claude-sdk-event-translator.ts
@@ -61,6 +61,8 @@ interface PartitionState {
 	readonly finalized: ReadonlySet<string>;
 	readonly fingerprints: readonly string[];
 	readonly activeStreamId?: string;
+	/** A child result/abort closes only this forwarded stream. */
+	readonly terminated?: boolean;
 }
 
 /**
@@ -390,20 +392,27 @@ function terminalIsError(source: Record<string, unknown>): boolean {
 		|| /^error/.test(String(source.subtype ?? "")) || /^aborted/.test(String(source.terminal_reason ?? ""));
 }
 
+function drainPartition(
+	partition: PartitionState,
+	partitionKey: PartitionKey,
+	events: ClaudeSdkTranslatedEvent[],
+	source: Record<string, unknown>,
+): PartitionState {
+	for (const partial of partition.partials.values()) {
+		partition = emitAssistantEnd(partition, partitionKey, [partial.id], blocksFor(partial), undefined, partial.timestamp, events);
+	}
+	for (const tool of partition.openTools.values()) {
+		const result = toolResultMessage(tool, "Tool call ended before a result was received.", true, timestampFor(source));
+		events.push(annotate({ type: "message_end", message: result }, partitionKey));
+		events.push(annotate({ type: "tool_execution_end", toolCallId: tool.id, toolName: tool.name, result: { content: result.content }, isError: true }, partitionKey));
+	}
+	return { ...partition, openTools: new Map(), activeStreamId: undefined, terminated: true };
+}
+
 function drain(state: ClaudeSdkTranslatorState, events: ClaudeSdkTranslatedEvent[], source: Record<string, unknown>): ClaudeSdkTranslatorState {
 	let next: ClaudeSdkTranslatorState = { ...state, partitions: new Map(state.partitions), terminated: true };
-	for (const [partitionKey, original] of state.partitions) {
-		let partition = original;
-		for (const partial of partition.partials.values()) {
-			partition = emitAssistantEnd(partition, partitionKey, [partial.id], blocksFor(partial), undefined, partial.timestamp, events);
-		}
-		for (const tool of partition.openTools.values()) {
-			const result = toolResultMessage(tool, "Tool call ended before a result was received.", true, timestampFor(source));
-			events.push(annotate({ type: "message_end", message: result }, partitionKey));
-			events.push(annotate({ type: "tool_execution_end", toolCallId: tool.id, toolName: tool.name, result: { content: result.content }, isError: true }, partitionKey));
-		}
-		partition = { ...partition, openTools: new Map(), activeStreamId: undefined };
-		next = updatePartition(next, partitionKey, partition);
+	for (const [partitionKey, partition] of state.partitions) {
+		next = updatePartition(next, partitionKey, drainPartition(partition, partitionKey, events, source));
 	}
 	const error = terminalIsError(source);
 	const terminalReason = nonEmptyString(source.terminal_reason);
@@ -444,6 +453,9 @@ export function translateClaudeSdkEvent(state: ClaudeSdkTranslatorState, input: 
 		return { state: { ...state, partitions: new Map(state.partitions) }, events, diagnostics: [diagnostic("late_event", partitionKey, "event arrived after terminal result")] };
 	}
 	let partition = state.partitions.get(partitionKey) ?? EMPTY_PARTITION;
+	if (partition.terminated) {
+		return { state: updatePartition(state, partitionKey, partition), events, diagnostics: [diagnostic("late_event", partitionKey, "event arrived after partition terminal result")] };
+	}
 	const type = nonEmptyString(input.type);
 	if (!type) return { state: updatePartition(state, partitionKey, partition), events, diagnostics: [diagnostic("malformed", partitionKey, "SDK event is missing type")] };
 
@@ -457,7 +469,12 @@ export function translateClaudeSdkEvent(state: ClaudeSdkTranslatorState, input: 
 	}
 	let next = updatePartition(state, partitionKey, partition);
 
-	if (isTerminalEvent(type, input)) return { state: drain(next, events, input), events, diagnostics };
+	if (isTerminalEvent(type, input)) {
+		if (partitionKey !== ROOT) {
+			return { state: updatePartition(next, partitionKey, drainPartition(partition, partitionKey, events, input)), events, diagnostics };
+		}
+		return { state: drain(next, events, input), events, diagnostics };
+	}
 
 	if (type === "assistant") {
 		const message = isRecord(input.message) ? input.message : undefined;

--- a/tests2/core/claude-sdk-event-translator.test.ts
+++ b/tests2/core/claude-sdk-event-translator.test.ts
@@ -8,6 +8,7 @@ import {
 	createClaudeSdkTranslatorState,
 	translateClaudeSdkEvent,
 	type ClaudeSdkTranslation,
+	type ClaudeSdkTranslatorState,
 } from "../../src/server/agent/claude-sdk-event-translator.ts";
 
 type FixtureRecord = Record<string, unknown>;
@@ -33,7 +34,7 @@ function fixtureMessages(record: FixtureRecord): readonly unknown[] {
 	return record.messages as readonly unknown[];
 }
 
-function feed(inputs: readonly unknown[]): { state: unknown; events: Event[]; diagnostics: Event[] } {
+function feed(inputs: readonly unknown[]): { state: ClaudeSdkTranslatorState; events: Event[]; diagnostics: Event[] } {
 	let state = createClaudeSdkTranslatorState();
 	const events: Event[] = [];
 	const diagnostics: Event[] = [];
@@ -276,6 +277,84 @@ describe("Claude Agent SDK event translator", () => {
 		expect(events.some((event) => event.parentToolUseId === childRootName && textInMessage(event, "child"))).toBe(true);
 		expect(events.some((event) => event.parentToolUseId === undefined && textInMessage(event, "root"))).toBe(true);
 		expect(events).toContainEqual(expect.objectContaining({ type: "tool_execution_end", toolCallId: "toString", parentToolUseId: "constructor" }));
+	});
+
+	it("reconciles all streamed assistant identities exactly once and suppresses late frames", () => {
+		const messages = fixtureMessages(fixture("root-tool-lifecycle.json"));
+		const streamedAndFinal = feed(messages.slice(0, 6));
+		const assistantEnds = streamedAndFinal.events.filter((event) => messageWithRole(event, "assistant"));
+		expect(assistantEnds).toHaveLength(1);
+		expect(JSON.stringify(streamedAndFinal.events)).not.toContain("argumentsJson");
+
+		for (const event of [
+			{ type: "stream_event", uuid: "root-assistant-1", event: { type: "content_block_delta", index: 0, delta: { type: "text_delta", text: "late" } } },
+			{ type: "stream_event", uuid: "late-envelope", event: { type: "content_block_delta", index: 0, message: { id: "root-model-message-1" }, delta: { type: "text_delta", text: "late" } } },
+		]) {
+			const late = translateClaudeSdkEvent(streamedAndFinal.state, event);
+			expect(late.events).toEqual([]);
+			expect(late.diagnostics).toMatchObject([{ code: "late_event" }]);
+		}
+
+		const terminal = translateClaudeSdkEvent(streamedAndFinal.state, fixture("terminal-and-permission.json").resultSuccess);
+		expect(terminal.events.filter((event) => messageWithRole(event as unknown as Event, "assistant"))).toHaveLength(0);
+
+		const twoMessages = feed([
+			{ type: "stream_event", uuid: "envelope-1", event: { type: "message_start", message: { id: "model-1", content: [] } } },
+			{ type: "assistant", uuid: "envelope-1", message: { id: "model-1", content: [{ type: "text", text: "one" }] } },
+			{ type: "stream_event", uuid: "envelope-2", event: { type: "message_start", message: { id: "model-2", content: [] } } },
+			{ type: "assistant", uuid: "envelope-2", message: { id: "model-2", content: [{ type: "text", text: "two" }] } },
+			fixture("terminal-and-permission.json").resultSuccess,
+		]);
+		expect(twoMessages.events.filter((event) => messageWithRole(event, "assistant"))).toHaveLength(2);
+		const partitionPartials = [...((twoMessages.state as unknown as { partitions: ReadonlyMap<unknown, { partials: ReadonlyMap<unknown, unknown> }> }).partitions.values())]
+			.reduce((total, partition) => total + partition.partials.size, 0);
+		expect(partitionPartials).toBe(0);
+	});
+
+	it("keeps stream updates monotonic and maps normalized content indexes", () => {
+		let state = createClaudeSdkTranslatorState();
+		state = translateClaudeSdkEvent(state, { type: "stream_event", uuid: "stream", event: { type: "message_start", message: { id: "model", content: [] } } }).state;
+		state = translateClaudeSdkEvent(state, { type: "stream_event", uuid: "stream", event: { type: "content_block_start", index: 0, content_block: { type: "text", text: "first" } } }).state;
+		state = translateClaudeSdkEvent(state, { type: "stream_event", uuid: "stream", event: { type: "content_block_stop", index: 0 } }).state;
+		for (const event of [
+			{ type: "stream_event", uuid: "stream", event: { type: "content_block_start", index: 0, content_block: { type: "text", text: "replay" } } },
+			{ type: "stream_event", uuid: "stream", event: { type: "content_block_delta", index: 0, delta: { type: "text_delta", text: "late" } } },
+		]) {
+			const duplicate = translateClaudeSdkEvent(state, event);
+			expect(duplicate.events).toEqual([]);
+			expect(duplicate.diagnostics).toMatchObject([{ code: "duplicate" }]);
+		}
+		const usageOnly = translateClaudeSdkEvent(state, { type: "stream_event", uuid: "stream", event: { type: "message_delta", usage: { input_tokens: 2 } } });
+		expect(usageOnly.events).toEqual([]);
+
+		const normalized = feed([
+			{ type: "stream_event", uuid: "indexes", event: { type: "content_block_start", index: 0, content_block: { type: "image", source: "unsupported" } } },
+			{ type: "stream_event", uuid: "indexes", event: { type: "content_block_start", index: 1, content_block: { type: "text", text: "kept" } } },
+		]);
+		const update = normalized.events.at(-1) as Event;
+		expect(update.assistantMessageEvent).toMatchObject({ type: "text_start", contentIndex: 0 });
+	});
+
+	it("completes every batched tool result in block order without synthetic failures", () => {
+		const inputs: unknown[] = [
+			{ type: "assistant", uuid: "parallel", message: { content: [
+				{ type: "tool_use", id: "tool-one", name: "Read", input: { path: "one" } },
+				{ type: "tool_use", id: "tool-two", name: "Glob", input: { pattern: "two" } },
+			], stop_reason: "tool_use" } },
+			{ type: "user", uuid: "parallel-results", message: { content: [
+				{ type: "tool_result", tool_use_id: "tool-one", content: "one" },
+				{ type: "tool_result", tool_use_id: "tool-two", content: "two", is_error: true },
+			] } },
+			fixture("terminal-and-permission.json").resultSuccess,
+		];
+		const { events, diagnostics } = feed(inputs);
+		expect(diagnostics).toEqual([]);
+		const ends = events.filter((event) => event.type === "tool_execution_end");
+		expect(ends).toEqual([
+			expect.objectContaining({ toolCallId: "tool-one", isError: false }),
+			expect.objectContaining({ toolCallId: "tool-two", isError: true }),
+		]);
+		expect(JSON.stringify(events)).not.toContain("ended before a result was received");
 	});
 
 	it("remains an offline translator seam with no existing session setup or dispatch coupling", () => {

--- a/tests2/core/claude-sdk-event-translator.test.ts
+++ b/tests2/core/claude-sdk-event-translator.test.ts
@@ -1,0 +1,195 @@
+// v2-native — Offline translator contract. Listed in tests-map.json `v2Native`.
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+import {
+	createClaudeSdkTranslatorState,
+	translateClaudeSdkEvent,
+	type ClaudeSdkTranslation,
+} from "../../src/server/agent/claude-sdk-event-translator.ts";
+
+type FixtureRecord = Record<string, unknown>;
+type Event = Record<string, unknown>;
+
+const FIXTURE_ROOT = fileURLToPath(
+	new URL("../fixtures/claude-sdk-event-translator/", import.meta.url),
+);
+const REPOSITORY_ROOT = fileURLToPath(new URL("../../", import.meta.url));
+
+function fixture(name: string): FixtureRecord {
+	return JSON.parse(readFileSync(path.join(FIXTURE_ROOT, name), "utf8")) as FixtureRecord;
+}
+
+function fixtureMessages(record: FixtureRecord): readonly unknown[] {
+	expect(record.fixtureSchema).toBe("claude-sdk-event-translator/v1");
+	expect(record.provenance).toMatchObject({
+		kind: "hand-authored captured-shape record",
+		source: "@anthropic-ai/claude-agent-sdk published declarations",
+		sdkVersion: "0.3.220",
+	});
+	expect(record.messages).toBeInstanceOf(Array);
+	return record.messages as readonly unknown[];
+}
+
+function feed(inputs: readonly unknown[]): { state: unknown; events: Event[]; diagnostics: Event[] } {
+	let state = createClaudeSdkTranslatorState();
+	const events: Event[] = [];
+	const diagnostics: Event[] = [];
+	for (const input of inputs) {
+		const result = translateClaudeSdkEvent(state, input) as ClaudeSdkTranslation;
+		state = result.state;
+		events.push(...(result.events as unknown as Event[]));
+		diagnostics.push(...(result.diagnostics as unknown as Event[]));
+	}
+	return { state, events, diagnostics };
+}
+
+function eventIndex(events: readonly Event[], predicate: (event: Event) => boolean): number {
+	const index = events.findIndex(predicate);
+	expect(index).toBeGreaterThanOrEqual(0);
+	return index;
+}
+
+function messageWithRole(event: Event, role: string): boolean {
+	return event.type === "message_end"
+		&& !!event.message
+		&& typeof event.message === "object"
+		&& (event.message as Event).role === role;
+}
+
+function textInMessage(event: Event, text: string): boolean {
+	const content = (event.message as Event | undefined)?.content;
+	return Array.isArray(content) && content.some((block) =>
+		!!block && typeof block === "object" && (block as Event).text === text,
+	);
+}
+
+describe("Claude Agent SDK event translator", () => {
+	it("translates captured text, thinking, tool use, and matching tool result in Pi lifecycle order", () => {
+		const record = fixture("root-tool-lifecycle.json");
+		const { events, diagnostics } = feed(fixtureMessages(record));
+
+		expect(diagnostics).toEqual([]);
+		const assistantEnd = eventIndex(events, (event) => messageWithRole(event, "assistant"));
+		const toolStart = eventIndex(events, (event) => event.type === "tool_execution_start");
+		const toolResult = eventIndex(events, (event) => messageWithRole(event, "toolResult"));
+		const toolEnd = eventIndex(events, (event) => event.type === "tool_execution_end");
+		expect(assistantEnd).toBeLessThan(toolStart);
+		expect(toolStart).toBeLessThan(toolResult);
+		expect(toolResult).toBeLessThan(toolEnd);
+		expect(events[toolStart]).toMatchObject({ toolCallId: "tool-root-1" });
+		expect(events[toolResult]).toMatchObject({ message: { toolCallId: "tool-root-1" } });
+		expect(events[toolEnd]).toMatchObject({ toolCallId: "tool-root-1", isError: false });
+
+		const updates = events.filter((event) => event.type === "message_update");
+		expect(updates.some((event) => textInMessage(event, "I will inspect it."))).toBe(true);
+		expect(updates.some((event) => {
+			const content = (event.message as Event | undefined)?.content;
+			return Array.isArray(content) && content.some((block) =>
+				!!block && typeof block === "object" && (block as Event).type === "thinking",
+			);
+		})).toBe(true);
+	});
+
+	it("partitions interleaved root and child frames before UUID, message, or tool accumulation", () => {
+		const record = fixture("interleaved-subagents.json");
+		const { events, diagnostics } = feed(fixtureMessages(record));
+
+		expect(diagnostics).toEqual([]);
+		const childA = events.filter((event) => event.parentToolUseId === "parent-tool-a");
+		const childB = events.filter((event) => event.parentToolUseId === "parent-tool-b");
+		const root = events.filter((event) => event.parentToolUseId === undefined);
+		expect(childA.length).toBeGreaterThan(0);
+		expect(childB.length).toBeGreaterThan(0);
+		expect(root.length).toBeGreaterThan(0);
+		expect(childA.every((event) => event.parentToolUseId === "parent-tool-a")).toBe(true);
+		expect(childB.every((event) => event.parentToolUseId === "parent-tool-b")).toBe(true);
+		expect(childA.some((event) => textInMessage(event, "child A continued"))).toBe(true);
+		expect(root.some((event) => textInMessage(event, "root only"))).toBe(true);
+
+		const childAssistantEnd = eventIndex(childB, (event) => messageWithRole(event, "assistant"));
+		const childToolStart = eventIndex(childB, (event) => event.type === "tool_execution_start");
+		const childToolResult = eventIndex(childB, (event) => messageWithRole(event, "toolResult"));
+		const childToolEnd = eventIndex(childB, (event) => event.type === "tool_execution_end");
+		expect(childAssistantEnd).toBeLessThan(childToolStart);
+		expect(childToolStart).toBeLessThan(childToolResult);
+		expect(childToolResult).toBeLessThan(childToolEnd);
+		expect(childB[childToolStart]).toMatchObject({ toolCallId: "child-tool-b" });
+		expect(childB[childToolEnd]).toMatchObject({ toolCallId: "child-tool-b", isError: false });
+	});
+
+	it("atomically drains dangling tools and emits one root agent end for terminal success, error, and abort forms", () => {
+		const root = fixture("root-tool-lifecycle.json");
+		const terminal = fixture("terminal-and-permission.json");
+		const beforeToolResult = fixtureMessages(root).slice(0, -1);
+
+		for (const terminalKey of ["resultSuccess", "resultError", "assistantAbort"] as const) {
+			const { events, diagnostics } = feed([...beforeToolResult, terminal[terminalKey]]);
+			expect(diagnostics).toEqual([]);
+			const danglingResult = eventIndex(events, (event) => messageWithRole(event, "toolResult"));
+			const danglingEnd = eventIndex(events, (event) => event.type === "tool_execution_end");
+			const agentEnd = eventIndex(events, (event) => event.type === "agent_end");
+			expect(danglingResult).toBeLessThan(danglingEnd);
+			expect(danglingEnd).toBeLessThan(agentEnd);
+			expect(events[danglingEnd]).toMatchObject({ toolCallId: "tool-root-1", isError: true });
+			expect(events.filter((event) => event.type === "agent_end")).toHaveLength(1);
+		}
+	});
+
+	it("makes duplicate and late frames no-ops without mutating prior state or input", () => {
+		const messages = fixtureMessages(fixture("root-tool-lifecycle.json"));
+		const initial = createClaudeSdkTranslatorState();
+		const initialSnapshot = structuredClone(initial);
+		const input = structuredClone(messages[5]);
+		const inputSnapshot = structuredClone(input);
+
+		const first = translateClaudeSdkEvent(initial, input);
+		expect(initial).toEqual(initialSnapshot);
+		expect(input).toEqual(inputSnapshot);
+		expect(first.events.length).toBeGreaterThan(0);
+
+		const duplicate = translateClaudeSdkEvent(first.state, input);
+		expect(duplicate.events).toEqual([]);
+		expect(duplicate.diagnostics.some((diagnostic) => diagnostic.code === "duplicate" || diagnostic.code === "late_event")).toBe(true);
+
+		const terminal = fixture("terminal-and-permission.json").resultSuccess;
+		const ended = translateClaudeSdkEvent(first.state, terminal);
+		const late = translateClaudeSdkEvent(ended.state, input);
+		expect(late.events).toEqual([]);
+		expect(late.diagnostics).toMatchObject([{ code: "late_event" }]);
+	});
+
+	it("degrades unknown, malformed, permission-relevant, and cyclic input safely without fabricated identities", () => {
+		const record = fixture("terminal-and-permission.json");
+		const state = createClaudeSdkTranslatorState();
+		const unknown = translateClaudeSdkEvent(state, record.unknownFuture);
+		expect(unknown.events).toEqual([]);
+		expect(unknown.diagnostics).toMatchObject([{ code: "unknown_kind" }]);
+
+		const malformed = translateClaudeSdkEvent(unknown.state, { type: "assistant", parent_tool_use_id: "child-malformed", message: [] });
+		expect(malformed.events).toEqual([]);
+		expect(malformed.diagnostics).toMatchObject([{ code: "malformed", partition: "child-malformed" }]);
+
+		const permission = translateClaudeSdkEvent(malformed.state, record.permissionDenied);
+		expect(() => translateClaudeSdkEvent(permission.state, record.permissionDenied)).not.toThrow();
+		expect(permission.diagnostics.every((diagnostic) => typeof diagnostic.detail === "string" && diagnostic.detail.length <= 500)).toBe(true);
+
+		const cyclic: Event = { type: "stream_event", parent_tool_use_id: "child-cyclic" };
+		cyclic.event = cyclic;
+		expect(() => translateClaudeSdkEvent(permission.state, cyclic)).not.toThrow();
+	});
+
+	it("remains an offline translator seam with no existing session setup or dispatch coupling", () => {
+		const translator = readFileSync(
+			path.join(REPOSITORY_ROOT, "src/server/agent/claude-sdk-event-translator.ts"),
+			"utf8",
+		);
+		expect(translator).not.toMatch(/node:(?:child_process|fs|http|https|net)/);
+		for (const file of ["src/server/agent/session-manager.ts", "src/server/agent/session-setup.ts"]) {
+			const source = readFileSync(path.join(REPOSITORY_ROOT, file), "utf8");
+			expect(source).not.toContain("claude-sdk-event-translator");
+		}
+	});
+});

--- a/tests2/core/claude-sdk-event-translator.test.ts
+++ b/tests2/core/claude-sdk-event-translator.test.ts
@@ -142,6 +142,44 @@ describe("Claude Agent SDK event translator", () => {
 		}
 	});
 
+	it("drains a child terminal locally while root tools and the root terminal remain live", () => {
+		let state = createClaudeSdkTranslatorState();
+		state = translateClaudeSdkEvent(state, {
+			type: "assistant", uuid: "root-open", message: { content: [{ type: "tool_use", id: "root-tool", name: "Read", input: {} }], stop_reason: "tool_use" },
+		}).state;
+		state = translateClaudeSdkEvent(state, {
+			type: "assistant", parent_tool_use_id: "child-parent", uuid: "child-open", message: { content: [{ type: "tool_use", id: "child-tool", name: "Bash", input: {} }], stop_reason: "tool_use" },
+		}).state;
+
+		const childAbort = translateClaudeSdkEvent(state, {
+			type: "result", parent_tool_use_id: "child-parent", subtype: "error_during_execution", is_error: true, error: "child aborted",
+		});
+		expect(childAbort.diagnostics).toEqual([]);
+		expect(childAbort.events).toEqual([
+			expect.objectContaining({ type: "message_end", parentToolUseId: "child-parent", message: expect.objectContaining({ role: "toolResult", toolCallId: "child-tool", isError: true }) }),
+			expect.objectContaining({ type: "tool_execution_end", parentToolUseId: "child-parent", toolCallId: "child-tool", isError: true }),
+		]);
+		expect(childAbort.events.some((event) => event.type === "agent_end")).toBe(false);
+
+		const rootResult = translateClaudeSdkEvent(childAbort.state, {
+			type: "user", message: { content: [{ type: "tool_result", tool_use_id: "root-tool", content: "root completed" }] },
+		});
+		expect(rootResult.diagnostics).toEqual([]);
+		expect(rootResult.events).toEqual([
+			expect.objectContaining({ type: "message_end", message: expect.objectContaining({ role: "toolResult", toolCallId: "root-tool", isError: false }) }),
+			expect.objectContaining({ type: "tool_execution_end", toolCallId: "root-tool", isError: false }),
+		]);
+
+		const lateChild = translateClaudeSdkEvent(rootResult.state, {
+			type: "stream_event", parent_tool_use_id: "child-parent", uuid: "child-late", event: { type: "message_start", message: { id: "child-late", content: [] } },
+		});
+		expect(lateChild.events).toEqual([]);
+		expect(lateChild.diagnostics).toMatchObject([{ code: "late_event", partition: "child-parent" }]);
+
+		const rootTerminal = translateClaudeSdkEvent(lateChild.state, { type: "result", subtype: "success" });
+		expect(rootTerminal.events).toEqual([expect.objectContaining({ type: "agent_end" })]);
+	});
+
 	it("makes duplicate and late frames no-ops without mutating prior state or input", () => {
 		const messages = fixtureMessages(fixture("root-tool-lifecycle.json"));
 		const initial = createClaudeSdkTranslatorState();

--- a/tests2/core/claude-sdk-event-translator.test.ts
+++ b/tests2/core/claude-sdk-event-translator.test.ts
@@ -135,6 +135,9 @@ describe("Claude Agent SDK event translator", () => {
 			expect(danglingEnd).toBeLessThan(agentEnd);
 			expect(events[danglingEnd]).toMatchObject({ toolCallId: "tool-root-1", isError: true });
 			expect(events.filter((event) => event.type === "agent_end")).toHaveLength(1);
+			if (terminalKey === "assistantAbort") {
+				expect(events[agentEnd]).toMatchObject({ error: "Request aborted by caller" });
+			}
 		}
 	});
 

--- a/tests2/core/claude-sdk-event-translator.test.ts
+++ b/tests2/core/claude-sdk-event-translator.test.ts
@@ -125,7 +125,7 @@ describe("Claude Agent SDK event translator", () => {
 		const terminal = fixture("terminal-and-permission.json");
 		const beforeToolResult = fixtureMessages(root).slice(0, -1);
 
-		for (const terminalKey of ["resultSuccess", "resultError", "assistantAbort"] as const) {
+		for (const terminalKey of ["resultSuccess", "resultError", "resultAbort", "assistantAbort", "assistantError"] as const) {
 			const { events, diagnostics } = feed([...beforeToolResult, terminal[terminalKey]]);
 			expect(diagnostics).toEqual([]);
 			const danglingResult = eventIndex(events, (event) => messageWithRole(event, "toolResult"));
@@ -135,8 +135,8 @@ describe("Claude Agent SDK event translator", () => {
 			expect(danglingEnd).toBeLessThan(agentEnd);
 			expect(events[danglingEnd]).toMatchObject({ toolCallId: "tool-root-1", isError: true });
 			expect(events.filter((event) => event.type === "agent_end")).toHaveLength(1);
-			if (terminalKey === "assistantAbort") {
-				expect(events[agentEnd]).toMatchObject({ error: "Request aborted by caller" });
+			if (terminalKey !== "resultSuccess") {
+				expect(events[agentEnd]).toMatchObject({ claudeSdk: { terminal: { error: expect.any(String) } } });
 			}
 		}
 	});
@@ -176,12 +176,106 @@ describe("Claude Agent SDK event translator", () => {
 		expect(malformed.diagnostics).toMatchObject([{ code: "malformed", partition: "child-malformed" }]);
 
 		const permission = translateClaudeSdkEvent(malformed.state, record.permissionDenied);
-		expect(() => translateClaudeSdkEvent(permission.state, record.permissionDenied)).not.toThrow();
+		expect(permission.diagnostics).toEqual([]);
+		expect(permission.events).toMatchObject([{
+			type: "message_end",
+			message: { role: "toolResult", toolCallId: "permission-tool-1", toolName: "Bash", isError: true, timestamp: 1700000000000 },
+		}]);
+		const repeatedPermission = translateClaudeSdkEvent(permission.state, record.permissionDenied);
+		expect(repeatedPermission.events).toEqual([]);
+		expect(repeatedPermission.diagnostics).toMatchObject([{ code: "duplicate" }]);
 		expect(permission.diagnostics.every((diagnostic) => typeof diagnostic.detail === "string" && diagnostic.detail.length <= 500)).toBe(true);
 
 		const cyclic: Event = { type: "stream_event", parent_tool_use_id: "child-cyclic" };
 		cyclic.event = cyclic;
 		expect(() => translateClaudeSdkEvent(permission.state, cyclic)).not.toThrow();
+	});
+
+	it("emits declaration-conformant Pi event and message shapes", () => {
+		const root = feed(fixtureMessages(fixture("root-tool-lifecycle.json"))).events;
+		const stream = fixture("streamed-tool-input.json");
+		const streamed = feed(stream.valid as readonly unknown[]).events;
+		const permission = translateClaudeSdkEvent(createClaudeSdkTranslatorState(), fixture("terminal-and-permission.json").permissionDenied).events as unknown as Event[];
+		for (const event of [...root, ...streamed, ...permission]) {
+			if (event.type === "message_update") {
+				expect(event.assistantMessageEvent).toBeTypeOf("object");
+			}
+			const message = event.message as Event | undefined;
+			if (message?.role === "assistant") {
+				expect(message).not.toHaveProperty("id");
+				expect(message.timestamp).toBeTypeOf("number");
+				expect(message.usage).toMatchObject({ input: expect.any(Number), output: expect.any(Number), totalTokens: expect.any(Number), cost: { total: expect.any(Number) } });
+				expect(["stop", "length", "toolUse", "error", "aborted"]).toContain(message.stopReason);
+				for (const block of message.content as Event[]) {
+					if (block.type === "thinking") expect(block).not.toHaveProperty("signature");
+					if (block.type === "toolCall") expect(block.arguments).toBeTypeOf("object");
+				}
+			}
+			if (message?.role === "toolResult") {
+				expect(message).toMatchObject({ toolCallId: expect.any(String), toolName: expect.any(String), timestamp: expect.any(Number), isError: expect.any(Boolean) });
+			}
+			if (event.type === "agent_end") expect(event).not.toHaveProperty("error");
+		}
+	});
+
+	it("preserves repeated streaming deltas and parses tool JSON without leaking raw partial strings", () => {
+		const repeat = {
+			type: "stream_event", uuid: "repeat-1", session_id: "repeat",
+			event: { type: "content_block_delta", index: 0, delta: { type: "text_delta", text: " " } },
+		};
+		let state = createClaudeSdkTranslatorState();
+		state = translateClaudeSdkEvent(state, { type: "stream_event", uuid: "repeat-1", event: { type: "content_block_start", index: 0, content_block: { type: "text", text: "" } } }).state;
+		const first = translateClaudeSdkEvent(state, repeat);
+		const second = translateClaudeSdkEvent(first.state, repeat);
+		expect(first.diagnostics).toEqual([]);
+		expect(second.diagnostics).toEqual([]);
+		expect(textInMessage(second.events[0] as unknown as Event, "  ")).toBe(true);
+
+		const streamed = fixture("streamed-tool-input.json");
+		for (const [name, inputs, expected] of [["valid", streamed.valid, { pattern: "*.ts" }], ["truncated", streamed.truncated, {}]] as const) {
+			const { events, diagnostics } = feed(inputs as readonly unknown[]);
+			expect(diagnostics, name).toEqual([]);
+			const start = events.find((event) => event.type === "tool_execution_start");
+			expect(start).toMatchObject({ args: expected });
+			expect(JSON.stringify(events)).not.toContain("[object Object]");
+		}
+	});
+
+	it("preserves declared redacted thinking and signature deltas and ignores plain user echoes", () => {
+		const frames: unknown[] = [
+			{ type: "stream_event", uuid: "thinking-1", event: { type: "message_start", message: { id: "thinking-message", role: "assistant", content: [] } } },
+			{ type: "stream_event", uuid: "thinking-delta", event: { type: "content_block_start", index: 0, content_block: { type: "thinking", thinking: "reason", signature: "old" } } },
+			{ type: "stream_event", uuid: "thinking-signature", event: { type: "content_block_delta", index: 0, delta: { type: "signature_delta", signature: "new" } } },
+			{ type: "stream_event", uuid: "thinking-redacted", event: { type: "content_block_start", index: 1, content_block: { type: "redacted_thinking", data: "opaque" } } },
+		];
+		const { events, diagnostics } = feed(frames);
+		expect(diagnostics).toEqual([]);
+		const last = events.at(-1) as Event;
+		const blocks = (last.message as Event).content as Event[];
+		expect(blocks).toEqual(expect.arrayContaining([
+			expect.objectContaining({ type: "thinking", thinking: "reason", thinkingSignature: "new" }),
+			expect.objectContaining({ type: "thinking", redacted: true, thinkingSignature: "opaque" }),
+		]));
+		const plainUser = translateClaudeSdkEvent(createClaudeSdkTranslatorState(), { type: "user", uuid: "plain-user", message: { role: "user", content: "hello" } });
+		expect(plainUser.events).toEqual([]);
+		expect(plainUser.diagnostics).toEqual([]);
+	});
+
+	it("keeps hostile parent, UUID, and tool identities structurally separate", () => {
+		const childRootName = "__claude_sdk_root__";
+		const inputs: unknown[] = [
+			{ type: "assistant", uuid: "__proto__", message: { role: "assistant", content: [{ type: "text", text: "root" }], stop_reason: "end_turn" } },
+			{ type: "assistant", parent_tool_use_id: childRootName, uuid: "__proto__", message: { role: "assistant", content: [{ type: "text", text: "child" }], stop_reason: "end_turn" } },
+			{ type: "assistant", parent_tool_use_id: "constructor", uuid: "constructor", message: { role: "assistant", content: [{ type: "tool_use", id: "toString", name: "Read", input: {} }], stop_reason: "tool_use" } },
+			{ type: "user", parent_tool_use_id: "constructor", uuid: "toString", message: { role: "user", content: [{ type: "tool_result", tool_use_id: "toString", content: "ok" }] } },
+			...(["__proto__", "toString"] as const).map((parent_tool_use_id) => ({ type: "assistant", parent_tool_use_id, uuid: parent_tool_use_id, message: { role: "assistant", content: [{ type: "text", text: parent_tool_use_id }], stop_reason: "end_turn" } })),
+		];
+		expect(() => feed(inputs)).not.toThrow();
+		const { events, diagnostics } = feed(inputs);
+		expect(diagnostics).toEqual([]);
+		expect(events.some((event) => event.parentToolUseId === childRootName && textInMessage(event, "child"))).toBe(true);
+		expect(events.some((event) => event.parentToolUseId === undefined && textInMessage(event, "root"))).toBe(true);
+		expect(events).toContainEqual(expect.objectContaining({ type: "tool_execution_end", toolCallId: "toString", parentToolUseId: "constructor" }));
 	});
 
 	it("remains an offline translator seam with no existing session setup or dispatch coupling", () => {

--- a/tests2/fixtures/claude-sdk-event-translator/interleaved-subagents.json
+++ b/tests2/fixtures/claude-sdk-event-translator/interleaved-subagents.json
@@ -1,0 +1,67 @@
+{
+  "fixtureSchema": "claude-sdk-event-translator/v1",
+  "provenance": {
+    "kind": "hand-authored captured-shape record",
+    "source": "@anthropic-ai/claude-agent-sdk published declarations",
+    "sdkVersion": "0.3.220",
+    "claudeCodeVersion": "2.1.220",
+    "note": "Offline declaration-shape fixture. parent_tool_use_id is deliberately interleaved to pin partition-before-accumulation."
+  },
+  "scenario": "root traffic is interleaved with two forwarded subagent partitions; children must never share UUID or tool lookup state with root",
+  "messages": [
+    {
+      "type": "stream_event",
+      "uuid": "shared-uuid",
+      "session_id": "sdk-session-2",
+      "event": { "type": "content_block_start", "index": 0, "content_block": { "type": "text", "text": "root " } }
+    },
+    {
+      "type": "stream_event",
+      "uuid": "shared-uuid",
+      "session_id": "sdk-session-2",
+      "parent_tool_use_id": "parent-tool-a",
+      "event": { "type": "content_block_start", "index": 0, "content_block": { "type": "text", "text": "child A " } }
+    },
+    {
+      "type": "stream_event",
+      "uuid": "shared-uuid",
+      "session_id": "sdk-session-2",
+      "parent_tool_use_id": "parent-tool-b",
+      "event": { "type": "content_block_start", "index": 0, "content_block": { "type": "tool_use", "id": "child-tool-b", "name": "Glob", "input": { "pattern": "*.ts" } } }
+    },
+    {
+      "type": "stream_event",
+      "uuid": "shared-uuid",
+      "session_id": "sdk-session-2",
+      "parent_tool_use_id": "parent-tool-a",
+      "event": { "type": "content_block_delta", "index": 0, "delta": { "type": "text_delta", "text": "continued" } }
+    },
+    {
+      "type": "assistant",
+      "uuid": "shared-uuid",
+      "session_id": "sdk-session-2",
+      "parent_tool_use_id": "parent-tool-a",
+      "message": { "role": "assistant", "content": [ { "type": "text", "text": "child A continued" } ], "stop_reason": "end_turn" }
+    },
+    {
+      "type": "assistant",
+      "uuid": "shared-uuid",
+      "session_id": "sdk-session-2",
+      "parent_tool_use_id": "parent-tool-b",
+      "message": { "role": "assistant", "content": [ { "type": "tool_use", "id": "child-tool-b", "name": "Glob", "input": { "pattern": "*.ts" } } ], "stop_reason": "tool_use" }
+    },
+    {
+      "type": "assistant",
+      "uuid": "shared-uuid",
+      "session_id": "sdk-session-2",
+      "message": { "role": "assistant", "content": [ { "type": "text", "text": "root only" } ], "stop_reason": "end_turn" }
+    },
+    {
+      "type": "user",
+      "uuid": "child-result-b",
+      "session_id": "sdk-session-2",
+      "parent_tool_use_id": "parent-tool-b",
+      "message": { "role": "user", "content": [ { "type": "tool_result", "tool_use_id": "child-tool-b", "content": "src/index.ts" } ] }
+    }
+  ]
+}

--- a/tests2/fixtures/claude-sdk-event-translator/root-tool-lifecycle.json
+++ b/tests2/fixtures/claude-sdk-event-translator/root-tool-lifecycle.json
@@ -1,0 +1,70 @@
+{
+  "fixtureSchema": "claude-sdk-event-translator/v1",
+  "provenance": {
+    "kind": "hand-authored captured-shape record",
+    "source": "@anthropic-ai/claude-agent-sdk published declarations",
+    "sdkVersion": "0.3.220",
+    "claudeCodeVersion": "2.1.220",
+    "recordedAt": "2026-04-03",
+    "note": "Offline declaration-shape fixture; it is not a recording from a live runtime."
+  },
+  "scenario": "root assistant streams text, thinking, and a tool call before a matching user tool result",
+  "messages": [
+    {
+      "type": "stream_event",
+      "uuid": "root-assistant-1",
+      "session_id": "sdk-session-1",
+      "event": { "type": "message_start", "message": { "id": "root-model-message-1", "role": "assistant", "content": [] } }
+    },
+    {
+      "type": "stream_event",
+      "uuid": "root-assistant-1",
+      "session_id": "sdk-session-1",
+      "event": { "type": "content_block_start", "index": 0, "content_block": { "type": "text", "text": "" } }
+    },
+    {
+      "type": "stream_event",
+      "uuid": "root-assistant-1",
+      "session_id": "sdk-session-1",
+      "event": { "type": "content_block_delta", "index": 0, "delta": { "type": "text_delta", "text": "I will inspect it." } }
+    },
+    {
+      "type": "stream_event",
+      "uuid": "root-assistant-1",
+      "session_id": "sdk-session-1",
+      "event": { "type": "content_block_start", "index": 1, "content_block": { "type": "thinking", "thinking": "I should read the file first.", "signature": "sig-1" } }
+    },
+    {
+      "type": "stream_event",
+      "uuid": "root-assistant-1",
+      "session_id": "sdk-session-1",
+      "event": { "type": "content_block_start", "index": 2, "content_block": { "type": "tool_use", "id": "tool-root-1", "name": "Read", "input": { "path": "README.md" } } }
+    },
+    {
+      "type": "assistant",
+      "uuid": "root-assistant-1",
+      "session_id": "sdk-session-1",
+      "message": {
+        "id": "root-model-message-1",
+        "role": "assistant",
+        "content": [
+          { "type": "text", "text": "I will inspect it." },
+          { "type": "thinking", "thinking": "I should read the file first.", "signature": "sig-1" },
+          { "type": "tool_use", "id": "tool-root-1", "name": "Read", "input": { "path": "README.md" } }
+        ],
+        "stop_reason": "tool_use"
+      }
+    },
+    {
+      "type": "user",
+      "uuid": "root-tool-result-1",
+      "session_id": "sdk-session-1",
+      "message": {
+        "role": "user",
+        "content": [
+          { "type": "tool_result", "tool_use_id": "tool-root-1", "content": "# Bobbit\n" }
+        ]
+      }
+    }
+  ]
+}

--- a/tests2/fixtures/claude-sdk-event-translator/streamed-tool-input.json
+++ b/tests2/fixtures/claude-sdk-event-translator/streamed-tool-input.json
@@ -1,0 +1,23 @@
+{
+  "fixtureSchema": "claude-sdk-event-translator/v1",
+  "provenance": {
+    "kind": "hand-authored captured-shape record",
+    "source": "@anthropic-ai/claude-agent-sdk published declarations",
+    "sdkVersion": "0.3.220",
+    "claudeCodeVersion": "2.1.220",
+    "note": "SDKPartialAssistantMessage / BetaRawMessageStreamEvent tool_use input_json_delta sequence, including a truncated JSON form."
+  },
+  "valid": [
+    { "type": "stream_event", "uuid": "stream-envelope-start", "session_id": "sdk-stream-1", "timestamp_ms": 10, "event": { "type": "message_start", "message": { "id": "stream-model-1", "role": "assistant", "content": [] } } },
+    { "type": "stream_event", "uuid": "stream-envelope-block", "session_id": "sdk-stream-1", "timestamp_ms": 10, "event": { "type": "content_block_start", "index": 0, "content_block": { "type": "tool_use", "id": "stream-tool-1", "name": "Glob", "input": {} } } },
+    { "type": "stream_event", "uuid": "stream-envelope-delta-a", "session_id": "sdk-stream-1", "timestamp_ms": 10, "event": { "type": "content_block_delta", "index": 0, "delta": { "type": "input_json_delta", "partial_json": "{\"pattern\":" } } },
+    { "type": "stream_event", "uuid": "stream-envelope-delta-b", "session_id": "sdk-stream-1", "timestamp_ms": 10, "event": { "type": "content_block_delta", "index": 0, "delta": { "type": "input_json_delta", "partial_json": "\"*.ts\"}" } } },
+    { "type": "result", "subtype": "success", "uuid": "stream-result", "session_id": "sdk-stream-1", "is_error": false, "num_turns": 1, "result": "", "total_cost_usd": 0, "usage": { "input_tokens": 1, "output_tokens": 1 } }
+  ],
+  "truncated": [
+    { "type": "stream_event", "uuid": "truncated-start", "session_id": "sdk-stream-2", "event": { "type": "message_start", "message": { "id": "truncated-model-1", "role": "assistant", "content": [] } } },
+    { "type": "stream_event", "uuid": "truncated-block", "session_id": "sdk-stream-2", "event": { "type": "content_block_start", "index": 0, "content_block": { "type": "tool_use", "id": "truncated-tool-1", "name": "Glob", "input": {} } } },
+    { "type": "stream_event", "uuid": "truncated-delta", "session_id": "sdk-stream-2", "event": { "type": "content_block_delta", "index": 0, "delta": { "type": "input_json_delta", "partial_json": "{\"pattern\":" } } },
+    { "type": "result", "subtype": "success", "uuid": "truncated-result", "session_id": "sdk-stream-2", "is_error": false, "num_turns": 1, "result": "", "total_cost_usd": 0, "usage": { "input_tokens": 1, "output_tokens": 1 } }
+  ]
+}

--- a/tests2/fixtures/claude-sdk-event-translator/terminal-and-permission.json
+++ b/tests2/fixtures/claude-sdk-event-translator/terminal-and-permission.json
@@ -1,0 +1,60 @@
+{
+  "fixtureSchema": "claude-sdk-event-translator/v1",
+  "provenance": {
+    "kind": "hand-authored captured-shape record",
+    "source": "@anthropic-ai/claude-agent-sdk published declarations",
+    "sdkVersion": "0.3.220",
+    "claudeCodeVersion": "2.1.220",
+    "note": "Offline declaration-shape fixture covering terminal result/error/abort and permission-denial system forms."
+  },
+  "resultSuccess": {
+    "type": "result",
+    "subtype": "success",
+    "uuid": "result-success-1",
+    "session_id": "sdk-session-3",
+    "duration_ms": 42,
+    "duration_api_ms": 35,
+    "is_error": false,
+    "num_turns": 1,
+    "result": "Completed",
+    "total_cost_usd": 0.0042,
+    "usage": { "input_tokens": 123, "output_tokens": 45, "cache_read_input_tokens": 0, "cache_creation_input_tokens": 0 }
+  },
+  "resultError": {
+    "type": "result",
+    "subtype": "error_during_execution",
+    "uuid": "result-error-1",
+    "session_id": "sdk-session-4",
+    "duration_ms": 9,
+    "duration_api_ms": 8,
+    "is_error": true,
+    "num_turns": 1,
+    "result": "Tool failed",
+    "errors": ["tool timeout"],
+    "total_cost_usd": 0.0009,
+    "usage": { "input_tokens": 9, "output_tokens": 2 }
+  },
+  "assistantAbort": {
+    "type": "assistant",
+    "uuid": "aborted-assistant-1",
+    "session_id": "sdk-session-5",
+    "is_error": true,
+    "error": "Request aborted by caller",
+    "message": { "role": "assistant", "content": [], "stop_reason": "error" }
+  },
+  "permissionDenied": {
+    "type": "system",
+    "subtype": "permission_denied",
+    "uuid": "permission-denied-1",
+    "session_id": "sdk-session-6",
+    "tool_name": "Bash",
+    "tool_use_id": "permission-tool-1",
+    "message": "Permission denied for Bash"
+  },
+  "unknownFuture": {
+    "type": "future_sdk_message",
+    "uuid": "future-1",
+    "session_id": "sdk-session-6",
+    "payload": { "safe": "retain only if understood" }
+  }
+}

--- a/tests2/fixtures/claude-sdk-event-translator/terminal-and-permission.json
+++ b/tests2/fixtures/claude-sdk-event-translator/terminal-and-permission.json
@@ -5,7 +5,7 @@
     "source": "@anthropic-ai/claude-agent-sdk published declarations",
     "sdkVersion": "0.3.220",
     "claudeCodeVersion": "2.1.220",
-    "note": "Offline declaration-shape fixture covering terminal result/error/abort and permission-denial system forms."
+    "note": "Offline declaration-shape fixture covering SDKResultSuccess/SDKResultError terminal reasons, SDKAssistantMessage aborted/error markers, and SDKPermissionDeniedMessage."
   },
   "resultSuccess": {
     "type": "result",
@@ -29,17 +29,36 @@
     "duration_api_ms": 8,
     "is_error": true,
     "num_turns": 1,
-    "result": "Tool failed",
-    "errors": ["tool timeout"],
+    "errors": ["tool timeout", "execution stopped"],
     "total_cost_usd": 0.0009,
     "usage": { "input_tokens": 9, "output_tokens": 2 }
+  },
+  "resultAbort": {
+    "type": "result",
+    "subtype": "success",
+    "uuid": "result-abort-1",
+    "session_id": "sdk-session-5",
+    "duration_ms": 3,
+    "duration_api_ms": 2,
+    "is_error": false,
+    "num_turns": 1,
+    "result": "",
+    "terminal_reason": "aborted_streaming",
+    "total_cost_usd": 0,
+    "usage": { "input_tokens": 1, "output_tokens": 0 }
   },
   "assistantAbort": {
     "type": "assistant",
     "uuid": "aborted-assistant-1",
     "session_id": "sdk-session-5",
-    "is_error": true,
-    "error": "Request aborted by caller",
+    "aborted": true,
+    "message": { "role": "assistant", "content": [], "stop_reason": "end_turn" }
+  },
+  "assistantError": {
+    "type": "assistant",
+    "uuid": "errored-assistant-1",
+    "session_id": "sdk-session-5",
+    "error": "server_error",
     "message": { "role": "assistant", "content": [], "stop_reason": "error" }
   },
   "permissionDenied": {
@@ -47,6 +66,7 @@
     "subtype": "permission_denied",
     "uuid": "permission-denied-1",
     "session_id": "sdk-session-6",
+    "timestamp_ms": 1700000000000,
     "tool_name": "Bash",
     "tool_use_id": "permission-tool-1",
     "message": "Permission denied for Bash"

--- a/tests2/tests-map.json
+++ b/tests2/tests-map.json
@@ -2136,6 +2136,15 @@
         "tier": "unit",
         "project": "integration"
       }
+    },
+    {
+      "path": "tests2/core/claude-sdk-event-translator.test.ts",
+      "reason": "Offline fixture-driven contract for Claude Agent SDK stream translation: Pi event ordering, partition isolation, terminal drains, duplicate/late suppression, malformed safety, immutability, and no runtime coupling.",
+      "execution": {
+        "runner": "vitest",
+        "tier": "unit",
+        "project": "core"
+      }
     }
   ],
   "journeys": [


### PR DESCRIPTION
## Summary

- add a pure, offline Claude Agent SDK to Pi event translator
- enforce partition-before-accumulation for root and subagent streams
- cover ordering, exactly-once, streamed tools, terminal/error/abort, hostile identities, malformed input, and idempotency with captured-shape fixtures
- document G0 findings and recommendation-only product decisions

## Verification

- `npm run build`
- `npm run check`
- `npm run test:unit`
- `npm run test:browser`
- `npm run test:e2e`
- focused translator suite: 13 tests passed

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)
