### PR TITLE
Match New Session plus accent

### DIFF
--- a/src/app/sidebar.ts
+++ b/src/app/sidebar.ts
@@ -1732,7 +1732,7 @@ function renderProjectContent(projectTree: SidebarProjectTree) {
 						<span class="sidebar-compound-icon" data-testid="sidebar-add-session-icon">
 							${icon(MessagesSquare, "xs", "sidebar-compound-base")}
 							<svg data-testid="sidebar-add-session-plus" class="sidebar-compound-plus" viewBox="0 0 10 10">
-								<path d="M5 1V9M1 5H9" stroke="var(--primary)" stroke-width="2.5" stroke-linecap="round"/>
+								<path d="M5 1V9M1 5H9" stroke="${getProjectAccentColor(project)}" stroke-width="2.5" stroke-linecap="round"/>
 							</svg>
 						</span>
 					</button>

--- a/tests2/browser/e2e/sidebar-font-scale.spec.ts
+++ b/tests2/browser/e2e/sidebar-font-scale.spec.ts
@@ -393,6 +393,10 @@ test.describe("Sidebar font scale (full-stack UI)", () => {
 		await openApp(page);
 		await resetSidebarVisualState(page, goalTitle);
 
+		const goalPlusStroke = await page.locator('button[title^="New goal in"] [data-testid="sidebar-add-goal-plus"] path').first().getAttribute("stroke");
+		const sessionPlusStroke = await page.locator('button[title^="New session in"] [data-testid="sidebar-add-session-plus"] path').first().getAttribute("stroke");
+		expect(sessionPlusStroke, "New Session plus should match the New Goal plus color").toBe(goalPlusStroke);
+
 		await setSidebarFontSizeDirect(page, 14);
 		const expandedSmall = await measureSidebarVisualAffordances(page);
 		await setSidebarFontSizeDirect(page, 24);


### PR DESCRIPTION
## Summary
- match the New Session plus overlay to the project-accented New Goal plus
- add browser regression coverage for the overlay color

## Tests
- npm run check
- targeted Playwright sidebar visual affordance test

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)