### PR TITLE
Remove runtime audits from releases

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -101,9 +101,7 @@ Run, in this order, and **stop on any failure**:
 
 ```bash
 npm ci                          # clean install, lockfile authoritative
-npm audit --omit=dev            # zero vulnerabilities in root runtime deps
 npm run build                   # full build; emits declarations used by test type-checks
-npm run audit:packed-consumer   # zero vulnerabilities in a fresh tarball consumer
 npm run check                   # type-check server + web + tests against fresh dist
 npm run test:unit               # fast unit suite
 npm run test:browser            # Playwright browser journeys
@@ -111,13 +109,12 @@ npm run test:e2e                # API + worktree/Docker/MCP/restart E2E
 ```
 
 Rules:
-- **Both audits must show 0 vulnerabilities** at every severity. The packed-consumer command installs the just-built tarball under normal npm settings because a clean root audit cannot see dependency-owned shrinkwrap findings. Any finding blocks publish; there are no release exceptions.
-- Registry advisory availability is deliberately release-only, not part of normal unit, browser, or E2E gates. If the advisory service or clean consumer install is unavailable, stop the release rather than skipping the packed-consumer audit.
+- Runtime registry audits are deliberately outside the release process. Do not run `npm audit` or `audit:packed-consumer` as release gates; mutable advisory data must not change eligibility for an unchanged commit.
 - Don't skip browser or E2E tests "because they're slow" — releases are the one place flakes bite users.
-- Build must precede both `audit:packed-consumer` and `check`: the audit packs built output, while `tsconfig.tests2.json` follows intentional imports of emitted `dist/server/*.js` declarations.
+- Build must precede `check` because `tsconfig.tests2.json` follows intentional imports of emitted `dist/server/*.js` declarations.
 - If any test fails, the failure is the bug. Fix it or abort the release; do not retry hoping it's flaky.
 
-Long-running steps (`build`, `audit:packed-consumer`, `test:browser`, `test:e2e`) should use `bash_bg` so output stays inspectable.
+Long-running steps (`build`, `test:browser`, `test:e2e`) should use `bash_bg` so output stays inspectable.
 
 ## 3. Decide whether to bump the binary sub-packages
 
@@ -388,7 +385,7 @@ Report to the user:
 - Version + tag + GitHub release URL (`gh release view v<new-version> --json url -q .url`)
 - npm package URL (`https://www.npmjs.com/package/@gresearch/bobbit/v/<new-version>`) — provenance is attached automatically by CI
 - Whether binaries were republished, and which versions
-- Root and packed-consumer audit results (both must be clean)
+- Required build, type-check, unit, browser, and E2E gate results
 
 ## Rules / best practices
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -122,9 +122,11 @@ Two consequences worth stating plainly, so nobody rediscovers them as bugs:
 
 The tag is lightweight rather than annotated. Nothing in this repository reads tag objects — no `git describe`, no signature verification — and immutability rather than annotation provides the protection, so the distinction costs nothing here.
 
-## Required packed-consumer audit
+## Optional manual packed-consumer audit
 
-A root audit and a packed-consumer audit are both required before publication:
+Runtime registry audits are diagnostic tools, not release gates. Neither `.github/workflows/release-publish.yml` nor the `/release` preflight runs `npm audit` or `audit:packed-consumer`, and advisory findings do not determine release eligibility. Registry advisory data can change without a source change, so making it authoritative would make identical release commits pass or fail at different times.
+
+A maintainer investigating dependency exposure may run:
 
 ```bash
 npm audit --omit=dev
@@ -132,17 +134,11 @@ npm run build
 npm run audit:packed-consumer
 ```
 
-The build must precede `audit:packed-consumer` because the command packs the built Bobbit package. It then installs that tarball into a clean private consumer with normal lockfile ownership and runs `npm audit --omit=dev --json`. Publication normally requires npm to exit successfully with zero `info`, `low`, `moderate`, `high`, `critical`, and total vulnerabilities.
+The build must precede `audit:packed-consumer` because the command packs the built Bobbit package. It installs that tarball into a clean private consumer with normal lockfile ownership and runs `npm audit --omit=dev --json`. This can reveal dependency-owned shrinkwrap findings that a root audit cannot see.
 
-One narrow accepted-risk exception applies to the Pi-owned path `@earendil-works/pi-coding-agent@0.82.1 > minimatch@10.2.5 > brace-expansion@5.0.7` reported for `GHSA-mh99-v99m-4gvg`. That exact finding may leave the packed-consumer audit at exit code 1 with one high vulnerability without blocking merge or release eligibility. It must remain visible in the complete audit output and final release report; the exception does not make the package audit-clean and must not be implemented by an audit fix, override, vendoring, forking, repacking, suppression, or a weakened check.
+The command uses fresh home, config, cache, and temporary directories; empty user/global npm configuration; and the public npm registry. It does not inherit auth tokens or custom registry credentials, and pack/install lifecycle scripts are disabled. These controls make the diagnostic reproducible without turning mutable registry output into publication policy.
 
