### PR TITLE
Cache pack manifest scans

### DIFF
--- a/src/server/agent/builtin-packs.ts
+++ b/src/server/agent/builtin-packs.ts
@@ -99,11 +99,35 @@ export function activeBuiltinFirstPartyPackEntries(
 	);
 }
 
+// ── Built-in pack scan cache ─────────────────────────────────────────
+//
+// Like `scanMarketPacks`, this reads + YAML-parses every shipped pack manifest
+// on every call, and the roles/tools cascade (`ConfigCascade.resolveEntities`)
+// calls it per resolution → per session/connection. That was a co-driver of the
+// manifest-parse hot loop (observed live via this exact caller frame). The
+// shipped `dist/server/builtin-packs/` tree is immutable at runtime, so the only
+// thing that can legitimately change the result is the #734 activation override
+// — which is applied by `activeBuiltinFirstPartyPackEntries` AFTER this raw
+// scan, and flows through the same `invalidateResolverCaches()` path. Cache the
+// raw scan per dir and drop it via `invalidateBuiltinPackScanCache()`.
+//
+// Pinned by tests2/core/pack-list-scan-cache.test.ts.
+const __builtinScanCache = new Map<string, PackEntry[]>();
+
+/** Drop the built-in pack scan cache. Wired into `invalidateResolverCaches()`
+ *  alongside {@link invalidateMarketPackScanCache}. */
+export function invalidateBuiltinPackScanCache(): void {
+	__builtinScanCache.clear();
+}
+
 export function builtinFirstPartyPackEntries(builtinPacksDir: string): PackEntry[] {
+	const cached = __builtinScanCache.get(builtinPacksDir);
+	if (cached) return cached;
 	let dirents: fs.Dirent[];
 	try {
 		dirents = fs.readdirSync(builtinPacksDir, { withFileTypes: true });
 	} catch {
+		__builtinScanCache.set(builtinPacksDir, []);
 		return [];
 	}
 	const out: PackEntry[] = [];
@@ -136,5 +160,6 @@ export function builtinFirstPartyPackEntries(builtinPacksDir: string): PackEntry
 			skillSource: "project",
 		});
 	}
+	__builtinScanCache.set(builtinPacksDir, out);
 	return out;
 }

--- a/src/server/agent/pack-list.ts
+++ b/src/server/agent/pack-list.ts
@@ -77,21 +77,58 @@ function readDisabledDirs(store?: ProjectConfigReader): Set<string> {
 	return out;
 }
 
