### PR TITLE
Fix streaming transcript render storm

### DIFF
--- a/src/ui/components/AgentInterface.ts
+++ b/src/ui/components/AgentInterface.ts
@@ -1242,10 +1242,10 @@ export class AgentInterface extends LitElement {
 						this._streamingContainer.turnStartTime = (this.session?.state as any).turnStartTime ?? null;
 						this._streamingContainer.setMessage(ev.message, !isStreaming);
 					}
-					// message_update doesn't go through Lit's `requestUpdate` (the
-					// streaming container manages its own DOM), so route through
-					// updateComplete + _pinIfSticking to follow growth.
-					this._updateAndPin();
+					// StreamingMessageContainer batches its own renders via rAF. Do not
+					// request an AgentInterface update here: that re-renders the whole
+					// transcript for every cumulative token frame. Its ResizeObserver
+					// already owns follow-tail pinning when the stream grows.
 					break;
 			}
 		});

--- a/src/ui/components/AgentInterface.ts
+++ b/src/ui/components/AgentInterface.ts
@@ -949,6 +949,10 @@ export class AgentInterface extends LitElement {
 				}
 			});
 
+			// This is the outer transcript wrapper from render(), not the
+			// <message-list> child. It contains both the stable message list and
+			// <streaming-message-container>, so token-driven stream growth reaches
+			// this observer without requiring an AgentInterface render.
 			const contentContainer = this._scrollContainer.querySelector(".max-w-5xl");
 			if (contentContainer) {
 				this._resizeObserver.observe(contentContainer);
@@ -1244,8 +1248,9 @@ export class AgentInterface extends LitElement {
 					}
 					// StreamingMessageContainer batches its own renders via rAF. Do not
 					// request an AgentInterface update here: that re-renders the whole
-					// transcript for every cumulative token frame. Its ResizeObserver
-					// already owns follow-tail pinning when the stream grows.
+					// transcript for every cumulative token frame. AgentInterface's
+					// ResizeObserver watches the outer transcript wrapper containing this
+					// stream container and owns follow-tail pinning when it grows.
 					break;
 			}
 		});

--- a/tests2/dom/permission-card-ux.test.ts
+++ b/tests2/dom/permission-card-ux.test.ts
@@ -188,6 +188,27 @@ describe("AgentInterface stream bridge", () => {
 		assert.equal(session.streamFn, wrapped, "re-subscribing must preserve the existing default wrapper");
 	});
 
+	it("routes message_update only to the rAF-batched streaming container", async () => {
+		const session = new FixtureSession([]);
+		session.state.isStreaming = true;
+		const { el } = await mountSession(session);
+		const streamingContainer = (el as any)._streamingContainer;
+		assert.ok(streamingContainer, "streaming container should be mounted");
+
+		let hostUpdates = 0;
+		const originalRequestUpdate = el.requestUpdate.bind(el);
+		el.requestUpdate = () => {
+			hostUpdates++;
+			originalRequestUpdate();
+		};
+
+		const message = { id: "stream-1", role: "assistant", content: [{ type: "text", text: "partial" }] };
+		session.emit({ type: "message_update", message });
+
+		assert.equal(hostUpdates, 0, "cumulative token frames must not re-render the whole AgentInterface transcript");
+		assert.equal(streamingContainer._pendingMessage, message, "the streaming container should still receive the latest frame");
+	});
+
 	it("installs the proxy wrapper on Pi Agent.streamFunction without repeated wrapping", async () => {
 		const session = new Agent({ streamFn: (() => undefined) as never });
 		const { el } = await mountSession(session);


### PR DESCRIPTION
## Summary
- stop `message_update` frames from requesting a full `AgentInterface` render
- keep streaming updates in the rAF-batched `StreamingMessageContainer`, with its existing `ResizeObserver` owning follow-tail behavior
- add a DOM regression test that pins the no-host-render boundary

## Testing
- `npm run check`
- `npm run test:unit` — 9,327 passed, 20 skipped
- focused scroll browser coverage — 14 passed
- real-stream E2E — 1 passed
- full `npm run test:browser` — 698 passed, 8 skipped, 4 flaky retries recovered; command exited on the per-spec wall-time budget for two unrelated specs

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)