-Any additional vulnerability, different package version/path/advisory, or other unaccepted finding remains blocking. An install, advisory-service, malformed-report, or cleanup failure also remains blocking. Always run and report the preflight; the accepted risk changes only the disposition of the exact finding above.
-
-The command runs npm with fresh home, config, cache, and temporary directories; empty user/global npm configuration; and the public npm registry. It does not inherit auth tokens or custom registry credentials, and pack/install lifecycle scripts are disabled. This isolates release evidence from developer credentials and prevents a package lifecycle hook from executing during the security check.
-
-Normal unit, browser, and E2E suites intentionally do not query or assert registry advisory output because that feed can change without a source change. The packed-consumer E2E remains deterministic: it verifies consumer lock creation, dependency-owned shrinkwrap presence, installed graph validity, coordinated Pi versions, known dependency version/path floors, and bundled binary resolution/smoke behavior. Live advisory enforcement belongs only to this required release preflight.
-
-A clean root audit is still useful, but it is not consumer evidence. npm may honor a dependency's published `npm-shrinkwrap.json` only after Bobbit is installed as a package, so the consumer can resolve a different tree from the repository checkout. See the [Pi `0.82.1` compatibility outcome](pi-runtime-compatibility.md#pi-0821-compatibility-outcome) for the current dependency constraints.
+Unit, browser, and E2E suites intentionally do not query or assert live advisory output. The packed-consumer E2E instead verifies deterministic properties: consumer lock creation, dependency-owned shrinkwrap presence, installed graph validity, coordinated Pi versions, known dependency version/path floors, and bundled binary resolution and smoke behavior. See the [Pi `0.82.1` compatibility outcome](pi-runtime-compatibility.md#pi-0821-compatibility-outcome) for the current dependency constraints.
 
 ## Bundled fd/rg binaries
 

--- a/tests2/core/release-skill-preflight-order.test.ts
+++ b/tests2/core/release-skill-preflight-order.test.ts
@@ -35,6 +35,7 @@ import {
 import { assertDistTagAdvances } from "../../scripts/release/dist-tag-guard.mjs";
 
 const skill = readFileSync(resolve(process.cwd(), ".claude/skills/release/SKILL.md"), "utf8");
+const releaseDocs = readFileSync(resolve(process.cwd(), "docs/releasing.md"), "utf8");
 
 type WorkflowStep = { name?: string; uses?: string; with?: Record<string, unknown>; run?: string };
 type WorkflowJob = {
@@ -740,22 +741,23 @@ describe("release contract rules", () => {
 });
 
 describe("release skill pre-flight order", () => {
-	it("audits the built tarball consumer before type-checking and tests", () => {
+	it("runs deterministic quality gates without runtime registry audits", () => {
 		assert.equal(
 			packageJson.scripts?.["audit:packed-consumer"],
 			"node scripts/release-packed-consumer-audit.mjs",
 		);
-		assert.ok(position("npm ci") < position("npm audit --omit=dev"));
-		assert.ok(position("npm audit --omit=dev") < position("npm run build"));
-		assert.ok(position("npm run build") < position("npm run audit:packed-consumer"));
-		assert.ok(position("npm run audit:packed-consumer") < position("npm run check"));
+		assert.doesNotMatch(skill, /^npm audit|^npm run audit:packed-consumer/gm);
+		assert.ok(position("npm ci") < position("npm run build"));
+		assert.ok(position("npm run build") < position("npm run check"));
 		assert.ok(position("npm run check") < position("npm run test:unit"));
-		assert.ok(position("npm run test:unit") < position("npm run test:e2e"));
+		assert.ok(position("npm run test:unit") < position("npm run test:browser"));
+		assert.ok(position("npm run test:browser") < position("npm run test:e2e"));
 	});
 
-	it("keeps mutable advisory availability release-only and blocks every finding", () => {
-		assert.match(skill, /Registry advisory availability is deliberately release-only/);
-		assert.match(skill, /Any finding blocks publish; there are no release exceptions/);
+	it("documents runtime registry audits as optional diagnostics only", () => {
+		assert.match(skill, /Runtime registry audits are deliberately outside the release process/);
+		assert.match(releaseDocs, /## Optional manual packed-consumer audit/);
+		assert.match(releaseDocs, /advisory findings do not determine release eligibility/);
 	});
 });
 


### PR DESCRIPTION
## Summary

- remove root and packed-consumer audits from `/release` preflight gates
- retain the packed-consumer audit as an optional manual diagnostic
- pin that mutable registry advisory data cannot determine release eligibility
- preserve deterministic build, type-check, unit, browser, and E2E release gates

## Why

Runtime audits were explicitly out of scope for the automated release process, but the release skill and documentation still treated them as blocking manual gates. This became visible while preparing `0.16.0-rc.1`, when new registry advisories stopped the release despite no change to the candidate commit.

The publication workflow already excludes audits. This aligns the operator workflow and documentation with that boundary.

## Validation

- `npx vitest run tests2/core/release-skill-preflight-order.test.ts --retry=0` — 44 passed
- `git diff --check`

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)
