### PR TITLE
Fix browser release gate races

### DIFF
--- a/src/app/api.ts
+++ b/src/app/api.ts
@@ -26,6 +26,7 @@ import { errorFromResponse, errorDetails } from "./error-helpers.js";
 import { dispatchGateStatusCacheUpdated } from "./gate-status-events.js";
 import { showHeaderToast } from "./header-toast.js";
 import { ensureProjectPlayFinishSoundOverride } from "./play-finish-sound.js";
+import { remoteStateRequestKey, remoteStateRequestOrder } from "./remote-state-request-order.js";
 export { errorFromResponse, errorDetails };
 // `dialogs.ts` is heavy (~90 kB) and only needed once the user opens a dialog;
 // route these through `dialogs-lazy.js` so it stays out of the eager
@@ -1569,24 +1570,26 @@ export async function refreshPrStatusCache(skipRender = false): Promise<boolean>
 
 	const results = await Promise.all(
 		goalsWithBranch.map(async (g) => {
+			const ticket = remoteStateRequestOrder.begin(remoteStateRequestKey("sidebar", g.id, "pr"));
 			try {
 				const res = await gatewayFetch(`/api/goals/${g.id}/pr-status?optional=1&intent=sidebar`);
-				if (res.status === 204 || res.status === 404) return { goalId: g.id, pr: null, noPr: true };
-				if (!res.ok) return { goalId: g.id, pr: null, noPr: false };
+				if (res.status === 204 || res.status === 404) return { goalId: g.id, pr: null, noPr: true, ticket };
+				if (!res.ok) return { goalId: g.id, pr: null, noPr: false, ticket };
 				const snapshot = parseRemoteStateSnapshot<RemotePrStatus>(await res.json());
 				const data = snapshot.data;
 				const pr = data && typeof data === "object" && typeof data.state === "string"
 					? { ...data, ...snapshot, state: data.state, url: sanitizePullRequestUrl(data.url) }
 					: null;
-				return { goalId: g.id, pr, noPr: data === null && !snapshot.stale && !snapshot.lastError };
+				return { goalId: g.id, pr, noPr: data === null && !snapshot.stale && !snapshot.lastError, ticket };
 			} catch {
-				return { goalId: g.id, pr: null, noPr: false };
+				return { goalId: g.id, pr: null, noPr: false, ticket };
 			}
 		})
 	);
 
 	let changed = false;
