### PR TITLE
Stabilize Windows base-path unit gate

### DIFF
--- a/docs/testing-v2/windows-unit-gate-base-path-audit.md
+++ b/docs/testing-v2/windows-unit-gate-base-path-audit.md
@@ -1,0 +1,66 @@
+# Windows unit-gate base-path audit
+
+## Context
+
+This audit records the Windows diagnosis and qualification for the base-path gateway integration coverage. The governing constraints remain the [unit-gate operating model](unit-gate.md), including its 25-second per-file wall budget, and the fixture ownership rules in [Cross-OS test authoring](cross-os-test-authoring.md).
+
+## Failure evidence
+
+In GitHub Actions [run 30812190708, job 91681321263](https://github.com/G-Research/bobbit/actions/runs/30812190708/job/91681321263), every assertion passed, but the reporter measured `tests2/integration/base-path-gateway-routes.test.ts` at about 29,200 ms. The five sandbox-network shutdown phases took 10,297, 10,077, 7,734, 294, and 83 ms: 28,539 ms in total. Their corresponding gateway startups took only 5–13 ms.
+
+The imbalance identified shutdown ownership, rather than startup or cumulative assertion cost, as the cause of the file-budget breach.
+
+## Lifecycle fix
+
+Successful sandbox-network creation is now owned by the `SessionManager` instance that created it. An `already-exists` result does not grant ownership to another manager. The successful creator publishes synchronously consumed, exact-once cleanup, preventing a later manager from waiting on or removing a resource it did not create.
+
+The integration fixture uses `createRunChild` for its mutable child and `removeOwnedRunChild` only after gateway shutdown and restoration of the process state. This retains exact cleanup ownership under the harness run root.
+
+## Regression and qualification
+
+Retry-free focused qualification ran the base-path coverage three consecutive times on native Windows. Each run completed in about 1.2 seconds, with shutdown phases of 1–7 ms, providing substantial headroom below the 25-second file budget.
+
+Historical focused timings for other reported files were:
+
+| Coverage | Native Windows timing |
+| --- | ---: |
+| Message author | 2.23 s |
+| Stateless cookie | 4.69 s |
+| WebSocket frame | 4.54 s |
+| Gate reset | 8.22 s |
+
+The focused regression and full gate were qualified with the repository commands, including:
+
+```powershell
+npm run check
+npm run test:unit -- --retry=0
+$env:BOBBIT_V2_RETRY_FREE = '1'; npm run test:browser -- --retries=0
+$env:BOBBIT_V2_RETRY_FREE = '1'; npm run test:e2e
+```
+
+The full implementation gate passed build, check, focused reproduction, unit, browser, and E2E qualification after the OAuth restart issue described below was fixed.
+
+## Recent Windows failure audit
+
+| Run | Disposition | Evidence |
+| --- | --- | --- |
+| [30812190708](https://github.com/G-Research/bobbit/actions/runs/30812190708) | Actionable; fixed here | Base-path assertions passed, but non-owned sandbox-network shutdown consumed 28,539 ms and breached the file budget. |
+| [30806487088](https://github.com/G-Research/bobbit/actions/runs/30806487088) | Duplicate of PR #1096 | The packed-audit `ENOENT` failure is already covered by the cross-OS reliability work. |
+| [30760780858](https://github.com/G-Research/bobbit/actions/runs/30760780858) | Sandbox fixed by PR #1095; intermittent cases still actionable | Message-author and stateless-cookie failures remain separate intermittent work; focused native timings were 2.23 s and 4.69 s. |
+| [30800679923](https://github.com/G-Research/bobbit/actions/runs/30800679923) | Sandbox fixed by PR #1095; intermittent cases still actionable | WebSocket-frame and gate-reset failures remain separate intermittent work; focused native timings were 4.54 s and 8.22 s. |
+| [30759710982](https://github.com/G-Research/bobbit/actions/runs/30759710982) | Fixed by PR #1077 | No remaining duplicate in this change. |
+| [30799500277](https://github.com/G-Research/bobbit/actions/runs/30799500277) | Fixed by PRs #1092 and #1095 | No remaining duplicate in this change. |
+
+## PR #1096 non-overlap
+
+PR #1096, **Qualify cross-OS test reliability**, owns the Windows packed-audit `ENOENT` fix. This change does not duplicate it: it repairs sandbox-network lifecycle ownership and the base-path fixture cleanup ordering. The two changes can therefore be rebased in either order without sharing a causal fix.
+
+## OAuth restart regression
+
+Faster gateway shutdown exposed a latent `ECONNRESET` in OAuth restart coverage: a pooled fetch connection could be reused across the restart boundary. The restart probe now uses a dedicated `node:http` request with `agent: false` and `Connection: close`, preserving the assertion that the first attempt succeeds without adding retries or weakening the restart check.
+
+## Rejected alternatives
+
+Partitioning the base-path suite was rejected. The scenarios were not independently expensive; one lifecycle ownership defect accounted for nearly the entire file time. Splitting the file would have hidden that defect while scattering cohesive base-path coverage.
+
+No `docs/debugging.md` entry was added. The diagnosis is fixture-specific, while the reusable rule—exact resource ownership and cleanup after owned children settle—is already documented in the unit-gate and cross-OS authoring guides linked above.

--- a/src/server/agent/session-manager.ts
+++ b/src/server/agent/session-manager.ts
@@ -2760,10 +2760,11 @@ export class SessionManager {
 
 	/** Network name for sandbox containers. */
 	private static readonly SANDBOX_NETWORK = "bobbit-sandbox-net";
+	private ownsSandboxNetwork = false;
 
 	/**
 	 * Ensure the Docker bridge network for sandboxed containers exists.
-	 * Idempotent — checks with `docker network inspect` first.
+	 * Idempotent — concurrent creation reports `already exists`.
 	 */
 	async ensureSandboxNetwork(): Promise<string> {
 		const name = SessionManager.SANDBOX_NETWORK;
@@ -2773,6 +2774,7 @@ export class SessionManager {
 				"--driver", "bridge",
 				"--opt", "com.docker.network.bridge.enable_icc=false",
 			], { timeout: 15_000 });
+			this.ownsSandboxNetwork = true;
 			console.log(`[session-manager] Created Docker network "${name}"`);
 		} catch (err: any) {
 			const msg = err.stderr || err.message || "";
@@ -2786,10 +2788,11 @@ export class SessionManager {
 	}
 
 	/**
-	 * Remove the sandbox Docker network. Non-fatal if it doesn't exist
+	 * Remove this manager's sandbox Docker network. Non-fatal if it doesn't exist
 	 * or has connected containers.
 	 */
 	async cleanupSandboxNetwork(): Promise<void> {
+		if (!this.ownsSandboxNetwork) return;
 		try {
 			await this.commandRunner.execFile("docker", ["network", "rm", SessionManager.SANDBOX_NETWORK], { timeout: 10_000 });
 			console.log(`[session-manager] Removed Docker network "${SessionManager.SANDBOX_NETWORK}"`);

--- a/src/server/agent/session-manager.ts
+++ b/src/server/agent/session-manager.ts
@@ -2793,6 +2793,9 @@ export class SessionManager {
 	 */
 	async cleanupSandboxNetwork(): Promise<void> {
 		if (!this.ownsSandboxNetwork) return;
+		// Consume ownership before yielding so repeated or concurrent cleanup calls
+		// cannot issue more than one removal attempt for the same creation grant.
+		this.ownsSandboxNetwork = false;
 		try {
 			await this.commandRunner.execFile("docker", ["network", "rm", SessionManager.SANDBOX_NETWORK], { timeout: 10_000 });
 			console.log(`[session-manager] Removed Docker network "${SessionManager.SANDBOX_NETWORK}"`);

--- a/tests/e2e/anthropic-oauth-restart-sandbox-lock.spec.ts
+++ b/tests/e2e/anthropic-oauth-restart-sandbox-lock.spec.ts
@@ -8,6 +8,7 @@ import {
 	utimesSync,
 	writeFileSync,
 } from "node:fs";
+import { request } from "node:http";
 import { join } from "node:path";
 
 import { test, expect } from "./gateway-harness.js";
@@ -38,11 +39,25 @@ function writeAnthropicCredential(file: string, credential: OAuthRow): void {
 }
 
 async function oauthStatus(baseURL: string): Promise<Record<string, unknown>> {
-	const response = await fetch(`${baseURL}/api/oauth/status?provider=anthropic`, {
-		headers: { Authorization: `Bearer ${process.env.BOBBIT_TOKEN}` },
+	const { status, body } = await new Promise<{ status: number | undefined; body: string }>((resolve, reject) => {
+		const client = request(`${baseURL}/api/oauth/status?provider=anthropic`, {
+			agent: false,
+			headers: {
+				Authorization: `Bearer ${process.env.BOBBIT_TOKEN}`,
+				Connection: "close",
+			},
+		}, response => {
+			let body = "";
+			response.setEncoding("utf8");
+			response.on("data", chunk => { body += chunk; });
+			response.once("error", reject);
+			response.once("end", () => resolve({ status: response.statusCode, body }));
+		});
+		client.once("error", reject);
+		client.end();
 	});
-	expect(response.status).toBe(200);
-	return response.json() as Promise<Record<string, unknown>>;
+	expect(status).toBe(200);
+	return JSON.parse(body) as Record<string, unknown>;
 }
 
 async function assertMockModelUsesStoredCredential(access: string): Promise<void> {

--- a/tests2/core/run-isolation.test.ts
+++ b/tests2/core/run-isolation.test.ts
@@ -420,10 +420,27 @@ describe("unit run isolation", () => {
       expect(readFileSync(config, "utf8"), config).toContain(playwrightRetryPolicy);
   });
 
-  it("keeps the gateway fixture beneath the inherited run root", () => {
+  it("keeps the gateway fixtures beneath the inherited run root", () => {
     const source = readFileSync("tests2/harness/gateway.ts", "utf8");
     expect(source).toContain('from "./run-isolation.js"');
     expect(source).toContain("createRunChild");
     expect(source).toContain("getRunRoot");
+
+    const basePathSource = readFileSync(
+      "tests2/integration/helpers/base-path-gateway-fixture.ts",
+      "utf8",
+    );
+    expect(basePathSource).toContain('from "../../harness/run-isolation.js"');
+    expect(basePathSource).toContain('createRunChild("base-path-gateway")');
+    expect(basePathSource.match(/removeOwnedRunChild\(root\)/g)).toHaveLength(2);
+    expect(basePathSource).toMatch(
+      /catch \(error\) \{\s*try \{ await gateway!\.shutdown\(\); \} catch \{[^}]*\}\s*restoreProcessState\(processState\);\s*removeOwnedRunChild\(root\);/,
+    );
+    expect(basePathSource).toMatch(
+      /async shutdown\(\) \{\s*try \{ await gateway\.shutdown\(\); \}\s*finally \{[\s\S]*?restoreProcessState\(processState\);\s*removeOwnedRunChild\(root\);/,
+    );
+    expect(basePathSource).not.toContain("tmpdir");
+    expect(basePathSource).not.toContain("mkdtempSync");
+    expect(basePathSource).not.toContain("rmSync");
   });
 });

--- a/tests2/core/session-manager-sandbox-network-ownership.test.ts
+++ b/tests2/core/session-manager-sandbox-network-ownership.test.ts
@@ -1,0 +1,78 @@
+import assert from "node:assert/strict";
+import { describe, it } from "vitest";
+import { SessionManager } from "../../src/server/agent/session-manager.js";
+import type { CommandRunner } from "../../src/server/gateway-deps.js";
+
+type NetworkCreateOutcome = "created" | "already-exists";
+
+type DockerCall = {
+	file: string;
+	args: string[];
+};
+
+function recordingRunner(createOutcome: NetworkCreateOutcome = "created"): {
+	runner: CommandRunner;
+	calls: DockerCall[];
+} {
+	const calls: DockerCall[] = [];
+	const runner: CommandRunner = {
+		async execFile(file, args) {
+			calls.push({ file, args: [...args] });
+			if (args[0] === "network" && args[1] === "create" && createOutcome === "already-exists") {
+				throw Object.assign(new Error("network with name bobbit-sandbox-net already exists"), {
+					stderr: "network with name bobbit-sandbox-net already exists",
+				});
+			}
+			return { stdout: "", stderr: "" };
+		},
+	};
+	return { runner, calls };
+}
+
+function managerWith(runner: CommandRunner): SessionManager {
+	return new SessionManager({
+		commandRunner: runner,
+		// Avoid constructing unrelated durable stores; these lifecycle methods do
+		// not consult project context.
+		projectContextManager: {} as any,
+	});
+}
+
+describe("SessionManager sandbox network ownership", () => {
+	it("does not invoke Docker when cleanup runs before ensure", async () => {
+		const { runner, calls } = recordingRunner();
+		const manager = managerWith(runner);
+
+		await manager.cleanupSandboxNetwork();
+
+		assert.deepEqual(calls, [], "cleanup before ensure must not invoke Docker");
+	});
+
+	it("does not remove a network that another manager already created", async () => {
+		const { runner, calls } = recordingRunner("already-exists");
+		const manager = managerWith(runner);
+
+		await manager.ensureSandboxNetwork();
+		await manager.cleanupSandboxNetwork();
+
+		assert.deepEqual(
+			calls.map(({ args }) => args.slice(0, 2)),
+			[["network", "create"]],
+			"a manager that observes an existing network must not remove it",
+		);
+	});
+
+	it("removes exactly once when this manager created the network", async () => {
+		const { runner, calls } = recordingRunner();
+		const manager = managerWith(runner);
+
+		await manager.ensureSandboxNetwork();
+		await manager.cleanupSandboxNetwork();
+
+		assert.equal(
+			calls.filter(({ args }) => args[0] === "network" && args[1] === "rm").length,
+			1,
+			"the creating manager must remove its network exactly once",
+		);
+	});
+});

--- a/tests2/core/session-manager-sandbox-network-ownership.test.ts
+++ b/tests2/core/session-manager-sandbox-network-ownership.test.ts
@@ -4,29 +4,47 @@ import { SessionManager } from "../../src/server/agent/session-manager.js";
 import type { CommandRunner } from "../../src/server/gateway-deps.js";
 
 type NetworkCreateOutcome = "created" | "already-exists";
+type NetworkRemoveOutcome = "removed" | "failed";
 
 type DockerCall = {
 	file: string;
 	args: string[];
 };
 
-function recordingRunner(createOutcome: NetworkCreateOutcome = "created"): {
+type RecordingRunnerOptions = {
+	createOutcomes?: NetworkCreateOutcome[];
+	removeOutcome?: NetworkRemoveOutcome;
+};
+
+function recordingRunner(options: RecordingRunnerOptions = {}): {
 	runner: CommandRunner;
 	calls: DockerCall[];
 } {
 	const calls: DockerCall[] = [];
+	const createOutcomes = options.createOutcomes ?? ["created"];
+	let createCallIndex = 0;
 	const runner: CommandRunner = {
 		async execFile(file, args) {
 			calls.push({ file, args: [...args] });
-			if (args[0] === "network" && args[1] === "create" && createOutcome === "already-exists") {
-				throw Object.assign(new Error("network with name bobbit-sandbox-net already exists"), {
-					stderr: "network with name bobbit-sandbox-net already exists",
-				});
+			if (args[0] === "network" && args[1] === "create") {
+				const outcome = createOutcomes[createCallIndex++] ?? createOutcomes.at(-1) ?? "created";
+				if (outcome === "already-exists") {
+					throw Object.assign(new Error("network with name bobbit-sandbox-net already exists"), {
+						stderr: "network with name bobbit-sandbox-net already exists",
+					});
+				}
+			}
+			if (args[0] === "network" && args[1] === "rm" && options.removeOutcome === "failed") {
+				throw new Error("network has active endpoints");
 			}
 			return { stdout: "", stderr: "" };
 		},
 	};
 	return { runner, calls };
+}
+
+function networkOperations(calls: DockerCall[]): string[] {
+	return calls.map(({ args }) => args.slice(0, 2).join(" "));
 }
 
 function managerWith(runner: CommandRunner): SessionManager {
@@ -49,30 +67,97 @@ describe("SessionManager sandbox network ownership", () => {
 	});
 
 	it("does not remove a network that another manager already created", async () => {
-		const { runner, calls } = recordingRunner("already-exists");
+		const { runner, calls } = recordingRunner({ createOutcomes: ["already-exists"] });
 		const manager = managerWith(runner);
 
 		await manager.ensureSandboxNetwork();
 		await manager.cleanupSandboxNetwork();
 
 		assert.deepEqual(
-			calls.map(({ args }) => args.slice(0, 2)),
-			[["network", "create"]],
+			networkOperations(calls),
+			["network create"],
 			"a manager that observes an existing network must not remove it",
 		);
 	});
 
-	it("removes exactly once when this manager created the network", async () => {
+	it("removes exactly once across repeated sequential cleanup", async () => {
 		const { runner, calls } = recordingRunner();
 		const manager = managerWith(runner);
 
 		await manager.ensureSandboxNetwork();
 		await manager.cleanupSandboxNetwork();
+		await manager.cleanupSandboxNetwork();
 
-		assert.equal(
-			calls.filter(({ args }) => args[0] === "network" && args[1] === "rm").length,
-			1,
-			"the creating manager must remove its network exactly once",
+		assert.deepEqual(networkOperations(calls), ["network create", "network rm"]);
+	});
+
+	it("removes exactly once across concurrent cleanup", async () => {
+		const { runner, calls } = recordingRunner();
+		const manager = managerWith(runner);
+
+		await manager.ensureSandboxNetwork();
+		await Promise.all([
+			manager.cleanupSandboxNetwork(),
+			manager.cleanupSandboxNetwork(),
+			manager.cleanupSandboxNetwork(),
+		]);
+
+		assert.deepEqual(networkOperations(calls), ["network create", "network rm"]);
+	});
+
+	it("preserves creation ownership across repeated ensure calls", async () => {
+		const { runner, calls } = recordingRunner({ createOutcomes: ["created", "already-exists"] });
+		const manager = managerWith(runner);
+
+		await manager.ensureSandboxNetwork();
+		await manager.ensureSandboxNetwork();
+		await manager.cleanupSandboxNetwork();
+
+		assert.deepEqual(
+			networkOperations(calls),
+			["network create", "network create", "network rm"],
 		);
+	});
+
+	it("can reacquire ownership after cleanup consumes the previous grant", async () => {
+		const { runner, calls } = recordingRunner({ createOutcomes: ["created", "created"] });
+		const manager = managerWith(runner);
+
+		await manager.ensureSandboxNetwork();
+		await manager.cleanupSandboxNetwork();
+		await manager.ensureSandboxNetwork();
+		await manager.cleanupSandboxNetwork();
+
+		assert.deepEqual(
+			networkOperations(calls),
+			["network create", "network rm", "network create", "network rm"],
+		);
+	});
+
+	it("only lets the creating manager remove a shared network", async () => {
+		const { runner, calls } = recordingRunner({ createOutcomes: ["created", "already-exists"] });
+		const creator = managerWith(runner);
+		const observer = managerWith(runner);
+
+		await creator.ensureSandboxNetwork();
+		await observer.ensureSandboxNetwork();
+		await observer.cleanupSandboxNetwork();
+		await creator.cleanupSandboxNetwork();
+
+		assert.deepEqual(
+			networkOperations(calls),
+			["network create", "network create", "network rm"],
+		);
+	});
+
+	it("consumes ownership after a non-fatal removal failure", async () => {
+		const { runner, calls } = recordingRunner({ removeOutcome: "failed" });
+		const manager = managerWith(runner);
+
+		await manager.ensureSandboxNetwork();
+		await manager.cleanupSandboxNetwork();
+		await manager.cleanupSandboxNetwork();
+
+		assert.deepEqual(networkOperations(calls), ["network create", "network rm"]);
 	});
 });

--- a/tests2/integration/helpers/base-path-gateway-fixture.ts
+++ b/tests2/integration/helpers/base-path-gateway-fixture.ts
@@ -2,13 +2,9 @@ import { randomUUID } from "node:crypto";
 import {
 	existsSync,
 	mkdirSync,
-	mkdtempSync,
-	realpathSync,
-	rmSync,
 	writeFileSync,
 } from "node:fs";
 import http from "node:http";
-import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import WebSocket, { type ClientOptions } from "ws";
@@ -27,6 +23,7 @@ import { realClock, realCommandRunner, realFs, type GatewayDeps } from "../../..
 import { scaffoldBobbitDir } from "../../../src/server/scaffold.js";
 import { loopbackForBind } from "../../../src/server/cli-loopback.js";
 import { createGateway, type GatewayConfig } from "../../../src/server/server.js";
+import { createRunChild, removeOwnedRunChild } from "../../harness/run-isolation.js";
 
 const REPO_ROOT = resolve(fileURLToPath(new URL("../../..", import.meta.url)));
 // This test branch is developed in parallel with the gateway foundation branch.
@@ -164,8 +161,7 @@ export async function bootGateway(
 	options: BootGatewayOptions = {},
 ): Promise<RunningGateway> {
 	const processState = captureProcessState();
-	let root = mkdtempSync(join(tmpdir(), "bobbit-base-path-gateway-"));
-	try { root = realpathSync(root); } catch { /* platform edge */ }
+	const root = createRunChild("base-path-gateway");
 	const stateDir = join(root, "state");
 	const staticDir = join(root, "static");
 	mkdirSync(stateDir, { recursive: true });
@@ -226,7 +222,7 @@ export async function bootGateway(
 	} catch (error) {
 		try { await gateway!.shutdown(); } catch { /* best-effort rejected-start cleanup */ }
 		restoreProcessState(processState);
-		rmSync(root, { recursive: true, force: true });
+		removeOwnedRunChild(root);
 		throw error;
 	}
 	const peerHost = loopbackForBind(host.trim());
@@ -258,7 +254,7 @@ export async function bootGateway(
 				// createGateway resolves these process-wide values during startup. Restore
 				// every one before deleting the directories they previously referenced.
 				restoreProcessState(processState);
-				rmSync(root, { recursive: true, force: true });
+				removeOwnedRunChild(root);
 			}
 		},
 	};

--- a/tests2/tests-map.json
+++ b/tests2/tests-map.json
@@ -76,6 +76,15 @@
       }
     },
     {
+      "path": "tests2/core/session-manager-sandbox-network-ownership.test.ts",
+      "reason": "Focused failing-first regression pinning per-SessionManager Docker sandbox-network creation ownership: non-creators never remove the shared network and its creator removes it during owned cleanup.",
+      "execution": {
+        "runner": "vitest",
+        "tier": "unit",
+        "project": "core"
+      }
+    },
+    {
       "path": "tests2/core/anthropic-oauth-pi-callback-contract-repro.test.ts",
       "reason": "Focused failing-first Anthropic OAuth regression pinning Pi's loopback callback and complete current authorization scope set, so the stale Console callback and reduced legacy scope contract cannot return.",
       "execution": {


### PR DESCRIPTION
## Summary
- make sandbox-network cleanup exact-owner and exact-once
- enforce harness-owned base-path fixture allocation and deletion
- pin ownership regressions and isolate OAuth restart HTTP client lifecycle
- document the Windows failure audit, qualification timings, and PR #1096 non-overlap

## Validation
- three consecutive retry-free Windows base-path runs with ~1.2s wall and 1-7ms shutdown
- focused historical Windows outlier profiling
- workflow build, type-check, retry-free unit, browser, E2E, security, and implementation reviews

PR #1096 exclusively owns the packed-audit `ENOENT` fix; this branch does not duplicate it.

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)