### PR TITLE
Add workflow failure guidance

### DIFF
--- a/defaults/workflow-authoring-guide.md
+++ b/defaults/workflow-authoring-guide.md
@@ -212,6 +212,19 @@ Practical implications when authoring workflows:
 
 There are four step `type:` values: `command`, `llm-review`, `agent-qa`, `human-signoff`.
 
+Every type accepts optional `failureGuidance`, a static Markdown string with check-specific diagnostic and remediation advice for the team lead:
+
+```yaml
+- name: "Browser journey"
+  type: command
+  run: npm run test:browser
+  failureGuidance: |
+    Inspect the retained Playwright trace first.
+    Re-run only the failing journey after fixing the product behavior.
+```
+
+Bobbit appends this Markdown under **Workflow remediation guidance** after the matching failed step's authoritative `gate_inspect(...)` instruction. It is included only for an actual failure and is sourced from the goal's frozen workflow snapshot. It is not interpolated, does not embed verifier output, and cannot reset, revisit, route, re-signal, or automatically remediate a gate. See [Failure remediation guidance](../docs/goals-workflows-tasks.md#failure-remediation-guidance) for selection rules and notification behavior.
+
 ### 4.1 `type: command` — three shapes
 
 ```yaml

--- a/docs/goals-workflows-tasks.md
+++ b/docs/goals-workflows-tasks.md
@@ -223,6 +223,7 @@ interface VerifyStep {
   optionalLabel?: string; // Human-readable label for the goal-creation toggle.
   label?: string;     // Human-signoff card title only (type: "human-signoff").
   description?: string; // Tooltip text shown as ⓘ icon next to the toggle. For agent-qa steps, overridden when no component has config.qa_start_command set.
+  failureGuidance?: string; // Static Markdown sent to the team lead only if this step actually fails.
 }
 
 interface WorkflowGate {
@@ -307,7 +308,7 @@ The validator does **not** reject template tokens in free-form `run:` or `prompt
 
 #### Workflow editor authoring
 
-Settings → Workflows exposes the same schema as inline workflow YAML. Authors can edit gate `id`, `name`, `dependsOn`, `content`, `injectDownstream`, `optional`, `manual`, and `metadata`; verification step `type`, command/run source, prompt, role, component, timeout, phase, description, optional toggle, and `optionalLabel`; and `human-signoff`-specific `label` and `prompt` fields.
+Settings → Workflows exposes the same schema as inline workflow YAML. Authors can edit gate `id`, `name`, `dependsOn`, `content`, `injectDownstream`, `optional`, `manual`, and `metadata`; verification step `type`, command/run source, prompt, role, component, timeout, phase, description, optional toggle, `optionalLabel`, and multiline **Failure guidance**; and `human-signoff`-specific `label` and `prompt` fields. Failure guidance is type-independent, so changing a verification step between command, LLM review, agent QA, and human sign-off preserves it. Read-only workflow and proposal inspectors keep guidance out of the collapsed step summary and show configured Markdown in a default-closed **Failure guidance** disclosure.
 
 Timeout authoring is type-aware and leaving the field empty does not serialize a default. Command steps show the generic 300-second default and the 1200-second component `command: unit` exception. `llm-review` shows the 1200-second per-active-turn default. `agent-qa` explains that its omitted value is the greater of 1200 seconds and component `qa_max_duration_minutes + 5m`. Review-agent help also states that a positive explicit value may be shorter and that provider backoff is excluded.
 
@@ -524,6 +525,28 @@ Gates can define automated verification that runs when signaled:
 - **Combined** — mechanical + qualitative steps across phases
 
 Verification is async. On signal, the verification status is `"running"`. On completion: the gate transitions to `"passed"` (all steps pass) or `"failed"` (any step fails, with details). A WebSocket event `gate_verification_complete` is emitted. If no verification is defined, the gate auto-passes.
+
+#### Failure remediation guidance
+
+Every verification-step type (`command`, `llm-review`, `agent-qa`, and `human-signoff`) accepts optional `failureGuidance`. It is static, workflow-authored Markdown for explaining how the team lead should diagnose and remediate that specific check. Use it for durable, check-specific advice rather than copied logs or expected verifier output.
+
+```yaml
+verify:
+  - name: Browser journey
+    type: command
+    run: npm run test:browser
+    failureGuidance: |
+      Inspect the retained Playwright trace first.
+      Re-run only the failing journey after fixing the product behavior.
+```
+
+When a step actually fails, Bobbit keeps the existing compact, inspect-first notification: it names the failed step and gives the authoritative `gate_inspect(...)` instruction. Immediately after that instruction, Bobbit appends the matching authored Markdown under **Workflow remediation guidance**. If multiple steps fail, each receives only its own matching guidance. Matching uses the result's original position and requires the authored step's name and type to agree; a mismatch fails closed rather than attaching unrelated advice.
+
+Guidance is omitted for passed, skipped, waiting, restart-interrupted, unrelated, identity-mismatched, blank, or absent steps. A waiting or restart-interrupted row is not treated as an actual verifier failure. Guidance does not replace diagnostics: Bobbit does not interpolate it with runtime tokens or command/reviewer output, and the failure notification does not embed verifier output. The team lead should use `gate_inspect` as the authoritative diagnostic source.
+
+The persisted goal's frozen workflow snapshot is authoritative, including for resumed or restart-recovered failures. Editing the project workflow template after goal creation changes guidance only for future goal snapshots; it does not retroactively change an existing goal's advice. An existing goal changes only through explicit replacement of that goal's workflow snapshot.
+
+Guidance is advisory only. It does not automatically reset or revisit gates, route work, re-signal the gate, execute a remediation, or otherwise change verification transitions. The team lead retains judgement and follows the existing inspect, diagnose, fix, and re-signal loop.
 
 #### Review-agent timeout semantics
 

--- a/scripts/affected/impact-rules.mjs
+++ b/scripts/affected/impact-rules.mjs
@@ -1119,7 +1119,7 @@ export const UNRESOLVED_REPOSITORY_READ_AUDIT = Object.freeze([
 		consumer: "tests2/core/workflow-store.test.ts",
 		allowReason: "test-owned temporary, generated, cache, or in-memory fixture output",
 		reads: frozen([
-			{ expression: "path.join(configDir, \"project.yaml\")", count: 1 },
+			{ expression: "path.join(configDir, \"project.yaml\")", count: 3 },
 		]),
 	},
 	{

--- a/scripts/affected/impact-rules.mjs
+++ b/scripts/affected/impact-rules.mjs
@@ -1119,7 +1119,7 @@ export const UNRESOLVED_REPOSITORY_READ_AUDIT = Object.freeze([
 		consumer: "tests2/core/workflow-store.test.ts",
 		allowReason: "test-owned temporary, generated, cache, or in-memory fixture output",
 		reads: frozen([
-			{ expression: "path.join(configDir, \"project.yaml\")", count: 3 },
+			{ expression: "path.join(configDir, \"project.yaml\")", count: 1 },
 		]),
 	},
 	{
@@ -1969,9 +1969,6 @@ export const UNRESOLVED_REPOSITORY_READ_AUDIT = Object.freeze([
 		declarations: frozen(["indirect:base-path-preview-contract"]),
 		reads: frozen([
 			{ expression: "path.resolve(relative)", count: 1 },
-			{ expression: "result.path", count: 1 },
-			{ expression: "literalPercent.path", count: 1 },
-			{ expression: "decodedName.path", count: 1 },
 		]),
 	},
 	{

--- a/scripts/affected/impact-rules.mjs
+++ b/scripts/affected/impact-rules.mjs
@@ -1969,6 +1969,9 @@ export const UNRESOLVED_REPOSITORY_READ_AUDIT = Object.freeze([
 		declarations: frozen(["indirect:base-path-preview-contract"]),
 		reads: frozen([
 			{ expression: "path.resolve(relative)", count: 1 },
+			{ expression: "result.path", count: 1 },
+			{ expression: "literalPercent.path", count: 1 },
+			{ expression: "decodedName.path", count: 1 },
 		]),
 	},
 	{

--- a/src/app/api.ts
+++ b/src/app/api.ts
@@ -2295,6 +2295,8 @@ export interface VerifyStep {
 	optionalLabel?: string;
 	role?: string;
 	description?: string;
+	/** Static workflow-authored Markdown sent to the team lead only when this step fails. */
+	failureGuidance?: string;
 	/** Structural reference: which component to run from (Phase 2). */
 	component?: string;
 	/** Structural reference: which command on that component to invoke (Phase 2). */

--- a/src/app/project-proposal-views.ts
+++ b/src/app/project-proposal-views.ts
@@ -11,6 +11,7 @@
  * with server-side code.
  */
 import { html, type TemplateResult } from "lit";
+import { ensureMarkdownBlock } from "../ui/lazy/markdown-block.js";
 
 // ---------------------------------------------------------------------------
 // Local types — kept structural so they're assignable to/from server seeds.
@@ -43,6 +44,8 @@ export interface ProposalVerifyStep {
 	/** Opt-in toggle label shown at goal creation for `optional: true` steps. */
 	optionalLabel?: string;
 	description?: string;
+	/** Static workflow-authored Markdown shown as advisory remediation guidance after a verification failure. */
+	failureGuidance?: string;
 	[key: string]: unknown;
 }
 
@@ -356,7 +359,21 @@ function stepCard(step: ProposalVerifyStep, componentNames: Set<string>): Templa
 			</summary>
 			<div class="wf-vstep-body"><div class="wf-vstep-fields">
 				${stepDetails(step, type, componentNames)}
+				${failureGuidanceDetails(step)}
 			</div></div>
+		</details>
+	`;
+}
+
+function failureGuidanceDetails(step: ProposalVerifyStep): TemplateResult {
+	if (!step.failureGuidance?.trim()) return html``;
+	ensureMarkdownBlock();
+	return html`
+		<details data-testid="wf-step-failure-guidance-details" class="wf-vstep-advanced">
+			<summary class="wf-vstep-advanced-summary">Failure guidance</summary>
+			<div class="wf-vstep-advanced-fields">
+				<markdown-block .content=${step.failureGuidance}></markdown-block>
+			</div>
 		</details>
 	`;
 }

--- a/src/app/state.ts
+++ b/src/app/state.ts
@@ -199,11 +199,12 @@ export interface Goal {
 			metadata?: Record<string, string>;
 			verify?: Array<{
 				name: string;
-				type: "command" | "llm-review";
+				type: "command" | "llm-review" | "agent-qa" | "human-signoff";
 				run?: string;
 				prompt?: string;
 				expect?: "success" | "failure";
 				timeout?: number;
+				failureGuidance?: string;
 			}>;
 		}>;
 	};

--- a/src/app/workflow-page.ts
+++ b/src/app/workflow-page.ts
@@ -16,6 +16,7 @@ import {
 } from "./api.js";
 import { state, renderApp } from "./state.js";
 import { setHashRoute } from "./routing.js";
+import { ensureMarkdownBlock } from "../ui/lazy/markdown-block.js";
 import { type ConfigOrigin, getConfigScope, setConfigScope, getConfigProjectId, renderOriginBadge, renderConfigScopeRow, revertOverride } from "./config-scope.js";
 
 // ============================================================================
@@ -985,6 +986,10 @@ function renderVerifyStepEditor(inst: EditorInstance, gate: WorkflowGate, gateId
 			: html`Empty = the greater of 1200s or the component <code>qa_max_duration_minutes + 5m</code> per active attempt/reminder/recovery turn. An explicit positive integer overrides this and may be shorter. Provider backoff is excluded.`;
 	const timeoutFieldId = `wf-step-timeout-${gateIdx}-${stepIdx}`;
 	const timeoutHintId = `${timeoutFieldId}-hint`;
+	const failureGuidanceFieldId = `wf-step-failure-guidance-${gateIdx}-${stepIdx}`;
+	const failureGuidanceHintId = `${failureGuidanceFieldId}-hint`;
+	const hasFailureGuidance = typeof step.failureGuidance === "string" && step.failureGuidance.trim().length > 0;
+	if (readOnly && hasFailureGuidance) ensureMarkdownBlock();
 	const showRoleField = stepType === "llm-review" || stepType === "agent-qa" || stepType === "human-signoff";
 	const showComponentField = stepType === "command" || stepType === "agent-qa";
 	const componentOptions = projectComponentNames;
@@ -1130,6 +1135,31 @@ function renderVerifyStepEditor(inst: EditorInstance, gate: WorkflowGate, gateId
 							${errs.label ? html`<div class="wf-field-error" data-testid="wf-step-label-error">${errs.label}</div>` : nothing}
 						</div>
 					` : nothing}
+
+					${readOnly
+						? hasFailureGuidance ? html`
+							<details class="wf-vstep-advanced" data-testid="wf-step-failure-guidance-details">
+								<summary class="wf-vstep-advanced-summary">Failure guidance</summary>
+								<div class="wf-vstep-advanced-fields">
+									<markdown-block .content=${step.failureGuidance!}></markdown-block>
+								</div>
+							</details>
+						` : nothing
+						: html`
+							<div class="wf-field">
+								<label class="wf-field-label" for=${failureGuidanceFieldId}>Failure guidance</label>
+								<textarea id=${failureGuidanceFieldId} class="wf-textarea" data-testid="wf-step-failure-guidance" rows="3"
+									.value=${step.failureGuidance || ""}
+									placeholder="Explain how to diagnose and remediate this step…"
+									aria-describedby=${failureGuidanceHintId}
+									@click=${(e: Event) => e.stopPropagation()}
+									@input=${(e: Event) => {
+										const value = (e.target as HTMLTextAreaElement).value;
+										updateStep({ failureGuidance: value.trim().length > 0 ? value : undefined });
+									}}></textarea>
+								<div id=${failureGuidanceHintId} class="wf-field-hint" data-testid="wf-step-failure-guidance-hint">Sent to the team lead only if this step fails. Markdown is supported. Guidance is advisory and does not reset or revisit gates.</div>
+							</div>
+						`}
 
 					<details class="wf-vstep-advanced" ?open=${!!(step.timeout || step.role || step.description || step.component || (step.phase != null && step.phase !== 0) || (saveAttempted && Object.keys(errs).length > 0))}>
 						<summary class="wf-vstep-advanced-summary">Advanced</summary>

--- a/src/server/agent/child-ready-to-merge.ts
+++ b/src/server/agent/child-ready-to-merge.ts
@@ -52,6 +52,7 @@ export function adaptReadyToMergeVerify(
 				name: "Master merged into branch",
 				type: "command" as const,
 				run: `echo 'child goal — merges locally into parent branch ${parentBranch}; no master merge required'`,
+				...(step.failureGuidance !== undefined ? { failureGuidance: step.failureGuidance } : {}),
 			};
 		}
 		if (step.name === "PR raised") {
@@ -59,6 +60,7 @@ export function adaptReadyToMergeVerify(
 				name: "PR raised",
 				type: "command" as const,
 				run: "echo 'child goal — only the root goal raises a PR'",
+				...(step.failureGuidance !== undefined ? { failureGuidance: step.failureGuidance } : {}),
 			};
 		}
 		return step;

--- a/src/server/agent/notify-team-lead-failure.ts
+++ b/src/server/agent/notify-team-lead-failure.ts
@@ -18,8 +18,14 @@ export interface FailureStepLike {
 	type: string;
 	passed: boolean;
 	skipped?: boolean;
-	status?: "waiting" | "running" | "passed" | "failed" | "skipped";
+	status?: "waiting" | "running" | "passed" | "failed" | "timeout" | "skipped";
 	output?: string;
+}
+
+export interface AuthoredFailureStepLike {
+	name: string;
+	type: string;
+	failureGuidance?: string;
 }
 
 const MAX_STEP_NAMES_LISTED = 5;
@@ -59,14 +65,20 @@ function isRestartInterruptedFailureStep(step: FailureStepLike): boolean {
  *              phases skipped after an earlier failure have no logs to inspect.
  *              Pass an empty array if step detail is unavailable — the
  *              builder degrades to a generic inspect/status prompt.
+ * @param authoredSteps Ordered step definitions from the goal's frozen workflow
+ *              snapshot. Guidance is joined only when result index, name, and
+ *              type all match, so missing or drifted definitions fail closed.
  */
 export function buildVerificationFailureMessage(
 	gateId: string,
 	steps: ReadonlyArray<FailureStepLike>,
+	authoredSteps?: ReadonlyArray<AuthoredFailureStepLike>,
 ): string {
-	const failed = steps.filter((s) =>
-		!s.passed && !s.skipped && !isRestartInterruptedFailureStep(s),
-	);
+	const failed = steps
+		.map((step, index) => ({ step, index }))
+		.filter(({ step }) =>
+			!step.passed && !step.skipped && !isRestartInterruptedFailureStep(step),
+		);
 
 	const lines: string[] = [];
 	lines.push("**Gate verification FAILED**");
@@ -84,17 +96,29 @@ export function buildVerificationFailureMessage(
 
 	const head = failed.slice(0, MAX_STEP_NAMES_LISTED);
 	const overflow = failed.length - head.length;
-	const namesQuoted = head.map((s) => `\`${s.name}\``).join(", ");
+	const namesQuoted = head.map(({ step }) => `\`${step.name}\``).join(", ");
 	let summary = `**Failed gate:** \`${gateId}\` — ${namesQuoted}`;
 	if (overflow > 0) summary += ` and ${overflow} more`;
 	lines.push(summary);
 	lines.push("");
 	lines.push("Inspect the failed gate output before retrying or continuing.");
 
-	for (const step of failed) {
+	for (const { step, index } of failed) {
 		lines.push("");
 		lines.push(`**Failed step:** ${describeFailedStep(step)}`);
 		appendInspectBlock(lines, gateInspectCommand(gateId, step.name));
+
+		const authored = authoredSteps?.[index];
+		const guidance = step.status !== "waiting"
+			&& authored?.name === step.name
+			&& authored.type === step.type
+			? authored.failureGuidance
+			: undefined;
+		if (typeof guidance === "string" && guidance.trim().length > 0) {
+			lines.push("");
+			lines.push("**Workflow remediation guidance**");
+			lines.push(guidance);
+		}
 	}
 
 	lines.push("");

--- a/src/server/agent/project-config-store.ts
+++ b/src/server/agent/project-config-store.ts
@@ -150,19 +150,19 @@ export interface Component {
 export type CommandStepStructural = {
 	name: string; type: "command"; component: string; command: string;
 	phase?: number; expect?: "success" | "failure"; timeout?: number;
-	optional?: boolean; label?: string; optionalLabel?: string; description?: string;
+	optional?: boolean; label?: string; optionalLabel?: string; description?: string; failureGuidance?: string;
 };
 
 export type CommandStepComponentRun = {
 	name: string; type: "command"; component: string; run: string;
 	phase?: number; expect?: "success" | "failure"; timeout?: number;
-	optional?: boolean; label?: string; optionalLabel?: string; description?: string;
+	optional?: boolean; label?: string; optionalLabel?: string; description?: string; failureGuidance?: string;
 };
 
 export type CommandStepFreeform = {
 	name: string; type: "command"; run: string;
 	phase?: number; expect?: "success" | "failure"; timeout?: number;
-	optional?: boolean; label?: string; optionalLabel?: string; description?: string;
+	optional?: boolean; label?: string; optionalLabel?: string; description?: string; failureGuidance?: string;
 };
 
 export type CommandStep = CommandStepStructural | CommandStepComponentRun | CommandStepFreeform;
@@ -170,18 +170,18 @@ export type CommandStep = CommandStepStructural | CommandStepComponentRun | Comm
 export type LlmReviewStep = {
 	name: string; type: "llm-review"; prompt: string;
 	role?: string; phase?: number; expect?: "success" | "failure";
-	timeout?: number; optional?: boolean; label?: string; optionalLabel?: string; description?: string;
+	timeout?: number; optional?: boolean; label?: string; optionalLabel?: string; description?: string; failureGuidance?: string;
 };
 
 export type AgentQaStep = {
 	name: string; type: "agent-qa"; prompt: string;
 	role?: string; component?: string; phase?: number; timeout?: number;
-	optional?: boolean; label?: string; optionalLabel?: string; description?: string;
+	optional?: boolean; label?: string; optionalLabel?: string; description?: string; failureGuidance?: string;
 };
 
 export type HumanSignoffStep = {
 	name: string; type: "human-signoff"; prompt: string; label: string;
-	phase?: number; optional?: boolean; optionalLabel?: string; description?: string;
+	phase?: number; optional?: boolean; optionalLabel?: string; description?: string; failureGuidance?: string;
 };
 
 export type InlineVerifyStep = CommandStep | LlmReviewStep | AgentQaStep | HumanSignoffStep;

--- a/src/server/agent/verification-harness.ts
+++ b/src/server/agent/verification-harness.ts
@@ -1011,7 +1011,7 @@ import { dispatchTrackedSystemPrompt } from "./session-manager.js";
 import { Semaphore } from "./semaphore.js";
 import { ChildTeamScheduler } from "./child-team-scheduler.js";
 import { applyReviewModelOverrides, applyModelString } from "./review-model-override.js";
-import { buildVerificationFailureMessage } from "./notify-team-lead-failure.js";
+import { buildVerificationFailureMessage, type FailureStepLike } from "./notify-team-lead-failure.js";
 
 import { buildVerificationReviewerMeta } from "./verification-reviewer-meta.js";
 import { THINKING_LEVELS } from "../../shared/thinking-levels.js";
@@ -4321,7 +4321,7 @@ export class VerificationHarness {
 		goalId: string,
 		gateId: string,
 		status: string,
-		failureContext?: { steps?: ReadonlyArray<{ name: string; type: string; passed: boolean; output?: string }>; goalBranch?: string },
+		failureContext?: { steps?: ReadonlyArray<FailureStepLike>; goalBranch?: string },
 	): void {
 		if (!this.notifyTeamLeadFn) return;
 		// Notify the goal's OWN team-lead first (intra-team signal).
@@ -4329,7 +4329,11 @@ export class VerificationHarness {
 			this.notifyTeamLeadFn(goalId, `Gate verification PASSED: "${gateId}". Downstream work for this gate can now proceed.`);
 		} else {
 			const steps = failureContext?.steps ?? [];
-			const message = buildVerificationFailureMessage(gateId, steps);
+			const frozenGate = this.projectContextManager
+				?.getContextForGoal(goalId)
+				?.goalStore.get(goalId)
+				?.workflow?.gates.find((gate) => gate.id === gateId);
+			const message = buildVerificationFailureMessage(gateId, steps, frozenGate?.verify);
 			this.notifyTeamLeadFn(goalId, message);
 		}
 	}

--- a/src/server/agent/verification-harness.ts
+++ b/src/server/agent/verification-harness.ts
@@ -4321,7 +4321,12 @@ export class VerificationHarness {
 		goalId: string,
 		gateId: string,
 		status: string,
-		failureContext?: { steps?: ReadonlyArray<FailureStepLike>; goalBranch?: string },
+		failureContext?: {
+			steps?: ReadonlyArray<FailureStepLike>;
+			goalBranch?: string;
+			/** False when the reported rows were synthesized outside workflow execution. */
+			workflowAligned?: boolean;
+		},
 	): void {
 		if (!this.notifyTeamLeadFn) return;
 		// Notify the goal's OWN team-lead first (intra-team signal).
@@ -4329,10 +4334,12 @@ export class VerificationHarness {
 			this.notifyTeamLeadFn(goalId, `Gate verification PASSED: "${gateId}". Downstream work for this gate can now proceed.`);
 		} else {
 			const steps = failureContext?.steps ?? [];
-			const frozenGate = this.projectContextManager
-				?.getContextForGoal(goalId)
-				?.goalStore.get(goalId)
-				?.workflow?.gates.find((gate) => gate.id === gateId);
+			const frozenGate = failureContext?.workflowAligned === false
+				? undefined
+				: this.projectContextManager
+					?.getContextForGoal(goalId)
+					?.goalStore.get(goalId)
+					?.workflow?.gates.find((gate) => gate.id === gateId);
 			const message = buildVerificationFailureMessage(gateId, steps, frozenGate?.verify);
 			this.notifyTeamLeadFn(goalId, message);
 		}
@@ -5193,7 +5200,11 @@ export class VerificationHarness {
 				status: "failed",
 			});
 			broadcastGateStatusChanged(this.broadcastFn, signal.goalId, signal.gateId, "failed");
-			this.notifyTeamLead(signal.goalId, signal.gateId, "failed", { steps: [errorStep], goalBranch });
+			this.notifyTeamLead(signal.goalId, signal.gateId, "failed", {
+				steps: [errorStep],
+				goalBranch,
+				workflowAligned: false,
+			});
 		}
 	}
 

--- a/src/server/agent/workflow-store.ts
+++ b/src/server/agent/workflow-store.ts
@@ -65,6 +65,8 @@ export interface VerifyStep {
 	optionalLabel?: string;
 	role?: string;
 	description?: string;
+	/** Static workflow-authored Markdown shown to the team lead only when this step fails. */
+	failureGuidance?: string;
 	/** Structural reference: which component to run from. */
 	component?: string;
 	/** Structural reference: which command on that component to invoke. */
@@ -154,6 +156,7 @@ function normalizeStep(raw: unknown): VerifyStep {
 
 	if (typeof r.role === "string") step.role = r.role;
 	if (typeof r.description === "string") step.description = r.description;
+	if (typeof r.failureGuidance === "string") step.failureGuidance = r.failureGuidance;
 	if (typeof r.component === "string") step.component = r.component;
 	if (typeof r.command === "string") step.command = r.command;
 	// Subgoal payload — only round-tripped when the field is a structured
@@ -371,6 +374,7 @@ function serializeStep(s: VerifyStep): Record<string, unknown> {
 	if (s.optionalLabel !== undefined) out.optionalLabel = s.optionalLabel;
 	if (s.role !== undefined) out.role = s.role;
 	if (s.description !== undefined) out.description = s.description;
+	if (s.failureGuidance !== undefined) out.failureGuidance = s.failureGuidance;
 	if (s.subgoal) {
 		const sg: Record<string, unknown> = {
 			planId: s.subgoal.planId,

--- a/src/server/agent/workflow-validator.ts
+++ b/src/server/agent/workflow-validator.ts
@@ -35,6 +35,7 @@ export interface ValidatorVerifyStep {
 	phase?: number;
 	expect?: string;
 	description?: string;
+	failureGuidance?: string;
 	subgoal?: unknown;
 	[k: string]: unknown;
 }
@@ -311,7 +312,7 @@ export function validateWorkflowDefinition(
 			const prefix = `Workflow "${wfId}", gate "${gateId}", step ${stepIndex + 1}`;
 			if (!isNonEmptyString(stepValue.name)) fail(`${prefix}: step must have a non-empty name`);
 			const type = stepValue.type === undefined ? "command" : stepValue.type;
-			for (const stringField of ["run", "prompt", "role", "label", "optionalLabel", "description", "component", "command"] as const) {
+			for (const stringField of ["run", "prompt", "role", "label", "optionalLabel", "description", "failureGuidance", "component", "command"] as const) {
 				if (stepValue[stringField] !== undefined && typeof stepValue[stringField] !== "string") fail(`${prefix}: ${stringField} must be a string`);
 			}
 			if (stepValue.optional !== undefined && typeof stepValue.optional !== "boolean") fail(`${prefix}: optional must be a boolean`);

--- a/src/server/state-migration/seed-default-workflows.ts
+++ b/src/server/state-migration/seed-default-workflows.ts
@@ -28,6 +28,7 @@ export interface SeededVerifyStep {
 	optional?: boolean;
 	label?: string;
 	description?: string;
+	failureGuidance?: string;
 	subgoal?: {
 		planId: string;
 		title: string;

--- a/tests2/browser/workflow-failure-guidance.spec.ts
+++ b/tests2/browser/workflow-failure-guidance.spec.ts
@@ -1,0 +1,219 @@
+// v2-native browser coverage for workflow-authored verification failure guidance.
+
+import { expect, test, type Locator, type Page } from "@playwright/test";
+import fs from "node:fs";
+import path from "node:path";
+import { buildBundle } from "./fixtures/build-bundle.js";
+
+const SHELL = path.resolve("tests/ui-fixtures/fixture-shell.html");
+const PROJECT_ENTRY = path.resolve("tests/ui-fixtures/goal-workflow-editor-entry.ts");
+const BUNDLE_DIR = path.resolve(".bobbit/tmp/ui-fixtures");
+const PROJECT_BUNDLE = path.join(BUNDLE_DIR, "workflow-failure-guidance-project-bundle.js");
+const EMBED_ENTRY = path.join(BUNDLE_DIR, "workflow-failure-guidance-embed-entry.ts");
+const EMBED_BUNDLE = path.join(BUNDLE_DIR, "workflow-failure-guidance-embed-bundle.js");
+const WORKFLOW_SRC = path.resolve("src/app/workflow-page.ts");
+const API_SRC = path.resolve("src/app/api.ts");
+const STATE_SRC = path.resolve("src/app/state.ts");
+const CONFIG_SCOPE_SRC = path.resolve("src/app/config-scope.ts");
+
+const GUIDANCE = "Inspect the **retained trace** first.\n\nRe-run only the failing journey.";
+const CUSTOM_GUIDANCE = "Check the **custom goal logs** before retrying.";
+
+type FixtureWorkflow = {
+	id: string;
+	name: string;
+	description: string;
+	gates: Array<{
+		id: string;
+		name: string;
+		dependsOn: string[];
+		verify: Array<Record<string, unknown>>;
+	}>;
+};
+
+function workflow(failureGuidance?: string): FixtureWorkflow {
+	return {
+		id: "failure-guidance-workflow",
+		name: "Failure Guidance Workflow",
+		description: "Focused failure guidance fixture",
+		gates: [{
+			id: "browser-gate",
+			name: "Browser gate",
+			dependsOn: [],
+			verify: [{
+				name: "Browser journey",
+				type: "command",
+				run: "npm run test:browser",
+				...(failureGuidance === undefined ? {} : { failureGuidance }),
+			}],
+		}],
+	};
+}
+
+function embedFixtureSource(): string {
+	return `
+		import { html, render } from "lit";
+		import { clearWorkflowEditorController, renderWorkflowEditor, renderWorkflowInspector } from "../../../src/app/workflow-page.js";
+		import { setRenderApp } from "../../../src/app/state.js";
+		import "../../../src/ui/lazy/safe-markdown-block.js";
+
+		let projectWorkflow;
+		let inlineWorkflow = null;
+		let customizing = false;
+		const clone = (value) => JSON.parse(JSON.stringify(value));
+
+		function draw() {
+			const current = inlineWorkflow || projectWorkflow;
+			render(html\`
+				<button data-testid="fixture-customize" @click=\${() => {
+					inlineWorkflow = clone(projectWorkflow);
+					customizing = true;
+					clearWorkflowEditorController();
+					draw();
+				}}>Customise for this goal</button>
+				<div data-testid="fixture-surface">
+					\${customizing
+						? renderWorkflowEditor({
+							workflow: current,
+							scope: "goal-draft",
+							onChange: (next) => { inlineWorkflow = clone(next); },
+						})
+						: renderWorkflowInspector({ workflow: current, scope: "goal-draft" })}
+				</div>
+			\`, document.getElementById("app"));
+		}
+
+		setRenderApp(draw);
+		window.__loadFailureGuidanceEmbed = (next) => {
+			projectWorkflow = clone(next);
+			inlineWorkflow = null;
+			customizing = false;
+			clearWorkflowEditorController();
+			draw();
+		};
+		window.__failureGuidanceInlineWorkflow = () => clone(inlineWorkflow);
+		window.__failureGuidanceEmbedReady = true;
+	`;
+}
+
+test.beforeAll(() => {
+	fs.mkdirSync(BUNDLE_DIR, { recursive: true });
+	fs.writeFileSync(EMBED_ENTRY, embedFixtureSource());
+	buildBundle({
+		entry: PROJECT_ENTRY,
+		outfile: PROJECT_BUNDLE,
+		deps: [PROJECT_ENTRY, WORKFLOW_SRC, API_SRC, STATE_SRC, CONFIG_SCOPE_SRC],
+	});
+	buildBundle({
+		entry: EMBED_ENTRY,
+		outfile: EMBED_BUNDLE,
+		deps: [EMBED_ENTRY, WORKFLOW_SRC, API_SRC, STATE_SRC, CONFIG_SCOPE_SRC],
+	});
+});
+
+function editor(page: Page): Locator {
+	return page.getByTestId("workflow-editor");
+}
+
+function step(page: Page): Locator {
+	return editor(page).getByTestId("wf-vstep-card").first();
+}
+
+async function expandGateAndStep(page: Page): Promise<void> {
+	const gate = editor(page).locator(".wf-gate-card").first();
+	const gateBody = gate.locator(".wf-gate-body");
+	if (!(await gateBody.isVisible())) await gate.locator(".wf-gate-header").click();
+	const stepBody = step(page).locator(".wf-vstep-body");
+	if (!(await stepBody.isVisible())) await step(page).locator(".wf-vstep-collapsed-header").click();
+	await expect(stepBody).toBeVisible();
+}
+
+async function loadProjectWorkflow(page: Page, value: FixtureWorkflow): Promise<void> {
+	await page.goto(`file://${SHELL.replace(/\\/g, "/")}`);
+	await page.addScriptTag({ path: PROJECT_BUNDLE });
+	await page.waitForFunction(() => (window as any).__goalWorkflowEditorReady === true);
+	await page.evaluate((wf) => (window as any).__loadGoalWorkflowFixture(wf), value);
+	await expect(editor(page)).toHaveAttribute("data-workflow-id", value.id);
+	await expandGateAndStep(page);
+}
+
+async function lastPutBody(page: Page): Promise<any> {
+	return page.evaluate(() => (window as any).__goalWorkflowFetchLog()
+		.filter((entry: any) => entry.method === "PUT").at(-1)?.body ?? null);
+}
+
+async function save(page: Page): Promise<any> {
+	await page.locator(".wf-nav-right").getByRole("button", { name: "Save", exact: true }).click();
+	await expect.poll(() => lastPutBody(page)).not.toBeNull();
+	return lastPutBody(page);
+}
+
+test("authors, type-switches, saves, reloads, and clears failure guidance", async ({ page }) => {
+	await loadProjectWorkflow(page, workflow());
+
+	const guidance = step(page).getByTestId("wf-step-failure-guidance");
+	const hint = step(page).getByTestId("wf-step-failure-guidance-hint");
+	await expect(step(page).getByLabel("Failure guidance", { exact: true })).toBeVisible();
+	await expect(guidance).toHaveAttribute("rows", "3");
+	await expect(guidance).toHaveAttribute("placeholder", "Explain how to diagnose and remediate this step…");
+	await expect(hint).toHaveText("Sent to the team lead only if this step fails. Markdown is supported. Guidance is advisory and does not reset or revisit gates.");
+	await expect(guidance).toHaveAttribute("aria-describedby", await hint.getAttribute("id") as string);
+
+	await guidance.fill(GUIDANCE);
+	await step(page).getByTestId("wf-step-type").selectOption("llm-review");
+	await expect(step(page).getByTestId("wf-step-failure-guidance")).toHaveValue(GUIDANCE);
+	await step(page).getByTestId("wf-step-prompt").fill("Review the browser journey");
+
+	const saved = await save(page);
+	expect(saved.gates[0].verify[0]).toMatchObject({
+		type: "llm-review",
+		prompt: "Review the browser journey",
+		failureGuidance: GUIDANCE,
+	});
+
+	await loadProjectWorkflow(page, {
+		...saved,
+		id: "failure-guidance-workflow",
+	});
+	await expect(step(page).getByTestId("wf-step-failure-guidance")).toHaveValue(GUIDANCE);
+
+	await step(page).getByTestId("wf-step-failure-guidance").fill("  \n  ");
+	const cleared = await save(page);
+	expect(cleared.gates[0].verify[0].failureGuidance).toBeUndefined();
+});
+
+test("goal customisation round-trips guidance and the inspector keeps it in default-closed details", async ({ page }) => {
+	await page.goto(`file://${SHELL.replace(/\\/g, "/")}`);
+	await page.addScriptTag({ path: EMBED_BUNDLE });
+	await page.waitForFunction(() => (window as any).__failureGuidanceEmbedReady === true);
+	await page.evaluate((wf) => (window as any).__loadFailureGuidanceEmbed(wf), workflow(GUIDANCE));
+
+	const inspector = page.getByTestId("workflow-inspector");
+	await expect(inspector).toBeVisible();
+	const collapsedHeader = inspector.locator(".wf-vstep-collapsed-header").first();
+	await expect(collapsedHeader).not.toContainText("retained trace");
+
+	const gate = inspector.locator(".wf-gate-card").first();
+	await gate.locator(".wf-gate-header").click();
+	await collapsedHeader.click();
+	const details = inspector.getByTestId("wf-step-failure-guidance-details");
+	await expect(details).toHaveJSProperty("open", false);
+	await expect(details.locator("summary")).toHaveText("Failure guidance");
+	await details.locator("summary").focus();
+	await details.locator("summary").press("Enter");
+	await expect(details).toHaveJSProperty("open", true);
+	await expect.poll(() => details.locator("markdown-block").evaluate((node: any) => node.textContent || ""))
+		.toContain("Inspect the retained trace first.");
+	await expect.poll(() => details.locator("markdown-block strong").textContent())
+		.toBe("retained trace");
+
+	await page.getByTestId("fixture-customize").click();
+	await expandGateAndStep(page);
+	const customField = step(page).getByTestId("wf-step-failure-guidance");
+	await expect(customField).toHaveValue(GUIDANCE);
+	await customField.fill(CUSTOM_GUIDANCE);
+	await step(page).getByTestId("wf-step-type").selectOption("agent-qa");
+	await expect(step(page).getByTestId("wf-step-failure-guidance")).toHaveValue(CUSTOM_GUIDANCE);
+	await expect.poll(() => page.evaluate(() => (window as any).__failureGuidanceInlineWorkflow()
+		.gates[0].verify[0].failureGuidance)).toBe(CUSTOM_GUIDANCE);
+});

--- a/tests2/browser/workflow-failure-guidance.spec.ts
+++ b/tests2/browser/workflow-failure-guidance.spec.ts
@@ -1,20 +1,18 @@
 // v2-native browser coverage for workflow-authored verification failure guidance.
 
-import { expect, test, type Locator, type Page } from "@playwright/test";
+import { expect, test, type Locator, type Page, type TestInfo } from "@playwright/test";
 import fs from "node:fs";
 import path from "node:path";
 import { buildBundle } from "./fixtures/build-bundle.js";
 
 const SHELL = path.resolve("tests/ui-fixtures/fixture-shell.html");
 const PROJECT_ENTRY = path.resolve("tests/ui-fixtures/goal-workflow-editor-entry.ts");
-const BUNDLE_DIR = path.resolve(".bobbit/tmp/ui-fixtures");
-const PROJECT_BUNDLE = path.join(BUNDLE_DIR, "workflow-failure-guidance-project-bundle.js");
-const EMBED_ENTRY = path.join(BUNDLE_DIR, "workflow-failure-guidance-embed-entry.ts");
-const EMBED_BUNDLE = path.join(BUNDLE_DIR, "workflow-failure-guidance-embed-bundle.js");
 const WORKFLOW_SRC = path.resolve("src/app/workflow-page.ts");
 const API_SRC = path.resolve("src/app/api.ts");
 const STATE_SRC = path.resolve("src/app/state.ts");
 const CONFIG_SCOPE_SRC = path.resolve("src/app/config-scope.ts");
+const SAFE_MARKDOWN_SRC = path.resolve("src/ui/lazy/safe-markdown-block.ts");
+const LIT_SRC = path.resolve("node_modules/lit/index.js");
 
 const GUIDANCE = "Inspect the **retained trace** first.\n\nRe-run only the failing journey.";
 const CUSTOM_GUIDANCE = "Check the **custom goal logs** before retrying.";
@@ -50,12 +48,23 @@ function workflow(failureGuidance?: string): FixtureWorkflow {
 	};
 }
 
-function embedFixtureSource(): string {
+function sourceImport(from: string, target: string): string {
+	const relative = path.relative(path.dirname(from), target)
+		.replace(/\\/g, "/")
+		.replace(/\.ts$/, ".js");
+	return relative.startsWith(".") ? relative : `./${relative}`;
+}
+
+function embedFixtureSource(entry: string): string {
+	const litImport = JSON.stringify(sourceImport(entry, LIT_SRC));
+	const workflowImport = JSON.stringify(sourceImport(entry, WORKFLOW_SRC));
+	const stateImport = JSON.stringify(sourceImport(entry, STATE_SRC));
+	const safeMarkdownImport = JSON.stringify(sourceImport(entry, SAFE_MARKDOWN_SRC));
 	return `
-		import { html, render } from "lit";
-		import { clearWorkflowEditorController, renderWorkflowEditor, renderWorkflowInspector } from "../../../src/app/workflow-page.js";
-		import { setRenderApp } from "../../../src/app/state.js";
-		import "../../../src/ui/lazy/safe-markdown-block.js";
+		import { html, render } from ${litImport};
+		import { clearWorkflowEditorController, renderWorkflowEditor, renderWorkflowInspector } from ${workflowImport};
+		import { setRenderApp } from ${stateImport};
+		import ${safeMarkdownImport};
 
 		let projectWorkflow;
 		let inlineWorkflow = null;
@@ -96,20 +105,28 @@ function embedFixtureSource(): string {
 	`;
 }
 
-test.beforeAll(() => {
-	fs.mkdirSync(BUNDLE_DIR, { recursive: true });
-	fs.writeFileSync(EMBED_ENTRY, embedFixtureSource());
+function buildProjectBundle(testInfo: TestInfo): string {
+	const bundle = testInfo.outputPath("fixture-bundles", "workflow-failure-guidance-project-bundle.js");
 	buildBundle({
 		entry: PROJECT_ENTRY,
-		outfile: PROJECT_BUNDLE,
+		outfile: bundle,
 		deps: [PROJECT_ENTRY, WORKFLOW_SRC, API_SRC, STATE_SRC, CONFIG_SCOPE_SRC],
 	});
+	return bundle;
+}
+
+function buildEmbedBundle(testInfo: TestInfo): string {
+	const entry = testInfo.outputPath("fixture-bundles", "workflow-failure-guidance-embed-entry.ts");
+	const bundle = testInfo.outputPath("fixture-bundles", "workflow-failure-guidance-embed-bundle.js");
+	fs.mkdirSync(path.dirname(entry), { recursive: true });
+	fs.writeFileSync(entry, embedFixtureSource(entry));
 	buildBundle({
-		entry: EMBED_ENTRY,
-		outfile: EMBED_BUNDLE,
-		deps: [EMBED_ENTRY, WORKFLOW_SRC, API_SRC, STATE_SRC, CONFIG_SCOPE_SRC],
+		entry,
+		outfile: bundle,
+		deps: [entry, WORKFLOW_SRC, API_SRC, STATE_SRC, CONFIG_SCOPE_SRC, SAFE_MARKDOWN_SRC, LIT_SRC],
 	});
-});
+	return bundle;
+}
 
 function editor(page: Page): Locator {
 	return page.getByTestId("workflow-editor");
@@ -128,9 +145,9 @@ async function expandGateAndStep(page: Page): Promise<void> {
 	await expect(stepBody).toBeVisible();
 }
 
-async function loadProjectWorkflow(page: Page, value: FixtureWorkflow): Promise<void> {
+async function loadProjectWorkflow(page: Page, value: FixtureWorkflow, projectBundle: string): Promise<void> {
 	await page.goto(`file://${SHELL.replace(/\\/g, "/")}`);
-	await page.addScriptTag({ path: PROJECT_BUNDLE });
+	await page.addScriptTag({ path: projectBundle });
 	await page.waitForFunction(() => (window as any).__goalWorkflowEditorReady === true);
 	await page.evaluate((wf) => (window as any).__loadGoalWorkflowFixture(wf), value);
 	await expect(editor(page)).toHaveAttribute("data-workflow-id", value.id);
@@ -148,8 +165,9 @@ async function save(page: Page): Promise<any> {
 	return lastPutBody(page);
 }
 
-test("authors, type-switches, saves, reloads, and clears failure guidance", async ({ page }) => {
-	await loadProjectWorkflow(page, workflow());
+test("authors, type-switches, saves, reloads, and clears failure guidance", async ({ page }, testInfo) => {
+	const projectBundle = buildProjectBundle(testInfo);
+	await loadProjectWorkflow(page, workflow(), projectBundle);
 
 	const guidance = step(page).getByTestId("wf-step-failure-guidance");
 	const hint = step(page).getByTestId("wf-step-failure-guidance-hint");
@@ -174,7 +192,7 @@ test("authors, type-switches, saves, reloads, and clears failure guidance", asyn
 	await loadProjectWorkflow(page, {
 		...saved,
 		id: "failure-guidance-workflow",
-	});
+	}, projectBundle);
 	await expect(step(page).getByTestId("wf-step-failure-guidance")).toHaveValue(GUIDANCE);
 
 	await step(page).getByTestId("wf-step-failure-guidance").fill("  \n  ");
@@ -182,9 +200,10 @@ test("authors, type-switches, saves, reloads, and clears failure guidance", asyn
 	expect(cleared.gates[0].verify[0].failureGuidance).toBeUndefined();
 });
 
-test("goal customisation round-trips guidance and the inspector keeps it in default-closed details", async ({ page }) => {
+test("goal customisation round-trips guidance and the inspector keeps it in default-closed details", async ({ page }, testInfo) => {
+	const embedBundle = buildEmbedBundle(testInfo);
 	await page.goto(`file://${SHELL.replace(/\\/g, "/")}`);
-	await page.addScriptTag({ path: EMBED_BUNDLE });
+	await page.addScriptTag({ path: embedBundle });
 	await page.waitForFunction(() => (window as any).__failureGuidanceEmbedReady === true);
 	await page.evaluate((wf) => (window as any).__loadFailureGuidanceEmbed(wf), workflow(GUIDANCE));
 

--- a/tests2/core/child-ready-to-merge-helper.test.ts
+++ b/tests2/core/child-ready-to-merge-helper.test.ts
@@ -95,6 +95,26 @@ describe("adaptReadyToMergeVerify", () => {
 		assert.match(out[1].run ?? "", /^echo 'child goal —/);
 	});
 
+	it("preserves only type-independent failure guidance on rewritten steps", () => {
+		const guidance = "Inspect the retained merge diagnostics before retrying.";
+		const verify: VerifyStep[] = [{
+			name: "PR raised",
+			type: "llm-review",
+			prompt: "This conflicting prompt must not survive the command rewrite.",
+			role: "reviewer",
+			description: "Original step description",
+			failureGuidance: guidance,
+		}];
+
+		const out = adaptReadyToMergeVerify(verify, { parentBranch: PARENT_BRANCH });
+		assert.deepEqual(out[0], {
+			name: "PR raised",
+			type: "command",
+			run: "echo 'child goal — only the root goal raises a PR'",
+			failureGuidance: guidance,
+		});
+	});
+
 	it("preserves step count (replace-not-drop)", () => {
 		const out = adaptReadyToMergeVerify(ROOT_RTM_VERIFY, { parentBranch: PARENT_BRANCH });
 		assert.equal(out.length, ROOT_RTM_VERIFY.length);

--- a/tests2/core/notify-team-lead-failure.test.ts
+++ b/tests2/core/notify-team-lead-failure.test.ts
@@ -8,6 +8,75 @@ import assert from "node:assert/strict";
 import { buildVerificationFailureMessage } from "../../src/server/agent/notify-team-lead-failure.ts";
 
 describe("buildVerificationFailureMessage", () => {
+	it("keeps the unguided failure message byte-for-byte compatible", () => {
+		const message = buildVerificationFailureMessage("execution", [
+			{ name: "Unit tests", type: "command", passed: false, output: "hidden failure output" },
+		]);
+
+		assert.equal(message, [
+			"**Gate verification FAILED**",
+			"",
+			"**Failed gate:** `execution` — `Unit tests`",
+			"",
+			"Inspect the failed gate output before retrying or continuing.",
+			"",
+			"**Failed step:** `Unit tests` (`command`)",
+			"**Inspect:**",
+			"```text",
+			'gate_inspect(gate_id="execution", section="verification", step="Unit tests", mode="tail", lines=120)',
+			"```",
+			"",
+			"**Next:** inspect each failed step, fix issues, then re-signal gate.",
+		].join("\n"));
+	});
+
+	it("adds distinct frozen workflow guidance only to matching failed steps after each inspect command", () => {
+		const message = buildVerificationFailureMessage("ready-to-merge", [
+			{ name: "Unit tests", type: "command", passed: false, output: "unit verifier output" },
+			{ name: "Passed review", type: "llm-review", passed: true, output: "review passed" },
+			{ name: "Skipped QA", type: "agent-qa", passed: false, skipped: true, output: "skipped" },
+			{ name: "Code review", type: "llm-review", passed: false, output: "review verifier output" },
+			{ name: "Restart command", type: "command", passed: false, status: "waiting", output: "restart interrupted" },
+		], [
+			{ name: "Unit tests", type: "command", failureGuidance: "Inspect **Vitest** artifacts.\nRe-run the focused suite." },
+			{ name: "Passed review", type: "llm-review", failureGuidance: "PASSED GUIDANCE MUST STAY HIDDEN" },
+			{ name: "Skipped QA", type: "agent-qa", failureGuidance: "SKIPPED GUIDANCE MUST STAY HIDDEN" },
+			{ name: "Code review", type: "llm-review", failureGuidance: "Check the review findings, then fix `src/app.ts`." },
+			{ name: "Restart command", type: "command", failureGuidance: "WAITING GUIDANCE MUST STAY HIDDEN" },
+		]);
+
+		const unitInspect = message.indexOf('gate_inspect(gate_id="ready-to-merge", section="verification", step="Unit tests", mode="tail", lines=120)');
+		const unitGuidance = message.indexOf("Inspect **Vitest** artifacts.");
+		const reviewStep = message.indexOf("**Failed step:** `Code review`");
+		const reviewInspect = message.indexOf('gate_inspect(gate_id="ready-to-merge", section="verification", step="Code review", mode="tail", lines=120)');
+		const reviewGuidance = message.indexOf("Check the review findings, then fix `src/app.ts`.");
+		assert.ok(unitInspect >= 0 && unitGuidance > unitInspect);
+		assert.ok(reviewStep > unitGuidance && reviewInspect > reviewStep && reviewGuidance > reviewInspect);
+		assert.equal(message.match(/\*\*Workflow remediation guidance\*\*/g)?.length, 2);
+		assert.doesNotMatch(message, /PASSED GUIDANCE|SKIPPED GUIDANCE|WAITING GUIDANCE/);
+		assert.doesNotMatch(message, /unit verifier output|review verifier output/);
+	});
+
+	it("fails closed when authored step identity or position differs and ignores blank guidance", () => {
+		const steps = [
+			{ name: "Unit tests", type: "command", passed: false },
+			{ name: "Review", type: "llm-review", passed: false },
+			{ name: "QA", type: "agent-qa", passed: false },
+			{ name: "Waiting review", type: "llm-review", passed: false, status: "waiting" as const, output: "still running" },
+		];
+		const baseline = buildVerificationFailureMessage("implementation", steps);
+		const message = buildVerificationFailureMessage("implementation", steps, [
+			{ name: "Different name", type: "command", failureGuidance: "WRONG NAME" },
+			{ name: "Review", type: "agent-qa", failureGuidance: "WRONG TYPE" },
+			{ name: "QA", type: "agent-qa", failureGuidance: "  \n\t" },
+			{ name: "Waiting review", type: "llm-review", failureGuidance: "WAITING" },
+			{ name: "Unrelated", type: "command", failureGuidance: "UNRELATED" },
+		]);
+
+		assert.equal(message, baseline);
+		assert.doesNotMatch(message, /Workflow remediation guidance|WRONG NAME|WRONG TYPE|WAITING|UNRELATED/);
+	});
+
 	it("formats command failures as compact markdown with inspect command and no output snippet", () => {
 		const message = buildVerificationFailureMessage("execution", [
 			{ name: "Unit tests", type: "command", passed: false, output: "AssertionError: expected 1 to equal 2" },

--- a/tests2/core/workflow-store.test.ts
+++ b/tests2/core/workflow-store.test.ts
@@ -223,4 +223,57 @@ describe("InlineWorkflowStore — round-trip", () => {
 		assert.equal(step.label, "Approve design");
 		assert.equal(step.optionalLabel, undefined);
 	});
+
+	it("preserves exact multiline failure guidance for every verification step type", () => {
+		writeProjectYaml(projectFor([]));
+		const store = makeStore();
+		const guidance = "Inspect the retained log first.\n\n- Re-run the focused check.\n- Fix **product behavior**.";
+
+		store.put({
+			id: "wf",
+			name: "Test workflow",
+			description: "",
+			gates: [{
+				id: "g",
+				name: "Gate",
+				dependsOn: [],
+				verify: [
+					{ name: "command", type: "command", run: "npm test", failureGuidance: guidance },
+					{ name: "review", type: "llm-review", prompt: "Review.", failureGuidance: guidance },
+					{ name: "qa", type: "agent-qa", prompt: "Test.", failureGuidance: guidance },
+					{
+						name: "child",
+						type: "subgoal",
+						failureGuidance: guidance,
+						subgoal: { planId: "child", title: "Child", spec: "Implement child." },
+					},
+					{ name: "signoff", type: "human-signoff", prompt: "Approve.", label: "Approve", failureGuidance: guidance },
+				],
+			}],
+			createdAt: 0,
+			updatedAt: 0,
+		});
+
+		const reloadedSteps = makeStore().getAll()[0].gates[0].verify!;
+		assert.deepEqual(reloadedSteps.map(step => step.failureGuidance), Array(5).fill(guidance));
+
+		const persisted = yaml.parse(fs.readFileSync(path.join(configDir, "project.yaml"), "utf-8")) as Record<string, any>;
+		const persistedSteps = persisted.workflows.wf.gates[0].verify as Array<Record<string, unknown>>;
+		assert.deepEqual(persistedSteps.map(step => step.failureGuidance), Array(5).fill(guidance));
+	});
+
+	it("omits absent failure guidance and ignores non-string stored values during normalization", () => {
+		writeProjectYaml(projectFor([
+			{ name: "absent", type: "command", run: "true" },
+			{ name: "malformed", type: "command", run: "true", failureGuidance: 42 },
+		]));
+		const store = makeStore();
+		const loaded = store.getAll()[0];
+		assert.deepEqual(loaded.gates[0].verify!.map(step => step.failureGuidance), [undefined, undefined]);
+
+		store.put(loaded);
+		const persisted = yaml.parse(fs.readFileSync(path.join(configDir, "project.yaml"), "utf-8")) as Record<string, any>;
+		const persistedSteps = persisted.workflows.wf.gates[0].verify as Array<Record<string, unknown>>;
+		assert.equal(persistedSteps.some(step => "failureGuidance" in step), false);
+	});
 });

--- a/tests2/core/workflow-store.test.ts
+++ b/tests2/core/workflow-store.test.ts
@@ -40,8 +40,13 @@ function writeProjectYaml(obj: Record<string, unknown>): void {
 	fs.writeFileSync(path.join(configDir, "project.yaml"), yaml.stringify(obj));
 }
 
+function makeStores(): { config: ProjectConfigStore; workflows: InlineWorkflowStore } {
+	const config = new ProjectConfigStore(configDir);
+	return { config, workflows: new InlineWorkflowStore(config) };
+}
+
 function makeStore(): InlineWorkflowStore {
-	return new InlineWorkflowStore(new ProjectConfigStore(configDir));
+	return makeStores().workflows;
 }
 
 /** Build a minimal project.yaml around a single workflow gate's verify[]. */
@@ -226,10 +231,10 @@ describe("InlineWorkflowStore — round-trip", () => {
 
 	it("preserves exact multiline failure guidance for every verification step type", () => {
 		writeProjectYaml(projectFor([]));
-		const store = makeStore();
+		const { config, workflows } = makeStores();
 		const guidance = "Inspect the retained log first.\n\n- Re-run the focused check.\n- Fix **product behavior**.";
 
-		store.put({
+		workflows.put({
 			id: "wf",
 			name: "Test workflow",
 			description: "",
@@ -254,12 +259,11 @@ describe("InlineWorkflowStore — round-trip", () => {
 			updatedAt: 0,
 		});
 
+		const serializedSteps = config.getWorkflows()!.wf.gates[0].verify!;
+		assert.deepEqual(serializedSteps.map(step => step.failureGuidance), Array(5).fill(guidance));
+
 		const reloadedSteps = makeStore().getAll()[0].gates[0].verify!;
 		assert.deepEqual(reloadedSteps.map(step => step.failureGuidance), Array(5).fill(guidance));
-
-		const persisted = yaml.parse(fs.readFileSync(path.join(configDir, "project.yaml"), "utf-8")) as Record<string, any>;
-		const persistedSteps = persisted.workflows.wf.gates[0].verify as Array<Record<string, unknown>>;
-		assert.deepEqual(persistedSteps.map(step => step.failureGuidance), Array(5).fill(guidance));
 	});
 
 	it("omits absent failure guidance and ignores non-string stored values during normalization", () => {
@@ -267,13 +271,13 @@ describe("InlineWorkflowStore — round-trip", () => {
 			{ name: "absent", type: "command", run: "true" },
 			{ name: "malformed", type: "command", run: "true", failureGuidance: 42 },
 		]));
-		const store = makeStore();
-		const loaded = store.getAll()[0];
+		const { config, workflows } = makeStores();
+		const loaded = workflows.getAll()[0];
 		assert.deepEqual(loaded.gates[0].verify!.map(step => step.failureGuidance), [undefined, undefined]);
 
-		store.put(loaded);
-		const persisted = yaml.parse(fs.readFileSync(path.join(configDir, "project.yaml"), "utf-8")) as Record<string, any>;
-		const persistedSteps = persisted.workflows.wf.gates[0].verify as Array<Record<string, unknown>>;
-		assert.equal(persistedSteps.some(step => "failureGuidance" in step), false);
+		workflows.put(loaded);
+		const serializedSteps = config.getWorkflows()!.wf.gates[0].verify!;
+		assert.equal(serializedSteps.some(step => "failureGuidance" in step), false);
+		assert.deepEqual(makeStore().getAll()[0].gates[0].verify!.map(step => step.failureGuidance), [undefined, undefined]);
 	});
 });

--- a/tests2/core/workflow-validator.test.ts
+++ b/tests2/core/workflow-validator.test.ts
@@ -127,7 +127,14 @@ describe("workflow-validator — positive cases", () => {
 			gates: [{
 				id: "verify",
 				name: "Verify",
-				verify: [{ name: "Legacy test", type: "command", component: "legacy", command: "test", timeout: 1 }],
+				verify: [{
+					name: "Legacy test",
+					type: "command",
+					component: "legacy",
+					command: "test",
+					timeout: 1,
+					failureGuidance: "Inspect the retained log.\n\nThen retry the focused test.",
+				}],
 			}],
 		};
 
@@ -412,6 +419,30 @@ describe("workflow-validator — negative cases", () => {
 		assert.match(errs[0].message, /unknown step type "wat"/);
 		// human-signoff must appear in the accepted-set hint so authors know about it.
 		assert.match(errs[0].message, /human-signoff/);
+	});
+
+	it("accepts string failure guidance and rejects malformed non-string guidance", () => {
+		const valid: ValidatorWorkflow = {
+			id: "guided",
+			name: "Guided",
+			gates: [{
+				id: "verify",
+				name: "Verify",
+				verify: [{
+					name: "Command",
+					type: "command",
+					run: "true",
+					failureGuidance: "Inspect the retained log.\n\nRetry only this check.",
+				}],
+			}],
+		};
+		assert.deepEqual(validateWorkflow(valid, components), []);
+
+		const malformed = structuredClone(valid) as unknown as Record<string, any>;
+		malformed.gates[0].verify[0].failureGuidance = ["not", "markdown"];
+		const errs = validateWorkflow(malformed as ValidatorWorkflow, components);
+		assert.ok(errs.some(error => /failureGuidance must be a string/.test(error.message)),
+			`expected failureGuidance string error, got: ${errs.map(error => error.message).join("; ")}`);
 	});
 
 	it.each([

--- a/tests2/dom/project-proposal-views.test.ts
+++ b/tests2/dom/project-proposal-views.test.ts
@@ -7,7 +7,13 @@ __syncBeforeAll(() => __syncCE());
 // No geometry — pure lit render + data-testid/text assertions.
 import { afterEach, describe, expect, it } from "vitest";
 import { render } from "lit";
-import { viewTabs, componentsView, workflowsView } from "../../src/app/project-proposal-views.js";
+import "../../src/ui/lazy/safe-markdown-block.js";
+import {
+	viewTabs,
+	componentsView,
+	workflowsView,
+	type ProposalWorkflow,
+} from "../../src/app/project-proposal-views.js";
 
 function host(): HTMLElement {
 	let el = document.getElementById("host");
@@ -64,6 +70,51 @@ describe("project proposal views", () => {
 		expect(el.querySelectorAll('[data-testid="workflow-card-quick-fix"]').length).toBe(1);
 		expect(el.querySelectorAll('[data-testid="workflow-card-feature"] [data-testid^="gate-node-"]').length).toBe(3);
 		expect(el.querySelector('[data-testid="workflow-card-feature"] [data-testid="gate-node-implementation"]')?.textContent).toContain("design-doc");
+	});
+
+	it("shows configured failure guidance only in default-closed step details", async () => {
+		const el = host();
+		const guidance = "Inspect the **retained trace** first.\n\n- Retry only this journey.";
+		const workflows: Record<string, ProposalWorkflow> = {
+			feature: {
+				id: "feature",
+				gates: [{
+					id: "implementation",
+					verify: [
+						{ name: "Browser journey", type: "command", run: "npm run test:browser", failureGuidance: guidance },
+						{ name: "No advice", type: "llm-review" },
+						{ name: "Blank advice", type: "agent-qa", failureGuidance: "  \n " },
+					],
+				}],
+			},
+		};
+
+		render(workflowsView(workflows, []), el);
+
+		const stepCards = el.querySelectorAll<HTMLDetailsElement>(".wf-vstep-card");
+		expect(stepCards).toHaveLength(3);
+		const collapsedSummary = stepCards[0].querySelector(":scope > summary");
+		expect(collapsedSummary?.textContent).not.toContain("Failure guidance");
+		expect(collapsedSummary?.textContent).not.toContain("retained trace");
+
+		const guidanceDetails = stepCards[0].querySelector<HTMLDetailsElement>(
+			'[data-testid="wf-step-failure-guidance-details"]',
+		);
+		expect(guidanceDetails).toBeTruthy();
+		expect(guidanceDetails?.open).toBe(false);
+		expect(guidanceDetails?.querySelector("summary")?.textContent).toContain("Failure guidance");
+		guidanceDetails!.open = true;
+		expect(guidanceDetails?.open).toBe(true);
+
+		const markdown = guidanceDetails?.querySelector("markdown-block") as (HTMLElement & {
+			content: string;
+			updateComplete?: Promise<unknown>;
+		}) | null;
+		expect(markdown?.content).toBe(guidance);
+		if (markdown?.updateComplete) await markdown.updateComplete;
+		expect(markdown?.querySelector("strong")?.textContent).toBe("retained trace");
+		expect(stepCards[1].querySelector('[data-testid="wf-step-failure-guidance-details"]')).toBeNull();
+		expect(stepCards[2].querySelector('[data-testid="wf-step-failure-guidance-details"]')).toBeNull();
 	});
 
 	it("viewTabs renders Components / Workflows / Settings", () => {

--- a/tests2/integration/verification-failure-guidance.test.ts
+++ b/tests2/integration/verification-failure-guidance.test.ts
@@ -1,0 +1,142 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { expect, test } from "vitest";
+
+import type { CommandRunner } from "../../src/server/gateway-deps.js";
+import { GateStore, type GateSignal } from "../../src/server/agent/gate-store.js";
+import { GoalStore, type PersistedGoal } from "../../src/server/agent/goal-store.js";
+import { VerificationHarness } from "../../src/server/agent/verification-harness.js";
+import type { Workflow, WorkflowGate } from "../../src/server/agent/workflow-store.js";
+import { createFakeVerificationCommandRunner } from "../harness/fake-verification-command-runner.js";
+
+const GOAL_ID = "failure-guidance-frozen-goal";
+const GATE_ID = "implementation";
+const START_TIME = 1_700_000_000_000;
+const FROZEN_GUIDANCE = "Inspect the **frozen** diagnostic first.\nRe-run only this command.";
+const MUTATED_GUIDANCE = "MUTATED TEMPLATE GUIDANCE MUST NOT BE USED";
+const VERIFIER_OUTPUT = "runtime verifier output must stay retained";
+
+const frozenWorkflow = {
+	id: "failure-guidance-workflow",
+	name: "Failure guidance workflow",
+	description: "Frozen notification guidance integration fixture.",
+	gates: [{
+		id: GATE_ID,
+		name: "Implementation",
+		dependsOn: [],
+		verify: [{
+			name: "Focused tests",
+			type: "command",
+			run: `node -e "console.error('${VERIFIER_OUTPUT}');process.exit(1)"`,
+			failureGuidance: FROZEN_GUIDANCE,
+		}],
+	}],
+	createdAt: START_TIME,
+	updatedAt: START_TIME,
+} as unknown as Workflow;
+
+const runtimeGate = {
+	...frozenWorkflow.gates[0],
+	verify: [{
+		name: "Focused tests",
+		type: "command",
+		run: `node -e "console.error('${VERIFIER_OUTPUT}');process.exit(1)"`,
+		failureGuidance: MUTATED_GUIDANCE,
+	}],
+} as unknown as WorkflowGate;
+
+const fakeGitRunner: CommandRunner = {
+	execFile: async (file, args) => {
+		if (file === "git" && args.join(" ") === "symbolic-ref refs/remotes/origin/HEAD") {
+			return { stdout: "refs/remotes/origin/main\n", stderr: "" };
+		}
+		throw new Error(`Unexpected command in failure-guidance fixture: ${file} ${args.join(" ")}`);
+	},
+};
+
+const roleStore = Object.freeze({ get: () => undefined, getAll: () => [] });
+
+test("live failure notification uses guidance from the reloaded frozen goal workflow", async () => {
+	const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "failure-guidance-integration-"));
+	try {
+		const initialGoalStore = new GoalStore(stateDir);
+		const goal: PersistedGoal = {
+			id: GOAL_ID,
+			title: "Frozen failure guidance",
+			cwd: stateDir,
+			state: "in-progress",
+			spec: "Prove notifications use the frozen workflow snapshot.",
+			createdAt: START_TIME,
+			updatedAt: START_TIME,
+			workflowId: frozenWorkflow.id,
+			workflow: frozenWorkflow,
+			enabledOptionalSteps: [],
+		};
+		initialGoalStore.put(goal);
+		await initialGoalStore.flush();
+
+		// Reload from disk to exercise the persisted frozen snapshot rather than
+		// sharing the authored workflow object with the live verifier.
+		const goalStore = new GoalStore(stateDir);
+		expect((goalStore.get(GOAL_ID)?.workflow?.gates[0].verify?.[0] as any)?.failureGuidance).toBe(FROZEN_GUIDANCE);
+
+		const gateStore = new GateStore(stateDir);
+		gateStore.initGatesForGoal(GOAL_ID, [GATE_ID]);
+		const context = {
+			goalStore,
+			gateStore,
+			projectConfigStore: undefined,
+			project: { id: "failure-guidance-project", name: "Failure Guidance" },
+			goalManager: { resolveRootMaxConcurrentChildren: () => 3 },
+		};
+		const projectContextManager = {
+			getContextForGoal: (goalId: string) => goalId === GOAL_ID ? context : undefined,
+		};
+		const harness = new VerificationHarness(
+			stateDir,
+			gateStore,
+			() => undefined,
+			roleStore as any,
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+			projectContextManager as any,
+			undefined,
+			{
+				commandRunner: fakeGitRunner,
+				commandStepRunner: createFakeVerificationCommandRunner(),
+			},
+		);
+		const notifications: string[] = [];
+		harness.setTeamLeadNotifier((_goalId, message) => notifications.push(message));
+
+		const signal: GateSignal = {
+			id: "failure-guidance-signal",
+			goalId: GOAL_ID,
+			gateId: GATE_ID,
+			sessionId: "failure-guidance-team-lead",
+			timestamp: START_TIME + 1,
+			commitSha: "0123456789abcdef0123456789abcdef01234567",
+			content: "Implementation ready for verification.",
+			verification: { status: "running", steps: [] },
+		};
+		signal.verification.steps = harness.beginVerification(signal, runtimeGate);
+		gateStore.recordSignal(signal);
+
+		await harness.verifyGateSignal(signal, runtimeGate, stateDir);
+
+		expect(notifications).toHaveLength(1);
+		const message = notifications[0];
+		const inspectIndex = message.indexOf('gate_inspect(gate_id="implementation", section="verification", step="Focused tests", mode="tail", lines=120)');
+		const guidanceIndex = message.indexOf(FROZEN_GUIDANCE);
+		expect(inspectIndex).toBeGreaterThanOrEqual(0);
+		expect(guidanceIndex).toBeGreaterThan(inspectIndex);
+		expect(message).toContain("**Workflow remediation guidance**");
+		expect(message).not.toContain(MUTATED_GUIDANCE);
+		expect(message).not.toContain(VERIFIER_OUTPUT);
+	} finally {
+		fs.rmSync(stateDir, { recursive: true, force: true });
+	}
+});

--- a/tests2/integration/verification-failure-guidance.test.ts
+++ b/tests2/integration/verification-failure-guidance.test.ts
@@ -6,45 +6,17 @@ import { expect, test } from "vitest";
 import type { CommandRunner } from "../../src/server/gateway-deps.js";
 import { GateStore, type GateSignal } from "../../src/server/agent/gate-store.js";
 import { GoalStore, type PersistedGoal } from "../../src/server/agent/goal-store.js";
+import { buildVerificationFailureMessage } from "../../src/server/agent/notify-team-lead-failure.js";
 import { VerificationHarness } from "../../src/server/agent/verification-harness.js";
 import type { Workflow, WorkflowGate } from "../../src/server/agent/workflow-store.js";
 import { createFakeVerificationCommandRunner } from "../harness/fake-verification-command-runner.js";
 
-const GOAL_ID = "failure-guidance-frozen-goal";
 const GATE_ID = "implementation";
 const START_TIME = 1_700_000_000_000;
 const FROZEN_GUIDANCE = "Inspect the **frozen** diagnostic first.\nRe-run only this command.";
 const MUTATED_GUIDANCE = "MUTATED TEMPLATE GUIDANCE MUST NOT BE USED";
 const VERIFIER_OUTPUT = "runtime verifier output must stay retained";
-
-const frozenWorkflow = {
-	id: "failure-guidance-workflow",
-	name: "Failure guidance workflow",
-	description: "Frozen notification guidance integration fixture.",
-	gates: [{
-		id: GATE_ID,
-		name: "Implementation",
-		dependsOn: [],
-		verify: [{
-			name: "Focused tests",
-			type: "command",
-			run: `node -e "console.error('${VERIFIER_OUTPUT}');process.exit(1)"`,
-			failureGuidance: FROZEN_GUIDANCE,
-		}],
-	}],
-	createdAt: START_TIME,
-	updatedAt: START_TIME,
-} as unknown as Workflow;
-
-const runtimeGate = {
-	...frozenWorkflow.gates[0],
-	verify: [{
-		name: "Focused tests",
-		type: "command",
-		run: `node -e "console.error('${VERIFIER_OUTPUT}');process.exit(1)"`,
-		failureGuidance: MUTATED_GUIDANCE,
-	}],
-} as unknown as WorkflowGate;
+const SYNTHETIC_ERROR = "synthetic harness setup failure";
 
 const fakeGitRunner: CommandRunner = {
 	execFile: async (file, args) => {
@@ -57,12 +29,40 @@ const fakeGitRunner: CommandRunner = {
 
 const roleStore = Object.freeze({ get: () => undefined, getAll: () => [] });
 
-test("live failure notification uses guidance from the reloaded frozen goal workflow", async () => {
+function workflowFor(goalId: string, stepName: string, failureGuidance: string): Workflow {
+	return {
+		id: `failure-guidance-workflow-${goalId}`,
+		name: "Failure guidance workflow",
+		description: "Frozen notification guidance integration fixture.",
+		gates: [{
+			id: GATE_ID,
+			name: "Implementation",
+			dependsOn: [],
+			verify: [{
+				name: stepName,
+				type: "command",
+				run: `node -e "console.error('${VERIFIER_OUTPUT}');process.exit(1)"`,
+				failureGuidance,
+			}],
+		}],
+		createdAt: START_TIME,
+		updatedAt: START_TIME,
+	} as unknown as Workflow;
+}
+
+async function runFailureNotification(options: {
+	goalId: string;
+	stepName: string;
+	projectConfigStore?: unknown;
+}): Promise<{ message: string; persistedGuidance: string | undefined }> {
 	const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "failure-guidance-integration-"));
 	try {
+		const frozenWorkflow = workflowFor(options.goalId, options.stepName, FROZEN_GUIDANCE);
+		const runtimeWorkflow = workflowFor(options.goalId, options.stepName, MUTATED_GUIDANCE);
+		const runtimeGate = runtimeWorkflow.gates[0] as WorkflowGate;
 		const initialGoalStore = new GoalStore(stateDir);
 		const goal: PersistedGoal = {
-			id: GOAL_ID,
+			id: options.goalId,
 			title: "Frozen failure guidance",
 			cwd: stateDir,
 			state: "in-progress",
@@ -76,22 +76,21 @@ test("live failure notification uses guidance from the reloaded frozen goal work
 		initialGoalStore.put(goal);
 		await initialGoalStore.flush();
 
-		// Reload from disk to exercise the persisted frozen snapshot rather than
-		// sharing the authored workflow object with the live verifier.
+		// Reload from disk so notification lookup exercises the persisted frozen
+		// snapshot rather than sharing the runtime verifier's workflow object.
 		const goalStore = new GoalStore(stateDir);
-		expect((goalStore.get(GOAL_ID)?.workflow?.gates[0].verify?.[0] as any)?.failureGuidance).toBe(FROZEN_GUIDANCE);
-
+		const persistedGuidance = goalStore.get(options.goalId)?.workflow?.gates[0].verify?.[0]?.failureGuidance;
 		const gateStore = new GateStore(stateDir);
-		gateStore.initGatesForGoal(GOAL_ID, [GATE_ID]);
+		gateStore.initGatesForGoal(options.goalId, [GATE_ID]);
 		const context = {
 			goalStore,
 			gateStore,
-			projectConfigStore: undefined,
+			projectConfigStore: options.projectConfigStore,
 			project: { id: "failure-guidance-project", name: "Failure Guidance" },
 			goalManager: { resolveRootMaxConcurrentChildren: () => 3 },
 		};
 		const projectContextManager = {
-			getContextForGoal: (goalId: string) => goalId === GOAL_ID ? context : undefined,
+			getContextForGoal: (goalId: string) => goalId === options.goalId ? context : undefined,
 		};
 		const harness = new VerificationHarness(
 			stateDir,
@@ -113,8 +112,8 @@ test("live failure notification uses guidance from the reloaded frozen goal work
 		harness.setTeamLeadNotifier((_goalId, message) => notifications.push(message));
 
 		const signal: GateSignal = {
-			id: "failure-guidance-signal",
-			goalId: GOAL_ID,
+			id: `failure-guidance-signal-${options.goalId}`,
+			goalId: options.goalId,
 			gateId: GATE_ID,
 			sessionId: "failure-guidance-team-lead",
 			timestamp: START_TIME + 1,
@@ -128,15 +127,46 @@ test("live failure notification uses guidance from the reloaded frozen goal work
 		await harness.verifyGateSignal(signal, runtimeGate, stateDir);
 
 		expect(notifications).toHaveLength(1);
-		const message = notifications[0];
-		const inspectIndex = message.indexOf('gate_inspect(gate_id="implementation", section="verification", step="Focused tests", mode="tail", lines=120)');
-		const guidanceIndex = message.indexOf(FROZEN_GUIDANCE);
-		expect(inspectIndex).toBeGreaterThanOrEqual(0);
-		expect(guidanceIndex).toBeGreaterThan(inspectIndex);
-		expect(message).toContain("**Workflow remediation guidance**");
-		expect(message).not.toContain(MUTATED_GUIDANCE);
-		expect(message).not.toContain(VERIFIER_OUTPUT);
+		return { message: notifications[0], persistedGuidance };
 	} finally {
 		fs.rmSync(stateDir, { recursive: true, force: true });
 	}
+}
+
+test("a genuine command step named Error receives guidance from the reloaded frozen workflow", async () => {
+	const { message, persistedGuidance } = await runFailureNotification({
+		goalId: "failure-guidance-real-error-goal",
+		stepName: "Error",
+	});
+
+	expect(persistedGuidance).toBe(FROZEN_GUIDANCE);
+	const inspectIndex = message.indexOf('gate_inspect(gate_id="implementation", section="verification", step="Error", mode="tail", lines=120)');
+	const guidanceIndex = message.indexOf(FROZEN_GUIDANCE);
+	expect(inspectIndex).toBeGreaterThanOrEqual(0);
+	expect(guidanceIndex).toBeGreaterThan(inspectIndex);
+	expect(message).toContain("**Workflow remediation guidance**");
+	expect(message).not.toContain(MUTATED_GUIDANCE);
+	expect(message).not.toContain(VERIFIER_OUTPUT);
+});
+
+test("a synthetic harness Error collision stays unaligned with authored workflow guidance", async () => {
+	const { message, persistedGuidance } = await runFailureNotification({
+		goalId: "failure-guidance-synthetic-error-goal",
+		stepName: "Error",
+		projectConfigStore: {
+			getWithDefaults: () => { throw new Error(SYNTHETIC_ERROR); },
+		},
+	});
+
+	expect(persistedGuidance).toBe(FROZEN_GUIDANCE);
+	expect(message).toBe(buildVerificationFailureMessage(GATE_ID, [{
+		name: "Error",
+		type: "command",
+		passed: false,
+		status: "failed",
+		output: SYNTHETIC_ERROR,
+	}]));
+	expect(message).not.toContain("Workflow remediation guidance");
+	expect(message).not.toContain(FROZEN_GUIDANCE);
+	expect(message).not.toContain(MUTATED_GUIDANCE);
 });

--- a/tests2/tests-map.json
+++ b/tests2/tests-map.json
@@ -868,6 +868,24 @@
       }
     },
     {
+      "path": "tests2/integration/verification-failure-guidance.test.ts",
+      "reason": "Integration coverage proving live failed-step notifications use advisory guidance from the reloaded goal's frozen workflow snapshot rather than a mutated runtime template, preserve inspect-first ordering, and omit verifier output.",
+      "execution": {
+        "runner": "vitest",
+        "tier": "unit",
+        "project": "integration"
+      }
+    },
+    {
+      "path": "tests2/browser/workflow-failure-guidance.spec.ts",
+      "reason": "Chromium workflow journey for authoring, type-switch preservation, saving, reloading, clearing, goal customisation, and default-closed Markdown inspection of verification failure guidance.",
+      "execution": {
+        "runner": "playwright",
+        "tier": "browser",
+        "project": "browser"
+      }
+    },
+    {
       "path": "tests2/browser/verification-timeout-remediation.spec.ts",
       "reason": "Deterministic Chromium journey using the real gate inspect/live renderers to pin structured timeout presentation, marker-derived timing, failed aggregate semantics, remediation validation, current/future/both scope routing, inherited-workflow customization ordering, active-snapshot isolation, and partial inline errors.",
       "execution": {

--- a/tests2/tests-map.json
+++ b/tests2/tests-map.json
@@ -869,7 +869,7 @@
     },
     {
       "path": "tests2/integration/verification-failure-guidance.test.ts",
-      "reason": "Integration coverage proving live failed-step notifications use advisory guidance from the reloaded goal's frozen workflow snapshot rather than a mutated runtime template, preserve inspect-first ordering, and omit verifier output.",
+      "reason": "Integration coverage proving genuine failed steps (including a command named Error) use advisory guidance from the reloaded goal's frozen workflow snapshot, while the harness's synthetic Error fallback cannot collide with authored guidance; also preserves inspect-first ordering and omits verifier output.",
       "execution": {
         "runner": "vitest",
         "tier": "unit",


### PR DESCRIPTION
## Summary
- add optional workflow-authored failure guidance across verification-step schemas, persistence, snapshots, proposals, and workflow UI
- append frozen-snapshot guidance only to matching failed-step team-lead notifications after the inspect instruction
- document advisory behavior and add core, integration, DOM, and browser coverage

## Validation
- implementation workflow: build, type-check, unit, browser, E2E, reviews, security, and QA passed
- documentation review passed

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)