-	for (const { goalId, pr, noPr } of results) {
+	for (const { goalId, pr, noPr, ticket } of results) {
+		if (!remoteStateRequestOrder.isCurrent(ticket)) continue;
 		const prev = state.prStatusCache.get(goalId);
 		if (pr) {
 			if (!prev
@@ -1631,6 +1634,7 @@ export function applyRemoteStateSnapshotMessage(message: unknown): boolean {
 				: snapshot.data && typeof snapshot.data.branch === "string" ? "git" : "pr";
 	if (resource !== "pr" && resource !== "pr_status") return false;
 
+	remoteStateRequestOrder.supersede(remoteStateRequestKey("sidebar", msg.goalId, "pr"));
 	const previous = state.prStatusCache.get(msg.goalId);
 	if (snapshot.data && typeof snapshot.data.state === "string") {
 		const next: RemotePrStatus = {

--- a/src/app/goal-dashboard.ts
+++ b/src/app/goal-dashboard.ts
@@ -11,6 +11,7 @@ import { gatewayFetch, deleteGoal, startTeam, teardownTeamWithDialog, getTeamSta
 import { runGitStatusRefresh, abortableSleep } from "./git-status-refresh.js";
 import { dispatchVerificationEvent } from "./verification-event-bus.js";
 import { GATE_STATUS_CLIENT_EVENT, shouldRefreshActiveVerificationsForEvent, shouldRefreshGateDetailsForEvent, shouldRefreshGateStatusForEvent } from "./gate-status-events.js";
+import { remoteStateRequestKey, remoteStateRequestOrder } from "./remote-state-request-order.js";
 import { getRouteFromHash, setGoalDashboardRoute, setHashRoute, type DashboardTabId } from "./routing.js";
 import { createAndConnectSession, connectToSession, startReattempt } from "./session-manager.js";
 import { showGoalDialog } from "./dialogs.js";
@@ -622,6 +623,7 @@ function applyDashboardRemoteStateSnapshot(message: Record<string, unknown>): bo
 			: typeof message.kind === "string" ? message.kind
 				: isGoalGitStatus(snapshot.data) ? "git" : "pr";
 	if (resource === "git" || resource === "repository") {
+		remoteStateRequestOrder.supersede(remoteStateRequestKey("dashboard", currentGoalId!, "git"));
 		if (!isGoalGitStatus(snapshot.data)) return false;
 		const next = withUntrackedStatusPreserved(gitStatus, { ...snapshot.data, ...snapshot }, false);
 		if (JSON.stringify(next) === JSON.stringify(gitStatus)) return false;
@@ -630,6 +632,8 @@ function applyDashboardRemoteStateSnapshot(message: Record<string, unknown>): bo
 		return true;
 	}
 	if (resource !== "pr" && resource !== "pr_status") return false;
+	remoteStateRequestOrder.supersede(remoteStateRequestKey("dashboard", currentGoalId!, "pr"));
+	remoteStateRequestOrder.supersede(remoteStateRequestKey("sidebar", currentGoalId!, "pr"));
 	return applyDashboardPrSnapshot(currentGoalId!, snapshot);
 }
 
@@ -790,6 +794,9 @@ export async function loadDashboardData(goalId: string): Promise<void> {
 	startTaskPolling(goalId);
 
 	try {
+		const gitTicket = remoteStateRequestOrder.begin(remoteStateRequestKey("dashboard", goalId, "git"));
+		const prTicket = remoteStateRequestOrder.begin(remoteStateRequestKey("dashboard", goalId, "pr"));
+		const sidebarPrTicket = remoteStateRequestOrder.begin(remoteStateRequestKey("sidebar", goalId, "pr"));
 		const [goalRes, tasksRes, commitsRes, fetchedGates, gitStatusRes, costRes, prStatusRes] = await Promise.all([
 			gatewayFetch(`/api/goals/${goalId}`),
 			gatewayFetch(`/api/goals/${goalId}/tasks`),
@@ -835,13 +842,15 @@ export async function loadDashboardData(goalId: string): Promise<void> {
 
 		if (gitStatusRes && gitStatusRes.ok) {
 			const snapshot = parseRemoteStateSnapshot<GoalGitStatus>(await gitStatusRes.json());
-			gitStatus = snapshot.data ? { ...snapshot.data, ...snapshot } : null;
-			gitRepoKnown = 'yes';
-			gitStatusLastRefreshAt = performance.now();
+			if (currentGoalId === goalId && remoteStateRequestOrder.isCurrent(gitTicket)) {
+				gitStatus = snapshot.data ? { ...snapshot.data, ...snapshot } : null;
+				gitRepoKnown = 'yes';
+				gitStatusLastRefreshAt = performance.now();
+			}
 		} else if (gitStatusRes && gitStatusRes.status === 400) {
 			try {
 				const body = await gitStatusRes.json();
-				if (body?.error === 'Not a git repository') gitRepoKnown = 'no';
+				if (currentGoalId === goalId && remoteStateRequestOrder.isCurrent(gitTicket) && body?.error === 'Not a git repository') gitRepoKnown = 'no';
 			} catch { /* ignore */ }
 		}
 
@@ -850,12 +859,16 @@ export async function loadDashboardData(goalId: string): Promise<void> {
 		}
 
 		if (prStatusRes && prStatusRes.status === 204) {
-			prStatus = null;
-			prSnapshotMetadata = undefined;
-			state.prStatusCache.delete(goalId);
+			if (currentGoalId === goalId && remoteStateRequestOrder.isCurrent(prTicket)) {
+				prStatus = null;
+				prSnapshotMetadata = undefined;
+			}
+			if (remoteStateRequestOrder.isCurrent(sidebarPrTicket)) state.prStatusCache.delete(goalId);
 		} else if (prStatusRes && prStatusRes.ok) {
 			const snapshot = parseRemoteStateSnapshot<PrStatus>(await prStatusRes.json());
-			applyDashboardPrSnapshot(goalId, snapshot);
+			if (currentGoalId === goalId && remoteStateRequestOrder.isCurrent(prTicket)) {
+				applyDashboardPrSnapshot(goalId, snapshot, remoteStateRequestOrder.isCurrent(sidebarPrTicket));
+			}
 		}
 
 		const teamState = await getTeamState(goalId);
@@ -1338,6 +1351,7 @@ async function refreshGoalGitStatus(
 	const ctl = new AbortController();
 	gitStatusAbort = ctl;
 	gitStatusLastRefreshAt = performance.now();
+	const ticket = remoteStateRequestOrder.begin(remoteStateRequestKey("dashboard", goalId, "git"));
 
 	let changed = false;
 	await runGitStatusRefresh(ctl.signal, {
@@ -1348,9 +1362,9 @@ async function refreshGoalGitStatus(
 			signal,
 		}),
 		sleep: abortableSleep,
-		isStale: () => currentGoalId !== goalId,
+		isStale: () => currentGoalId !== goalId || !remoteStateRequestOrder.isCurrent(ticket),
 		onOk: (data) => {
-			if (currentGoalId !== goalId) return;
+			if (currentGoalId !== goalId || !remoteStateRequestOrder.isCurrent(ticket)) return;
 			const next = withUntrackedStatusPreserved(gitStatus, data as GoalGitStatus, !!opts?.untracked);
 			if (JSON.stringify(next) !== JSON.stringify(gitStatus)) {
 				gitStatus = next;
@@ -1359,7 +1373,7 @@ async function refreshGoalGitStatus(
 			gitRepoKnown = 'yes';
 		},
 		onNotARepo: () => {
-			if (currentGoalId !== goalId) return;
+			if (currentGoalId !== goalId || !remoteStateRequestOrder.isCurrent(ticket)) return;
 			if (gitRepoKnown !== 'no' || gitStatus !== null) {
 				gitRepoKnown = 'no';
 				gitStatus = null;
@@ -1397,7 +1411,7 @@ function startGitStatusPolling(goalId: string): void {
 	}, ACTIVE_PR_POLL_INTERVAL_MS);
 }
 
-function applyDashboardPrSnapshot(goalId: string, snapshot: RemoteStateSnapshot<unknown>): boolean {
+function applyDashboardPrSnapshot(goalId: string, snapshot: RemoteStateSnapshot<unknown>, updateSidebar = true): boolean {
 	const metadata = copyRemoteStateMetadata(snapshot);
 	const metadataChanged = JSON.stringify(metadata) !== JSON.stringify(prSnapshotMetadata);
 	prSnapshotMetadata = metadata;
@@ -1405,11 +1419,11 @@ function applyDashboardPrSnapshot(goalId: string, snapshot: RemoteStateSnapshot<
 		const next: PrStatus = { ...snapshot.data, url: sanitizePullRequestUrl(snapshot.data.url)!, ...metadata };
 		if (JSON.stringify(next) === JSON.stringify(prStatus)) return metadataChanged;
 		prStatus = next;
-		state.prStatusCache.set(goalId, next);
+		if (updateSidebar) state.prStatusCache.set(goalId, next);
 		return true;
 	}
 	if (snapshot.data === null && !snapshot.stale && !snapshot.lastError) {
-		const cacheDeleted = state.prStatusCache.delete(goalId);
+		const cacheDeleted = updateSidebar ? state.prStatusCache.delete(goalId) : false;
 		const changed = prStatus !== null || cacheDeleted || metadataChanged;
 		prStatus = null;
 		return changed;
@@ -1420,7 +1434,7 @@ function applyDashboardPrSnapshot(goalId: string, snapshot: RemoteStateSnapshot<
 		const next = { ...prStatus, ...metadata };
 		if (JSON.stringify(next) !== JSON.stringify(prStatus)) {
 			prStatus = next;
-			state.prStatusCache.set(goalId, next);
+			if (updateSidebar) state.prStatusCache.set(goalId, next);
 			return true;
 		}
 	}
@@ -1428,11 +1442,14 @@ function applyDashboardPrSnapshot(goalId: string, snapshot: RemoteStateSnapshot<
 }
 
 async function refreshGoalPrStatus(goalId: string, intent: "automatic" | "visible" | "explicit"): Promise<void> {
+	const ticket = remoteStateRequestOrder.begin(remoteStateRequestKey("dashboard", goalId, "pr"));
+	const sidebarTicket = remoteStateRequestOrder.begin(remoteStateRequestKey("sidebar", goalId, "pr"));
 	try {
 		const res = await gatewayFetch(`/api/goals/${goalId}/pr-status?optional=1&intent=${intent}`).catch(() => null);
-		if (!res || currentGoalId !== goalId) return;
+		if (!res || currentGoalId !== goalId || !remoteStateRequestOrder.isCurrent(ticket)) return;
+		const updateSidebar = remoteStateRequestOrder.isCurrent(sidebarTicket);
 		if (res.status === 204) {
-			const cacheDeleted = state.prStatusCache.delete(goalId);
+			const cacheDeleted = updateSidebar ? state.prStatusCache.delete(goalId) : false;
 			const changed = prStatus !== null || prSnapshotMetadata !== undefined || cacheDeleted;
 			prStatus = null;
 			prSnapshotMetadata = undefined;
@@ -1441,7 +1458,8 @@ async function refreshGoalPrStatus(goalId: string, intent: "automatic" | "visibl
 		}
 		if (!res.ok) return;
 		const snapshot = parseRemoteStateSnapshot<PrStatus>(await res.json());
-		if (currentGoalId === goalId && applyDashboardPrSnapshot(goalId, snapshot)) renderApp();
+		if (currentGoalId === goalId && remoteStateRequestOrder.isCurrent(ticket)
+			&& applyDashboardPrSnapshot(goalId, snapshot, remoteStateRequestOrder.isCurrent(sidebarTicket))) renderApp();
 	} catch { /* retain last good PR state on transient errors */ }
 }
 
@@ -1834,25 +1852,11 @@ async function handlePrMerge(e: CustomEvent<{ method: string; admin?: boolean; b
 	} catch (err) {
 		widget.setMergeResult(err instanceof Error ? err.message : 'Network error');
 	}
-	// Re-fetch both git-status and pr-status
-	try {
-		const [gitRes, prRes] = await Promise.all([
-			gatewayFetch(`/api/goals/${goalId}/git-status?intent=explicit`).catch(() => null),
-			gatewayFetch(`/api/goals/${goalId}/pr-status?optional=1&intent=explicit`).catch(() => null),
-		]);
-		if (gitRes && gitRes.ok) {
-			const snapshot = parseRemoteStateSnapshot<GoalGitStatus>(await gitRes.json());
-			gitStatus = snapshot.data ? { ...snapshot.data, ...snapshot } : gitStatus;
-		}
-		if (prRes && prRes.status === 204) {
-			prStatus = null;
-			prSnapshotMetadata = undefined;
-			state.prStatusCache.delete(goalId);
-		} else if (prRes && prRes.ok) {
-			const snapshot = parseRemoteStateSnapshot<PrStatus>(await prRes.json());
-			applyDashboardPrSnapshot(goalId, snapshot);
-		}
-	} catch { /* ignore */ }
+	// Re-fetch both independent coordinator records through the ordered owners.
+	await Promise.all([
+		refreshGoalGitStatus(goalId, { intent: "explicit" }),
+		refreshGoalPrStatus(goalId, "explicit"),
+	]);
 	refreshPrStatusCache();
 	renderApp();
 }

--- a/src/app/remote-state-request-order.ts
+++ b/src/app/remote-state-request-order.ts
@@ -1,0 +1,47 @@
+/**
+ * Orders stale-while-revalidate REST projections against completion broadcasts.
+ *
+ * A request owns its keyed generation until another request begins or an
+ * accepted WebSocket completion supersedes it. Callers must check the ticket at
+ * the point where a REST result would mutate client state.
+ */
+export interface RemoteStateRequestTicket {
+	readonly key: string;
+	readonly generation: number;
+}
+
+export type RemoteStateClientSurface = "dashboard" | "session" | "sidebar";
+export type RemoteStateClientResource = "git" | "pr";
+
+export function remoteStateRequestKey(
+	surface: RemoteStateClientSurface,
+	ownerId: string,
+	resource: RemoteStateClientResource,
+): string {
+	return `${surface}\u0000${ownerId}\u0000${resource}`;
+}
+
+export class RemoteStateRequestOrder {
+	private readonly generations = new Map<string, number>();
+
+	begin(key: string): RemoteStateRequestTicket {
+		const generation = this.advance(key);
+		return { key, generation };
+	}
+
+	supersede(key: string): void {
+		this.advance(key);
+	}
+
+	isCurrent(ticket: RemoteStateRequestTicket): boolean {
+		return this.generations.get(ticket.key) === ticket.generation;
+	}
+
+	private advance(key: string): number {
+		const generation = (this.generations.get(key) ?? 0) + 1;
+		this.generations.set(key, generation);
+		return generation;
+	}
+}
+
+export const remoteStateRequestOrder = new RemoteStateRequestOrder();

--- a/src/app/session-manager.ts
+++ b/src/app/session-manager.ts
@@ -29,6 +29,7 @@ import { reconcilePackRenderersForProject } from "./pack-renderers.js";
 import { reconcilePackPanelsForProject, setSessionSwitcher } from "./pack-panels.js";
 import { hydrateSidePanelWorkspace } from "./side-panel-workspace.js";
 import { reconcilePackEntrypointsForProject } from "./pack-entrypoints.js";
+import { remoteStateRequestKey, remoteStateRequestOrder } from "./remote-state-request-order.js";
 import { runWidgetGitRefresh, abortableSleep, GIT_STATUS_BACKOFF_MS, type GitWidgetLike } from "./git-status-refresh.js";
 import { computeConnectGitState, setCachedRepoState, pruneGitRepoCache } from "./git-repo-cache.js";
 import { startTimeRefresh } from "./render-helpers.js";
@@ -3367,6 +3368,7 @@ function applyRemoteStateSnapshotForSession(sessionId: string, message: RemoteSt
 	const snapshot = message.snapshot;
 	const widget = ai as typeof ai & RemoteSnapshotWidgetState;
 	if (snapshot.source === "repository") {
+		remoteStateRequestOrder.supersede(remoteStateRequestKey("session", sessionId, "git"));
 		widget.remoteGitSnapshot = copyRemoteStateMetadata(snapshot);
 		// This frame is the completion corresponding to any cold REST envelope.
 		// Stop the provisional loading indicator even when failure retained no data.
@@ -3389,6 +3391,10 @@ function applyRemoteStateSnapshotForSession(sessionId: string, message: RemoteSt
 			if (!gitStatusPollTimer) startGitStatusPoll(sessionId);
 		}
 	} else {
+		remoteStateRequestOrder.supersede(remoteStateRequestKey("session", sessionId, "pr"));
+		const session = state.gatewaySessions.find((candidate) => candidate.id === sessionId);
+		const goalId = session?.teamGoalId ?? session?.goalId;
+		if (goalId) remoteStateRequestOrder.supersede(remoteStateRequestKey("sidebar", goalId, "pr"));
 		widget.remotePrSnapshot = copyRemoteStateMetadata(snapshot);
 		// A successful, explicit no-PR projection is represented as `data: null`.
 		// Failed/cold snapshots omit data and must preserve the last-good display.
@@ -3414,8 +3420,6 @@ function applyRemoteStateSnapshotForSession(sessionId: string, message: RemoteSt
 				ai.viewerCanMergeAsAdmin = data.viewerCanMergeAsAdmin === true;
 				ai.reviewDecision = typeof data.reviewDecision === "string" ? data.reviewDecision : undefined;
 				ai.headRefName = typeof data.headRefName === "string" ? data.headRefName : undefined;
-				const session = state.gatewaySessions.find((candidate) => candidate.id === sessionId);
-				const goalId = session?.teamGoalId ?? session?.goalId;
 				if (goalId) {
 					state.prStatusCache.set(goalId, {
 						state: data.state,
@@ -3507,6 +3511,7 @@ async function refreshGitStatusForSession(
 	if (prev) prev.abort();
 	const ctl = new AbortController();
 	_gitStatusAborts.set(sessionId, ctl);
+	const ticket = remoteStateRequestOrder.begin(remoteStateRequestKey("session", sessionId, "git"));
 
 	// Quiet recheck: for a session cached as git-less/empty (gitRepoKnown ===
 	// 'no' or 'hidden'), run the refresh silently in the background — do NOT flip
@@ -3531,7 +3536,7 @@ async function refreshGitStatusForSession(
 			return result;
 		},
 		sleep: abortableSleep,
-		isStale: () => activeSessionId() !== sessionId,
+		isStale: () => activeSessionId() !== sessionId || !remoteStateRequestOrder.isCurrent(ticket),
 		applyOk: (widget, data) => {
 			const next = withUntrackedStatusPreserved(widget.gitStatus as ClientGitStatus | undefined, data as ClientGitStatus, !!opts?.untracked);
 			widget.gitStatus = next;
@@ -3586,6 +3591,10 @@ async function refreshPrStatusForSession(sessionId: string, intent: "automatic" 
 
 	const ai = state.chatPanel?.agentInterface;
 	if (!ai) return;
+	const ticket = remoteStateRequestOrder.begin(remoteStateRequestKey("session", sessionId, "pr"));
+	const sidebarTicket = goalId
+		? remoteStateRequestOrder.begin(remoteStateRequestKey("sidebar", goalId, "pr"))
+		: undefined;
 	const clearPr = () => {
 		ai.prState = undefined;
 		ai.prUrl = undefined;
@@ -3603,10 +3612,12 @@ async function refreshPrStatusForSession(sessionId: string, intent: "automatic" 
 		// 204 is the established explicit no-PR result. Transport/HTTP failures
 		// retain the last-good PR display while the coordinator retries remotely.
 		if (!res) return;
+		const applySession = activeSessionId() === sessionId && remoteStateRequestOrder.isCurrent(ticket);
+		const applySidebar = !!goalId && !!sidebarTicket && remoteStateRequestOrder.isCurrent(sidebarTicket);
 		if (res.status === 204) {
-			if (activeSessionId() === sessionId) clearPr();
-			if (goalId) state.prStatusCache.delete(goalId);
-			renderApp();
+			if (applySession) clearPr();
+			if (applySidebar) state.prStatusCache.delete(goalId);
+			if (applySession || applySidebar) renderApp();
 			return;
 		}
 		if (!res.ok) return;
@@ -3614,7 +3625,7 @@ async function refreshPrStatusForSession(sessionId: string, intent: "automatic" 
 		const snapshot = parseRemoteStateSnapshot<Record<string, unknown>>(await res.json());
 		const data = snapshot.data;
 		let changed = false;
-		if (activeSessionId() === sessionId) {
+		if (activeSessionId() === sessionId && remoteStateRequestOrder.isCurrent(ticket)) {
 			const widget = ai as typeof ai & RemoteSnapshotWidgetState;
 			widget.remotePrSnapshot = copyRemoteStateMetadata(snapshot);
 			changed = true;
@@ -3632,8 +3643,10 @@ async function refreshPrStatusForSession(sessionId: string, intent: "automatic" 
 				ai.headRefName = typeof data.headRefName === "string" ? data.headRefName : undefined;
 			}
 		}
-		// Update goal grouping cache so sidebar reflects the new PR state immediately.
-		if (goalId && isRecord(data) && typeof data.state === "string") {
+		// Update goal grouping cache only while this REST result still owns the
+		// independent sidebar projection.
+		if (goalId && sidebarTicket && remoteStateRequestOrder.isCurrent(sidebarTicket)
+			&& isRecord(data) && typeof data.state === "string") {
 			state.prStatusCache.set(goalId, {
 				state: data.state,
 				...(sanitizePullRequestUrl(data.url) ? { url: sanitizePullRequestUrl(data.url) } : {}),
@@ -3644,7 +3657,8 @@ async function refreshPrStatusForSession(sessionId: string, intent: "automatic" 
 				...copyRemoteStateMetadata(snapshot),
 			});
 			changed = true;
-		} else if (goalId && data === null && !snapshot.stale && !snapshot.lastError) {
+		} else if (goalId && sidebarTicket && remoteStateRequestOrder.isCurrent(sidebarTicket)
+			&& data === null && !snapshot.stale && !snapshot.lastError) {
 			changed = state.prStatusCache.delete(goalId) || changed;
 		}
 		if (changed) renderApp();

--- a/tests/ui-fixtures/workflow-failure-guidance-embed-entry.ts
+++ b/tests/ui-fixtures/workflow-failure-guidance-embed-entry.ts
@@ -1,0 +1,44 @@
+import { html, render } from "lit";
+import { clearWorkflowEditorController, renderWorkflowEditor, renderWorkflowInspector } from "../../src/app/workflow-page.js";
+import { setRenderApp } from "../../src/app/state.js";
+import "../../src/ui/lazy/safe-markdown-block.js";
+
+let projectWorkflow: any;
+let inlineWorkflow: any = null;
+let customizing = false;
+
+function clone<T>(value: T): T {
+	return JSON.parse(JSON.stringify(value));
+}
+
+function draw(): void {
+	const current = inlineWorkflow || projectWorkflow;
+	render(html`
+		<button data-testid="fixture-customize" @click=${() => {
+			inlineWorkflow = clone(projectWorkflow);
+			customizing = true;
+			clearWorkflowEditorController();
+			draw();
+		}}>Customise for this goal</button>
+		<div data-testid="fixture-surface">
+			${customizing
+				? renderWorkflowEditor({
+					workflow: current,
+					scope: "goal-draft",
+					onChange: (next) => { inlineWorkflow = clone(next); },
+				})
+				: renderWorkflowInspector({ workflow: current, scope: "goal-draft" })}
+		</div>
+	`, document.getElementById("app"));
+}
+
+setRenderApp(draw);
+(window as any).__loadFailureGuidanceEmbed = (next: any) => {
+	projectWorkflow = clone(next);
+	inlineWorkflow = null;
+	customizing = false;
+	clearWorkflowEditorController();
+	draw();
+};
+(window as any).__failureGuidanceInlineWorkflow = () => clone(inlineWorkflow);
+(window as any).__failureGuidanceEmbedReady = true;

--- a/tests2/browser/journeys/remote-state-coordinator.journey.spec.ts
+++ b/tests2/browser/journeys/remote-state-coordinator.journey.spec.ts
@@ -140,7 +140,7 @@ async function setVisible(page: Page): Promise<void> {
  */
 test.describe("Journey: remote-state coordinator", () => {
 	test("keeps two clients and every active surface on one canonical Git and PR snapshot", async ({ page, context, gateway }) => {
-		test.setTimeout(130_000);
+		test.setTimeout(59_000);
 		let fixture: RemoteFixture | undefined;
 		let goalId = "";
 		let sessionId = "";
@@ -161,9 +161,11 @@ test.describe("Journey: remote-state coordinator", () => {
 		let releasePrRead: (() => void) | undefined;
 		let heldPrRead: Promise<void> | undefined;
 		const gitStatusRequests: string[] = [];
+		const prStatusRequests: string[] = [];
 		context.on("request", (request) => {
 			const url = request.url();
 			if (url.includes("/git-status")) gitStatusRequests.push(url);
+			if (url.includes("/pr-status")) prStatusRequests.push(url);
 		});
 
 		const holdNextGitFetch = (): Promise<void> => {
@@ -176,6 +178,7 @@ test.describe("Journey: remote-state coordinator", () => {
 		};
 
 		try {
+			await page.clock.install();
 			fixture = await createRemoteFixture("browser-proof");
 			goalId = (await createGoal({
 				title: `remote-state browser proof ${Date.now()}`,
@@ -260,6 +263,7 @@ test.describe("Journey: remote-state coordinator", () => {
 			await expect(dashboardWidget).toBeAttached({ timeout: 15_000 });
 
 			sessionPage = await context.newPage();
+			await sessionPage.clock.install();
 			let coldSessionGitReads = 0;
 			await sessionPage.route(`**/api/sessions/${sessionId}/git-status*`, async (route) => {
 				if (coldSessionGitReads++ > 0) {
@@ -368,9 +372,10 @@ test.describe("Journey: remote-state coordinator", () => {
 			await expect(page.locator("#git-status-dropdown")).toHaveCount(0);
 			await expect(sessionPage.locator("#git-status-dropdown")).toHaveCount(0);
 			const automaticReadsBeforeTick = gitStatusRequests.filter((url) => url.includes("intent=automatic")).length;
+			await sessionPage.clock.fastForward(30_000);
 			await expect.poll(
 				() => gitStatusRequests.filter((url) => url.includes("intent=automatic")).length,
-				{ timeout: 35_000 },
+				{ timeout: 5_000 },
 			).toBeGreaterThan(automaticReadsBeforeTick);
 			await expect.poll(() => gitFetches, { timeout: 10_000 }).toBe(2);
 			await expect.poll(() => widgetState(dashboardWidget), { timeout: 10_000 }).toMatchObject({ behind: 1 });
@@ -405,12 +410,16 @@ test.describe("Journey: remote-state coordinator", () => {
 			failGitFetches = false;
 			holdNextGitFetch();
 			const fetchesBeforeGitRecovery = gitFetches;
+			const explicitGitRequestsBeforeRecovery = gitStatusRequests.filter((url) => url.includes("intent=explicit")).length;
 			await Promise.all([
 				dashboardGitFailure.getByRole("button", { name: "Refresh" }).click(),
 				sessionGitFailure.getByRole("button", { name: "Refresh" }).click(),
 			]);
+			await expect.poll(
+				() => gitStatusRequests.filter((url) => url.includes("intent=explicit")).length,
+				{ timeout: 5_000 },
+			).toBeGreaterThan(explicitGitRequestsBeforeRecovery);
 			await expect.poll(() => gitFetches, { timeout: 10_000 }).toBe(fetchesBeforeGitRecovery + 1);
-			await page.waitForTimeout(300);
 			expect(gitFetches).toBe(fetchesBeforeGitRecovery + 1);
 			heldGitFetch = undefined;
 			releaseGitFetch?.();
@@ -469,12 +478,16 @@ test.describe("Journey: remote-state coordinator", () => {
 			prTitle = "Recovered coordinator PR";
 			reviewDecision = "APPROVED";
 			holdNextPrRead();
+			const explicitPrRequestsBeforeRecovery = prStatusRequests.filter((url) => url.includes("intent=explicit")).length;
 			await Promise.all([
 				dashboardRemoteStatus.getByRole("button", { name: "Refresh" }).click(),
 				sessionRemoteStatus.getByRole("button", { name: "Refresh" }).click(),
 			]);
+			await expect.poll(
+				() => prStatusRequests.filter((url) => url.includes("intent=explicit")).length,
+				{ timeout: 5_000 },
+			).toBeGreaterThan(explicitPrRequestsBeforeRecovery);
 			await expect.poll(() => prReads, { timeout: 10_000 }).toBe(5);
-			await page.waitForTimeout(300);
 			expect(prReads).toBe(5);
 			heldPrRead = undefined;
 			releasePrRead?.();
@@ -494,6 +507,68 @@ test.describe("Journey: remote-state coordinator", () => {
 			});
 			await expect(dashboardGoalRow.locator('a[title*="approved"]')).toBeVisible();
 			await expect(sessionGoalRow.locator('a[title*="approved"]')).toBeVisible();
+
+			// Deterministically retain an older SWR REST envelope in the browser while
+			// its background refresh completes and broadcasts a newer snapshot. The
+			// late response must not regress dashboard or shared sidebar metadata.
+			now += 20_000;
+			prTitle = "Completion wins over late REST";
+			holdNextPrRead();
+			let releaseOlderRest!: () => void;
+			const olderRestRelease = new Promise<void>((resolve) => { releaseOlderRest = resolve; });
+			let captureOlderRest!: (snapshot: SnapshotState) => void;
+			const olderRestCaptured = new Promise<SnapshotState>((resolve) => { captureOlderRest = resolve; });
+			let interceptedOlderRest = false;
+			const prRoute = `**/api/goals/${goalId}/pr-status*`;
+			await page.route(prRoute, async (route) => {
+				if (interceptedOlderRest || !route.request().url().includes("intent=visible")) {
+					await route.continue();
+					return;
+				}
+				interceptedOlderRest = true;
+				const response = await route.fetch();
+				const body = await response.text();
+				captureOlderRest(JSON.parse(body) as SnapshotState);
+				await olderRestRelease;
+				await route.fulfill({ response, body });
+			});
+
+			await setVisible(page);
+			const olderRestSnapshot = await olderRestCaptured;
+			expect(olderRestSnapshot).toMatchObject({
+				stale: true,
+				ageMs: 20_000,
+			});
+			expect(olderRestSnapshot.lastError).toBeUndefined();
+			await expect.poll(() => prReads, { timeout: 5_000 }).toBe(6);
+			heldPrRead = undefined;
+			releasePrRead?.();
+			await expect.poll(() => widgetState(dashboardWidget), { timeout: 10_000 }).toMatchObject({
+				prTitle,
+				prSnapshot: { stale: false, ageMs: 0, source: "pr" },
+			});
+			await expect.poll(() => widgetState(sessionWidget), { timeout: 10_000 }).toMatchObject({
+				prTitle,
+				prSnapshot: { stale: false, ageMs: 0, source: "pr" },
+			});
+			const completionSnapshot = (await widgetState(dashboardWidget)).prSnapshot!;
+			expect(completionSnapshot.lastError).toBeUndefined();
+			expect((await widgetState(sessionWidget)).prSnapshot?.lastError).toBeUndefined();
+			expect(completionSnapshot.refreshedAt).toBe(now);
+
+			releaseOlderRest();
+			await expect.poll(() => widgetState(dashboardWidget), { timeout: 5_000 }).toMatchObject({
+				prTitle,
+				prSnapshot: {
+					stale: false,
+					ageMs: 0,
+					refreshedAt: completionSnapshot.refreshedAt,
+				},
+			});
+			expect((await widgetState(dashboardWidget)).prSnapshot?.lastError).toBeUndefined();
+			await expect(dashboardGoalRow.locator('a[title*="remote stale"]')).toHaveCount(0);
+			await expect(dashboardGoalRow.locator('a[title*="remote offline"]')).toHaveCount(0);
+			await page.unroute(prRoute);
 
 			// Reload hydrates the same last-good snapshot into both clients without
 			// adding an external read while the canonical record is fresh.

--- a/tests2/browser/workflow-failure-guidance.spec.ts
+++ b/tests2/browser/workflow-failure-guidance.spec.ts
@@ -1,12 +1,12 @@
 // v2-native browser coverage for workflow-authored verification failure guidance.
 
-import { expect, test, type Locator, type Page, type TestInfo } from "@playwright/test";
-import fs from "node:fs";
+import { expect, test, type Locator, type Page } from "@playwright/test";
 import path from "node:path";
 import { buildBundle } from "./fixtures/build-bundle.js";
 
 const SHELL = path.resolve("tests/ui-fixtures/fixture-shell.html");
 const PROJECT_ENTRY = path.resolve("tests/ui-fixtures/goal-workflow-editor-entry.ts");
+const EMBED_ENTRY = path.resolve("tests/ui-fixtures/workflow-failure-guidance-embed-entry.ts");
 const WORKFLOW_SRC = path.resolve("src/app/workflow-page.ts");
 const API_SRC = path.resolve("src/app/api.ts");
 const STATE_SRC = path.resolve("src/app/state.ts");
@@ -14,8 +14,29 @@ const CONFIG_SCOPE_SRC = path.resolve("src/app/config-scope.ts");
 const SAFE_MARKDOWN_SRC = path.resolve("src/ui/lazy/safe-markdown-block.ts");
 const LIT_SRC = path.resolve("node_modules/lit/index.js");
 
+const RUN_ROOT = process.env.BOBBIT_E2E_TMP_ROOT;
+if (!RUN_ROOT) throw new Error("BOBBIT_E2E_TMP_ROOT must identify the coordinator-owned browser run root");
+const BUNDLE_DIR = path.join(RUN_ROOT, "ui-fixtures", "workflow-failure-guidance");
+const PROJECT_BUNDLE = path.join(BUNDLE_DIR, "project-bundle.js");
+const EMBED_BUNDLE = path.join(BUNDLE_DIR, "embed-bundle.js");
+
 const GUIDANCE = "Inspect the **retained trace** first.\n\nRe-run only the failing journey.";
 const CUSTOM_GUIDANCE = "Check the **custom goal logs** before retrying.";
+
+test.describe.configure({ retries: 0 });
+
+test.beforeAll(() => {
+	buildBundle({
+		entry: PROJECT_ENTRY,
+		outfile: PROJECT_BUNDLE,
+		deps: [PROJECT_ENTRY, WORKFLOW_SRC, API_SRC, STATE_SRC, CONFIG_SCOPE_SRC],
+	});
+	buildBundle({
+		entry: EMBED_ENTRY,
+		outfile: EMBED_BUNDLE,
+		deps: [EMBED_ENTRY, WORKFLOW_SRC, API_SRC, STATE_SRC, CONFIG_SCOPE_SRC, SAFE_MARKDOWN_SRC, LIT_SRC],
+	});
+});
 
 type FixtureWorkflow = {
 	id: string;
@@ -46,86 +67,6 @@ function workflow(failureGuidance?: string): FixtureWorkflow {
 			}],
 		}],
 	};
-}
-
-function sourceImport(from: string, target: string): string {
-	const relative = path.relative(path.dirname(from), target)
-		.replace(/\\/g, "/")
-		.replace(/\.ts$/, ".js");
-	return relative.startsWith(".") ? relative : `./${relative}`;
-}
-
-function embedFixtureSource(entry: string): string {
-	const litImport = JSON.stringify(sourceImport(entry, LIT_SRC));
-	const workflowImport = JSON.stringify(sourceImport(entry, WORKFLOW_SRC));
-	const stateImport = JSON.stringify(sourceImport(entry, STATE_SRC));
-	const safeMarkdownImport = JSON.stringify(sourceImport(entry, SAFE_MARKDOWN_SRC));
-	return `
-		import { html, render } from ${litImport};
-		import { clearWorkflowEditorController, renderWorkflowEditor, renderWorkflowInspector } from ${workflowImport};
-		import { setRenderApp } from ${stateImport};
-		import ${safeMarkdownImport};
-
-		let projectWorkflow;
-		let inlineWorkflow = null;
-		let customizing = false;
-		const clone = (value) => JSON.parse(JSON.stringify(value));
-
-		function draw() {
-			const current = inlineWorkflow || projectWorkflow;
-			render(html\`
-				<button data-testid="fixture-customize" @click=\${() => {
-					inlineWorkflow = clone(projectWorkflow);
-					customizing = true;
-					clearWorkflowEditorController();
-					draw();
-				}}>Customise for this goal</button>
-				<div data-testid="fixture-surface">
-					\${customizing
-						? renderWorkflowEditor({
-							workflow: current,
-							scope: "goal-draft",
-							onChange: (next) => { inlineWorkflow = clone(next); },
-						})
-						: renderWorkflowInspector({ workflow: current, scope: "goal-draft" })}
-				</div>
-			\`, document.getElementById("app"));
-		}
-
-		setRenderApp(draw);
-		window.__loadFailureGuidanceEmbed = (next) => {
-			projectWorkflow = clone(next);
-			inlineWorkflow = null;
-			customizing = false;
-			clearWorkflowEditorController();
-			draw();
-		};
-		window.__failureGuidanceInlineWorkflow = () => clone(inlineWorkflow);
-		window.__failureGuidanceEmbedReady = true;
-	`;
-}
-
-function buildProjectBundle(testInfo: TestInfo): string {
-	const bundle = testInfo.outputPath("fixture-bundles", "workflow-failure-guidance-project-bundle.js");
-	buildBundle({
-		entry: PROJECT_ENTRY,
-		outfile: bundle,
-		deps: [PROJECT_ENTRY, WORKFLOW_SRC, API_SRC, STATE_SRC, CONFIG_SCOPE_SRC],
-	});
-	return bundle;
-}
-
-function buildEmbedBundle(testInfo: TestInfo): string {
-	const entry = testInfo.outputPath("fixture-bundles", "workflow-failure-guidance-embed-entry.ts");
-	const bundle = testInfo.outputPath("fixture-bundles", "workflow-failure-guidance-embed-bundle.js");
-	fs.mkdirSync(path.dirname(entry), { recursive: true });
-	fs.writeFileSync(entry, embedFixtureSource(entry));
-	buildBundle({
-		entry,
-		outfile: bundle,
-		deps: [entry, WORKFLOW_SRC, API_SRC, STATE_SRC, CONFIG_SCOPE_SRC, SAFE_MARKDOWN_SRC, LIT_SRC],
-	});
-	return bundle;
 }
 
 function editor(page: Page): Locator {
@@ -165,9 +106,8 @@ async function save(page: Page): Promise<any> {
 	return lastPutBody(page);
 }
 
-test("authors, type-switches, saves, reloads, and clears failure guidance", async ({ page }, testInfo) => {
-	const projectBundle = buildProjectBundle(testInfo);
-	await loadProjectWorkflow(page, workflow(), projectBundle);
+test("authors, type-switches, saves, reloads, and clears failure guidance", async ({ page }) => {
+	await loadProjectWorkflow(page, workflow(), PROJECT_BUNDLE);
 
 	const guidance = step(page).getByTestId("wf-step-failure-guidance");
 	const hint = step(page).getByTestId("wf-step-failure-guidance-hint");
@@ -192,7 +132,7 @@ test("authors, type-switches, saves, reloads, and clears failure guidance", asyn
 	await loadProjectWorkflow(page, {
 		...saved,
 		id: "failure-guidance-workflow",
-	}, projectBundle);
+	}, PROJECT_BUNDLE);
 	await expect(step(page).getByTestId("wf-step-failure-guidance")).toHaveValue(GUIDANCE);
 
 	await step(page).getByTestId("wf-step-failure-guidance").fill("  \n  ");
@@ -200,10 +140,9 @@ test("authors, type-switches, saves, reloads, and clears failure guidance", asyn
 	expect(cleared.gates[0].verify[0].failureGuidance).toBeUndefined();
 });
 
-test("goal customisation round-trips guidance and the inspector keeps it in default-closed details", async ({ page }, testInfo) => {
-	const embedBundle = buildEmbedBundle(testInfo);
+test("goal customisation round-trips guidance and the inspector keeps it in default-closed details", async ({ page }) => {
 	await page.goto(`file://${SHELL.replace(/\\/g, "/")}`);
-	await page.addScriptTag({ path: embedBundle });
+	await page.addScriptTag({ path: EMBED_BUNDLE });
 	await page.waitForFunction(() => (window as any).__failureGuidanceEmbedReady === true);
 	await page.evaluate((wf) => (window as any).__loadFailureGuidanceEmbed(wf), workflow(GUIDANCE));
 

--- a/tests2/core/remote-state-request-order.test.ts
+++ b/tests2/core/remote-state-request-order.test.ts
@@ -1,0 +1,43 @@
+import assert from "node:assert/strict";
+import { describe, it } from "vitest";
+import {
+	RemoteStateRequestOrder,
+	remoteStateRequestKey,
+} from "../../src/app/remote-state-request-order.ts";
+
+describe("RemoteStateRequestOrder", () => {
+	it("rejects a REST ticket superseded by an accepted completion", () => {
+		const order = new RemoteStateRequestOrder();
+		const key = remoteStateRequestKey("dashboard", "goal-1", "pr");
+		const ticket = order.begin(key);
+
+		assert.equal(order.isCurrent(ticket), true);
+		order.supersede(key);
+		assert.equal(order.isCurrent(ticket), false);
+	});
+
+	it("lets a newer request supersede an older request for the same projection", () => {
+		const order = new RemoteStateRequestOrder();
+		const key = remoteStateRequestKey("session", "session-1", "git");
+		const older = order.begin(key);
+		const newer = order.begin(key);
+
+		assert.equal(order.isCurrent(older), false);
+		assert.equal(order.isCurrent(newer), true);
+	});
+
+	it("keeps surfaces, owners, and Git/PR resources independent", () => {
+		const order = new RemoteStateRequestOrder();
+		const dashboardPr = order.begin(remoteStateRequestKey("dashboard", "goal-1", "pr"));
+		const dashboardGit = order.begin(remoteStateRequestKey("dashboard", "goal-1", "git"));
+		const otherGoalPr = order.begin(remoteStateRequestKey("dashboard", "goal-2", "pr"));
+		const sidebarPr = order.begin(remoteStateRequestKey("sidebar", "goal-1", "pr"));
+
+		order.supersede(dashboardPr.key);
+
+		assert.equal(order.isCurrent(dashboardPr), false);
+		assert.equal(order.isCurrent(dashboardGit), true);
+		assert.equal(order.isCurrent(otherGoalPr), true);
+		assert.equal(order.isCurrent(sidebarPr), true);
+	});
+});

--- a/tests2/tests-map.json
+++ b/tests2/tests-map.json
@@ -499,6 +499,15 @@
       }
     },
     {
+      "path": "tests2/core/remote-state-request-order.test.ts",
+      "reason": "Pure keyed-generation coverage proving late REST projections are rejected after a WebSocket completion or newer request while dashboard/session/sidebar, goal, and Git/PR keys remain independent.",
+      "execution": {
+        "runner": "vitest",
+        "tier": "unit",
+        "project": "core"
+      }
+    },
+    {
       "path": "tests2/integration/remote-state-routes.test.ts",
       "reason": "In-process REST and WebSocket coverage for canonical remote read coalescing, safe snapshot envelopes, admin-versus-sandbox sidebar authorization, targeted sandbox delivery, PR cadence, local-only no-fetch behaviour, sibling worktree dirty-state isolation, and mutation invalidation.",
       "execution": {
@@ -509,7 +518,7 @@
     },
     {
       "path": "tests2/browser/journeys/remote-state-coordinator.journey.spec.ts",
-      "reason": "Comprehensive Chromium proof using a real local bare remote and credential-free GitHub fixture: a cold metadata-only Git read stays loading through completion and preserves the next automatic poll; two clients keep active session, dashboard, and sidebar state consistent; PR cadence coalesces; failures retain safe aged last-good state; concurrent explicit recovery stays single-flight; and reload hydration adds no fresh external call.",
+      "reason": "Comprehensive Chromium proof using deterministic client/server clocks, explicit response barriers, a real local bare remote, and a credential-free GitHub fixture: a held older REST envelope cannot regress a fresher completion; cold Git stays loading through completion; two clients keep session, dashboard, and sidebar state consistent; failures retain safe aged last-good state; recovery stays single-flight; and reload hydration adds no fresh external call.",
       "execution": {
         "runner": "playwright",
         "tier": "browser",


### PR DESCRIPTION
## Summary

- prevent late stale-while-revalidate REST responses from overwriting newer WebSocket completion snapshots
- keep request ordering independent across dashboard, session, sidebar, owner, and Git/PR projections
- make the remote-state journey deterministic with client clocks and an explicit late-response barrier
- build workflow-guidance fixture bundles once in the coordinator-owned run root instead of once per attempt
- disable retries for the deterministic workflow-guidance spec

## Release blocker

The `0.16.0-rc.1` retry-free browser gate exposed two issues:

1. A late stale PR REST envelope could regress a fresher completion under event-loop lag.
2. Per-attempt synchronous fixture builds could starve Chromium; the first attempt timed out and accumulated 423 seconds against the 60-second per-spec cap.

This fixes the underlying ordering and fixture ownership rather than rerunning or weakening the gate.

## Validation

- `npm run check`
- `npx vitest run tests2/core/remote-state-request-order.test.ts --retry=0` — 3 passed
- targeted retry-free browser run — 3 passed in 24.5s
- browser budget — 2 specs, 0 violations
- `git diff --check`

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)
