### PR TITLE
Test release validator boundaries

### DIFF
--- a/scripts/release/validate-release-commit.mjs
+++ b/scripts/release/validate-release-commit.mjs
@@ -42,29 +42,17 @@ function parseArgs(argv) {
 	return args;
 }
 
-function readJson(relativePath) {
-	return JSON.parse(readFileSync(join(REPO_ROOT, relativePath), "utf8"));
-}
-
-const runGit = args => spawnSync("git", args, { cwd: REPO_ROOT, encoding: "utf8" });
-
-function git(...args) {
-	const result = runGit(args);
-	if (result.status !== 0) {
-		throw new Error(`git ${args.join(" ")} failed: ${result.stderr?.trim() || result.status}`);
-	}
-	return result.stdout;
-}
-
-async function resolvePullRequest({ repository, sha, number, token }) {
+async function resolvePullRequest({ repository, sha, number, token, fetchImpl }) {
 	if (number) {
 		const { body } = await fetchJson(`${GITHUB_API}/repos/${repository}/pulls/${number}`, {
 			headers: githubHeaders(token),
+			fetchImpl,
 		});
 		return body;
 	}
 	const { body } = await fetchJson(`${GITHUB_API}/repos/${repository}/commits/${sha}/pulls`, {
 		headers: githubHeaders(token),
+		fetchImpl,
 	});
 	const candidates = Array.isArray(body) ? body : [];
 	return (
@@ -73,18 +61,18 @@ async function resolvePullRequest({ repository, sha, number, token }) {
 	);
 }
 
-async function isPublished(name, version) {
-	const { status } = await fetchJson(npmPackageUrl(name, version));
+async function isPublished(name, version, fetchImpl) {
+	const { status } = await fetchJson(npmPackageUrl(name, version), { fetchImpl });
 	if (status === 404) return false;
 	if (status === 200) return true;
 	throw new Error(`registry lookup for ${name}@${version} returned ${status}`);
 }
 
-async function assertOptionalDependenciesPublished(pkg) {
+async function assertOptionalDependenciesPublished(pkg, fetchImpl) {
 	const pins = Object.entries(pkg.optionalDependencies ?? {});
 	const missing = [];
 	for (const [name, version] of pins) {
-		if (!(await isPublished(name, version))) missing.push(`${name}@${version}`);
+		if (!(await isPublished(name, version, fetchImpl))) missing.push(`${name}@${version}`);
 	}
 	if (missing.length > 0) {
 		throw new ReleaseContractError(
@@ -94,16 +82,30 @@ async function assertOptionalDependenciesPublished(pkg) {
 	}
 }
 
-async function releaseExists({ repository, tag, token }) {
+async function releaseExists({ repository, tag, token, fetchImpl }) {
 	const { status } = await fetchJson(`${GITHUB_API}/repos/${repository}/releases/tags/${tag}`, {
 		headers: githubHeaders(token),
+		fetchImpl,
 	});
 	if (status === 200) return true;
 	if (status === 404) return false;
 	throw new Error(`release lookup for ${tag} returned ${status}`);
 }
 
-export async function validateReleaseCommit(args, env = process.env) {
+export async function validateReleaseCommit(args, env = process.env, options = {}) {
+	const root = options.root ?? REPO_ROOT;
+	const fetchImpl = options.fetchImpl ?? fetch;
+	const runGit =
+		options.runGit ?? (gitArgs => spawnSync("git", gitArgs, { cwd: root, encoding: "utf8" }));
+	const git = (...gitArgs) => {
+		const result = runGit(gitArgs);
+		if (result.status !== 0) {
+			throw new Error(`git ${gitArgs.join(" ")} failed: ${result.stderr?.trim() || result.status}`);
+		}
+		return result.stdout;
+	};
+	const readJson = relativePath => JSON.parse(readFileSync(join(root, relativePath), "utf8"));
+
 	const mode = args.mode ?? "merged";
 	if (mode !== "merged" && mode !== "pre-merge") {
 		throw new Error(`unknown --mode ${mode} (expected merged or pre-merge)`);
@@ -132,7 +134,7 @@ export async function validateReleaseCommit(args, env = process.env) {
 
 	let changelog = "";
 	try {
-		changelog = readFileSync(join(REPO_ROOT, CHANGELOG_PATH), "utf8");
+		changelog = readFileSync(join(root, CHANGELOG_PATH), "utf8");
 	} catch {
 		throw new ReleaseContractError(`missing ${CHANGELOG_PATH}`);
 	}
@@ -145,16 +147,17 @@ export async function validateReleaseCommit(args, env = process.env) {
 		sha,
 		number: args["pull-request"],
 		token,
+		fetchImpl,
 	});
 	assertPullRequestContract(pr, { version, repository, sha });
 
-	await assertOptionalDependenciesPublished(pkg);
+	await assertOptionalDependenciesPublished(pkg, fetchImpl);
 
 	const spec = `${pkg.name}@${version}`;
-	const published = await isPublished(pkg.name, version);
+	const published = await isPublished(pkg.name, version, fetchImpl);
 	let distTagBase = null;
 	if (published) {
-		const { body } = await fetchJson(npmAttestationUrl(pkg.name, version));
+		const { body } = await fetchJson(npmAttestationUrl(pkg.name, version), { fetchImpl });
 		assertPublishedArtifactMatches(extractProvenanceSource(body), { spec, repository, sha });
 		console.log(`${spec} was already published from ${sha}; this run will not republish it`);
 	} else {
@@ -162,6 +165,7 @@ export async function validateReleaseCommit(args, env = process.env) {
 			packageName: pkg.name,
 			distTag: distTagFor(version),
 			version,
+			fetchImpl,
 		});
 	}
 
@@ -171,7 +175,10 @@ export async function validateReleaseCommit(args, env = process.env) {
 		"dist-tag": distTagFor(version),
 		dist_tag_base: distTagBase ?? "",
 		"need-publish": String(!published),
-		"need-release": mode === "merged" ? String(!(await releaseExists({ repository, tag, token }))) : "false",
+		"need-release":
+			mode === "merged"
+				? String(!(await releaseExists({ repository, tag, token, fetchImpl })))
+				: "false",
 		"pull-request": String(pr?.number ?? ""),
 	};
 

--- a/tests2/core/release-publish-boundary-mutations.test.ts
+++ b/tests2/core/release-publish-boundary-mutations.test.ts
@@ -1,0 +1,124 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, it } from "vitest";
+import { parse as parseYaml } from "yaml";
+
+type Step = {
+	name?: string;
+	uses?: string;
+	run?: string;
+	with?: Record<string, unknown>;
+};
+type Job = {
+	permissions?: Record<string, string>;
+	steps?: Step[];
+};
+type Workflow = { jobs?: Record<string, Job> };
+
+const source = parseYaml(
+	readFileSync(resolve(".github/workflows/release-publish.yml"), "utf8"),
+) as Workflow;
+
+function job(workflow: Workflow, name: string): Job {
+	const value = workflow.jobs?.[name];
+	assert.ok(value, `missing ${name} job`);
+	return value;
+}
+
+function step(workflow: Workflow, jobName: string, name: string): Step {
+	const value = job(workflow, jobName).steps?.find(candidate => candidate.name === name);
+	assert.ok(value, `missing ${jobName}/${name} step`);
+	return value;
+}
+
+function assertPublishBoundary(workflow: Workflow): void {
+	assert.equal(job(workflow, "verify").permissions?.["id-token"], undefined);
+	assert.deepEqual(job(workflow, "publish").permissions, {
+		contents: "read",
+		"id-token": "write",
+	});
+
+	const steps = job(workflow, "publish").steps ?? [];
+	assert.ok(
+		!steps.some(candidate => (candidate.uses ?? "").startsWith("actions/checkout@")),
+		"publish must not check out repository code",
+	);
+	assert.ok(
+		!steps.some(candidate => /\bnpm (?:ci|install|run)\b|\bnode\s+scripts\//.test(candidate.run ?? "")),
+		"publish must not install dependencies or run repository scripts",
+	);
+
+	const stateCheck = step(workflow, "publish", "Confirm dist-tag state is unchanged");
+	const download = step(workflow, "publish", "Download verified release artifacts");
+	assert.ok(
+		steps.indexOf(stateCheck) < steps.indexOf(download),
+		"registry state must be checked before the artifact enters the privileged job",
+	);
+	assert.match(download.uses ?? "", /^actions\/download-artifact@[0-9a-f]{40}$/);
+	assert.match(String(download.with?.name ?? ""), /needs\.verify\.outputs\.artifact_name/);
+
+	const publish = step(workflow, "publish", "Publish verified artifact (OIDC trusted publishing)");
+	assert.match(
+		publish.run ?? "",
+		/npm publish release-artifact\/bobbit\.tgz --ignore-scripts --provenance/,
+		"publish must name the verified artifact and disable lifecycle scripts",
+	);
+}
+
+function mutated(change: (workflow: Workflow) => void): Workflow {
+	const workflow = structuredClone(source);
+	change(workflow);
+	return workflow;
+}
+
+describe("release publish privilege boundary mutations", () => {
+	it("accepts the reviewed workflow", () => {
+		assertPublishBoundary(source);
+	});
+
+	it("rejects checkout, install, and repository-script mutations", () => {
+		for (const mutation of [
+			mutated(workflow => {
+				job(workflow, "publish").steps?.push({ uses: "actions/checkout@" + "0".repeat(40) });
+			}),
+			mutated(workflow => {
+				job(workflow, "publish").steps?.push({ run: "npm ci" });
+			}),
+			mutated(workflow => {
+				job(workflow, "publish").steps?.push({ run: "node scripts/release/prepare.mjs" });
+			}),
+		]) {
+			assert.throws(() => assertPublishBoundary(mutation));
+		}
+	});
+
+	it("rejects publishing the workspace or enabling lifecycle scripts", () => {
+		for (const replacement of [
+			"npm publish --provenance",
+			"npm publish release-artifact/bobbit.tgz --provenance",
+		]) {
+			const mutation = mutated(workflow => {
+				step(workflow, "publish", "Publish verified artifact (OIDC trusted publishing)").run = replacement;
+			});
+			assert.throws(() => assertPublishBoundary(mutation));
+		}
+	});
+
+	it("rejects moving the artifact ahead of the serialized state check", () => {
+		const mutation = mutated(workflow => {
+			const steps = job(workflow, "publish").steps ?? [];
+			const checkIndex = steps.indexOf(step(workflow, "publish", "Confirm dist-tag state is unchanged"));
+			const downloadIndex = steps.indexOf(step(workflow, "publish", "Download verified release artifacts"));
+			[steps[checkIndex], steps[downloadIndex]] = [steps[downloadIndex], steps[checkIndex]];
+		});
+		assert.throws(() => assertPublishBoundary(mutation));
+	});
+
+	it("rejects granting OIDC authority to repository verification", () => {
+		const mutation = mutated(workflow => {
+			job(workflow, "verify").permissions = { "id-token": "write" };
+		});
+		assert.throws(() => assertPublishBoundary(mutation));
+	});
+});

--- a/tests2/fixtures/release/npm-attestations-bobbit-0.15.1.json
+++ b/tests2/fixtures/release/npm-attestations-bobbit-0.15.1.json
@@ -1,0 +1,143 @@
+{
+  "attestations": [
+    {
+      "predicateType": "https://github.com/npm/attestation/tree/main/specs/publish/v0.1",
+      "bundle": {
+        "mediaType": "application/vnd.dev.sigstore.bundle+json;version=0.2",
+        "verificationMaterial": {
+          "publicKey": {
+            "hint": "SHA256:DhQ8wR5APBvFHLF/+Tc+AYvPOdTpcIDqOhxsBHRwC7U"
+          },
+          "tlogEntries": [
+            {
+              "logIndex": "2281281377",
+              "logId": {
+                "keyId": "wNI9atQGlz+VWfO6LRygH4QUfY/8W4RFwiT5i5WRgB0="
+              },
+              "kindVersion": {
+                "kind": "dsse",
+                "version": "0.0.1"
+              },
+              "integratedTime": "1785342578",
+              "inclusionPromise": {
+                "signedEntryTimestamp": "MEYCIQCz0p8n+Emg/I63ak7oukLyGZnlXS4yyQKuUdNPFgVVSAIhAOCTXYZSbk0YZTuqSgEAJZdbq1tFxP6TfmAVtWsjz7ZX"
+              },
+              "inclusionProof": {
+                "logIndex": "2159377115",
+                "rootHash": "MkVRFtwfT1jEJnFcwENV9nfVu/ZVBJVqgoBgsuUd6H0=",
+                "treeSize": "2159377125",
+                "hashes": [
+                  "jDdXITGrvrenKVgaVnw/NdhkDbhLprWWeWymWqOWTgk=",
+                  "GAFjKkS1GprLUwkYBWKx8M3GClayBcWe2fjBVp6Hh+s=",
+                  "BlsSK+ENOQuy7W26JQJCkxmv5xqKMtX19nChyGIqBVk=",
+                  "xOecD+NvG7XlYnsPa7QAAPXKRqO/n2EIkvGiGrTPo2Q=",
+                  "HVfdqfU48PsTNz6jcHZGoUEaxY64Qys6Yoe6jCUwnt4=",
+                  "AE7nanf0AYzMv2yD0n5pCX104YTU6PSLHaxIIWep9AI=",
+                  "Px8QVryRt0YG64YlD+1iu9ooP0Tq3MJPdR0j8sN/WK0=",
+                  "452CkIN2GOiKAnqWOyZLQv9mqq1it3tQiQtBaE0h+fg=",
+                  "EM77gce6DAE5uXAeWeTZpyozNCQFer0TyHdJCQyDXyA=",
+                  "moukt0amxTDeJAPjn9Ls25xJlJAkrUt6vhP2DSv4pPI=",
+                  "aD3edTmYvOMI+KbOK75KNEZfV+uUz9PXo5f4rpvsZ+k=",
+                  "CMd4p8pJQdQ+gXDcf23lRFJ/RXIcH1BJ7Fsz/7wusbw=",
+                  "MJV8xheHUw7Ji5y6T2FzqJMC0Sgj8o8QaV8oO1N8qOo=",
+                  "uQwYFCP5g094lv3Tztc7HsXV3kS4kWpkKliDyg0pD9A=",
+                  "6UUeSzpK17UhYXYjFoZS79LfiZduAw/qyfBLorlcWkk=",
+                  "afXGlQDQVAWEMC8uq0Mj6bI74lhhn5oWgFOS4DmDOso=",
+                  "b+xUZfuENQxvSOJxzNvYvRG8eVphfszPpZmuf4/cQ6c=",
+                  "OVsvZCKnWA+498QUIaQCtitUT6huDbC7SmhH1l8MxXI=",
+                  "xH/DCseLHr9eKoYT8qsORZK7zVdEGYWHuVtsVrD95wY="
+                ],
+                "checkpoint": {
+                  "envelope": "rekor.sigstore.dev - 1193050959916656506\n2159377125\nMkVRFtwfT1jEJnFcwENV9nfVu/ZVBJVqgoBgsuUd6H0=\n\n— rekor.sigstore.dev wNI9ajBGAiEAtKxtyBoMRyCGFGyW2lK+vFSOKJjfVHyUfzl5A+pK7SQCIQCZi0wVhcLYfVF29E7xmJQAjWSp/omf2eLLEZ8VLbsCHQ==\n"
+                }
+              },
+              "canonicalizedBody": "eyJhcGlWZXJzaW9uIjoiMC4wLjEiLCJraW5kIjoiZHNzZSIsInNwZWMiOnsiZW52ZWxvcGVIYXNoIjp7ImFsZ29yaXRobSI6InNoYTI1NiIsInZhbHVlIjoiZmRiYzFkY2Q4ZjM1ODMwNWQ5YThlNmVmMDkwZjMwYWRjMzVlNTYxZDY0NzVkNWEzY2JhMjkyMjEwMTdiZTg2YiJ9LCJwYXlsb2FkSGFzaCI6eyJhbGdvcml0aG0iOiJzaGEyNTYiLCJ2YWx1ZSI6IjYxNDMxZjk5ZGM4NjgyYTkzMGRkOTQ0YTYzMmFlZDQ5MzFjMWU4MmNmZmU0MzExMjc2ZTM3YmY1MDI2MzQ0YWYifSwic2lnbmF0dXJlcyI6W3sic2lnbmF0dXJlIjoiTUVVQ0lRRENySDJvT0h6Zm9FWjM1dzl6cFBkdk1uVkVDaVV5bk9hVHRNM0NhNWJoalFJZ1dIY1dJR0tKRnhadmVBeDlKOGFIOTk2RlQrc0VvODJCbTQ1R0FEdUUzU3M9IiwidmVyaWZpZXIiOiJMUzB0TFMxQ1JVZEpUaUJRVlVKTVNVTWdTMFZaTFMwdExTMEtUVVpyZDBWM1dVaExiMXBKZW1vd1EwRlJXVWxMYjFwSmVtb3dSRUZSWTBSUlowRkZXVFpaWVRkWEt5czNZVlZRZW5aTlZISmxla2cyV1dONE0yTXJTQXBQUzFsRFkwNUhlV0pLV2xORFNuRXZabVEzVVdFNGRYVkJTM1JrU1d0VlVYUlJhVVZMUlZKb1FXMUZOV3hOVFVwb1VEaFBhMFJQWVRKblBUMEtMUzB0TFMxRlRrUWdVRlZDVEVsRElFdEZXUzB0TFMwdENnPT0ifV19fQ=="
+            }
+          ],
+          "timestampVerificationData": {
+            "rfc3161Timestamps": []
+          }
+        },
+        "dsseEnvelope": {
+          "payload": "eyJfdHlwZSI6Imh0dHBzOi8vaW4tdG90by5pby9TdGF0ZW1lbnQvdjAuMSIsInN1YmplY3QiOlt7Im5hbWUiOiJwa2c6bnBtLyU0MGdyZXNlYXJjaC9ib2JiaXRAMC4xNS4xIiwiZGlnZXN0Ijp7InNoYTUxMiI6ImQ3MTJhNzZiYTc5YWM5OWVkN2NhZGRiZDk5NDg4MGNiNThiZTg2MTNiY2Q0Y2VjOTk0YjY2ZDVlODFkMzkwNDZmOGUwOWVjMTM3ODI5MWY5YTAwMjQ1YzYyNzMwOTAyYjE5NGJhMTI1NTlhOTUwYWY5MDk4NDI4N2I2OGM2ZDNhIn19XSwicHJlZGljYXRlVHlwZSI6Imh0dHBzOi8vZ2l0aHViLmNvbS9ucG0vYXR0ZXN0YXRpb24vdHJlZS9tYWluL3NwZWNzL3B1Ymxpc2gvdjAuMSIsInByZWRpY2F0ZSI6eyJuYW1lIjoiQGdyZXNlYXJjaC9ib2JiaXQiLCJ2ZXJzaW9uIjoiMC4xNS4xIiwicmVnaXN0cnkiOiJodHRwczovL3JlZ2lzdHJ5Lm5wbWpzLm9yZyJ9fQ==",
+          "payloadType": "application/vnd.in-toto+json",
+          "signatures": [
+            {
+              "sig": "MEUCIQDCrH2oOHzfoEZ35w9zpPdvMnVECiUynOaTtM3Ca5bhjQIgWHcWIGKJFxZveAx9J8aH996FT+sEo82Bm45GADuE3Ss=",
+              "keyid": "SHA256:DhQ8wR5APBvFHLF/+Tc+AYvPOdTpcIDqOhxsBHRwC7U"
+            }
+          ]
+        }
+      },
+      "signedAccessSignatureUrl": ""
+    },
+    {
+      "predicateType": "https://slsa.dev/provenance/v1",
+      "bundle": {
+        "mediaType": "application/vnd.dev.sigstore.bundle.v0.3+json",
+        "verificationMaterial": {
+          "certificate": {
+            "rawBytes": "MIIHDTCCBpSgAwIBAgIUL71jQbawdLLmRylWhP0swjn4O9EwCgYIKoZIzj0EAwMwNzEVMBMGA1UEChMMc2lnc3RvcmUuZGV2MR4wHAYDVQQDExVzaWdzdG9yZS1pbnRlcm1lZGlhdGUwHhcNMjYwNzI5MTYyOTM0WhcNMjYwNzI5MTYzOTM0WjAAMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEbmPGvX8Nv/kzsr9KsyKES0l+zi6q3SgHgRzDvDSyfwJe+VxMiiqnV5d2wwDHbNUkttyAk4EJOo+x3E6c+3dNmaOCBbMwggWvMA4GA1UdDwEB/wQEAwIHgDATBgNVHSUEDDAKBggrBgEFBQcDAzAdBgNVHQ4EFgQUhsgkwDDZ3rjnSeX3UDALg0kFBvQwHwYDVR0jBBgwFoAU39Ppz1YkEZb5qNjpKFWixi4YZD8wagYDVR0RAQH/BGAwXoZcaHR0cHM6Ly9naXRodWIuY29tL0ctUmVzZWFyY2gvYm9iYml0Ly5naXRodWIvd29ya2Zsb3dzL3JlbGVhc2UtcHVibGlzaC55bWxAcmVmcy90YWdzL3YwLjE1LjEwOQYKKwYBBAGDvzABAQQraHR0cHM6Ly90b2tlbi5hY3Rpb25zLmdpdGh1YnVzZXJjb250ZW50LmNvbTASBgorBgEEAYO/MAECBARwdXNoMDYGCisGAQQBg78wAQMEKGY0ZjgxMzdmMjFkMWQxM2Q0MWJmNTJhN2UxZjg3MWUwYmE2MTVjZGEwHAYKKwYBBAGDvzABBAQOUHVibGlzaCB0byBucG0wHwYKKwYBBAGDvzABBQQRRy1SZXNlYXJjaC9ib2JiaXQwHwYKKwYBBAGDvzABBgQRcmVmcy90YWdzL3YwLjE1LjEwOwYKKwYBBAGDvzABCAQtDCtodHRwczovL3Rva2VuLmFjdGlvbnMuZ2l0aHVidXNlcmNvbnRlbnQuY29tMGwGCisGAQQBg78wAQkEXgxcaHR0cHM6Ly9naXRodWIuY29tL0ctUmVzZWFyY2gvYm9iYml0Ly5naXRodWIvd29ya2Zsb3dzL3JlbGVhc2UtcHVibGlzaC55bWxAcmVmcy90YWdzL3YwLjE1LjEwOAYKKwYBBAGDvzABCgQqDChmNGY4MTM3ZjIxZDFkMTNkNDFiZjUyYTdlMWY4NzFlMGJhNjE1Y2RhMB0GCisGAQQBg78wAQsEDwwNZ2l0aHViLWhvc3RlZDA0BgorBgEEAYO/MAEMBCYMJGh0dHBzOi8vZ2l0aHViLmNvbS9HLVJlc2VhcmNoL2JvYmJpdDA4BgorBgEEAYO/MAENBCoMKGY0ZjgxMzdmMjFkMWQxM2Q0MWJmNTJhN2UxZjg3MWUwYmE2MTVjZGEwIQYKKwYBBAGDvzABDgQTDBFyZWZzL3RhZ3MvdjAuMTUuMTAaBgorBgEEAYO/MAEPBAwMCjExNjAwNjUwODkwLQYKKwYBBAGDvzABEAQfDB1odHRwczovL2dpdGh1Yi5jb20vRy1SZXNlYXJjaDAYBgorBgEEAYO/MAERBAoMCDIxMzQxOTY1MGwGCisGAQQBg78wARIEXgxcaHR0cHM6Ly9naXRodWIuY29tL0ctUmVzZWFyY2gvYm9iYml0Ly5naXRodWIvd29ya2Zsb3dzL3JlbGVhc2UtcHVibGlzaC55bWxAcmVmcy90YWdzL3YwLjE1LjEwOAYKKwYBBAGDvzABEwQqDChmNGY4MTM3ZjIxZDFkMTNkNDFiZjUyYTdlMWY4NzFlMGJhNjE1Y2RhMBQGCisGAQQBg78wARQEBgwEcHVzaDBYBgorBgEEAYO/MAEVBEoMSGh0dHBzOi8vZ2l0aHViLmNvbS9HLVJlc2VhcmNoL2JvYmJpdC9hY3Rpb25zL3J1bnMvMzA0NzA4OTc0MjYvYXR0ZW1wdHMvMTAWBgorBgEEAYO/MAEWBAgMBnB1YmxpYzA8BgorBgEEAYO/MAEYBC4MLHJlcG86Ry1SZXNlYXJjaC9ib2JiaXQ6cmVmOnJlZnMvdGFncy92MC4xNS4xMIGKBgorBgEEAdZ5AgQCBHwEegB4AHYA3T0wasbHETJjGR4cmWc3AqJKXrjePK3/h4pygC8p7o4AAAGfrrW+uwAABAMARzBFAiBb/nZ0gcgvbkA06ADQMl+U1X2tf1RVC4rlLLXNyqbwYAIhAKKk7oKUjd7aye106zZqOchlAVHa8bcwPNgg3romEQdAMAoGCCqGSM49BAMDA2cAMGQCMCiIfLKVnmpt0ERYpBDxfHDGZ8wEj4XGjlfKMLr1uYilANWpn49BhXXsvC2UccS2IAIwczOHBtyznoRqY2XO1QPYcrUjMD7ThhdBujL2K/xPVOf9cvBra8hEZJvEBW5rWMtB"
+          },
+          "tlogEntries": [
+            {
+              "logIndex": "2281281031",
+              "logId": {
+                "keyId": "wNI9atQGlz+VWfO6LRygH4QUfY/8W4RFwiT5i5WRgB0="
+              },
+              "kindVersion": {
+                "kind": "dsse",
+                "version": "0.0.1"
+              },
+              "integratedTime": "1785342574",
+              "inclusionPromise": {
+                "signedEntryTimestamp": "MEYCIQDru2k12DjiuCTNtcUvJNxkag8tPFiK1C4wdyCgLdXVvAIhAJmdTFDENYPTlxQZhfPy32SPTj/FQQZMEw+NNacIQQmu"
+              },
+              "inclusionProof": {
+                "logIndex": "2159376769",
+                "rootHash": "xJ4QD/CHyTf1a9tgb/mnJEcCrDyA42ud5CRmOg3Qqa8=",
+                "treeSize": "2159376777",
+                "hashes": [
+                  "9IyFCLnBBE5mSXJn5kXw8Oonq2fZEJVuEwMHAv5Ds5w=",
+                  "5hkQbCiXhd+JbRYT40Y/wS5Y3wQMbfFf6Dt3ebAsqtg=",
+                  "rvmfk90HwKWSRL4bYNso7Pv/n/Uhc3KttGHdbHt8n+w=",
+                  "Ih8UZxtTZU4LW1QAkNlnI2xf7AT/zKcd4UH0V8xhtS4=",
+                  "R4GsiFgMvrcdHMUuyW0v2ZYqFNZ7EWoukLIrX3d4TFA=",
+                  "oX4/fYnvo4NIruobZZNjX7VioyHckT8hiXpbE8XnSzY=",
+                  "moukt0amxTDeJAPjn9Ls25xJlJAkrUt6vhP2DSv4pPI=",
+                  "aD3edTmYvOMI+KbOK75KNEZfV+uUz9PXo5f4rpvsZ+k=",
+                  "CMd4p8pJQdQ+gXDcf23lRFJ/RXIcH1BJ7Fsz/7wusbw=",
+                  "MJV8xheHUw7Ji5y6T2FzqJMC0Sgj8o8QaV8oO1N8qOo=",
+                  "uQwYFCP5g094lv3Tztc7HsXV3kS4kWpkKliDyg0pD9A=",
+                  "6UUeSzpK17UhYXYjFoZS79LfiZduAw/qyfBLorlcWkk=",
+                  "afXGlQDQVAWEMC8uq0Mj6bI74lhhn5oWgFOS4DmDOso=",
+                  "b+xUZfuENQxvSOJxzNvYvRG8eVphfszPpZmuf4/cQ6c=",
+                  "OVsvZCKnWA+498QUIaQCtitUT6huDbC7SmhH1l8MxXI=",
+                  "xH/DCseLHr9eKoYT8qsORZK7zVdEGYWHuVtsVrD95wY="
+                ],
+                "checkpoint": {
+                  "envelope": "rekor.sigstore.dev - 1193050959916656506\n2159376777\nxJ4QD/CHyTf1a9tgb/mnJEcCrDyA42ud5CRmOg3Qqa8=\n\n— rekor.sigstore.dev wNI9ajBFAiBzEs+eDeyQsaH7mkmAa+6/t8e83rrQTll7zty9G9hbPwIhAM1sz6wMZZYIvr5zlp5FCM7sy5qngFphYlGtG2+B8Cyr\n"
+                }
+              },
+              "canonicalizedBody": "eyJhcGlWZXJzaW9uIjoiMC4wLjEiLCJraW5kIjoiZHNzZSIsInNwZWMiOnsiZW52ZWxvcGVIYXNoIjp7ImFsZ29yaXRobSI6InNoYTI1NiIsInZhbHVlIjoiMTI5ZGIzZDM1NThiOGUwNGFmMWUyNjkzM2FiNmE4ODUyMjRlYmI0OTgzZWEyNDJiMTk2NmU1OTQ4NzA4YzcwMCJ9LCJwYXlsb2FkSGFzaCI6eyJhbGdvcml0aG0iOiJzaGEyNTYiLCJ2YWx1ZSI6ImZlMmE5ODU1OGIxZGQ4MDVkZGIzNzE4MGQwNTE0MTkyYzVkNzMxMTYxNWQ5MjJiOWJlM2M5YTY1YmQ2MjE3YzkifSwic2lnbmF0dXJlcyI6W3sic2lnbmF0dXJlIjoiTUVRQ0lET3RMRFAyaUpKZnNzOTNDVXBxcFE1blBuSEh3Y0tsQlRQL2cwV0xLbG55QWlCczlxNUxoRUd6clh5bVFoTEtKeUwzOERhd01iQWVJQkVUTG9HWHJ4QVFzZz09IiwidmVyaWZpZXIiOiJMUzB0TFMxQ1JVZEpUaUJEUlZKVVNVWkpRMEZVUlMwdExTMHRDazFKU1VoRVZFTkRRbkJUWjBGM1NVSkJaMGxWVERjeGFsRmlZWGRrVEV4dFVubHNWMmhRTUhOM2FtNDBUemxGZDBObldVbExiMXBKZW1vd1JVRjNUWGNLVG5wRlZrMUNUVWRCTVZWRlEyaE5UV015Ykc1ak0xSjJZMjFWZFZwSFZqSk5ValIzU0VGWlJGWlJVVVJGZUZaNllWZGtlbVJIT1hsYVV6RndZbTVTYkFwamJURnNXa2RzYUdSSFZYZElhR05PVFdwWmQwNTZTVFZOVkZsNVQxUk5NRmRvWTA1TmFsbDNUbnBKTlUxVVdYcFBWRTB3VjJwQlFVMUdhM2RGZDFsSUNrdHZXa2w2YWpCRFFWRlpTVXR2V2tsNmFqQkVRVkZqUkZGblFVVmliVkJIZGxnNFRuWXZhM3B6Y2psTGMzbExSVk13YkN0NmFUWnhNMU5uU0dkU2VrUUtka1JUZVdaM1NtVXJWbmhOYVdseGJsWTFaREozZDBSSVlrNVZhM1IwZVVGck5FVktUMjhyZURORk5tTXJNMlJPYldGUFEwSmlUWGRuWjFkMlRVRTBSd3BCTVZWa1JIZEZRaTkzVVVWQmQwbElaMFJCVkVKblRsWklVMVZGUkVSQlMwSm5aM0pDWjBWR1FsRmpSRUY2UVdSQ1owNVdTRkUwUlVablVWVm9jMmRyQ25kRVJGb3pjbXB1VTJWWU0xVkVRVXhuTUd0R1FuWlJkMGgzV1VSV1VqQnFRa0puZDBadlFWVXpPVkJ3ZWpGWmEwVmFZalZ4VG1wd1MwWlhhWGhwTkZrS1drUTRkMkZuV1VSV1VqQlNRVkZJTDBKSFFYZFliMXBqWVVoU01HTklUVFpNZVRsdVlWaFNiMlJYU1hWWk1qbDBUREJqZEZWdFZucGFWMFo1V1RKbmRncFpiVGxwV1cxc01FeDVOVzVoV0ZKdlpGZEpkbVF5T1hsaE1scHpZak5rZWt3elNteGlSMVpvWXpKVmRHTklWbWxpUjJ4NllVTTFOV0pYZUVGamJWWnRDbU41T1RCWlYyUjZURE5aZDB4cVJURk1ha1YzVDFGWlMwdDNXVUpDUVVkRWRucEJRa0ZSVVhKaFNGSXdZMGhOTmt4NU9UQmlNblJzWW1rMWFGa3pVbkFLWWpJMWVreHRaSEJrUjJneFdXNVdlbHBZU21waU1qVXdXbGMxTUV4dFRuWmlWRUZUUW1kdmNrSm5SVVZCV1U4dlRVRkZRMEpCVW5ka1dFNXZUVVJaUndwRGFYTkhRVkZSUW1jM09IZEJVVTFGUzBkWk1GcHFaM2hOZW1SdFRXcEdhMDFYVVhoTk1sRXdUVmRLYlU1VVNtaE9NbFY0V21wbk0wMVhWWGRaYlVVeUNrMVVWbXBhUjBWM1NFRlpTMHQzV1VKQ1FVZEVkbnBCUWtKQlVVOVZTRlpwWWtkc2VtRkRRakJpZVVKMVkwY3dkMGgzV1V0TGQxbENRa0ZIUkhaNlFVSUtRbEZSVWxKNU1WTmFXRTVzV1ZoS2FtRkRPV2xpTWtwcFlWaFJkMGgzV1V0TGQxbENRa0ZIUkhaNlFVSkNaMUZTWTIxV2JXTjVPVEJaVjJSNlRETlpkd3BNYWtVeFRHcEZkMDkzV1V0TGQxbENRa0ZIUkhaNlFVSkRRVkYwUkVOMGIyUklVbmRqZW05MlRETlNkbUV5Vm5WTWJVWnFaRWRzZG1KdVRYVmFNbXd3Q21GSVZtbGtXRTVzWTIxT2RtSnVVbXhpYmxGMVdUSTVkRTFIZDBkRGFYTkhRVkZSUW1jM09IZEJVV3RGV0dkNFkyRklVakJqU0UwMlRIazVibUZZVW04S1pGZEpkVmt5T1hSTU1HTjBWVzFXZWxwWFJubFpNbWQyV1cwNWFWbHRiREJNZVRWdVlWaFNiMlJYU1haa01qbDVZVEphYzJJelpIcE1NMHBzWWtkV2FBcGpNbFYwWTBoV2FXSkhiSHBoUXpVMVlsZDRRV050Vm0xamVUa3dXVmRrZWt3eldYZE1ha1V4VEdwRmQwOUJXVXRMZDFsQ1FrRkhSSFo2UVVKRFoxRnhDa1JEYUcxT1IxazBUVlJOTTFwcVNYaGFSRVpyVFZST2EwNUVSbWxhYWxWNVdWUmtiRTFYV1RST2VrWnNUVWRLYUU1cVJURlpNbEpvVFVJd1IwTnBjMGNLUVZGUlFtYzNPSGRCVVhORlJIZDNUbG95YkRCaFNGWnBURmRvZG1NelVteGFSRUV3UW1kdmNrSm5SVVZCV1U4dlRVRkZUVUpEV1UxS1IyZ3daRWhDZWdwUGFUaDJXakpzTUdGSVZtbE1iVTUyWWxNNVNFeFdTbXhqTWxab1kyMU9iMHd5U25aWmJVcHdaRVJCTkVKbmIzSkNaMFZGUVZsUEwwMUJSVTVDUTI5TkNrdEhXVEJhYW1kNFRYcGtiVTFxUm10TlYxRjRUVEpSTUUxWFNtMU9WRXBvVGpKVmVGcHFaek5OVjFWM1dXMUZNazFVVm1wYVIwVjNTVkZaUzB0M1dVSUtRa0ZIUkhaNlFVSkVaMUZVUkVKR2VWcFhXbnBNTTFKb1dqTk5kbVJxUVhWTlZGVjFUVlJCWVVKbmIzSkNaMFZGUVZsUEwwMUJSVkJDUVhkTlEycEZlQXBPYWtGM1RtcFZkMDlFYTNkTVVWbExTM2RaUWtKQlIwUjJla0ZDUlVGUlprUkNNVzlrU0ZKM1kzcHZka3d5WkhCa1IyZ3hXV2sxYW1JeU1IWlNlVEZUQ2xwWVRteFpXRXBxWVVSQldVSm5iM0pDWjBWRlFWbFBMMDFCUlZKQ1FXOU5RMFJKZUUxNlVYaFBWRmt4VFVkM1IwTnBjMGRCVVZGQ1p6YzRkMEZTU1VVS1dHZDRZMkZJVWpCalNFMDJUSGs1Ym1GWVVtOWtWMGwxV1RJNWRFd3dZM1JWYlZaNldsZEdlVmt5WjNaWmJUbHBXVzFzTUV4NU5XNWhXRkp2WkZkSmRncGtNamw1WVRKYWMySXpaSHBNTTBwc1lrZFdhR015VlhSalNGWnBZa2RzZW1GRE5UVmlWM2hCWTIxV2JXTjVPVEJaVjJSNlRETlpkMHhxUlRGTWFrVjNDazlCV1V0TGQxbENRa0ZIUkhaNlFVSkZkMUZ4UkVOb2JVNUhXVFJOVkUweldtcEplRnBFUm10TlZFNXJUa1JHYVZwcVZYbFpWR1JzVFZkWk5FNTZSbXdLVFVkS2FFNXFSVEZaTWxKb1RVSlJSME5wYzBkQlVWRkNaemM0ZDBGU1VVVkNaM2RGWTBoV2VtRkVRbGxDWjI5eVFtZEZSVUZaVHk5TlFVVldRa1Z2VFFwVFIyZ3daRWhDZWs5cE9IWmFNbXd3WVVoV2FVeHRUblppVXpsSVRGWktiR015Vm1oamJVNXZUREpLZGxsdFNuQmtRemxvV1ROU2NHSXlOWHBNTTBveENtSnVUWFpOZWtFd1RucEJORTlVWXpCTmFsbDJXVmhTTUZwWE1YZGtTRTEyVFZSQlYwSm5iM0pDWjBWRlFWbFBMMDFCUlZkQ1FXZE5RbTVDTVZsdGVIQUtXWHBCT0VKbmIzSkNaMFZGUVZsUEwwMUJSVmxDUXpSTlRFaEtiR05IT0RaU2VURlRXbGhPYkZsWVNtcGhRemxwWWpKS2FXRllVVFpqYlZadFQyNUtiQXBhYmsxMlpFZEdibU41T1RKTlF6UjRUbE0wZUUxSlIwdENaMjl5UW1kRlJVRmtXalZCWjFGRFFraDNSV1ZuUWpSQlNGbEJNMVF3ZDJGellraEZWRXBxQ2tkU05HTnRWMk16UVhGS1MxaHlhbVZRU3pNdmFEUndlV2RET0hBM2J6UkJRVUZIWm5KeVZ5dDFkMEZCUWtGTlFWSjZRa1pCYVVKaUwyNWFNR2RqWjNZS1ltdEJNRFpCUkZGTmJDdFZNVmd5ZEdZeFVsWkROSEpzVEV4WVRubHhZbmRaUVVsb1FVdExhemR2UzFWcVpEZGhlV1V4TURaNlduRlBZMmhzUVZaSVlRbzRZbU4zVUU1blp6TnliMjFGVVdSQlRVRnZSME5EY1VkVFRUUTVRa0ZOUkVFeVkwRk5SMUZEVFVOcFNXWk1TMVp1YlhCME1FVlNXWEJDUkhobVNFUkhDbG80ZDBWcU5GaEhhbXhtUzAxTWNqRjFXV2xzUVU1WGNHNDBPVUpvV0ZoemRrTXlWV05qVXpKSlFVbDNZM3BQU0VKMGVYcHViMUp4V1RKWVR6RlJVRmtLWTNKVmFrMUVOMVJvYUdSQ2RXcE1Na3N2ZUZCV1QyWTVZM1pDY21FNGFFVmFTblpGUWxjMWNsZE5kRUlLTFMwdExTMUZUa1FnUTBWU1ZFbEdTVU5CVkVVdExTMHRMUW89In1dfX0="
+            }
+          ],
+          "timestampVerificationData": {
+            "rfc3161Timestamps": []
+          }
+        },
+        "dsseEnvelope": {
+          "payload": "eyJfdHlwZSI6Imh0dHBzOi8vaW4tdG90by5pby9TdGF0ZW1lbnQvdjEiLCJzdWJqZWN0IjpbeyJuYW1lIjoicGtnOm5wbS8lNDBncmVzZWFyY2gvYm9iYml0QDAuMTUuMSIsImRpZ2VzdCI6eyJzaGE1MTIiOiJkNzEyYTc2YmE3OWFjOTllZDdjYWRkYmQ5OTQ4ODBjYjU4YmU4NjEzYmNkNGNlYzk5NGI2NmQ1ZTgxZDM5MDQ2ZjhlMDllYzEzNzgyOTFmOWEwMDI0NWM2MjczMDkwMmIxOTRiYTEyNTU5YTk1MGFmOTA5ODQyODdiNjhjNmQzYSJ9fV0sInByZWRpY2F0ZVR5cGUiOiJodHRwczovL3Nsc2EuZGV2L3Byb3ZlbmFuY2UvdjEiLCJwcmVkaWNhdGUiOnsiYnVpbGREZWZpbml0aW9uIjp7ImJ1aWxkVHlwZSI6Imh0dHBzOi8vc2xzYS1mcmFtZXdvcmsuZ2l0aHViLmlvL2dpdGh1Yi1hY3Rpb25zLWJ1aWxkdHlwZXMvd29ya2Zsb3cvdjEiLCJleHRlcm5hbFBhcmFtZXRlcnMiOnsid29ya2Zsb3ciOnsicmVmIjoicmVmcy90YWdzL3YwLjE1LjEiLCJyZXBvc2l0b3J5IjoiaHR0cHM6Ly9naXRodWIuY29tL0ctUmVzZWFyY2gvYm9iYml0IiwicGF0aCI6Ii5naXRodWIvd29ya2Zsb3dzL3JlbGVhc2UtcHVibGlzaC55bWwifX0sImludGVybmFsUGFyYW1ldGVycyI6eyJnaXRodWIiOnsiZXZlbnRfbmFtZSI6InB1c2giLCJyZXBvc2l0b3J5X2lkIjoiMTE2MDA2NTA4OSIsInJlcG9zaXRvcnlfb3duZXJfaWQiOiIyMTM0MTk2NSJ9fSwicmVzb2x2ZWREZXBlbmRlbmNpZXMiOlt7InVyaSI6ImdpdCtodHRwczovL2dpdGh1Yi5jb20vRy1SZXNlYXJjaC9ib2JiaXRAcmVmcy90YWdzL3YwLjE1LjEiLCJkaWdlc3QiOnsiZ2l0Q29tbWl0IjoiZjRmODEzN2YyMWQxZDEzZDQxYmY1MmE3ZTFmODcxZTBiYTYxNWNkYSJ9fV19LCJydW5EZXRhaWxzIjp7ImJ1aWxkZXIiOnsiaWQiOiJodHRwczovL2dpdGh1Yi5jb20vYWN0aW9ucy9ydW5uZXIvZ2l0aHViLWhvc3RlZCJ9LCJtZXRhZGF0YSI6eyJpbnZvY2F0aW9uSWQiOiJodHRwczovL2dpdGh1Yi5jb20vRy1SZXNlYXJjaC9ib2JiaXQvYWN0aW9ucy9ydW5zLzMwNDcwODk3NDI2L2F0dGVtcHRzLzEifX19fQ==",
+          "payloadType": "application/vnd.in-toto+json",
+          "signatures": [
+            {
+              "sig": "MEQCIDOtLDP2iJJfss93CUpqpQ5nPnHHwcKlBTP/g0WLKlnyAiBs9q5LhEGzrXymQhLKJyL38DawMbAeIBETLoGXrxAQsg==",
+              "keyid": ""
+            }
+          ]
+        }
+      },
+      "signedAccessSignatureUrl": ""
+    }
+  ]
+}

--- a/tests2/integration/release-validator.test.ts
+++ b/tests2/integration/release-validator.test.ts
@@ -1,0 +1,232 @@
+import assert from "node:assert/strict";
+import { readFileSync, writeFileSync } from "node:fs";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { afterEach, describe, it } from "vitest";
+import { extractProvenanceSource, RELEASE_WORKFLOW_PATH } from "../../scripts/release/release-contract.mjs";
+import { validateReleaseCommit } from "../../scripts/release/validate-release-commit.mjs";
+
+const roots: string[] = [];
+const repository = "G-Research/bobbit";
+const packageName = "@test/release";
+const previousVersion = "1.0.0";
+const version = "1.1.0";
+
+function packageFiles(root: string, packageVersion: string, changelog: string): void {
+	writeFileSync(
+		join(root, "package.json"),
+		`${JSON.stringify({ name: packageName, version: packageVersion }, null, 2)}\n`,
+	);
+	writeFileSync(
+		join(root, "package-lock.json"),
+		`${JSON.stringify(
+			{
+				name: packageName,
+				version: packageVersion,
+				lockfileVersion: 3,
+				packages: { "": { name: packageName, version: packageVersion } },
+			},
+			null,
+			2,
+		)}\n`,
+	);
+	writeFileSync(join(root, "CHANGELOG.md"), changelog);
+}
+
+type GitResult = { status: number; stdout: string; stderr: string };
+
+async function releaseRepository(): Promise<{
+	root: string;
+	sha: string;
+	runGit: (args: string[]) => GitResult;
+}> {
+	const root = await mkdtemp(join(tmpdir(), "bobbit-release-validator-"));
+	roots.push(root);
+	const sha = "a".repeat(40);
+	const previousNotes = "Previous release notes remain immutable. ".repeat(4);
+	const previousChangelog = `# Changelog\n\n## v${previousVersion}\n\n${previousNotes}\n`;
+	const currentNotes = "Reviewed release notes explain the user-visible changes clearly. ".repeat(3);
+	packageFiles(
+		root,
+		version,
+		`# Changelog\n\n## v${version}\n\n${currentNotes}\n\n## v${previousVersion}\n\n${previousNotes}\n`,
+	);
+
+	const ok = (stdout: string): GitResult => ({ status: 0, stdout, stderr: "" });
+	const runGit = (args: string[]): GitResult => {
+		if (args.join(" ") === `show ${sha}^:package.json`) {
+			return ok(`${JSON.stringify({ name: packageName, version: previousVersion })}\n`);
+		}
+		if (args.join(" ") === `rev-parse --verify ${sha}^^{commit}`) return ok(`${"b".repeat(40)}\n`);
+		if (args.join(" ") === `show ${sha}^:CHANGELOG.md`) return ok(previousChangelog);
+		return { status: 128, stdout: "", stderr: `unexpected git command: ${args.join(" ")}` };
+	};
+	return { root, sha, runGit };
+}
+
+function pullRequest(sha: string): object {
+	return {
+		number: 42,
+		merged_at: "2026-08-05T00:00:00Z",
+		merge_commit_sha: sha,
+		base: { ref: "main" },
+		head: { ref: `release/v${version}`, repo: { full_name: repository } },
+		title: `chore(release): v${version}`,
+	};
+}
+
+function provenance(sha: string): object {
+	const statement = {
+		predicate: {
+			buildDefinition: {
+				externalParameters: {
+					workflow: {
+						repository: `https://github.com/${repository}`,
+						path: RELEASE_WORKFLOW_PATH,
+					},
+				},
+				resolvedDependencies: [
+					{
+						uri: `git+https://github.com/${repository}@refs/heads/main`,
+						digest: { gitCommit: sha },
+					},
+				],
+			},
+		},
+	};
+	return {
+		attestations: [
+			{
+				predicateType: "https://slsa.dev/provenance/v1",
+				bundle: {
+					dsseEnvelope: {
+						payload: Buffer.from(JSON.stringify(statement), "utf8").toString("base64"),
+					},
+				},
+			},
+		],
+	};
+}
+
+type RegistryState = {
+	published?: boolean;
+	attestation?: object;
+	distTagVersion?: string;
+	releaseStatus?: number;
+};
+
+function responses(sha: string, state: RegistryState = {}): typeof fetch {
+	return (async input => {
+		const url = String(input);
+		let status = 200;
+		let body: object | null;
+		if (url === `https://api.github.com/repos/${repository}/commits/${sha}/pulls`) {
+			body = [pullRequest(sha)];
+		} else if (url === `https://registry.npmjs.org/%40test%2Frelease/${version}`) {
+			status = state.published ? 200 : 404;
+			body = state.published ? { name: packageName, version } : null;
+		} else if (url === "https://registry.npmjs.org/%40test%2Frelease/latest") {
+			body = { version: state.distTagVersion ?? previousVersion };
+		} else if (url === `https://registry.npmjs.org/-/npm/v1/attestations/%40test%2Frelease@${version}`) {
+			body = state.attestation ?? provenance(sha);
+		} else if (url === `https://api.github.com/repos/${repository}/releases/tags/v${version}`) {
+			status = state.releaseStatus ?? 404;
+			body = status === 200 ? { tag_name: `v${version}` } : null;
+		} else {
+			throw new Error(`unexpected request: ${url}`);
+		}
+		return new Response(body === null ? null : JSON.stringify(body), {
+			status,
+			headers: { "content-type": "application/json" },
+		});
+	}) as typeof fetch;
+}
+
+afterEach(async () => {
+	await Promise.all(roots.splice(0).map(root => rm(root, { recursive: true, force: true })));
+});
+
+describe("release validator integration", () => {
+	it("validates a complete release commit and emits the publish baseline", async () => {
+		const { root, sha, runGit } = await releaseRepository();
+		const result = await validateReleaseCommit(
+			{ mode: "merged", repository, sha },
+			{ GITHUB_TOKEN: "test-token" },
+			{ root, runGit, fetchImpl: responses(sha) },
+		);
+		assert.deepEqual(result, {
+			tag: `v${version}`,
+			version,
+			"dist-tag": "latest",
+			dist_tag_base: previousVersion,
+			"need-publish": "true",
+			"need-release": "true",
+			"pull-request": "42",
+		});
+	});
+
+	it("accepts an already-published version only with matching provenance", async () => {
+		const { root, sha, runGit } = await releaseRepository();
+		const result = await validateReleaseCommit(
+			{ mode: "merged", repository, sha },
+			{ GITHUB_TOKEN: "test-token" },
+			{
+				root,
+				runGit,
+				fetchImpl: responses(sha, {
+					published: true,
+					attestation: provenance(sha),
+					releaseStatus: 200,
+				}),
+			},
+		);
+		assert.equal(result?.["need-publish"], "false");
+		assert.equal(result?.["need-release"], "false");
+		assert.equal(result?.dist_tag_base, "");
+	});
+
+	it("parses the captured npm attestation and rejects its different source commit", async () => {
+		const fixture = JSON.parse(
+			readFileSync(
+				resolve("tests2/fixtures/release/npm-attestations-bobbit-0.15.1.json"),
+				"utf8",
+			),
+		);
+		assert.deepEqual(extractProvenanceSource(fixture), {
+			sha: "f4f8137f21d1d13d41bf52a7e1f871e0ba615cda",
+			repository: "https://github.com/G-Research/bobbit",
+			path: RELEASE_WORKFLOW_PATH,
+		});
+
+		const { root, sha, runGit } = await releaseRepository();
+		await assert.rejects(
+			validateReleaseCommit(
+				{ mode: "merged", repository, sha },
+				{ GITHUB_TOKEN: "test-token" },
+				{ root, runGit, fetchImpl: responses(sha, { published: true, attestation: fixture }) },
+			),
+			/was published from commit f4f8137f/,
+		);
+	});
+
+	it("fails closed on a stale dist-tag baseline or unexpected GitHub status", async () => {
+		const { root, sha, runGit } = await releaseRepository();
+		await assert.rejects(
+			validateReleaseCommit(
+				{ mode: "merged", repository, sha },
+				{ GITHUB_TOKEN: "test-token" },
+				{ root, runGit, fetchImpl: responses(sha, { distTagVersion: "1.2.0" }) },
+			),
+			/refusing to move latest backwards/,
+		);
+		await assert.rejects(
+			validateReleaseCommit(
+				{ mode: "merged", repository, sha },
+				{ GITHUB_TOKEN: "test-token" },
+				{ root, runGit, fetchImpl: responses(sha, { releaseStatus: 403 }) },
+			),
+			/release lookup for v1\.1\.0 returned 403/,
+		);
+	});
+});

--- a/tests2/tests-map.json
+++ b/tests2/tests-map.json
@@ -1444,6 +1444,24 @@
       }
     },
     {
+      "path": "tests2/core/release-publish-boundary-mutations.test.ts",
+      "reason": "Mutation-tests the npm publishing privilege boundary by proving checkout, dependency installation, repository scripts, workspace publication, lifecycle scripts, premature artifact download, and OIDC-enabled verification are all rejected.",
+      "execution": {
+        "runner": "vitest",
+        "tier": "unit",
+        "project": "core"
+      }
+    },
+    {
+      "path": "tests2/integration/release-validator.test.ts",
+      "reason": "Exercises the complete release validator against temporary release files plus deterministic Git and GitHub/npm responses, including unpublished releases, provenance-authorized reruns, a captured npm attestation, stale dist-tags, and unexpected API statuses.",
+      "execution": {
+        "runner": "vitest",
+        "tier": "unit",
+        "project": "integration"
+      }
+    },
+    {
       "path": "tests2/core/release-skill-preflight-order.test.ts",
       "reason": "Pins the merge-authorized release workflow, least-privilege artifact handoff, serialized dist-tag advancement, provenance-based reruns, GitHub release creation, and release contract rules for PR intent, versions, lockfile, changelog, and optional dependency pins.",
       "execution": {


### PR DESCRIPTION
Follow-up test hardening for the release pipeline merged in #1063.

## What this adds

- End-to-end invocation of `validateReleaseCommit` across temporary release files with deterministic Git, GitHub, and npm responses.
- Coverage for a new unpublished release, a provenance-authorized rerun, stale dist-tag rejection, and fail-closed GitHub API status handling.
- A captured real npm attestation fixture for `@gresearch/bobbit@0.15.1`, including the production DSSE/SLSA response shape.
- Mutation tests proving the OIDC-enabled publish job rejects checkout, dependency installation, repository scripts, workspace publication, lifecycle scripts, artifact download before the serialized state check, and OIDC authority on verification.
- Narrow dependency-injection seams for validator filesystem/Git/fetch inputs; CLI production defaults are unchanged.

## Validation

- `npm run check`
- Validator integration: 4 passed
- Publish-boundary mutations: 5 passed
- Existing release contract suite: 44 passed

Rebased onto `main` after #1063 merged; the PR now contains only this test-hardening follow-up.

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)
