### PR TITLE
Make cross-origin PATCH requests work

### DIFF
--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -43,6 +43,44 @@ obtain the weak operator cookie. Cookies have
 localhost HTTP mode. Individual cookies are not independently revocable;
 rotating the signing key invalidates all of them.
 
+### Cross-origin API preflight
+
+Every `/api/` response advertises the API's complete request-method contract:
+`GET`, `POST`, `PUT`, `PATCH`, `DELETE`, and `OPTIONS`. An `OPTIONS` preflight
+returns `204` and additionally caches that approval for 600 seconds via
+`Access-Control-Max-Age`. This lets a UI on a different origin perform every
+supported API mutation, including `PATCH`, rather than having the browser
+reject a valid request before it reaches the gateway.
+
+The preflight allows these non-simple request headers:
+
+- `Authorization`
+- `Content-Type`
+- `If-Match`
+- `X-Bobbit-Session-Id`
+- `X-Bobbit-Spawning-Session`
+- `X-Bobbit-Session-Secret`
+
+These headers are permitted so authenticated, concurrency-aware, and
+session-scoped API calls can cross origins; permission is not authentication.
+In particular, a remote UI normally authenticates with its explicit Bearer
+token. CORS is intentionally non-credentialed: the gateway does not send
+`Access-Control-Allow-Credentials`, so browsers must not rely on cross-origin
+cookie authentication. Same-origin cookie flows remain governed by their
+normal authentication rules.
+
+This does not broaden the origin policy. A gateway serving its UI reflects the
+request origin (and varies by `Origin`); a gateway not serving the UI continues
+to advertise `*`. The method and header contract is separate from that origin
+decision.
+
+For example, the side-panel workspace persists a tab edit through
+`PATCH /api/sessions/:id/side-panel-workspace/tabs/:tabId`. When the UI and
+gateway use different origins, the browser preflights that `PATCH` before the
+request. Advertising `PATCH`, `Authorization`, and any applicable session or
+concurrency header lets the persistence request reach its existing route, so a
+side-panel edit is retained instead of appearing to be forgotten after reload.
+
 ### Driving the gateway from an agent
 
 Agents should prefer the **`bobbit` tool group** over hand-rolled `curl` for

