### PR TITLE
fix(test): remove in-worktree node_modules junction footgun from browser-chaos

### DIFF
--- a/scripts/testing-v2/browser-chaos.mjs
+++ b/scripts/testing-v2/browser-chaos.mjs
@@ -436,6 +436,12 @@ export function createEphemeralWorktree(label) {
 		execFileSync("git", ["worktree", "add", "--detach", dir, "HEAD"], { cwd: REPO_ROOT, stdio: "pipe" });
 		return dir;
 	} catch (err) {
+		// Provisioning (root + shared node_modules reparse point) already ran above,
+		// but this failure happens BEFORE the campaign's cleanup-protected lifecycle.
+		// Without this, a failed `git worktree add` would leak a live junction in
+		// os.tmpdir(). Unlink-first cleanup here so no reparse point survives the
+		// error path (junction-safe: cleanupBrowserChaosRoot removes the link first).
+		cleanupBrowserChaosRoot();
 		throw new Error(`git worktree add failed: ${err.stderr || err.message}`);
 	}
 }

--- a/scripts/testing-v2/browser-chaos.mjs
+++ b/scripts/testing-v2/browser-chaos.mjs
@@ -31,13 +31,15 @@
  * runs. The campaign is therefore heavy (a UI mutant ≈ one `vite build` + two
  * Playwright specs). It gates the switchover only — it is NOT part of test:v2.
  *