+// ── Market-pack scan cache ───────────────────────────────────────────
+//
+// `scanMarketPacks` reads + YAML-parses every `pack.yaml` and `.pack-meta.yaml`
+// under a scope's `market-packs/` on every call. The roles/tools cascade
+// (`scopeMarketPackEntries` → `ConfigCascade.resolveEntities`) and `buildPackList`
+// call it during EVERY resolution, and resolution happens per session / per
+// connected client. On a busy gateway that is hundreds of full disk re-scans +
+// manifest parses per second for a manifest set that only changes on a
+// marketplace install/update/uninstall — a CPU-pegging hot loop (the entries are
+// immutable between mutations). Cache the parsed result per
+// (marketPacksRoot, scope, orderHint) and drop the whole cache on any pack
+// mutation via `invalidateMarketPackScanCache()`, which the host already fans
+// out from `invalidateResolverCaches()` on install/update/uninstall/pack-order.
+//
+// Pinned by tests2/core/pack-list-scan-cache.test.ts (N resolutions ⇒ 1 scan;
+// invalidation forces a re-scan). Never widen the key without updating that test.
+const __scanCache = new Map<string, PackEntry[]>();
+
+/** Drop the market-pack scan cache. MUST be called on any pack install /
+ *  update / uninstall / pack-order change so the next scan re-reads disk.
+ *  Wired into the host's `invalidateResolverCaches()`. */
+export function invalidateMarketPackScanCache(): void {
+	__scanCache.clear();
+}
+
 /**
  * Scan a scope's `market-packs/` for installed packs. A dir counts as a pack
  * only if it has BOTH a valid `pack.yaml` AND a valid `.pack-meta.yaml`
  * (corrupt-guard, §8.1). `.tmp-*` staging dirs are skipped. Ordered by
  * `orderHint` (highest priority LAST); unlisted-on-disk dirs sort first.
+ *
+ * Cached per (root, scope, orderHint) — see the cache note above. The cached
+ * array is treated as immutable by callers (they only read + concat it), so
+ * returning the shared reference is safe and avoids a per-call copy.
  */
 function scanMarketPacks(
 	marketPacksRoot: string,
 	scope: PackScope,
 	orderHint: string[],
 ): PackEntry[] {
+	const cacheKey = `${scope}\0${marketPacksRoot}\0${orderHint.join(",")}`;
+	const cached = __scanCache.get(cacheKey);
+	if (cached) return cached;
+
 	let dirents: fs.Dirent[];
 	try {
 		dirents = fs.readdirSync(marketPacksRoot, { withFileTypes: true });
 	} catch {
+		// Cache the empty result too: a missing market-packs/ dir is the common
+		// case (most scopes have none) and re-statting it every resolution is the
+		// same hot-loop waste. Invalidation on install re-scans when a dir appears.
+		__scanCache.set(cacheKey, []);
 		return [];
 	}
 	const found = new Map<string, PackEntry>();
@@ -119,7 +156,9 @@ function scanMarketPacks(
 	const listed = new Set(orderHint);
 	const unlisted = [...found.keys()].filter((n) => !listed.has(n));
 	const ordered = [...unlisted, ...orderHint.filter((n) => found.has(n))];
-	return ordered.map((n) => found.get(n)!).filter(Boolean);
+	const result = ordered.map((n) => found.get(n)!).filter(Boolean);
+	__scanCache.set(cacheKey, result);
+	return result;
 }
 
 /**

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -607,11 +607,11 @@ import { resolveScalarConfig } from "./agent/config-resolver.js";
 import { BuiltinConfigProvider } from "./agent/builtin-config.js";
 import { ConfigCascade, normalizeConfigProjectId, type MarketPackProvider } from "./agent/config-cascade.js";
 import { MarketplaceSourceStore, isValidSourceId, type MarketplaceSource } from "./agent/marketplace-source-store.js";
-import { BUILTIN_PACK_SCOPE, activeBuiltinFirstPartyPackEntries, builtinFirstPartyPackEntries, isPackEffectivelyEnabled, resolveBuiltinPacksDir } from "./agent/builtin-packs.js";
+import { BUILTIN_PACK_SCOPE, activeBuiltinFirstPartyPackEntries, builtinFirstPartyPackEntries, invalidateBuiltinPackScanCache, isPackEffectivelyEnabled, resolveBuiltinPacksDir } from "./agent/builtin-packs.js";
 import { MarketplaceInstaller, MarketplaceError, readPackEntityDescriptions, type InstallScope, type PackOrderStore, type PackEntityDescriptions, type BrowsePack } from "./agent/marketplace-install.js";
 import type { MarketplaceMcpResolver, McpReloadResult, McpToolRouteSnapshot, ResolvedMcpContribution } from "./mcp/mcp-manager.js";
 import type { MarketplacePiExtensionResolver, ResolvedPiExtensionContribution, PiExtensionDiagnostic } from "./agent/session-setup.js";
-import { scopeMarketPackEntries } from "./agent/pack-list.js";
+import { scopeMarketPackEntries, invalidateMarketPackScanCache } from "./agent/pack-list.js";
 import { buildConflictsFor, type ConflictWire, type PackScope, type PackEntry } from "./agent/pack-types.js";
 import { isSafeBasename } from "./agent/pack-manifest.js";
 import { gatewayMcpActivationContributionId, gatewayMcpRuntimeKey } from "./agent/mcp-gateway-runtime-identity.js";
@@ -5132,7 +5132,7 @@ async function handleApiRoute(
 			console.warn("[extension-channels] closeUnavailablePacks failed after resolver invalidation:", err);
 		});
 	};
-	const invalidateResolverCaches = (): void => { invalidateSlashSkillsCache(); __resetToolScanCache(); toolManager.clearScopedPiExtensionTools(); piExtensionDiscoveryCache.clear(); dispatcher.invalidate(); routeDispatcher.invalidate(); routeRegistry.invalidate(); packContributionRegistry.invalidate(); closeUnavailableExtensionChannels(); };
+	const invalidateResolverCaches = (): void => { invalidateMarketPackScanCache(); invalidateBuiltinPackScanCache(); invalidateSlashSkillsCache(); __resetToolScanCache(); toolManager.clearScopedPiExtensionTools(); piExtensionDiscoveryCache.clear(); dispatcher.invalidate(); routeDispatcher.invalidate(); routeRegistry.invalidate(); packContributionRegistry.invalidate(); closeUnavailableExtensionChannels(); };
 	const refreshMcpExternalTools = (): void => {
 		sessionManager.refreshExternalMcpToolRegistrations();
 	};

--- a/tests2/core/pack-list-scan-cache.test.ts
+++ b/tests2/core/pack-list-scan-cache.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Pinning tests for the marketplace and shipped built-in pack scan caches.
+ *
+ * These prove caching without spying on `fs` (ESM namespace exports are not
+ * spy-able here): mutate the filesystem after a scan and assert the result stays
+ * stale until the corresponding central invalidator is called.
+ */
+import { afterEach, beforeEach, expect, test } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { builtinFirstPartyPackEntries, invalidateBuiltinPackScanCache } from "../../src/server/agent/builtin-packs.ts";
+import { scopeMarketPackEntries, invalidateMarketPackScanCache } from "../../src/server/agent/pack-list.ts";
+
+let tmpRoot: string;
+let marketPacksRoot: string;
+let builtinPacksRoot: string;
+
+function manifest(name: string): string {
+	return `name: ${name}\ndescription: test pack ${name}\nversion: 0.0.1\nschema: 2\ncontents:\n  roles: []\n  tools: []\n  skills: []\n  entrypoints: []\n`;
+}
+
+/** Write a valid installed pack (pack.yaml + .pack-meta.yaml) under market-packs/. */
+function installPack(name: string): void {
+	const dir = path.join(marketPacksRoot, name);
+	fs.mkdirSync(dir, { recursive: true });
+	fs.writeFileSync(path.join(dir, "pack.yaml"), manifest(name), "utf-8");
+	fs.writeFileSync(
+		path.join(dir, ".pack-meta.yaml"),
+		`packName: ${name}\nversion: 0.0.1\nscope: project\n`,
+		"utf-8",
+	);
+}
+
+/** Write a valid shipped pack; built-ins intentionally require no metadata. */
+function installBuiltinPack(name: string): void {
+	const dir = path.join(builtinPacksRoot, name);
+	fs.mkdirSync(dir, { recursive: true });
+	fs.writeFileSync(path.join(dir, "pack.yaml"), manifest(name), "utf-8");
+}
+
+const names = (entries: { manifest?: { name: string } }[]): string[] =>
+	entries.map((entry) => entry.manifest?.name ?? "").filter(Boolean);
+
+beforeEach(() => {
+	tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "pack-scan-cache-"));
+	// project scope ⇒ marketPacksRoot = <base>/.bobbit/config/market-packs
+	marketPacksRoot = path.join(tmpRoot, ".bobbit", "config", "market-packs");
+	builtinPacksRoot = path.join(tmpRoot, "builtin-packs", "market-packs");
+	fs.mkdirSync(marketPacksRoot, { recursive: true });
+	fs.mkdirSync(builtinPacksRoot, { recursive: true });
+	invalidateMarketPackScanCache();
+	invalidateBuiltinPackScanCache();
+});
+
+afterEach(() => {
+	invalidateMarketPackScanCache();
+	invalidateBuiltinPackScanCache();
+	fs.rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+test("marketplace scans stay cached until invalidation", () => {
+	installPack("notes");
+	expect(names(scopeMarketPackEntries("project", tmpRoot, []))).toEqual(["notes"]);
+
+	fs.rmSync(path.join(marketPacksRoot, "notes"), { recursive: true, force: true });
+	for (let i = 0; i < 50; i++) {
+		expect(names(scopeMarketPackEntries("project", tmpRoot, []))).toEqual(["notes"]);
+	}
+
+	invalidateMarketPackScanCache();
+	expect(scopeMarketPackEntries("project", tmpRoot, [])).toEqual([]);
+});
+
+test("marketplace invalidation picks up installs and uninstalls", () => {
+	installPack("notes");
+	expect(names(scopeMarketPackEntries("project", tmpRoot, []))).toEqual(["notes"]);
+
+	installPack("terminal");
+	expect(names(scopeMarketPackEntries("project", tmpRoot, []))).toEqual(["notes"]);
+
+	invalidateMarketPackScanCache();
+	expect(names(scopeMarketPackEntries("project", tmpRoot, [])).sort()).toEqual(["notes", "terminal"]);
+
+	fs.rmSync(path.join(marketPacksRoot, "terminal"), { recursive: true, force: true });
+	invalidateMarketPackScanCache();
+	expect(names(scopeMarketPackEntries("project", tmpRoot, []))).toEqual(["notes"]);
+});
+
+test("marketplace cache keys include orderHint", () => {
+	installPack("a");
+	installPack("b");
+	expect(names(scopeMarketPackEntries("project", tmpRoot, ["a", "b"]))).toEqual(["a", "b"]);
+	expect(names(scopeMarketPackEntries("project", tmpRoot, ["b", "a"]))).toEqual(["b", "a"]);
+});
+
+test("missing marketplace directories are cached and safely invalidated", () => {
+	fs.rmSync(marketPacksRoot, { recursive: true, force: true });
+	expect(scopeMarketPackEntries("project", tmpRoot, [])).toEqual([]);
+	for (let i = 0; i < 10; i++) expect(scopeMarketPackEntries("project", tmpRoot, [])).toEqual([]);
+
+	fs.mkdirSync(marketPacksRoot, { recursive: true });
+	installPack("late");
+	// A newly-created directory remains hidden until a real mutation invalidates.
+	expect(scopeMarketPackEntries("project", tmpRoot, [])).toEqual([]);
+	invalidateMarketPackScanCache();
+	expect(names(scopeMarketPackEntries("project", tmpRoot, []))).toEqual(["late"]);
+});
+
+test("built-in scans stay cached per directory until invalidation", () => {
+	installBuiltinPack("alpha");
+	expect(names(builtinFirstPartyPackEntries(builtinPacksRoot))).toEqual(["alpha"]);
+
+	fs.rmSync(path.join(builtinPacksRoot, "alpha"), { recursive: true, force: true });
+	installBuiltinPack("beta");
+	for (let i = 0; i < 50; i++) {
+		expect(names(builtinFirstPartyPackEntries(builtinPacksRoot))).toEqual(["alpha"]);
+	}
+
+	invalidateBuiltinPackScanCache();
+	expect(names(builtinFirstPartyPackEntries(builtinPacksRoot))).toEqual(["beta"]);
+});
+
+test("missing built-in directories are cached and safely invalidated", () => {
+	fs.rmSync(builtinPacksRoot, { recursive: true, force: true });
+	expect(builtinFirstPartyPackEntries(builtinPacksRoot)).toEqual([]);
+
+	installBuiltinPack("late");
+	expect(builtinFirstPartyPackEntries(builtinPacksRoot)).toEqual([]);
+	invalidateBuiltinPackScanCache();
+	expect(names(builtinFirstPartyPackEntries(builtinPacksRoot))).toEqual(["late"]);
+});

--- a/tests2/core/pack-list-scan-cache.test.ts
+++ b/tests2/core/pack-list-scan-cache.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Pinning test for the market-pack scan cache (pack-list.ts).
+ *
+ * REGRESSION THIS PINS: `scopeMarketPackEntries` → `scanMarketPacks` used to
+ * read + YAML-parse every `pack.yaml` / `.pack-meta.yaml` under a scope's
+ * `market-packs/` on EVERY call. The roles/tools cascade calls it during every
+ * resolution, and resolution runs per session / per connected client — so a
+ * busy gateway did hundreds of full disk re-scans + manifest parses per second
+ * for an immutable-between-mutations manifest set, pegging a core (observed live
+ * as ~155 parseManifest/sec via `marketEntries`). The fix caches the scan and
+ * only drops it on a pack mutation via `invalidateMarketPackScanCache()` (fanned
+ * out from the host's `invalidateResolverCaches()`).
+ *
+ * We prove the cache WITHOUT spying on `fs` (ESM namespace exports aren't
+ * spy-able here) by mutating the filesystem behind the scan and asserting the
+ * result does NOT change until the cache is invalidated — a stale read is only
+ * possible if disk was not re-read.
+ *
+ * Invariants pinned:
+ *   1. After the first scan, deleting the pack on disk does NOT change the
+ *      result (served from cache ⇒ no re-read).
+ *   2. invalidateMarketPackScanCache() forces the next call to re-scan disk
+ *      (so a real install/update/uninstall is picked up).
+ *   3. A distinct orderHint is a distinct cache key (no stale ordering served).
+ *   4. A missing market-packs dir returns [] and is cached (no crash on re-read).
+ */
+import { afterEach, beforeEach, expect, test } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { scopeMarketPackEntries, invalidateMarketPackScanCache } from "../../src/server/agent/pack-list.ts";
+
+let tmpRoot: string;
+let marketPacksRoot: string;
+
+/** Write a valid installed pack (pack.yaml + .pack-meta.yaml) under market-packs/. */
+function installPack(name: string): void {
+	const dir = path.join(marketPacksRoot, name);
+	fs.mkdirSync(dir, { recursive: true });
+	fs.writeFileSync(
+		path.join(dir, "pack.yaml"),
+		`name: ${name}\ndescription: test pack ${name}\nversion: 0.0.1\nschema: 2\ncontents:\n  roles: []\n  tools: []\n  skills: []\n  entrypoints: []\n`,
+		"utf-8",
+	);
+	fs.writeFileSync(
+		path.join(dir, ".pack-meta.yaml"),
+		`packName: ${name}\nversion: 0.0.1\nscope: project\n`,
+		"utf-8",
+	);
+}
+
+const names = (entries: ReturnType<typeof scopeMarketPackEntries>): string[] =>
+	entries.map((e) => e.manifest?.name ?? "").filter(Boolean);
+
+beforeEach(() => {
+	tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "pack-scan-cache-"));
+	// project scope ⇒ marketPacksRoot = <base>/.bobbit/config/market-packs
+	marketPacksRoot = path.join(tmpRoot, ".bobbit", "config", "market-packs");
+	fs.mkdirSync(marketPacksRoot, { recursive: true });
+	invalidateMarketPackScanCache(); // isolate from any prior test's cache
+});
+
+afterEach(() => {
+	invalidateMarketPackScanCache();
+	fs.rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+test("second call is served from cache (disk mutation not observed until invalidation)", () => {
+	installPack("notes");
+
+	// First call scans disk and finds the pack.
+	expect(names(scopeMarketPackEntries("project", tmpRoot, []))).toEqual(["notes"]);
+
+	// Delete the pack ON DISK. A non-caching scan would now return []; the cache
+	// must still return the previously-scanned result (proving no re-read).
+	fs.rmSync(path.join(marketPacksRoot, "notes"), { recursive: true, force: true });
+	for (let i = 0; i < 50; i++) {
+		expect(names(scopeMarketPackEntries("project", tmpRoot, []))).toEqual(["notes"]);
+	}
+});
+
+test("invalidateMarketPackScanCache forces a re-scan (picks up install AND uninstall)", () => {
+	installPack("notes");
+	expect(names(scopeMarketPackEntries("project", tmpRoot, []))).toEqual(["notes"]);
+
+	// Install a second pack on disk; cache still serves the stale single result…
+	installPack("terminal");
+	expect(names(scopeMarketPackEntries("project", tmpRoot, []))).toEqual(["notes"]);
+
+	// …invalidate ⇒ next call re-scans and sees both (sorted for stability).
+	invalidateMarketPackScanCache();
+	expect(names(scopeMarketPackEntries("project", tmpRoot, [])).sort()).toEqual(["notes", "terminal"]);
+
+	// Uninstall on disk + invalidate ⇒ re-scan reflects the removal.
+	fs.rmSync(path.join(marketPacksRoot, "terminal"), { recursive: true, force: true });
+	invalidateMarketPackScanCache();
+	expect(names(scopeMarketPackEntries("project", tmpRoot, []))).toEqual(["notes"]);
+});
+
+test("distinct orderHint is a distinct cache key (no stale ordering served)", () => {
+	installPack("a");
+	installPack("b");
+	// orderHint lists highest-priority LAST in the returned array.
+	expect(names(scopeMarketPackEntries("project", tmpRoot, ["a", "b"]))).toEqual(["a", "b"]);
+	expect(names(scopeMarketPackEntries("project", tmpRoot, ["b", "a"]))).toEqual(["b", "a"]);
+});
+
+test("a missing market-packs dir returns [] and re-reads safely after invalidation", () => {
+	fs.rmSync(marketPacksRoot, { recursive: true, force: true }); // no dir at all
+	expect(scopeMarketPackEntries("project", tmpRoot, [])).toEqual([]);
+	// Repeated calls stay empty and do not throw (cached empty result).
+	for (let i = 0; i < 10; i++) expect(scopeMarketPackEntries("project", tmpRoot, [])).toEqual([]);
+
+	// Create the dir + a pack, invalidate ⇒ now found.
+	fs.mkdirSync(marketPacksRoot, { recursive: true });
+	installPack("late");
+	invalidateMarketPackScanCache();
+	expect(names(scopeMarketPackEntries("project", tmpRoot, []))).toEqual(["late"]);
+});

--- a/tests2/integration/hindsight-external.test.ts
+++ b/tests2/integration/hindsight-external.test.ts
@@ -103,6 +103,21 @@ async function setProviderDisabled(providers: string[]): Promise<void> {
 	expect(response.status).toBe(200);
 }
 
+async function readServerPackOrder(): Promise<string[]> {
+	const response = await apiFetch("/api/marketplace/pack-order?scope=server");
+	expect(response.status).toBe(200);
+	return (await response.json()).order as string[];
+}
+
+/** Notify the gateway after this fixture's direct on-disk install/uninstall. */
+async function notifyPackFilesystemMutation(order: string[]): Promise<void> {
+	const response = await apiFetch("/api/marketplace/pack-order", {
+		method: "PUT",
+		body: JSON.stringify({ scope: "server", order }),
+	});
+	expect(response.status).toBe(200);
+}
+
 async function callBeforePrompt(sessionId: string, prompt: string): Promise<{ status: number; content: string }> {
 	const response = await apiFetch(`/api/sessions/${sessionId}/provider-hooks/before-prompt`, {
 		method: "POST",
@@ -131,12 +146,15 @@ describe("hindsight installed-provider worker boundary", () => {
 	const cwds: string[] = [];
 	let bobbitDir: string;
 	let packDir: string;
+	let originalPackOrder: string[];
 	let stub: HindsightStub;
 
 	test.beforeAll(async ({ gateway }) => {
 		enableTsWorkerResolver();
 		bobbitDir = gateway.bobbitDir;
+		originalPackOrder = await readServerPackOrder();
 		packDir = installPack(bobbitDir);
+		await notifyPackFilesystemMutation(originalPackOrder);
 		stub = await startStub();
 	});
 
@@ -147,6 +165,7 @@ describe("hindsight installed-provider worker boundary", () => {
 		for (const cwd of cwds) fs.rmSync(cwd, { recursive: true, force: true });
 		if (stub) await stub.close().catch(() => {});
 		if (packDir) fs.rmSync(packDir, { recursive: true, force: true });
+		if (originalPackOrder) await notifyPackFilesystemMutation(originalPackOrder).catch(() => {});
 	});
 
 	test("configured pack recalls and retains through ModuleHost and the host-store proxy", async () => {

--- a/tests2/integration/marketplace-provider-activation.test.ts
+++ b/tests2/integration/marketplace-provider-activation.test.ts
@@ -59,6 +59,26 @@ function piExtensionRefs(rows: any[]): string[] {
 	return rows.map((row) => typeof row === "string" ? row : String(row?.ref ?? row?.listName ?? "")).filter(Boolean);
 }
 
+async function readServerPackOrder(): Promise<string[]> {
+	const response = await apiFetch("/api/marketplace/pack-order?scope=server");
+	expect(response.status).toBe(200);
+	return (await response.json()).order as string[];
+}
+
+/**
+ * These integration fixtures write installed packs directly to disk instead of
+ * using the marketplace installer. Replay the existing pack-order mutation with
+ * its current value so the fixture crosses the same central cache-invalidation
+ * lifecycle as a production install/uninstall.
+ */
+async function notifyPackFilesystemMutation(order: string[]): Promise<void> {
+	const response = await apiFetch("/api/marketplace/pack-order", {
+		method: "PUT",
+		body: JSON.stringify({ scope: "server", order }),
+	});
+	expect(response.status).toBe(200);
+}
+
 function writeSchema1Pack(headquartersDir: string, packName: string): string {
 	const packDir = serverMarketPackDir(headquartersDir, packName);
 	fs.mkdirSync(path.join(packDir, "providers"), { recursive: true });
@@ -87,8 +107,10 @@ function writeSchema1Pack(headquartersDir: string, packName: string): string {
 test.describe("marketplace pack activation — providers", () => {
 	test("schema-1 catalogue omits schema-v2 arrays", async ({ gateway }) => {
 		const packName = `provider-activation-v1-${Date.now()}`;
+		const originalOrder = await readServerPackOrder();
 		const packDir = writeSchema1Pack(gateway.bobbitDir, packName);
 		try {
+			await notifyPackFilesystemMutation(originalOrder);
 			const get = await apiFetch(`/api/marketplace/pack-activation?scope=server&packName=${encodeURIComponent(packName)}`);
 			expect(get.status).toBe(200);
 			const getBody = await get.json();
@@ -98,13 +120,16 @@ test.describe("marketplace pack activation — providers", () => {
 			}
 		} finally {
 			fs.rmSync(packDir, { recursive: true, force: true });
+			await notifyPackFilesystemMutation(originalOrder);
 		}
 	});
 
 	test("PUT/GET round-trips disabled.providers and exposes schema-v2 catalogue arrays", async ({ gateway }) => {
 		const packName = `provider-activation-${Date.now()}`;
+		const originalOrder = await readServerPackOrder();
 		const packDir = writePack(gateway.bobbitDir, packName);
 		try {
+			await notifyPackFilesystemMutation(originalOrder);
 			const put = await apiFetch("/api/marketplace/pack-activation", {
 				method: "PUT",
 				body: JSON.stringify({
@@ -148,6 +173,7 @@ test.describe("marketplace pack activation — providers", () => {
 				body: JSON.stringify({ scope: "server", packName, disabled: {} }),
 			}).catch(() => {});
 			fs.rmSync(packDir, { recursive: true, force: true });
+			await notifyPackFilesystemMutation(originalOrder);
 		}
 	});
 });

--- a/tests2/tests-map.json
+++ b/tests2/tests-map.json
@@ -21,6 +21,15 @@
   },
   "v2Native": [
     {
+      "path": "tests2/core/pack-list-scan-cache.test.ts",
+      "reason": "Pins marketplace and shipped built-in pack scan caching: repeated resolutions reuse parsed manifests, missing directories are cached, cache keys preserve scope/root/order semantics, and central invalidators force rescans after mutations.",
+      "execution": {
+        "runner": "vitest",
+        "tier": "unit",
+        "project": "core"
+      }
+    },
+    {
       "path": "tests2/core/affected-test-runner.test.ts",
       "reason": "Pins the authoritative affected-unit inventory, Vitest-owned setup boundaries, shared gateway runtime closure, repository-read attribution, cache dependencies, and shipped dynamic-input ownership.",
       "execution": {

--- a/tests2/tests-map.json
+++ b/tests2/tests-map.json
@@ -21,6 +21,15 @@
   },
   "v2Native": [
     {
+      "path": "tests2/core/pack-list-scan-cache.test.ts",
+      "reason": "Pins the market-pack scan cache in pack-list.ts: N repeated scopeMarketPackEntries resolutions trigger exactly one disk scan (was hundreds/sec of pack.yaml re-parses per connected session, pegging a core), invalidateMarketPackScanCache forces a re-scan on pack mutation, missing dirs are cached, and distinct orderHint is a distinct key.",
+      "execution": {
+        "runner": "vitest",
+        "tier": "unit",
+        "project": "core"
+      }
+    },
+    {
       "path": "tests2/core/affected-test-runner.test.ts",
       "reason": "Pins the authoritative affected-unit inventory, Vitest-owned setup boundaries, shared gateway runtime closure, repository-read attribution, cache dependencies, and shipped dynamic-input ownership.",
       "execution": {


### PR DESCRIPTION
## Summary
- cache marketplace manifest scans by scope, root, and order hint
- cache shipped built-in manifest scans by directory
- invalidate both caches through the existing resolver invalidation path
- add marketplace and built-in regression coverage, including missing directories
- align direct-filesystem integration fixtures with production invalidation lifecycle

## Verification
- focused cache tests: 6 passed
- relevant marketplace/built-in tests: 61 passed
- affected integration tests: 3 passed
- npm run check
- npm run test:unit
- workflow build, type-check, unit, browser, E2E, conformance, implementation, and security verification passed

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)