--- a/scripts/affected/impact-rules.mjs
+++ b/scripts/affected/impact-rules.mjs
@@ -221,6 +221,7 @@ export const REPOSITORY_SCAN_RULES = Object.freeze([
 			"tests2/core/gateway-nondelete-push-boundary.test.ts",
 			"tests2/core/perm-frame-late-joiner-seq-gap.test.ts",
 			"tests2/core/spawn-node-execpath-invariant.test.ts",
+			"tests2/integration/extension-host-surface-token.test.ts",
 		]),
 	},
 	{
@@ -795,6 +796,13 @@ export const DYNAMIC_EXECUTABLE_CONSUMER_AUDIT = Object.freeze([
  * second read through an existing expression an intentional review event too.
  */
 export const UNRESOLVED_REPOSITORY_READ_AUDIT = Object.freeze([
+	{
+		consumer: "tests2/integration/extension-host-surface-token.test.ts",
+		declarations: frozen(["scan:server-typescript-source-guards"]),
+		reads: frozen([
+			{ expression: "join(SERVER_DIRECTORY, file)", count: 1 },
+		]),
+	},
 	{
 		consumer: "tests2/integration/verification-restart-resignal.test.ts",
 		allowReason: "isolated integration gateway, project, or harness-owned output",

--- a/scripts/affected/impact-rules.mjs
+++ b/scripts/affected/impact-rules.mjs
@@ -800,7 +800,7 @@ export const UNRESOLVED_REPOSITORY_READ_AUDIT = Object.freeze([
 		consumer: "tests2/integration/extension-host-surface-token.test.ts",
 		declarations: frozen(["scan:server-typescript-source-guards"]),
 		reads: frozen([
-			{ expression: "join(SERVER_DIRECTORY, file)", count: 1 },
+			{ expression: "sourcePath", count: 1 },
 		]),
 	},
 	{

--- a/src/server/cors.ts
+++ b/src/server/cors.ts
@@ -1,0 +1,18 @@
+/**
+ * CORS contract for every HTTP method dispatched by the `/api/` router.
+ *
+ * Keep this list in sync with route predicates. The integration test inventories
+ * those predicates so a newly routed method cannot be omitted from preflight.
+ */
+export const API_CORS_ALLOWED_METHODS = ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"] as const;
+
+export const API_CORS_ALLOWED_HEADERS = [
+	"Authorization",
+	"Content-Type",
+	"X-Bobbit-Session-Id",
+	"X-Bobbit-Spawning-Session",
+	"X-Bobbit-Session-Secret",
+] as const;
+
+// Keep policy changes responsive while avoiding a preflight for every mutation.
+export const API_CORS_PREFLIGHT_MAX_AGE_SECONDS = 600;

--- a/src/server/cors.ts
+++ b/src/server/cors.ts
@@ -9,6 +9,7 @@ export const API_CORS_ALLOWED_METHODS = ["GET", "POST", "PUT", "PATCH", "DELETE"
 export const API_CORS_ALLOWED_HEADERS = [
 	"Authorization",
 	"Content-Type",
+	"If-Match",
 	"X-Bobbit-Session-Id",
 	"X-Bobbit-Spawning-Session",
 	"X-Bobbit-Session-Secret",

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -36,6 +36,7 @@ import { recordBootTiming, readBootTimings, BOOT_TIMING_FILE } from "./dev-boot-
 import { bootLog, bootMark, makePhaseTimer, SLOW_PHASE_MS } from "./boot-profile.js";
 import { touchGatewayRestartSentinel } from "./harness-signal.js";
 import { BOBBIT_APP_INFO } from "./app-info.js";
+import { API_CORS_ALLOWED_HEADERS, API_CORS_ALLOWED_METHODS, API_CORS_PREFLIGHT_MAX_AGE_SECONDS } from "./cors.js";
 import { isSetupComplete } from "./setup-status.js";
 export { isSetupComplete };
 import { WebSocketServer, type WebSocket } from "ws";
@@ -3583,8 +3584,9 @@ export function createGateway(config: GatewayConfig, deps?: GatewayDeps) {
 			const corsOrigin = config.staticDir ? (req.headers.origin || "*") : "*";
 			res.setHeader("Access-Control-Allow-Origin", corsOrigin);
 			if (corsOrigin !== "*") res.setHeader("Vary", "Origin");
-			res.setHeader("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS");
-			res.setHeader("Access-Control-Allow-Headers", "Authorization, Content-Type, X-Bobbit-Session-Id, X-Bobbit-Spawning-Session");
+			res.setHeader("Access-Control-Allow-Methods", API_CORS_ALLOWED_METHODS.join(", "));
+			res.setHeader("Access-Control-Allow-Headers", API_CORS_ALLOWED_HEADERS.join(", "));
+			res.setHeader("Access-Control-Max-Age", API_CORS_PREFLIGHT_MAX_AGE_SECONDS);
 
 			if (req.method === "OPTIONS") {
 				res.writeHead(204);

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -3586,9 +3586,9 @@ export function createGateway(config: GatewayConfig, deps?: GatewayDeps) {
 			if (corsOrigin !== "*") res.setHeader("Vary", "Origin");
 			res.setHeader("Access-Control-Allow-Methods", API_CORS_ALLOWED_METHODS.join(", "));
 			res.setHeader("Access-Control-Allow-Headers", API_CORS_ALLOWED_HEADERS.join(", "));
-			res.setHeader("Access-Control-Max-Age", API_CORS_PREFLIGHT_MAX_AGE_SECONDS);
 
 			if (req.method === "OPTIONS") {
+				res.setHeader("Access-Control-Max-Age", API_CORS_PREFLIGHT_MAX_AGE_SECONDS);
 				res.writeHead(204);
 				res.end();
 				return;

--- a/tests2/integration/extension-host-surface-token.test.ts
+++ b/tests2/integration/extension-host-surface-token.test.ts
@@ -1,15 +1,14 @@
-import { readFileSync } from "node:fs";
+import { readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { test, expect } from "./_e2e/in-process-harness.js";
 import { apiFetch, base, createSession, deleteSession, readE2EToken } from "./_e2e/e2e-setup.js";
 import { API_CORS_ALLOWED_HEADERS, API_CORS_ALLOWED_METHODS, API_CORS_PREFLIGHT_MAX_AGE_SECONDS } from "../../src/server/cors.js";
 
-const API_ROUTE_SOURCES = [
-	readFileSync(fileURLToPath(new URL("../../src/server/server.ts", import.meta.url)), "utf8"),
-	readFileSync(fileURLToPath(new URL("../../src/server/side-panel-workspace-routes.ts", import.meta.url)), "utf8"),
-	readFileSync(fileURLToPath(new URL("../../src/server/agent/nested-goal-routes.ts", import.meta.url)), "utf8"),
-	readFileSync(fileURLToPath(new URL("../../src/server/pr-walkthrough/routes.ts", import.meta.url)), "utf8"),
-] as const;
+const SERVER_DIRECTORY = fileURLToPath(new URL("../../src/server/", import.meta.url));
+const API_ROUTE_SOURCES = readdirSync(SERVER_DIRECTORY, { recursive: true, encoding: "utf8" })
+	.filter(file => file.endsWith(".ts") && !file.endsWith(".test.ts"))
+	.map(file => readFileSync(join(SERVER_DIRECTORY, file), "utf8"));
 
 function headerList(value: string | null): string[] {
 	return (value ?? "").split(",").map(item => item.trim()).filter(Boolean);
@@ -31,7 +30,7 @@ test("CORS preflight advertises every routed API method and required request met
 		headers: {
 			Origin: origin,
 			"Access-Control-Request-Method": "POST",
-			"Access-Control-Request-Headers": "authorization,content-type,x-bobbit-session-id,x-bobbit-session-secret",
+			"Access-Control-Request-Headers": "authorization,content-type,if-match,x-bobbit-session-id,x-bobbit-session-secret",
 		},
 	});
 	expect(res.status).toBe(204);
@@ -82,7 +81,7 @@ test("authenticated cross-origin side-panel workspace PATCH persists after its p
 			headers: {
 				Origin: origin,
 				"Access-Control-Request-Method": "PATCH",
-				"Access-Control-Request-Headers": "authorization,content-type,x-bobbit-session-id,x-bobbit-session-secret",
+				"Access-Control-Request-Headers": "authorization,content-type,if-match,x-bobbit-session-id,x-bobbit-session-secret",
 			},
 		});
 		expect(preflight.status).toBe(204);
@@ -104,6 +103,7 @@ test("authenticated cross-origin side-panel workspace PATCH persists after its p
 			}),
 		});
 		expect(patch.status).toBe(200);
+		expect(patch.headers.get("access-control-max-age")).toBeNull();
 
 		const refetched = await apiFetch(`/api/sessions/${sessionId}/side-panel-workspace`);
 		expect(refetched.status).toBe(200);
@@ -112,6 +112,32 @@ test("authenticated cross-origin side-panel workspace PATCH persists after its p
 			title: "Persisted cross-origin update",
 			state: { selectedSection: "details" },
 		});
+
+		const closePreflight = await fetch(`${base()}${tabPath}`, {
+			method: "OPTIONS",
+			headers: {
+				Origin: origin,
+				"Access-Control-Request-Method": "DELETE",
+				"Access-Control-Request-Headers": "authorization,if-match",
+			},
+		});
+		expect(closePreflight.status).toBe(204);
+		expect(headerList(closePreflight.headers.get("access-control-allow-methods")).map(method => method.toUpperCase())).toContain("DELETE");
+		expect(headerList(closePreflight.headers.get("access-control-allow-headers")).map(header => header.toLowerCase())).toContain("if-match");
+
+		const close = await fetch(`${base()}${tabPath}`, {
+			method: "DELETE",
+			headers: {
+				Origin: origin,
+				Authorization: `Bearer ${readE2EToken()}`,
+				"If-Match": `"${persisted.revision}"`,
+			},
+		});
+		expect(close.status).toBe(200);
+
+		const closedWorkspace = await apiFetch(`/api/sessions/${sessionId}/side-panel-workspace`);
+		expect(closedWorkspace.status).toBe(200);
+		expect((await closedWorkspace.json()).tabs.find((tab: any) => tab.id === tabId)).toBeUndefined();
 	} finally {
 		await deleteSession(sessionId);
 	}

--- a/tests2/integration/extension-host-surface-token.test.ts
+++ b/tests2/integration/extension-host-surface-token.test.ts
@@ -20,6 +20,30 @@ test("CORS preflight allows scoped Host API session headers", async () => {
 	}
 });
 
+test("CORS preflight authorizes PATCH for a cross-origin side-panel workspace tab update", async () => {
+	const sessionId = await createSession();
+	try {
+		const tabId = "proposal:goal";
+		const res = await fetch(`${base()}/api/sessions/${sessionId}/side-panel-workspace/tabs/${encodeURIComponent(tabId)}`, {
+			method: "OPTIONS",
+			headers: {
+				Origin: "https://remote-ui.example.test",
+				"Access-Control-Request-Method": "PATCH",
+				"Access-Control-Request-Headers": "authorization,content-type,x-bobbit-session-id",
+			},
+		});
+		expect(res.status).toBe(204);
+		const methods = (res.headers.get("access-control-allow-methods") ?? "")
+			.split(",")
+			.map(method => method.trim().toUpperCase());
+		if (!methods.includes("PATCH")) {
+			throw new Error("PATCH preflight regression: Access-Control-Allow-Methods must include PATCH for side-panel workspace tab updates");
+		}
+	} finally {
+		await deleteSession(sessionId);
+	}
+});
+
 test("POST /api/ext/surface-token denies caller-selected pack-bound identities", async () => {
 	const sessionId = await createSession();
 	try {

--- a/tests2/integration/extension-host-surface-token.test.ts
+++ b/tests2/integration/extension-host-surface-token.test.ts
@@ -1,5 +1,6 @@
-import { readFileSync } from "node:fs";
-import { dirname, resolve } from "node:path";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import ts from "typescript";
 import { test, expect } from "./_e2e/in-process-harness.js";
@@ -9,6 +10,17 @@ import { API_CORS_ALLOWED_HEADERS, API_CORS_ALLOWED_METHODS, API_CORS_PREFLIGHT_
 const SERVER_FILE = fileURLToPath(new URL("../../src/server/server.ts", import.meta.url));
 
 type RouteHandler = { sourceFile: string; name: string };
+type ImportedHandler = { modulePath: string; exportedName: string };
+
+const NON_ROUTE_REQ_CALLEES = new Set([
+	"cookieTryAuth",
+	"headerValue",
+	"isArray",
+	"proxyRequest",
+	"readBody",
+	"revisionFromRequest",
+	"verifyCallerSession",
+]);
 
 function sourceFile(sourcePath: string): ts.SourceFile {
 	return ts.createSourceFile(sourcePath, readFileSync(sourcePath, "utf8"), ts.ScriptTarget.Latest, true);
@@ -16,19 +28,23 @@ function sourceFile(sourcePath: string): ts.SourceFile {
 
 function namedFunction(source: ts.SourceFile, name: string): ts.FunctionLikeDeclarationBase {
 	let found: ts.FunctionLikeDeclarationBase | undefined;
-	const find = (node: ts.Node): void => {
-		if (ts.isFunctionDeclaration(node) && node.name?.text === name) found = node;
-		ts.forEachChild(node, find);
+	const find = (node: ts.Node): boolean => {
+		if (ts.isFunctionDeclaration(node) && node.name?.text === name) {
+			found = node;
+			return true;
+		}
+		return ts.forEachChild(node, find) ?? false;
 	};
 	find(source);
-	if (!found?.body) throw new Error(`API route handler ${name} was not found in ${source.fileName}`);
+	if (!found) throw new Error(`API route handler ${name} was not found in ${source.fileName}`);
+	if (!found.body) throw new Error(`API route handler ${name} has no body in ${source.fileName}`);
 	return found;
 }
 
 function apiBoundaryMethods(): string[] {
 	const source = sourceFile(SERVER_FILE);
 	let apiBranch: ts.Statement | undefined;
-	const findApiBranch = (node: ts.Node): void => {
+	const findApiBranch = (node: ts.Node): boolean => {
 		if (ts.isIfStatement(node) && ts.isCallExpression(node.expression)
 			&& ts.isPropertyAccessExpression(node.expression.expression)
 			&& node.expression.expression.name.text === "startsWith"
@@ -38,59 +54,91 @@ function apiBoundaryMethods(): string[] {
 			&& node.expression.expression.expression.name.text === "pathname"
 			&& node.expression.arguments.some(argument => ts.isStringLiteral(argument) && argument.text === "/api/")) {
 			apiBranch = node.thenStatement;
-			return;
+			return true;
 		}
-		ts.forEachChild(node, findApiBranch);
+		return ts.forEachChild(node, findApiBranch) ?? false;
 	};
 	findApiBranch(source);
 	if (!apiBranch) throw new Error("The /api/ router boundary was not found in server.ts");
 
-	const methods = new Set<string>();
-	const add = (node: ts.Expression): void => {
-		if (!ts.isStringLiteral(node) || !/^[A-Z]+$/.test(node.text)) {
-			throw new Error("The /api/ router boundary must use uppercase method literals");
-		}
-		methods.add(node.text);
-	};
-	const visit = (node: ts.Node): void => {
-		if (ts.isBinaryExpression(node) && [
-			ts.SyntaxKind.EqualsEqualsToken,
-			ts.SyntaxKind.EqualsEqualsEqualsToken,
-			ts.SyntaxKind.ExclamationEqualsToken,
-			ts.SyntaxKind.ExclamationEqualsEqualsToken,
-		].includes(node.operatorToken.kind)) {
-			if (isReqMethod(node.left, new Set())) add(node.right);
-			if (isReqMethod(node.right, new Set())) add(node.left);
-		}
-		if (ts.isSwitchStatement(node) && isReqMethod(node.expression, new Set())) {
-			for (const clause of node.caseBlock.clauses) if (ts.isCaseClause(clause)) add(clause.expression);
-		}
-		ts.forEachChild(node, visit);
-	};
-	visit(apiBranch);
-	return [...methods];
+	return methodLiterals(apiBranch, {
+		allowNonDispatchReqMethod: (node) => {
+			const parent = node.parent;
+			return (ts.isCallExpression(parent) && parent.arguments.includes(node)
+				&& ts.isIdentifier(parent.expression) && parent.expression.text === "normalizeApiRouteLabel")
+				|| (ts.isPropertyAssignment(parent) && parent.initializer === node)
+				|| (ts.isBinaryExpression(parent) && parent.left === node && parent.operatorToken.kind === ts.SyntaxKind.BarBarToken)
+				|| ts.isTemplateSpan(parent);
+		},
+	});
+}
+
+function calleeName(expression: ts.LeftHandSideExpression): string | undefined {
+	if (ts.isIdentifier(expression)) return expression.text;
+	if (ts.isPropertyAccessExpression(expression)) return expression.name.text;
+	return undefined;
+}
+
+function callReceivesReq(call: ts.CallExpression): boolean {
+	return call.arguments.some((argument) => {
+		if (ts.isIdentifier(argument) && argument.text === "req") return true;
+		if (!ts.isObjectLiteralExpression(argument)) return false;
+		return argument.properties.some((property) => {
+			if (ts.isShorthandPropertyAssignment(property)) return property.name.text === "req";
+			return ts.isPropertyAssignment(property)
+				&& (ts.isIdentifier(property.name) || ts.isStringLiteral(property.name))
+				&& property.name.text === "req"
+				&& ts.isIdentifier(property.initializer) && property.initializer.text === "req";
+		});
+	});
+}
+
+function resolveImportedHandler(sourcePath: string, delegateName: string, modulePath: string): string {
+	if (!modulePath.startsWith(".")) {
+		throw new Error(`API route delegate ${delegateName} must use a relative named import, received ${modulePath}`);
+	}
+	const pathWithoutExtension = modulePath.replace(/\.(?:[cm]?js|ts)$/, "");
+	const candidates = [
+		resolve(dirname(sourcePath), `${pathWithoutExtension}.ts`),
+		resolve(dirname(sourcePath), pathWithoutExtension, "index.ts"),
+	];
+	const resolved = candidates.find(existsSync);
+	if (!resolved) {
+		throw new Error(`API route delegate ${delegateName} import ${modulePath} did not resolve to a .ts file or index.ts`);
+	}
+	return resolved;
 }
 
 function importedRouteHandlers(source: ts.SourceFile, body: ts.Node, sourcePath: string): RouteHandler[] {
-	const imports = new Map<string, string>();
+	const imports = new Map<string, ImportedHandler>();
 	for (const statement of source.statements) {
 		if (!ts.isImportDeclaration(statement) || !ts.isStringLiteral(statement.moduleSpecifier)) continue;
 		const bindings = statement.importClause?.namedBindings;
 		if (!bindings || !ts.isNamedImports(bindings)) continue;
-		for (const binding of bindings.elements) imports.set(binding.name.text, statement.moduleSpecifier.text);
+		for (const binding of bindings.elements) {
+			imports.set(binding.name.text, {
+				modulePath: statement.moduleSpecifier.text,
+				exportedName: binding.propertyName?.text ?? binding.name.text,
+			});
+		}
 	}
 
 	const handlers: RouteHandler[] = [];
 	const find = (node: ts.Node): void => {
-		if (ts.isCallExpression(node) && ts.isIdentifier(node.expression)
-			&& /^(?:handle|tryHandle).*(?:Route|Request)$/.test(node.expression.text)
-			&& node.arguments.some(argument => ts.isIdentifier(argument) && argument.text === "req")) {
-			const modulePath = imports.get(node.expression.text);
-			if (!modulePath) throw new Error(`API route delegate ${node.expression.text} must be an imported handler`);
-			handlers.push({
-				name: node.expression.text,
-				sourceFile: resolve(dirname(sourcePath), modulePath.replace(/\.js$/, ".ts")),
-			});
+		if (ts.isCallExpression(node) && callReceivesReq(node)) {
+			const delegateName = calleeName(node.expression);
+			if (delegateName && NON_ROUTE_REQ_CALLEES.has(delegateName)) {
+				// Verified request helpers are not API route delegates.
+			} else {
+				const imported = delegateName ? imports.get(delegateName) : undefined;
+				if (!imported) {
+					throw new Error(`API route delegate ${delegateName ?? "<computed>"} must be an imported handler or allowlisted as non-routing`);
+				}
+				handlers.push({
+					name: imported.exportedName,
+					sourceFile: resolveImportedHandler(sourcePath, delegateName!, imported.modulePath),
+				});
+			}
 		}
 		ts.forEachChild(node, find);
 	};
@@ -103,7 +151,11 @@ function isReqMethod(node: ts.Expression, aliases: ReadonlySet<string>): boolean
 		|| (ts.isIdentifier(node) && aliases.has(node.text));
 }
 
-function methodLiterals(body: ts.Node): string[] {
+type MethodLiteralOptions = {
+	allowNonDispatchReqMethod?: (node: ts.PropertyAccessExpression) => boolean;
+};
+
+function methodLiterals(body: ts.Node, options: MethodLiteralOptions = {}): string[] {
 	const aliases = new Set<string>();
 	const objectLiterals = new Map<string, ts.ObjectLiteralExpression>();
 	const methods = new Set<string>();
@@ -113,11 +165,17 @@ function methodLiterals(body: ts.Node): string[] {
 		ts.SyntaxKind.ExclamationEqualsToken,
 		ts.SyntaxKind.ExclamationEqualsEqualsToken,
 	]);
-	const addMethod = (node: ts.Expression): void => {
-		if (!ts.isStringLiteral(node) || !/^[A-Z]+$/.test(node.text)) {
+	const addMethodName = (name: string): void => {
+		if (!/^[A-Z]+$/.test(name)) {
 			throw new Error(`API method dispatch must use an uppercase string literal in ${body.getSourceFile().fileName}`);
 		}
-		methods.add(node.text);
+		methods.add(name);
+	};
+	const addMethod = (node: ts.Expression): void => {
+		if (!ts.isStringLiteral(node)) {
+			throw new Error(`API method dispatch must use an uppercase string literal in ${body.getSourceFile().fileName}`);
+		}
+		addMethodName(node.text);
 	};
 	const lookupMethods = (target: ts.Expression): void => {
 		const map = ts.isObjectLiteralExpression(target)
@@ -131,19 +189,23 @@ function methodLiterals(body: ts.Node): string[] {
 			if (!property.name || !ts.isIdentifier(property.name) && !ts.isStringLiteral(property.name)) {
 				throw new Error(`API method lookup must use named method keys in ${body.getSourceFile().fileName}`);
 			}
-			addMethod(ts.isIdentifier(property.name)
-				? ts.factory.createStringLiteral(property.name.text)
-				: property.name);
+			addMethodName(property.name.text);
 		}
 	};
 	const visit = (node: ts.Node): void => {
 		if (ts.isPropertyAccessExpression(node) && ts.isIdentifier(node.expression) && node.expression.text === "req" && node.name.text === "method") {
 			const parent = node.parent;
 			const supported = (ts.isVariableDeclaration(parent) && parent.initializer === node)
-				|| (ts.isBinaryExpression(parent) && (parent.left === node || parent.right === node))
+				|| (ts.isBinaryExpression(parent) && comparisonOperators.has(parent.operatorToken.kind)
+					&& (parent.left === node || parent.right === node))
 				|| (ts.isSwitchStatement(parent) && parent.expression === node)
-				|| (ts.isElementAccessExpression(parent) && parent.argumentExpression === node);
-			if (!supported) throw new Error(`Unsupported API method dispatch in ${body.getSourceFile().fileName}`);
+				|| (ts.isElementAccessExpression(parent) && parent.argumentExpression === node)
+				|| (ts.isPropertyAssignment(parent) && parent.initializer === node)
+				|| ts.isTemplateSpan(parent)
+				|| options.allowNonDispatchReqMethod?.(node) === true;
+			if (!supported) {
+				throw new Error(`req.method appears in an unrecognized position in ${body.getSourceFile().fileName}; extract it to a local alias or extend the inventory`);
+			}
 		}
 		if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name) && node.initializer) {
 			if (isReqMethod(node.initializer, aliases)) aliases.add(node.name.text);
@@ -167,9 +229,12 @@ function methodLiterals(body: ts.Node): string[] {
 	return [...methods].sort();
 }
 
-function routedApiMethods(): string[] {
-	const handlers = [{ sourceFile: SERVER_FILE, name: "handleApiRoute" }];
-	const methods = new Set<string>(apiBoundaryMethods());
+function routedApiMethods(
+	rootHandler: RouteHandler = { sourceFile: SERVER_FILE, name: "handleApiRoute" },
+	boundaryMethods: readonly string[] = apiBoundaryMethods(),
+): string[] {
+	const handlers = [rootHandler];
+	const methods = new Set<string>(boundaryMethods);
 	const visited = new Set<string>();
 	for (let index = 0; index < handlers.length; index++) {
 		const handler = handlers[index]!;
@@ -187,6 +252,60 @@ function routedApiMethods(): string[] {
 function headerList(value: string | null): string[] {
 	return (value ?? "").split(",").map(item => item.trim()).filter(Boolean);
 }
+
+function fixtureSource(fileName: string, text: string): ts.SourceFile {
+	return ts.createSourceFile(fileName, text, ts.ScriptTarget.Latest, true);
+}
+
+test("CORS inventory rejects untracked req-receiving calls", () => {
+	for (const [label, call] of [
+		["direct", "untracked(req)"],
+		["object property", "untracked({ req: req })"],
+		["object shorthand", "untracked({ req })"],
+	] as const) {
+		const source = fixtureSource(`${label}.ts`, `function handleApiRoute(req: unknown) { ${call}; }`);
+		expect(() => importedRouteHandlers(source, namedFunction(source, "handleApiRoute").body!, source.fileName))
+			.toThrow("API route delegate untracked must be an imported handler or allowlisted as non-routing");
+	}
+
+	const source = fixtureSource("bare-import.ts", `
+		import { delegated } from "non-relative-package";
+		function handleApiRoute(req: unknown) { delegated(req); }
+	`);
+	expect(() => importedRouteHandlers(source, namedFunction(source, "handleApiRoute").body!, source.fileName))
+		.toThrow("API route delegate delegated must use a relative named import, received non-relative-package");
+});
+
+test("CORS inventory includes methods from imported req-receiving delegates", () => {
+	const fixtureDirectory = mkdtempSync(join(tmpdir(), "bobbit-cors-route-inventory-"));
+	const rootPath = join(fixtureDirectory, "root.ts");
+	try {
+		writeFileSync(rootPath, `
+			import { handleFutureRoutes } from "./delegate.js";
+			import { handleIndexedRoutes } from "./nested";
+			function handleApiRoute(req: unknown) {
+				handleFutureRoutes({ req });
+				return handleIndexedRoutes(req);
+			}
+		`);
+		writeFileSync(join(fixtureDirectory, "delegate.ts"), `
+			export function handleFutureRoutes({ req }: { req: { method: string } }) {
+				return req.method === "HEAD";
+			}
+		`);
+		mkdirSync(join(fixtureDirectory, "nested"));
+		writeFileSync(join(fixtureDirectory, "nested", "index.ts"), `
+			export function handleIndexedRoutes(req: { method: string }) {
+				return req.method === "CONNECT";
+			}
+		`);
+
+		expect(API_CORS_ALLOWED_METHODS).not.toContain("HEAD");
+		expect(routedApiMethods({ sourceFile: rootPath, name: "handleApiRoute" }, [])).toEqual(["CONNECT", "HEAD"]);
+	} finally {
+		rmSync(fixtureDirectory, { recursive: true, force: true });
+	}
+});
 
 test("CORS preflight advertises every routed API method and required request metadata", async () => {
 	const origin = "http://127.0.0.1:5173";

--- a/tests2/integration/extension-host-surface-token.test.ts
+++ b/tests2/integration/extension-host-surface-token.test.ts
@@ -1,44 +1,117 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 import { test, expect } from "./_e2e/in-process-harness.js";
-import { apiFetch, base, createSession, deleteSession } from "./_e2e/e2e-setup.js";
+import { apiFetch, base, createSession, deleteSession, readE2EToken } from "./_e2e/e2e-setup.js";
+import { API_CORS_ALLOWED_HEADERS, API_CORS_ALLOWED_METHODS, API_CORS_PREFLIGHT_MAX_AGE_SECONDS } from "../../src/server/cors.js";
 
-test("CORS preflight allows scoped Host API session headers", async () => {
+const API_ROUTE_SOURCES = [
+	readFileSync(fileURLToPath(new URL("../../src/server/server.ts", import.meta.url)), "utf8"),
+	readFileSync(fileURLToPath(new URL("../../src/server/side-panel-workspace-routes.ts", import.meta.url)), "utf8"),
+	readFileSync(fileURLToPath(new URL("../../src/server/agent/nested-goal-routes.ts", import.meta.url)), "utf8"),
+	readFileSync(fileURLToPath(new URL("../../src/server/pr-walkthrough/routes.ts", import.meta.url)), "utf8"),
+] as const;
+
+function headerList(value: string | null): string[] {
+	return (value ?? "").split(",").map(item => item.trim()).filter(Boolean);
+}
+
+function routedMethodLiterals(): string[] {
+	const methods = new Set<string>();
+	const predicate = /req\.method\s*(?:===|!==)\s*["']([A-Z]+)["']|["']([A-Z]+)["']\s*(?:===|!==)\s*req\.method/g;
+	for (const source of API_ROUTE_SOURCES) {
+		for (const match of source.matchAll(predicate)) methods.add(match[1] ?? match[2]);
+	}
+	return [...methods].sort();
+}
+
+test("CORS preflight advertises every routed API method and required request metadata", async () => {
+	const origin = "http://127.0.0.1:5173";
 	const res = await fetch(`${base()}/api/ext/route/run`, {
 		method: "OPTIONS",
 		headers: {
-			Origin: "http://127.0.0.1:5173",
+			Origin: origin,
 			"Access-Control-Request-Method": "POST",
-			"Access-Control-Request-Headers": "authorization,content-type,x-bobbit-session-id",
+			"Access-Control-Request-Headers": "authorization,content-type,x-bobbit-session-id,x-bobbit-session-secret",
 		},
 	});
 	expect(res.status).toBe(204);
-	const allowed = res.headers.get("access-control-allow-headers")?.toLowerCase() ?? "";
-	expect(allowed).toContain("authorization");
-	expect(allowed).toContain("content-type");
-	expect(allowed).toContain("x-bobbit-session-id");
-	if (res.headers.get("access-control-allow-origin") !== "*") {
+	expect(headerList(res.headers.get("access-control-allow-methods")).map(method => method.toUpperCase()))
+		.toEqual([...API_CORS_ALLOWED_METHODS]);
+	expect(routedMethodLiterals()).toEqual([...API_CORS_ALLOWED_METHODS].sort());
+	expect(headerList(res.headers.get("access-control-allow-headers")).map(header => header.toLowerCase()).sort())
+		.toEqual([...API_CORS_ALLOWED_HEADERS].map(header => header.toLowerCase()).sort());
+	expect(Number(res.headers.get("access-control-max-age"))).toBe(API_CORS_PREFLIGHT_MAX_AGE_SECONDS);
+	expect(API_CORS_PREFLIGHT_MAX_AGE_SECONDS).toBeGreaterThan(0);
+	expect(API_CORS_PREFLIGHT_MAX_AGE_SECONDS).toBeLessThanOrEqual(86_400);
+	expect(res.headers.get("access-control-allow-credentials")).toBeNull();
+
+	// Preserve the existing wildcard/reflection decision and pair Vary only with reflection.
+	const allowedOrigin = res.headers.get("access-control-allow-origin");
+	if (allowedOrigin === "*") {
+		expect(res.headers.get("vary")?.toLowerCase() ?? "").not.toContain("origin");
+	} else {
+		expect(allowedOrigin).toBe(origin);
 		expect(res.headers.get("vary")?.toLowerCase()).toContain("origin");
 	}
 });
 
-test("CORS preflight authorizes PATCH for a cross-origin side-panel workspace tab update", async () => {
+test("authenticated cross-origin side-panel workspace PATCH persists after its preflight", async () => {
 	const sessionId = await createSession();
 	try {
 		const tabId = "proposal:goal";
-		const res = await fetch(`${base()}/api/sessions/${sessionId}/side-panel-workspace/tabs/${encodeURIComponent(tabId)}`, {
+		const tabPath = `/api/sessions/${sessionId}/side-panel-workspace/tabs/${encodeURIComponent(tabId)}`;
+		const opened = await apiFetch(`/api/sessions/${sessionId}/side-panel-workspace/open`, {
+			method: "POST",
+			body: JSON.stringify({
+				tab: {
+					id: tabId,
+					kind: "proposal",
+					title: "Goal Proposal",
+					label: "Goal",
+					source: { type: "proposal", sessionId, proposalType: "goal" },
+					updatedAt: 1,
+				},
+			}),
+		});
+		expect(opened.status).toBe(200);
+		const workspace = await opened.json();
+
+		const origin = "https://remote-ui.example.test";
+		const preflight = await fetch(`${base()}${tabPath}`, {
 			method: "OPTIONS",
 			headers: {
-				Origin: "https://remote-ui.example.test",
+				Origin: origin,
 				"Access-Control-Request-Method": "PATCH",
-				"Access-Control-Request-Headers": "authorization,content-type,x-bobbit-session-id",
+				"Access-Control-Request-Headers": "authorization,content-type,x-bobbit-session-id,x-bobbit-session-secret",
 			},
 		});
-		expect(res.status).toBe(204);
-		const methods = (res.headers.get("access-control-allow-methods") ?? "")
-			.split(",")
-			.map(method => method.trim().toUpperCase());
-		if (!methods.includes("PATCH")) {
-			throw new Error("PATCH preflight regression: Access-Control-Allow-Methods must include PATCH for side-panel workspace tab updates");
-		}
+		expect(preflight.status).toBe(204);
+		expect(headerList(preflight.headers.get("access-control-allow-methods")).map(method => method.toUpperCase())).toContain("PATCH");
+
+		const patch = await fetch(`${base()}${tabPath}`, {
+			method: "PATCH",
+			headers: {
+				Origin: origin,
+				Authorization: `Bearer ${readE2EToken()}`,
+				"Content-Type": "application/json",
+			},
+			body: JSON.stringify({
+				baseRevision: workspace.revision,
+				patch: {
+					title: "Persisted cross-origin update",
+					state: { selectedSection: "details" },
+				},
+			}),
+		});
+		expect(patch.status).toBe(200);
+
+		const refetched = await apiFetch(`/api/sessions/${sessionId}/side-panel-workspace`);
+		expect(refetched.status).toBe(200);
+		const persisted = await refetched.json();
+		expect(persisted.tabs.find((tab: any) => tab.id === tabId)).toMatchObject({
+			title: "Persisted cross-origin update",
+			state: { selectedSection: "details" },
+		});
 	} finally {
 		await deleteSession(sessionId);
 	}

--- a/tests2/integration/extension-host-surface-token.test.ts
+++ b/tests2/integration/extension-host-surface-token.test.ts
@@ -1,26 +1,191 @@
-import { readFileSync, readdirSync } from "node:fs";
-import { join } from "node:path";
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import ts from "typescript";
 import { test, expect } from "./_e2e/in-process-harness.js";
 import { apiFetch, base, createSession, deleteSession, readE2EToken } from "./_e2e/e2e-setup.js";
 import { API_CORS_ALLOWED_HEADERS, API_CORS_ALLOWED_METHODS, API_CORS_PREFLIGHT_MAX_AGE_SECONDS } from "../../src/server/cors.js";
 
-const SERVER_DIRECTORY = fileURLToPath(new URL("../../src/server/", import.meta.url));
-const API_ROUTE_SOURCES = readdirSync(SERVER_DIRECTORY, { recursive: true, encoding: "utf8" })
-	.filter(file => file.endsWith(".ts") && !file.endsWith(".test.ts"))
-	.map(file => readFileSync(join(SERVER_DIRECTORY, file), "utf8"));
+const SERVER_FILE = fileURLToPath(new URL("../../src/server/server.ts", import.meta.url));
+
+type RouteHandler = { sourceFile: string; name: string };
+
+function sourceFile(sourcePath: string): ts.SourceFile {
+	return ts.createSourceFile(sourcePath, readFileSync(sourcePath, "utf8"), ts.ScriptTarget.Latest, true);
+}
+
+function namedFunction(source: ts.SourceFile, name: string): ts.FunctionLikeDeclarationBase {
+	let found: ts.FunctionLikeDeclarationBase | undefined;
+	const find = (node: ts.Node): void => {
+		if (ts.isFunctionDeclaration(node) && node.name?.text === name) found = node;
+		ts.forEachChild(node, find);
+	};
+	find(source);
+	if (!found?.body) throw new Error(`API route handler ${name} was not found in ${source.fileName}`);
+	return found;
+}
+
+function apiBoundaryMethods(): string[] {
+	const source = sourceFile(SERVER_FILE);
+	let apiBranch: ts.Statement | undefined;
+	const findApiBranch = (node: ts.Node): void => {
+		if (ts.isIfStatement(node) && ts.isCallExpression(node.expression)
+			&& ts.isPropertyAccessExpression(node.expression.expression)
+			&& node.expression.expression.name.text === "startsWith"
+			&& ts.isPropertyAccessExpression(node.expression.expression.expression)
+			&& ts.isIdentifier(node.expression.expression.expression.expression)
+			&& node.expression.expression.expression.expression.text === "url"
+			&& node.expression.expression.expression.name.text === "pathname"
+			&& node.expression.arguments.some(argument => ts.isStringLiteral(argument) && argument.text === "/api/")) {
+			apiBranch = node.thenStatement;
+			return;
+		}
+		ts.forEachChild(node, findApiBranch);
+	};
+	findApiBranch(source);
+	if (!apiBranch) throw new Error("The /api/ router boundary was not found in server.ts");
+
+	const methods = new Set<string>();
+	const add = (node: ts.Expression): void => {
+		if (!ts.isStringLiteral(node) || !/^[A-Z]+$/.test(node.text)) {
+			throw new Error("The /api/ router boundary must use uppercase method literals");
+		}
+		methods.add(node.text);
+	};
+	const visit = (node: ts.Node): void => {
+		if (ts.isBinaryExpression(node) && [
+			ts.SyntaxKind.EqualsEqualsToken,
+			ts.SyntaxKind.EqualsEqualsEqualsToken,
+			ts.SyntaxKind.ExclamationEqualsToken,
+			ts.SyntaxKind.ExclamationEqualsEqualsToken,
+		].includes(node.operatorToken.kind)) {
+			if (isReqMethod(node.left, new Set())) add(node.right);
+			if (isReqMethod(node.right, new Set())) add(node.left);
+		}
+		if (ts.isSwitchStatement(node) && isReqMethod(node.expression, new Set())) {
+			for (const clause of node.caseBlock.clauses) if (ts.isCaseClause(clause)) add(clause.expression);
+		}
+		ts.forEachChild(node, visit);
+	};
+	visit(apiBranch);
+	return [...methods];
+}
+
+function importedRouteHandlers(source: ts.SourceFile, body: ts.Node, sourcePath: string): RouteHandler[] {
+	const imports = new Map<string, string>();
+	for (const statement of source.statements) {
+		if (!ts.isImportDeclaration(statement) || !ts.isStringLiteral(statement.moduleSpecifier)) continue;
+		const bindings = statement.importClause?.namedBindings;
+		if (!bindings || !ts.isNamedImports(bindings)) continue;
+		for (const binding of bindings.elements) imports.set(binding.name.text, statement.moduleSpecifier.text);
+	}
+
+	const handlers: RouteHandler[] = [];
+	const find = (node: ts.Node): void => {
+		if (ts.isCallExpression(node) && ts.isIdentifier(node.expression)
+			&& /^(?:handle|tryHandle).*(?:Route|Request)$/.test(node.expression.text)
+			&& node.arguments.some(argument => ts.isIdentifier(argument) && argument.text === "req")) {
+			const modulePath = imports.get(node.expression.text);
+			if (!modulePath) throw new Error(`API route delegate ${node.expression.text} must be an imported handler`);
+			handlers.push({
+				name: node.expression.text,
+				sourceFile: resolve(dirname(sourcePath), modulePath.replace(/\.js$/, ".ts")),
+			});
+		}
+		ts.forEachChild(node, find);
+	};
+	find(body);
+	return handlers;
+}
+
+function isReqMethod(node: ts.Expression, aliases: ReadonlySet<string>): boolean {
+	return (ts.isPropertyAccessExpression(node) && ts.isIdentifier(node.expression) && node.expression.text === "req" && node.name.text === "method")
+		|| (ts.isIdentifier(node) && aliases.has(node.text));
+}
+
+function methodLiterals(body: ts.Node): string[] {
+	const aliases = new Set<string>();
+	const objectLiterals = new Map<string, ts.ObjectLiteralExpression>();
+	const methods = new Set<string>();
+	const comparisonOperators = new Set([
+		ts.SyntaxKind.EqualsEqualsToken,
+		ts.SyntaxKind.EqualsEqualsEqualsToken,
+		ts.SyntaxKind.ExclamationEqualsToken,
+		ts.SyntaxKind.ExclamationEqualsEqualsToken,
+	]);
+	const addMethod = (node: ts.Expression): void => {
+		if (!ts.isStringLiteral(node) || !/^[A-Z]+$/.test(node.text)) {
+			throw new Error(`API method dispatch must use an uppercase string literal in ${body.getSourceFile().fileName}`);
+		}
+		methods.add(node.text);
+	};
+	const lookupMethods = (target: ts.Expression): void => {
+		const map = ts.isObjectLiteralExpression(target)
+			? target
+			: ts.isIdentifier(target) ? objectLiterals.get(target.text) : undefined;
+		if (!map) throw new Error(`API method lookup must use a local object literal in ${body.getSourceFile().fileName}`);
+		for (const property of map.properties) {
+			if (!ts.isPropertyAssignment(property) && !ts.isMethodDeclaration(property)) {
+				throw new Error(`API method lookup has an unsupported property in ${body.getSourceFile().fileName}`);
+			}
+			if (!property.name || !ts.isIdentifier(property.name) && !ts.isStringLiteral(property.name)) {
+				throw new Error(`API method lookup must use named method keys in ${body.getSourceFile().fileName}`);
+			}
+			addMethod(ts.isIdentifier(property.name)
+				? ts.factory.createStringLiteral(property.name.text)
+				: property.name);
+		}
+	};
+	const visit = (node: ts.Node): void => {
+		if (ts.isPropertyAccessExpression(node) && ts.isIdentifier(node.expression) && node.expression.text === "req" && node.name.text === "method") {
+			const parent = node.parent;
+			const supported = (ts.isVariableDeclaration(parent) && parent.initializer === node)
+				|| (ts.isBinaryExpression(parent) && (parent.left === node || parent.right === node))
+				|| (ts.isSwitchStatement(parent) && parent.expression === node)
+				|| (ts.isElementAccessExpression(parent) && parent.argumentExpression === node);
+			if (!supported) throw new Error(`Unsupported API method dispatch in ${body.getSourceFile().fileName}`);
+		}
+		if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name) && node.initializer) {
+			if (isReqMethod(node.initializer, aliases)) aliases.add(node.name.text);
+			if (ts.isObjectLiteralExpression(node.initializer)) objectLiterals.set(node.name.text, node.initializer);
+		}
+		if (ts.isBinaryExpression(node) && comparisonOperators.has(node.operatorToken.kind)) {
+			if (isReqMethod(node.left, aliases)) addMethod(node.right);
+			if (isReqMethod(node.right, aliases)) addMethod(node.left);
+		}
+		if (ts.isSwitchStatement(node) && isReqMethod(node.expression, aliases)) {
+			for (const clause of node.caseBlock.clauses) {
+				if (ts.isCaseClause(clause)) addMethod(clause.expression);
+			}
+		}
+		if (ts.isElementAccessExpression(node) && node.argumentExpression && isReqMethod(node.argumentExpression, aliases)) {
+			lookupMethods(node.expression);
+		}
+		ts.forEachChild(node, visit);
+	};
+	visit(body);
+	return [...methods].sort();
+}
+
+function routedApiMethods(): string[] {
+	const handlers = [{ sourceFile: SERVER_FILE, name: "handleApiRoute" }];
+	const methods = new Set<string>(apiBoundaryMethods());
+	const visited = new Set<string>();
+	for (let index = 0; index < handlers.length; index++) {
+		const handler = handlers[index]!;
+		const key = `${handler.sourceFile}:${handler.name}`;
+		if (visited.has(key)) continue;
+		visited.add(key);
+		const source = sourceFile(handler.sourceFile);
+		const route = namedFunction(source, handler.name);
+		for (const method of methodLiterals(route.body!)) methods.add(method);
+		handlers.push(...importedRouteHandlers(source, route.body!, handler.sourceFile));
+	}
+	return [...methods].sort();
+}
 
 function headerList(value: string | null): string[] {
 	return (value ?? "").split(",").map(item => item.trim()).filter(Boolean);
-}
-
-function routedMethodLiterals(): string[] {
-	const methods = new Set<string>();
-	const predicate = /req\.method\s*(?:===|!==)\s*["']([A-Z]+)["']|["']([A-Z]+)["']\s*(?:===|!==)\s*req\.method/g;
-	for (const source of API_ROUTE_SOURCES) {
-		for (const match of source.matchAll(predicate)) methods.add(match[1] ?? match[2]);
-	}
-	return [...methods].sort();
 }
 
 test("CORS preflight advertises every routed API method and required request metadata", async () => {
@@ -36,7 +201,7 @@ test("CORS preflight advertises every routed API method and required request met
 	expect(res.status).toBe(204);
 	expect(headerList(res.headers.get("access-control-allow-methods")).map(method => method.toUpperCase()))
 		.toEqual([...API_CORS_ALLOWED_METHODS]);
-	expect(routedMethodLiterals()).toEqual([...API_CORS_ALLOWED_METHODS].sort());
+	expect(routedApiMethods()).toEqual([...API_CORS_ALLOWED_METHODS].sort());
 	expect(headerList(res.headers.get("access-control-allow-headers")).map(header => header.toLowerCase()).sort())
 		.toEqual([...API_CORS_ALLOWED_HEADERS].map(header => header.toLowerCase()).sort());
 	expect(Number(res.headers.get("access-control-max-age"))).toBe(API_CORS_PREFLIGHT_MAX_AGE_SECONDS);


### PR DESCRIPTION
## Why this work exists

When the Bobbit UI and gateway run on different origins — for example, a remote gateway, a reverse proxy on another host, or a development UI connected to a separate gateway — the browser asks the gateway for permission before sending some requests.

The gateway did not list `PATCH` as an allowed method. The browser therefore blocked every cross-origin `PATCH` before it reached Bobbit, even though Bobbit has valid `PATCH` endpoints.

## User story and impact

A user changes state in the side panel while connected to a remote gateway. The change appears locally, but after a reload the panel forgets it because the browser prevented the save request from reaching the gateway.

This PR makes those saves work. It also enables other existing `PATCH` features to work when the UI and gateway are on different origins.

## What changed

- Preflight responses now advertise every method the API currently serves: `GET`, `POST`, `PUT`, `PATCH`, `DELETE`, and `OPTIONS`.
- Required request headers are allowed, including `Authorization`, `If-Match`, and `X-Bobbit-Session-Secret`.
- Browsers may cache a successful preflight for 10 minutes, reducing repeated `OPTIONS` requests.
- Cross-origin cookies remain disabled. Remote gateways continue to use explicit Bearer authentication.
- The existing origin policy is unchanged; this PR does not grant access to any new origins.

## Developer impact

The CORS values now have one shared contract instead of a separate string embedded in the server. A regression test scans the server routes and fails if a developer adds a new HTTP method without also advertising it in preflight responses.

The affected-test graph records that source scan, so changes to server route files select this regression test automatically.

## Evidence

Before the fix, the focused regression failed because `Access-Control-Allow-Methods` did not contain `PATCH`.

After the fix, automated coverage proves the full flow:

1. create and open a side-panel tab;
2. preflight a `PATCH` from a different origin;
3. send the authenticated update;
4. reload the workspace and confirm the state persisted;
5. preflight and perform an `If-Match` tab close, then confirm the close persisted.

The build, type check, unit, browser, and E2E suites all pass. Implementation, security, and documentation review gates also pass.

## Cost and risk

The runtime cost is small: a few response headers and one cached preflight every 10 minutes per browser request shape. The route scan runs only in tests. No new dependency, authentication mechanism, or origin permission was added.

## What this enables

- reliable side-panel persistence with remote gateways;
- working browser `PATCH` requests through cross-origin reverse proxies;
- separate UI and gateway origins during development;
- a guard against future API methods silently becoming unusable cross-origin.

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)