- * ─── Junction-safe teardown ─────────────────────────────────────────────────────
- * The ephemeral worktree's node_modules is a Windows junction into the primary
- * repo's node_modules. `unlinkNodeModulesJunction` UNLINKS the reparse point
- * (non-recursively) BEFORE any recursive delete, so neither `git worktree remove`
- * nor `fs.rmSync` can descend THROUGH the junction and wipe the shared tree.
- * This is the same fix chaos.mjs carries (see docs/testing-v2/node-modules-
- * corruption-rca.md) — do NOT reintroduce delete-through-junction.
+ * ─── Junction-safe teardown (campaign-scoped chaos root — PR #956) ───────────────
+ * The campaign worktree is created as a SIBLING of a single shared node_modules
+ * reparse point inside a campaign-scoped "chaos root" under os.tmpdir(). NO
+ * node_modules link ever lives INSIDE the worktree, so neither `git worktree
+ * remove` nor a recursive `fs.rmSync` of the worktree can descend THROUGH a
+ * junction into the shared/primary tree. Teardown unlinks the shared reparse
+ * point FIRST, then removes the root. This is the same primary fix chaos.mjs
+ * carries (see docs/testing-v2/node-modules-corruption-rca.md) — do NOT
+ * reintroduce an in-worktree node_modules junction (`ensureNodeModulesJunction`).
  *
  * ─── Honest attribution ─────────────────────────────────────────────────────────
  * caught    = a Playwright JSON report names a FAILING test in the targeted spec
@@ -51,7 +53,7 @@ import { execFileSync, spawnSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
 // ── Paths / repo resolution (mirrors chaos.mjs) ────────────────────────────────
 
@@ -148,6 +150,16 @@ const PLAYWRIGHT_CLI = path.join(PRIMARY_NODE_MODULES, "playwright", "cli.js");
 // uses for vitest.
 const TSC_ENTRY = path.join(PRIMARY_NODE_MODULES, "typescript", "bin", "tsc");
 const VITE_ENTRY = path.join(PRIMARY_NODE_MODULES, "vite", "bin", "vite.js");
+
+// Campaign-scoped container ("chaos root"): holds ONE shared node_modules
+// junction plus the campaign worktree as a SIBLING. Node / Vite / Playwright
+// resolve modules by walking UP from <BROWSER_CHAOS_ROOT>/wt-*/… to
+// <BROWSER_CHAOS_ROOT>/node_modules, so nothing resolvable ever lives inside the
+// throwaway worktree (= a deletion root). Primary fix for the node_modules-wipe
+// bug (PR #956): a recursive worktree delete can no longer descend through an
+// in-worktree junction into the shared/primary tree. See
+// docs/testing-v2/node-modules-corruption-rca.md.
+const BROWSER_CHAOS_ROOT = path.join(os.tmpdir(), `bobbit-browser-chaos-root-${process.pid}-${Date.now()}`);
 
 // --corpus <name> selects tests2/chaos/browser-mutants-<name>.json and suffixes
 // the report paths with -<name>, so two coders can run DISJOINT corpus files +
@@ -390,38 +402,88 @@ function classifyRun(r, durationMs) {
 	return { result: "error", detail: `exit ${r.exitCode} but NO attributed failing spec — harness error (${durationMs}ms)`, tests: [] };
 }
 
-// ── Worktree management (junction-safe teardown reused from chaos.mjs) ──────────
+// ── Worktree management (campaign-scoped chaos root — mirrors chaos.mjs PR #956) ─
 
-function createEphemeralWorktree(label) {
-	const tmpDir = path.join(os.tmpdir(), `bobbit-browser-chaos-${label}-${Date.now()}`);
+// Provision the campaign-scoped chaos root ONCE per run: the container dir plus a
+// SINGLE shared `node_modules` reparse point pointing at the complete toolchain
+// tree. The campaign worktree is created as a SIBLING (see createEphemeralWorktree)
+// and resolves modules by walking up to this link — so NO node_modules link lives
+// inside a worktree that a force-delete could descend through.
+export function ensureBrowserChaosRoot(root = BROWSER_CHAOS_ROOT, nmTarget = PRIMARY_NODE_MODULES) {
+	fs.mkdirSync(root, { recursive: true });
+	const link = path.join(root, "node_modules");
+	if (!fs.existsSync(link)) {
+		if (!fs.existsSync(nmTarget)) {
+			console.warn(`[browser-chaos] Warning: toolchain node_modules not found at ${nmTarget}`);
+			return root;
+		}
+		// On Windows use 'junction' for directories; on POSIX use 'dir' symlink.
+		const type = process.platform === "win32" ? "junction" : "dir";
+		fs.symlinkSync(nmTarget, link, type);
+	}
+	return root;
+}
+
+export function createEphemeralWorktree(label) {
+	// Sibling of the shared node_modules inside the chaos root. NO per-worktree
+	// node_modules link is created — the worktree resolves modules by walking up
+	// to <BROWSER_CHAOS_ROOT>/node_modules, so nothing resolvable lives in this
+	// deletion root and a force-delete can never descend through a junction into
+	// the shared/primary tree (the node_modules-wipe bug).
+	ensureBrowserChaosRoot();
+	const dir = path.join(BROWSER_CHAOS_ROOT, `wt-${label}`);
 	try {
-		execFileSync("git", ["worktree", "add", "--detach", tmpDir, "HEAD"], { cwd: REPO_ROOT, stdio: "pipe" });
-		return tmpDir;
+		execFileSync("git", ["worktree", "add", "--detach", dir, "HEAD"], { cwd: REPO_ROOT, stdio: "pipe" });
+		return dir;
 	} catch (err) {
 		throw new Error(`git worktree add failed: ${err.stderr || err.message}`);
 	}
 }
 
-function ensureNodeModulesJunction(worktreePath) {
-	const link = path.join(worktreePath, "node_modules");
-	if (fs.existsSync(link)) return;
-	if (!fs.existsSync(PRIMARY_NODE_MODULES)) {
-		console.warn(`[browser-chaos] Warning: primary node_modules not found at ${PRIMARY_NODE_MODULES}`);
-		return;
-	}
-	try {
-		const type = process.platform === "win32" ? "junction" : "dir";
-		fs.symlinkSync(PRIMARY_NODE_MODULES, link, type);
-	} catch (err) {
-		console.warn(`[browser-chaos] Warning: failed to create node_modules junction: ${err.message}`);
+// Remove ONLY a reparse point (junction/symlink), NEVER following it into its
+// target. On Windows a directory junction is a directory that is NOT a symlink
+// per lstat, so it must be removed with rmdir (non-recursive); a POSIX/Windows
+// symlink is removed with unlink. Refuse a real (non-link) entry — recursively
+// deleting that would be the exact footgun this helper exists to prevent.
+export function unlinkReparsePoint(p) {
+	const st = fs.lstatSync(p); // let it throw if absent — callers guard with existsSync
+	if (process.platform === "win32" && st.isDirectory() && !st.isSymbolicLink()) {
+		fs.rmdirSync(p); // Windows directory junction
+	} else if (st.isSymbolicLink()) {
+		fs.unlinkSync(p); // POSIX/Windows symlink
+	} else {
+		throw new Error("refusing to reparse-unlink a real entry: " + p);
 	}
 }
 
-// Remove the node_modules reparse point (junction/symlink) WITHOUT following it.
-// On Windows both `git worktree remove --force` and Node's recursive fs.rmSync
-// can descend THROUGH a directory junction and delete the target's contents (the
-// shared node_modules tree) instead of just unlinking the link. We therefore
-// unlink the link itself, non-recursively, first. (Same fix as chaos.mjs.)
+// Campaign teardown: remove the single shared node_modules reparse point FIRST
+// (so it can never be traversed), then recursively delete the chaos root. By the
+// time rm -rf runs, the junction is already gone — nothing external to descend
+// into. If the reparse point survives the unlink attempt, REFUSE the recursive
+// delete and leave the root in place rather than risk traversing the junction.
+export function cleanupBrowserChaosRoot(root = BROWSER_CHAOS_ROOT) {
+	const link = path.join(root, "node_modules");
+	try {
+		if (fs.existsSync(link)) unlinkReparsePoint(link);
+	} catch (e) {
+		console.warn(`[browser-chaos] junction unlink: ${e.message}`);
+	}
+	if (fs.existsSync(link)) {
+		console.warn(`[browser-chaos] node_modules reparse point still present after unlink; skipping recursive delete of ${root} to avoid traversing the junction`);
+		return;
+	}
+	try {
+		fs.rmSync(root, { recursive: true, force: true });
+	} catch { /* best-effort */ }
+}
+
+// Defensive belt-and-braces (retained from #956): even though no junction now
+// lives inside a worktree under the campaign-scoped-root design,
+// removeEphemeralWorktree still unlinks any node_modules reparse point BEFORE any
+// recursive delete. On Windows both `git worktree remove --force` and Node's
+// recursive fs.rmSync can descend THROUGH a directory junction and delete the
+// target's contents (the shared node_modules tree) instead of just unlinking the
+// link. We therefore unlink the link itself, non-recursively, first.
 function unlinkNodeModulesJunction(worktreePath) {
 	const link = path.join(worktreePath, "node_modules");
 	let st;
@@ -463,7 +525,7 @@ function unlinkNodeModulesJunction(worktreePath) {
 	}
 }
 
-function removeEphemeralWorktree(worktreePath) {
+export function removeEphemeralWorktree(worktreePath) {
 	if (!worktreePath) return;
 	try {
 		unlinkNodeModulesJunction(worktreePath);
@@ -800,8 +862,6 @@ async function main() {
 	}
 
 	try {
-		ensureNodeModulesJunction(worktreePath);
-
 		// Initial full build so dist/server + dist/ui exist and are CLEAN. Each
 		// step invokes its JS entry directly (no npm/.bin) for determinism.
 		console.log(`\n[browser-chaos] initial full build (packs + server + ui)…`);
@@ -813,7 +873,7 @@ async function main() {
 			if (!r.ok) {
 				console.error(`[browser-chaos] initial build:${label} FAILED — cannot run browser mutation campaign.`);
 				console.error(((r.stdout || "") + "\n" + (r.stderr || "")).slice(-1500));
-				if (!keepWorktree) removeEphemeralWorktree(worktreePath);
+				if (!keepWorktree) { removeEphemeralWorktree(worktreePath); cleanupBrowserChaosRoot(); }
 				process.exit(1);
 			}
 		}
@@ -842,8 +902,12 @@ async function main() {
 			writeReports(results, { date: new Date().toISOString(), totalDurationMs: Date.now() - totalStart, partial: true, runner: "browser-chaos.mjs" });
 		}
 	} finally {
-		if (!keepWorktree) removeEphemeralWorktree(worktreePath);
-		else console.log(`[browser-chaos] --keep-worktree: leaving ${worktreePath} in place (remember to \`git worktree remove\`).`);
+		if (!keepWorktree) {
+			removeEphemeralWorktree(worktreePath);
+			cleanupBrowserChaosRoot();
+		} else {
+			console.log(`[browser-chaos] --keep-worktree: leaving ${worktreePath} in place (remember to \`git worktree remove\` + delete ${BROWSER_CHAOS_ROOT}).`);
+		}
 	}
 
 	const meta = { date: new Date().toISOString(), totalDurationMs: Date.now() - totalStart, mutantCount: mutants.length, runner: "browser-chaos.mjs", partial: false };
@@ -876,7 +940,11 @@ async function main() {
 	console.log("\n✓ browser-chaos.mjs complete");
 }
 
-main().catch(err => {
-	console.error("[browser-chaos] Fatal error:", err);
-	process.exit(1);
-});
+// CLI-only guard: importing this module (e.g. from a test) must NOT run a
+// campaign. Only run main() when executed directly as a script.
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+	main().catch(err => {
+		console.error("[browser-chaos] Fatal error:", err);
+		process.exit(1);
+	});
+}

--- a/tests2/core/browser-chaos-worktree-safety.test.ts
+++ b/tests2/core/browser-chaos-worktree-safety.test.ts
@@ -1,0 +1,165 @@
+import fs from "node:fs";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+// Import the browser-chaos runner as a namespace. The module is CLI-guarded, so
+// importing it must NOT run a campaign — it only exposes the FS-safety helpers.
+import * as browserChaos from "../../scripts/testing-v2/browser-chaos.mjs";
+
+/**
+ * Reproducing test for the browser-chaos.mjs node_modules-wipe footgun.
+ *
+ * PR #956 removed the in-worktree `node_modules` junction from chaos.mjs (pinned
+ * by chaos-worktree-safety.test.ts) but browser-chaos.mjs still carried the same
+ * `ensureNodeModulesJunction` in-worktree junction + only the defensive unlink-
+ * first layer. This test pins the SAME campaign-scoped-root invariant for
+ * browser-chaos: junction-safe unlink, teardown that never deletes through a
+ * live junction, and the absence of the in-worktree junction footgun.
+ *
+ * The filesystem policy below models the one dangerous property of an NTFS
+ * junction: recursively deleting a root while its junction remains can erase the
+ * external target. Keeping the model in memory makes this safety contract
+ * deterministic without creating or Defender-scanning real reparse points.
+ */
+
+type VirtualEntry =
+	| { kind: "dir" }
+	| { kind: "file"; content: string }
+	| { kind: "junction"; target: string };
+
+class VirtualJunctionPolicy {
+	private readonly entries = new Map<string, VirtualEntry>();
+
+	constructor() {
+		vi.spyOn(fs, "existsSync").mockImplementation((entry) => this.entries.has(this.key(entry)));
+		vi.spyOn(fs, "lstatSync").mockImplementation(((entry: fs.PathLike) => {
+			const value = this.entries.get(this.key(entry));
+			if (!value) throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+			return {
+				isDirectory: () => value.kind === "dir" || (value.kind === "junction" && process.platform === "win32"),
+				isSymbolicLink: () => value.kind === "junction" && process.platform !== "win32",
+			};
+		}) as typeof fs.lstatSync);
+		vi.spyOn(fs, "rmdirSync").mockImplementation(((entry: fs.PathLike) => this.unlinkJunction(entry)) as typeof fs.rmdirSync);
+		vi.spyOn(fs, "unlinkSync").mockImplementation(((entry: fs.PathLike) => this.unlinkJunction(entry)) as typeof fs.unlinkSync);
+		vi.spyOn(fs, "rmSync").mockImplementation(((entry: fs.PathLike, options?: fs.RmDirOptions) => this.remove(entry, options)) as typeof fs.rmSync);
+	}
+
+	mkdir(entry: string): void {
+		this.entries.set(this.key(entry), { kind: "dir" });
+	}
+
+	write(entry: string, content: string): void {
+		this.entries.set(this.key(entry), { kind: "file", content });
+	}
+
+	junction(target: string, link: string): void {
+		this.entries.set(this.key(link), { kind: "junction", target: this.key(target) });
+	}
+
+	exists(entry: string): boolean {
+		return this.entries.has(this.key(entry));
+	}
+
+	read(entry: string): string | undefined {
+		const value = this.entries.get(this.key(entry));
+		return value?.kind === "file" ? value.content : undefined;
+	}
+
+	private key(entry: fs.PathLike): string {
+		return path.resolve(String(entry));
+	}
+
+	private unlinkJunction(entry: fs.PathLike): void {
+		const key = this.key(entry);
+		if (this.entries.get(key)?.kind !== "junction") throw new Error(`not a junction: ${key}`);
+		this.entries.delete(key);
+	}
+
+	private remove(entry: fs.PathLike, options?: fs.RmDirOptions): void {
+		const root = this.key(entry);
+		const prefix = `${root}${path.sep}`;
+		if (options?.recursive) {
+			// Model the Windows footgun: a recursive delete with a live junction
+			// traverses into its external target. The production helper must unlink
+			// every junction before reaching this operation.
+			for (const [key, value] of this.entries) {
+				if ((key === root || key.startsWith(prefix)) && value.kind === "junction") {
+					const targetPrefix = `${value.target}${path.sep}`;
+					for (const targetKey of [...this.entries.keys()]) {
+						if (targetKey === value.target || targetKey.startsWith(targetPrefix)) this.entries.delete(targetKey);
+					}
+				}
+			}
+			for (const key of [...this.entries.keys()]) {
+				if (key === root || key.startsWith(prefix)) this.entries.delete(key);
+			}
+			return;
+		}
+		this.entries.delete(root);
+	}
+}
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe("browser-chaos.mjs worktree teardown is junction-safe (node_modules-wipe reproducing test)", () => {
+	it("unlinkReparsePoint removes only the link and preserves the external junction target", () => {
+		expect(
+			typeof (browserChaos as Record<string, unknown>).unlinkReparsePoint,
+			"REPRO-FAIL: browser-chaos.unlinkReparsePoint is not a function (junction-safe unlink helper missing)",
+		).toBe("function");
+
+		const policy = new VirtualJunctionPolicy();
+		const sentinel = path.resolve("/virtual/browser-chaos/sentinel");
+		const marker = path.join(sentinel, "MARKER.txt");
+		const container = path.resolve("/virtual/browser-chaos/container");
+		const link = path.join(container, "node_modules");
+		policy.mkdir(sentinel);
+		policy.write(marker, "do-not-delete");
+		policy.mkdir(container);
+		policy.junction(sentinel, link);
+
+		const unlinkReparsePoint = (browserChaos as { unlinkReparsePoint: (entry: string) => void }).unlinkReparsePoint;
+		unlinkReparsePoint(link);
+
+		expect(policy.exists(link), "REPRO-FAIL: reparse point still present after unlinkReparsePoint").toBe(false);
+		expect(policy.exists(sentinel), "REPRO-FAIL: external junction target dir was deleted through the link").toBe(true);
+		expect(policy.exists(marker), "REPRO-FAIL: external junction target marker file was deleted through the link").toBe(true);
+		expect(policy.read(marker)).toBe("do-not-delete");
+	});
+
+	it("cleanupBrowserChaosRoot removes the chaos root but never deletes through the node_modules junction", () => {
+		expect(
+			typeof (browserChaos as Record<string, unknown>).cleanupBrowserChaosRoot,
+			"REPRO-FAIL: browser-chaos.cleanupBrowserChaosRoot is not a function (campaign-scoped teardown helper missing)",
+		).toBe("function");
+
+		const policy = new VirtualJunctionPolicy();
+		const sentinel = path.resolve("/virtual/browser-chaos/sentinel2");
+		const marker = path.join(sentinel, "MARKER.txt");
+		const chaosRoot = path.resolve("/virtual/browser-chaos/root");
+		const worktree = path.join(chaosRoot, "wt-campaign");
+		policy.mkdir(sentinel);
+		policy.write(marker, "shared-node-modules");
+		policy.mkdir(chaosRoot);
+		policy.junction(sentinel, path.join(chaosRoot, "node_modules"));
+		policy.mkdir(worktree);
+		policy.write(path.join(worktree, "file.txt"), "ephemeral");
+
+		const cleanupBrowserChaosRoot = (browserChaos as { cleanupBrowserChaosRoot: (root: string) => void }).cleanupBrowserChaosRoot;
+		cleanupBrowserChaosRoot(chaosRoot);
+
+		expect(policy.exists(chaosRoot), "REPRO-FAIL: cleanupBrowserChaosRoot did not remove the chaos root").toBe(false);
+		expect(policy.exists(sentinel), "REPRO-FAIL: cleanupBrowserChaosRoot deleted through the node_modules junction into the external target").toBe(true);
+		expect(policy.exists(marker), "REPRO-FAIL: cleanupBrowserChaosRoot deleted the external junction target marker file").toBe(true);
+		expect(policy.read(marker)).toBe("shared-node-modules");
+	});
+
+	it("ensureNodeModulesJunction is removed (the in-worktree junction footgun can never return)", () => {
+		expect(
+			(browserChaos as Record<string, unknown>).ensureNodeModulesJunction,
+			"REPRO-FAIL: browser-chaos.ensureNodeModulesJunction is still defined — the in-worktree node_modules junction must be removed",
+		).toBeUndefined();
+	});
+});

--- a/tests2/tests-map.json
+++ b/tests2/tests-map.json
@@ -1723,6 +1723,15 @@
       }
     },
     {
+      "path": "tests2/core/browser-chaos-worktree-safety.test.ts",
+      "reason": "Reproducing test for the browser-chaos node_modules-wipe footgun: pins junction-safe teardown (unlinkReparsePoint / cleanupBrowserChaosRoot preserve an external junction target) and the campaign-scoped-root layout (ensureNodeModulesJunction removed). PR #956 fixed this in chaos.mjs but browser-chaos.mjs still carried the in-worktree junction into a shared/primary tree. Temp-FS only, external-free core tier.",
+      "execution": {
+        "runner": "vitest",
+        "tier": "unit",
+        "project": "core"
+      }
+    },
+    {
       "path": "tests2/core/pi-rpc-agent-end-retry.test.ts",
       "reason": "Pi 0.80.5 RPC compatibility: retryable agent_end events carry willRetry=true before Pi internal auto-retry settles. Bobbit must not mark the session idle, drain queued prompts, revoke one-time grants, or resolve waitForIdle until the final non-retry agent_end.",
       "execution": {


### PR DESCRIPTION
## Problem

On Windows the primary checkout's `node_modules` intermittently **half-wipes** while the dev stack is live — agents/verification spawns then fail with `Cannot find package '@earendil-works/pi-*'`. One confirmed vector (RCA §13, `docs/testing-v2/node-modules-corruption-rca.md`) is a Windows directory **junction** to the shared `node_modules` living *inside* an ephemeral worktree: `git worktree remove --force` / recursive `fs.rmSync` can descend **through** the junction and delete the shared tree's contents instead of just unlinking the link.

**PR #956** fixed this in `chaos.mjs` — a campaign-scoped "chaos root" holding ONE shared `node_modules` junction with per-mutant worktrees as *siblings* (walk-up resolution), so nothing resolvable lives inside a deletion root — and pinned it with `tests2/core/chaos-worktree-safety.test.ts`.

**`browser-chaos.mjs` was missed by that rollout.** It still:
- created an in-worktree `node_modules` junction into the shared/primary tree (`ensureNodeModulesJunction`), and
- relied only on the *defensive* unlink-first teardown (no primary fix).

So a crashed/interrupted browser-chaos run — or any teardown that skips the unlink — can still descend the junction and half-wipe the primary tree.

## Fix

Port the #956 **primary** fix to `browser-chaos.mjs`:

- Campaign-scoped `BROWSER_CHAOS_ROOT` under `os.tmpdir()` holding ONE shared `node_modules` junction; the campaign worktree is created as a **sibling** (`<root>/wt-campaign`) that resolves modules by walking up — **no in-worktree junction**.
- **Delete** `ensureNodeModulesJunction` and its call site.
- Add `ensureBrowserChaosRoot` / `unlinkReparsePoint` / `cleanupBrowserChaosRoot` (teardown unlinks the shared reparse point **first**, then `rm -rf` the root; refuses to recurse if the link survives).
- Keep the defensive `unlinkNodeModulesJunction` in `removeEphemeralWorktree` (belt-and-braces).
- Add the `import.meta.url === pathToFileURL(process.argv[1]).href` **CLI guard** + `export` the FS-safety helpers, so the module is importable by a test without launching a campaign.

## Tests

New `tests2/core/browser-chaos-worktree-safety.test.ts` (temp-FS only, external-free **core** tier), mirroring `chaos-worktree-safety.test.ts`:
- `unlinkReparsePoint` removes only the link and preserves the external junction target + marker,
- `cleanupBrowserChaosRoot` removes the root but never deletes through a live junction,
- `ensureNodeModulesJunction` is `undefined` (the footgun can't return).

Local validation: both safety files pass (**6/6**); `browser-chaos.mjs --dry-run` lists mutants and exits 0 without creating a worktree.

> Note: the full browser-chaos campaign is heavy/gated (not part of `test:v2`), so end-to-end campaign behavior isn't exercised in CI — same validation posture as #956 (safety pinned by the temp-FS unit test; the FS-layout change mirrors the already-proven `chaos.mjs` fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)