### PR TITLE
Stabilize unit release gates

### DIFF
--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -1617,6 +1617,14 @@ let _gitStatusFake: ((cwd: string, containerId?: string, opts?: { untracked?: bo
 export function __setGitStatusFake(fn: typeof _gitStatusFake): void { _gitStatusFake = fn; }
 export function __clearGitStatusFake(): void { _gitStatusFake = undefined; }
 
+/** Test-only monotonic clock for the explicit remote-read burst marker. The
+ * production path always uses performance.now(); tests must install and clear
+ * the override explicitly. */
+let _remoteStateForceNowFake: (() => number) | undefined;
+export function __setRemoteStateForceNowFake(fn: () => number): void { _remoteStateForceNowFake = fn; }
+export function __clearRemoteStateForceNowFake(): void { _remoteStateForceNowFake = undefined; }
+function remoteStateForceNow(): number { return _remoteStateForceNowFake?.() ?? performance.now(); }
+
 function gitStatusCacheKey(cwd: string, containerId?: string, untracked?: boolean): string {
 	return `${containerId ?? 'host'}::${cwd}::${untracked ? 'u' : 's'}`;
 }
@@ -2970,7 +2978,7 @@ export function createGateway(config: GatewayConfig, deps?: GatewayDeps) {
 		intentValue: string | null,
 		binding?: RepositorySnapshotBinding,
 	) => {
-		const forceRequestedAt = performance.now();
+		const forceRequestedAt = remoteStateForceNow();
 		const legacyFetch = intentValue === "force";
 		const force = legacyFetch || intentValue === "explicit";
 		const readOpts = {
@@ -3351,7 +3359,7 @@ export function createGateway(config: GatewayConfig, deps?: GatewayDeps) {
 		address: RemoteStateAddress,
 		intentValue: string | null,
 	) => {
-		const forceRequestedAt = performance.now();
+		const forceRequestedAt = remoteStateForceNow();
 		const effectiveAddress: RemoteStateAddress = intentValue === "sidebar" && address.kind === "goal"
 			? { kind: "sidebar", id: address.id }
 			: address;

--- a/tests2/integration/_e2e/fake-cmd-setup.ts
+++ b/tests2/integration/_e2e/fake-cmd-setup.ts
@@ -37,7 +37,20 @@ class FakeChild extends EventEmitter {
 	kill(): boolean { return true; }
 }
 
+export interface FakeCommandSpawnBarrier {
+	/** Resolves only after the armed command has actually been spawned. */
+	readonly spawned: Promise<VerificationCommandSpawnSpec>;
+	/** Resolves when that exact fake child emits its terminal close. */
+	readonly closed: Promise<{ code: number | null; signal: NodeJS.Signals | null }>;
+}
+
+interface ArmedFakeCommandSpawn extends FakeCommandSpawnBarrier {
+	resolveSpawned(spec: VerificationCommandSpawnSpec): void;
+	resolveClosed(result: { code: number | null; signal: NodeJS.Signals | null }): void;
+}
+
 interface ResettableVerificationRunner extends VerificationCommandRunner {
+	armNextSpawn(): FakeCommandSpawnBarrier;
 	reset(): void;
 }
 
@@ -68,12 +81,15 @@ let fakePid = 950_000;
 
 function createManualVerificationRunner(clock: ManualClock): ResettableVerificationRunner {
 	const live = new Set<TrackedChild>();
+	let armedNextSpawn: ArmedFakeCommandSpawn | undefined;
 
 	const runner: ResettableVerificationRunner = {
 		nonDurable: true,
 		spawn(spec: VerificationCommandSpawnSpec): TrackedChild {
 			const child = new FakeChild(++fakePid);
 			const scripted = interpretFakeCommand(spec.command);
+			const spawnBarrier = armedNextSpawn;
+			armedNextSpawn = undefined;
 			let closed = false;
 			let killed = false;
 			let timedOut = false;
@@ -99,6 +115,7 @@ function createManualVerificationRunner(clock: ManualClock): ResettableVerificat
 				live.delete(tracked);
 				child.emit("exit", code, signal);
 				child.emit("close", code, signal);
+				spawnBarrier?.resolveClosed({ code, signal });
 			};
 
 			const tracked: TrackedChild & { _timedOut?: boolean } = {
@@ -130,11 +147,24 @@ function createManualVerificationRunner(clock: ManualClock): ResettableVerificat
 					emitClose(scripted.exitCode, null);
 				}, scripted.delayMs);
 			}
+			spawnBarrier?.resolveSpawned(spec);
 			return tracked;
+		},
+		armNextSpawn(): FakeCommandSpawnBarrier {
+			if (armedNextSpawn) {
+				throw new Error("[fake-command-step] the next spawn already has an armed lifecycle barrier");
+			}
+			let resolveSpawned!: ArmedFakeCommandSpawn["resolveSpawned"];
+			let resolveClosed!: ArmedFakeCommandSpawn["resolveClosed"];
+			const spawned = new Promise<VerificationCommandSpawnSpec>(resolve => { resolveSpawned = resolve; });
+			const closed = new Promise<{ code: number | null; signal: NodeJS.Signals | null }>(resolve => { resolveClosed = resolve; });
+			armedNextSpawn = { spawned, closed, resolveSpawned, resolveClosed };
+			return { spawned, closed };
 		},
 		reset(): void {
 			for (const child of [...live]) child.killTree("SIGTERM", 0);
 			live.clear();
+			armedNextSpawn = undefined;
 		},
 	};
 	return runner;
@@ -153,6 +183,19 @@ function runnerFor(clock: ManualClock): ResettableVerificationRunner {
 export function trackFakeCommandStepConnection(connection: WsConnection): WsConnection {
 	state.connections.add(connection);
 	return connection;
+}
+
+/**
+ * Arm a one-shot lifecycle barrier on the installed manual runner. The spawn
+ * and close promises retain their observations, so neither edge can be missed
+ * when verification performs asynchronous setup before spawning.
+ */
+export function armNextFakeCommandStepSpawn(gateway: FakeCommandStepGateway): FakeCommandSpawnBarrier {
+	const runner = runnerFor(gateway.clock);
+	if (gateway.teamManager.verificationHarness?.commandStepRunner !== runner) {
+		throw new Error("[fake-command-step] cannot arm spawn barrier before installing the manual runner");
+	}
+	return runner.armNextSpawn();
 }
 
 /**

--- a/tests2/integration/gate-reset-api.test.ts
+++ b/tests2/integration/gate-reset-api.test.ts
@@ -16,6 +16,7 @@ import {
 } from "./_e2e/e2e-setup.js";
 import { pollUntil } from "../../tests/e2e/test-utils/cleanup.js";
 import {
+	signalAndWaitForAuthoredGateWithFakeCommandBarrier,
 	trackGateApiConnection,
 	useGateApiTestSupport,
 	waitForAuthoredGateStatus,
@@ -530,12 +531,10 @@ test.describe("POST /api/goals/:goalId/gates/:gateId/reset", () => {
 		const goalId = goal.id;
 		try {
 			await waitForGoalSetupReady(goalId);
-			await signalGate(goalId, "root");
-			await waitForGateStatus(goalId, "root", "passed");
+			await signalAndWaitForAuthoredGateWithFakeCommandBarrier(goalId, "root", {}, "passed");
 			expect(await latestVerificationOutput(goalId, "root")).toContain("FRESH_ROOT_AFTER_RESET");
 
-			await signalGate(goalId, "child");
-			await waitForGateStatus(goalId, "child", "passed");
+			await signalAndWaitForAuthoredGateWithFakeCommandBarrier(goalId, "child", {}, "passed");
 			expect(await latestVerificationOutput(goalId, "child")).toContain("FRESH_CHILD_AFTER_RESET");
 
 			const reset = await resetGate(goalId, "root");
@@ -544,8 +543,7 @@ test.describe("POST /api/goals/:goalId/gates/:gateId/reset", () => {
 			await waitForGateStatus(goalId, "root", "pending");
 			await waitForGateStatus(goalId, "child", "pending");
 
-			await signalGate(goalId, "root");
-			await waitForGateStatus(goalId, "root", "passed");
+			await signalAndWaitForAuthoredGateWithFakeCommandBarrier(goalId, "root", {}, "passed");
 			const rootOutput = await latestVerificationOutput(goalId, "root");
 			expect(rootOutput).toContain("FRESH_ROOT_AFTER_RESET");
 			expect.soft(
@@ -553,8 +551,7 @@ test.describe("POST /api/goals/:goalId/gates/:gateId/reset", () => {
 				"FRESH_GATE_RESET_CACHE_REUSED: root gate reused pre-reset verification output after manual reset",
 			).not.toContain("[cached from prior signal]");
 
-			await signalGate(goalId, "child");
-			await waitForGateStatus(goalId, "child", "passed");
+			await signalAndWaitForAuthoredGateWithFakeCommandBarrier(goalId, "child", {}, "passed");
 			const childOutput = await latestVerificationOutput(goalId, "child");
 			expect(childOutput).toContain("FRESH_CHILD_AFTER_RESET");
 			expect.soft(

--- a/tests2/integration/helpers/gate-api-test-support.ts
+++ b/tests2/integration/helpers/gate-api-test-support.ts
@@ -1,4 +1,5 @@
 import {
+	armNextFakeCommandStepSpawn,
 	resetAndInstallFakeCommandStepTestState,
 	trackFakeCommandStepConnection,
 } from "../_e2e/fake-cmd-setup.js";
@@ -88,5 +89,32 @@ export async function signalAndWaitForAuthoredGate(
 	if (response.status !== 201) {
 		throw new Error(`signal ${goalId}/${gateId} failed: ${response.status} ${await response.text()}`);
 	}
+	return waitForAuthoredGateStatus(goalId, gateId, targetStatus);
+}
+
+/**
+ * Drive one zero-delay fake command only after verification has actually
+ * spawned it. This prevents rapid manual-clock polling from racing ahead of
+ * asynchronous Git/setup work that precedes the spawn.
+ */
+export async function signalAndWaitForAuthoredGateWithFakeCommandBarrier(
+	goalId: string,
+	gateId: string,
+	body: Record<string, unknown>,
+	targetStatus: string,
+): Promise<any> {
+	const gateway = await ensureGateway();
+	const lifecycle = armNextFakeCommandStepSpawn(gateway);
+	const response = await apiFetch(`/api/goals/${goalId}/gates/${gateId}/signal`, {
+		method: "POST",
+		body: JSON.stringify(body),
+	});
+	if (response.status !== 201) {
+		throw new Error(`signal ${goalId}/${gateId} failed: ${response.status} ${await response.text()}`);
+	}
+	await lifecycle.spawned;
+	gateway.clock.advance(0);
+	await lifecycle.closed;
+	await new Promise<void>(resolve => setImmediate(resolve));
 	return waitForAuthoredGateStatus(goalId, gateId, targetStatus);
 }

--- a/tests2/integration/remote-state-routes.test.ts
+++ b/tests2/integration/remote-state-routes.test.ts
@@ -4,6 +4,61 @@ import { basename, dirname, join } from "node:path";
 import { awaitableRm } from "../../tests/e2e/test-utils/cleanup.js";
 import { test, expect } from "./_e2e/in-process-harness.js";
 import { apiFetch, connectWs, createGoal, defaultProjectId, deleteGoal, deleteSession, gitCwd, nonGitCwd, registerProject } from "./_e2e/e2e-setup.js";
+import { loadServerTestRuntime } from "../harness/server-runtime.js";
+
+let serverModule: any;
+let forceRequestedAt = 1_000;
+
+function deterministicGitStatus(opts?: { untracked?: boolean }) {
+	return {
+		branch: "main",
+		primaryBranch: "main",
+		primaryRef: "refs/heads/main",
+		isOnPrimary: true,
+		status: [],
+		hasUpstream: true,
+		ahead: 0,
+		behind: 0,
+		aheadOfPrimary: 0,
+		behindPrimary: 0,
+		mergedIntoPrimary: true,
+		insertionsVsPrimary: 0,
+		deletionsVsPrimary: 0,
+		clean: true,
+		summary: "clean",
+		unpushed: false,
+		partial: false,
+		untrackedIncluded: opts?.untracked === true,
+	};
+}
+
+function crossForceCoalescingWindow(): void {
+	forceRequestedAt += 251;
+}
+
+function unexpectedRunnerCommand(file: string, args: readonly string[], options?: any): never {
+	throw new Error(`unexpected route command: ${commandName(file)} ${args.join(" ")} (cwd=${String(options?.cwd ?? "")})`);
+}
+
+function standardSingleRepositoryProbe(
+	file: string,
+	args: readonly string[],
+	repositoryRoot: string,
+): { stdout: string; stderr: string } | undefined {
+	if (commandName(file) !== "git") return undefined;
+	const command = args.join(" ");
+	if (command === "rev-parse --show-toplevel") return { stdout: `${repositoryRoot}\n`, stderr: "" };
+	if (command === "rev-parse --path-format=absolute --git-common-dir" || command === "rev-parse --git-common-dir") {
+		return { stdout: `${join(repositoryRoot, ".git")}\n`, stderr: "" };
+	}
+	if (command === "rev-parse --git-dir") return { stdout: ".git\n", stderr: "" };
+	if (command === "symbolic-ref --quiet --short HEAD") return { stdout: "fixture/route-head\n", stderr: "" };
+	if (args[0] === "check-ref-format" && args[1] === "--branch" && typeof args[2] === "string") {
+		if (/^[\-]|[\u0000-\u001f\u007f]|:\/\//.test(args[2])) throw new Error("invalid fixture branch");
+		return { stdout: `${args[2]}\n`, stderr: "" };
+	}
+	return undefined;
+}
 
 function commandName(file: string): string {
 	return basename(file).toLowerCase().replace(/\.(?:cmd|exe)$/, "");
@@ -67,6 +122,25 @@ async function removeSiblingWorktree(runner: any, primary: string, sibling: stri
  * and the only observed fetch is the injected command below.
  */
 test.describe("remote-state coordinator routes", () => {
+	test.beforeAll(async () => {
+		serverModule = (await loadServerTestRuntime()).server;
+		expect(typeof serverModule.__setGitStatusFake).toBe("function");
+		expect(typeof serverModule.__clearGitStatusFake).toBe("function");
+		expect(typeof serverModule.__setRemoteStateForceNowFake).toBe("function");
+		expect(typeof serverModule.__clearRemoteStateForceNowFake).toBe("function");
+	});
+
+	test.beforeEach(() => {
+		forceRequestedAt = 1_000;
+		serverModule.__setRemoteStateForceNowFake(() => forceRequestedAt);
+		serverModule.__setGitStatusFake(async (_cwd: string, _containerId?: string, opts?: { untracked?: boolean }) => deterministicGitStatus(opts));
+	});
+
+	test.afterEach(() => {
+		serverModule.__clearGitStatusFake();
+		serverModule.__clearRemoteStateForceNowFake();
+	});
+
 	test("coalesces session Git and PR reads and only broadcasts redacted snapshot envelopes", async ({ gateway }) => {
 		test.setTimeout(30_000);
 		const sessionId = await createRemoteStateSession(gateway, gitCwd());
@@ -132,7 +206,9 @@ test.describe("remote-state coordinator routes", () => {
 				if (endpoint.endsWith("/rulesets/73")) return { stdout: JSON.stringify({ current_user_can_bypass: "pull_requests_only" }), stderr: "" };
 				throw new Error(`unexpected permission API args: ${args.join(" ")}`);
 			}
-			return originalExecFile.call(runner, file, args, options);
+			const probe = standardSingleRepositoryProbe(file, args, gitCwd());
+			if (probe) return probe;
+			return unexpectedRunnerCommand(file, args, options);
 		};
 
 		try {
@@ -237,7 +313,7 @@ test.describe("remote-state coordinator routes", () => {
 
 			// Restricted sockets keep entity-addressed delivery for their authorized
 			// session; only the UI-only sidebar fanout is filtered.
-			await new Promise(resolve => setTimeout(resolve, 260));
+			crossForceCoalescingWindow();
 			const targetedCursor = sandboxWs.messageCount();
 			const beforeTargetedRead = prReads;
 			const targetedResponse = await apiFetch(`/api/sessions/${sessionId}/pr-status?intent=explicit`);
@@ -285,9 +361,9 @@ test.describe("remote-state coordinator routes", () => {
 			const beforeCustomPorts = prReads;
 			remoteOrigin = "ssh://git@example.github.test:2222/acme/widget.git";
 			// This SSH remote intentionally aliases the earlier HTTPS PR identity.
-			// Let the 250ms explicit-refresh coalescing window expire so this assertion
+			// Cross the explicit-refresh coalescing window deterministically so this
 			// observes a new authority-pinned permission cycle on every runner speed.
-			await new Promise(resolve => setTimeout(resolve, 260));
+			crossForceCoalescingWindow();
 			const sshPermissionStart = permissionApiCalls.length;
 			const sshResponse = await apiFetch(`/api/sessions/${sessionId}/pr-status?intent=explicit`);
 			expect(sshResponse.status).toBe(200);
@@ -384,7 +460,9 @@ test.describe("remote-state coordinator routes", () => {
 				(error as any).stderr = "fixture transport unavailable";
 				throw error;
 			}
-			return originalExecFile.call(runner, file, args, options);
+			const probe = standardSingleRepositoryProbe(file, args, gitCwd());
+			if (probe) return probe;
+			return unexpectedRunnerCommand(file, args, options);
 		};
 
 		try {
@@ -431,7 +509,7 @@ test.describe("remote-state coordinator routes", () => {
 			// A failed forced refresh retains the last-good null, but lastError makes
 			// it diagnostics-bearing stale state. optional=1 must not erase it as 204.
 			mode = "failure";
-			await new Promise(resolve => setTimeout(resolve, 260));
+			crossForceCoalescingWindow();
 			const failedResponse = await apiFetch(`/api/sessions/${sessionId}/pr-status?intent=explicit&optional=1`);
 			expect(failedResponse.status).toBe(200);
 			const failedBody = await failedResponse.json();
@@ -492,7 +570,10 @@ test.describe("remote-state coordinator routes", () => {
 			if (commandName(file) === "gh" && args[0] === "api") {
 				return { stdout: JSON.stringify({ data: { repository: { viewerPermission: "WRITE", pullRequest: { viewerCanMergeAsAdmin: false } } } }), stderr: "" };
 			}
-			return originalExecFile.call(runner, file, args, options);
+			if (commandName(file) === "git" && args[0] === "check-ref-format" && args[1] === "--branch") {
+				return { stdout: `${String(args[2])}\n`, stderr: "" };
+			}
+			return unexpectedRunnerCommand(file, args, options);
 		};
 
 		try {
@@ -600,7 +681,7 @@ test.describe("remote-state coordinator routes", () => {
 					stderr: "",
 				};
 			}
-			return originalExecFile.call(runner, file, args, options);
+			return unexpectedRunnerCommand(file, args, options);
 		};
 
 		try {
@@ -721,7 +802,9 @@ test.describe("remote-state coordinator routes", () => {
 				}, current] : [current];
 				return { stdout: JSON.stringify(results), stderr: "" };
 			}
-			return originalExecFile.call(runner, file, args, options);
+			const probe = standardSingleRepositoryProbe(file, args, ownedCwd);
+			if (probe) return probe;
+			return unexpectedRunnerCommand(file, args, options);
 		};
 
 		try {
@@ -752,26 +835,26 @@ test.describe("remote-state coordinator routes", () => {
 			expect(ghCalls.some(args => args[0] === "pr" && args[1] === "view")).toBe(false);
 
 			returnOutsideResult = true;
-			await new Promise(resolve => setTimeout(resolve, 260));
+			crossForceCoalescingWindow();
 			const escaped = await apiFetch(`/api/goals/${goalId}/pr-status?intent=explicit`);
 			expect(escaped.status).toBe(200);
 			const escapedBody = await escaped.json();
 			expect(escapedBody).toMatchObject({ stale: true, lastError: "unavailable", data: { number: 117, title: "owned 17" } });
 			expect(JSON.stringify(escapedBody)).not.toContain(outsideSentinel);
 			returnOutsideResult = false;
-			await new Promise(resolve => setTimeout(resolve, 260));
+			crossForceCoalescingWindow();
 			const recovered = await apiFetch(`/api/goals/${goalId}/pr-status?intent=explicit`);
 			expect(recovered.status).toBe(200);
 			expect(await recovered.json()).toMatchObject({ stale: false, data: { number: 117 } });
 
 			unsafeUrl = `https://${credentialSentinel}:secret@github.com/acme/owned-selector/pull/117`;
-			await new Promise(resolve => setTimeout(resolve, 260));
+			crossForceCoalescingWindow();
 			const rejectedCredentialUrl = await apiFetch(`/api/goals/${goalId}/pr-status?intent=explicit`);
 			const rejectedCredentialBody = await rejectedCredentialUrl.json();
 			expect(rejectedCredentialBody).toMatchObject({ stale: true, lastError: "unavailable", data: { number: 117 } });
 			expect(JSON.stringify(rejectedCredentialBody)).not.toContain(credentialSentinel);
 			unsafeUrl = undefined;
-			await new Promise(resolve => setTimeout(resolve, 260));
+			crossForceCoalescingWindow();
 			expect(await (await apiFetch(`/api/goals/${goalId}/pr-status?intent=explicit`)).json()).toMatchObject({ stale: false, data: { number: 117 } });
 
 			const callsBeforeInjectedMerge = ghCalls.length;
@@ -867,7 +950,7 @@ test.describe("remote-state coordinator routes", () => {
 					stderr: "",
 				};
 			}
-			return originalExecFile.call(runner, file, args, options);
+			return unexpectedRunnerCommand(file, args, options);
 		};
 
 		try {
@@ -1036,7 +1119,7 @@ test.describe("remote-state coordinator routes", () => {
 					stderr: "",
 				};
 			}
-			return originalExecFile.call(runner, file, args, options);
+			return unexpectedRunnerCommand(file, args, options);
 		};
 
 		try {
@@ -1180,7 +1263,7 @@ test.describe("remote-state coordinator routes", () => {
 					return { stdout: JSON.stringify({ data: { repository: { viewerPermission: "WRITE", pullRequest: { viewerCanMergeAsAdmin: false } } } }), stderr: "" };
 				}
 			}
-			return originalExecFile.call(runner, file, args, options);
+			return unexpectedRunnerCommand(file, args, options);
 		};
 
 		try {
@@ -1319,7 +1402,7 @@ test.describe("remote-state coordinator routes", () => {
 				if (args[0] === "pr" && args[1] === "merge") return { stdout: "merged", stderr: "" };
 				if (args[0] === "api") return { stdout: JSON.stringify({ data: { repository: { viewerPermission: "WRITE", pullRequest: { viewerCanMergeAsAdmin: false } } } }), stderr: "" };
 			}
-			return originalExecFile.call(runner, file, args, options);
+			return unexpectedRunnerCommand(file, args, options);
 		};
 
 		const exerciseOrientation = async (trusted: { goalId: string; cwd: string; repository: RepositoryFixture }, untrustedGoalId: string) => {
@@ -1434,7 +1517,9 @@ test.describe("remote-state coordinator routes", () => {
 			if (commandName(file) === "gh" && args[0] === "api") {
 				return { stdout: JSON.stringify({ data: { repository: { viewerPermission: "WRITE", pullRequest: { viewerCanMergeAsAdmin: false } } } }), stderr: "" };
 			}
-			return originalExecFile.call(runner, file, args, options);
+			const probe = standardSingleRepositoryProbe(file, args, hostCwd);
+			if (probe) return probe;
+			return unexpectedRunnerCommand(file, args, options);
 		};
 
 		try {
@@ -1467,7 +1552,7 @@ test.describe("remote-state coordinator routes", () => {
 				expect(await response.json()).toMatchObject({ stale: false, data: { state: "MERGED", title: "merge version 2" } });
 			}
 
-			await new Promise(resolve => setTimeout(resolve, 260));
+			crossForceCoalescingWindow();
 			const sessionMerge = await apiFetch(`/api/sessions/${sessionId}/pr-merge`, {
 				method: "POST",
 				body: JSON.stringify({ method: "rebase", branch }),
@@ -1480,7 +1565,7 @@ test.describe("remote-state coordinator routes", () => {
 			expect(await sessionFresh.json()).toMatchObject({ stale: false, data: { title: "merge version 3" } });
 
 			rejectMerge = true;
-			await new Promise(resolve => setTimeout(resolve, 260));
+			crossForceCoalescingWindow();
 			const readsBeforeRejectedMerge = prReads;
 			const rejectedMerge = await apiFetch(`/api/sessions/${sessionId}/pr-merge`, {
 				method: "POST",
@@ -1541,7 +1626,9 @@ test.describe("remote-state coordinator routes", () => {
 			if (commandName(file) === "gh" && args[0] === "api") {
 				return { stdout: JSON.stringify({ data: { repository: { viewerPermission: "WRITE", pullRequest: { viewerCanMergeAsAdmin: false } } } }), stderr: "" };
 			}
-			return originalExecFile.call(runner, file, args, options);
+			const probe = standardSingleRepositoryProbe(file, args, gitCwd());
+			if (probe) return probe;
+			return unexpectedRunnerCommand(file, args, options);
 		};
 
 		try {
@@ -1589,10 +1676,9 @@ test.describe("remote-state coordinator routes", () => {
 				failure = undefined;
 				version += 1;
 				gateway.clock.advance(1);
-				// Route force requests use a short real-time burst marker. Keep this
-				// recovery distinct from the previous explicit cycle while the two
-				// requests below still land in the same burst and join one flight.
-				await new Promise(resolve => setTimeout(resolve, 260));
+				// Keep this recovery distinct from the previous explicit cycle while the
+				// two requests below retain one burst timestamp and join one flight.
+				crossForceCoalescingWindow();
 				let releaseRecovery!: () => void;
 				let markRecoveryStarted!: () => void;
 				const recoveryStartedPromise = new Promise<void>(resolve => { markRecoveryStarted = resolve; });
@@ -1629,10 +1715,11 @@ test.describe("remote-state coordinator routes", () => {
 		test.setTimeout(30_000);
 		const primary = gitCwd();
 		const sibling = join(primary, `.remote-pr-head-sibling-${Date.now()}`);
-		const siblingBranch = `remote-pr-head-sibling-${Date.now()}`;
 		const runner = (gateway.sessionManager as any).commandRunner;
 		const originalExecFile = runner.execFile;
-		await runner.execFile("git", ["worktree", "add", "-b", siblingBranch, sibling], { cwd: primary, encoding: "utf-8", timeout: 10_000 });
+		// Head isolation is entirely runner-projected; only the final dirty-state
+		// scenario below needs a native sibling worktree.
+		mkdirSync(sibling, { recursive: true });
 		const primarySession = await createRemoteStateSession(gateway, primary);
 		const siblingSession = await createRemoteStateSession(gateway, sibling);
 		gateway.sessionManager.updateSessionMeta(primarySession, { branch: "" });
@@ -1696,7 +1783,9 @@ test.describe("remote-state coordinator routes", () => {
 			if (commandName(file) === "gh" && args[0] === "api") {
 				return { stdout: JSON.stringify({ data: { repository: { viewerPermission: "WRITE", pullRequest: { viewerCanMergeAsAdmin: false } } } }), stderr: "" };
 			}
-			return originalExecFile.call(runner, file, args, options);
+			const probe = standardSingleRepositoryProbe(file, args, primary);
+			if (probe) return probe;
+			return unexpectedRunnerCommand(file, args, options);
 		};
 
 		try {
@@ -1737,7 +1826,8 @@ test.describe("remote-state coordinator routes", () => {
 			primaryWs?.close();
 			siblingWs?.close();
 			await Promise.all([deleteSession(primarySession), deleteSession(siblingSession)]);
-			await removeSiblingWorktree(runner, primary, sibling);
+			const cleanup = await awaitableRm(sibling, { maxAttempts: 5, backoffMs: 50 });
+			expect(cleanup.removed, `head-isolation fixture cleanup failed: ${String(cleanup.lastError ?? "unknown error")}`).toBe(true);
 		}
 	});
 
@@ -1745,6 +1835,11 @@ test.describe("remote-state coordinator routes", () => {
 		test.setTimeout(30_000);
 		const primary = gitCwd();
 		const sibling = join(primary, `.remote-state-sibling-${Date.now()}`);
+		// This is the sole route scenario that owns native status fidelity. Evict
+		// deterministic projections before creating either worktree consumer.
+		serverModule.__clearGitStatusFake();
+		serverModule.invalidateGitStatusCache(primary);
+		serverModule.invalidateGitStatusCache(sibling);
 		const branch = `remote-state-sibling-${Date.now()}`;
 		const runner = (gateway.sessionManager as any).commandRunner;
 		const originalExecFile = runner.execFile;

--- a/tests2/tests-map.json
+++ b/tests2/tests-map.json
@@ -509,7 +509,7 @@
     },
     {
       "path": "tests2/integration/remote-state-routes.test.ts",
-      "reason": "In-process REST and WebSocket coverage for canonical remote read coalescing, safe snapshot envelopes, admin-versus-sandbox sidebar authorization, targeted sandbox delivery, PR cadence, local-only no-fetch behaviour, sibling worktree dirty-state isolation, and mutation invalidation.",
+      "reason": "In-process REST and WebSocket coverage with deterministic route-level Git projections for canonical remote read coalescing, safe snapshot envelopes, admin-versus-sandbox sidebar authorization, targeted sandbox delivery, PR cadence, local-only no-fetch behaviour, and mutation invalidation; the final sibling-worktree scenario retains native Git dirty-state fidelity.",
       "execution": {
         "runner": "vitest",
         "tier": "unit",


### PR DESCRIPTION
## Summary

- arm fake verification commands before signaling and drive the manual clock only after the command actually spawns
- eliminate the gate-reset test’s pre-spawn clock race
- replace native Git fanout in route-orchestration tests with fail-closed deterministic projections
- replace real 260ms coalescing sleeps with an explicit resettable test clock seam
- retain native Git fidelity in the sibling-worktree dirty-state scenario

## Release blocker

The retry-free `0.16.0-rc.1` unit gate exposed two reliability defects:

1. Gate polling could advance the manual clock entirely before asynchronous Git setup spawned a zero-delay fake command, leaving verification permanently `running`.
2. `remote-state-routes.test.ts` launched roughly 130 native Git processes and exceeded its 25-second file budget under Windows contention.

This fixes the barriers and test ownership instead of rerunning or raising budgets.

## Validation

- `npm run check`
- retry-free targeted integration run — 24 passed in 5.08s
- `gate-reset-api.test.ts` — 4.32s
- `remote-state-routes.test.ts` — 4.78s
- `git diff --check`

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)
