### PR TITLE
fix(release): support fresh retry branches

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -230,6 +230,12 @@ PR_URL=$(gh pr create \
 PR=$(gh pr view "$PR_URL" --json number -q .number)
 ```
 
+If an earlier PR for the same version was merged but failed before npm accepted
+the package, do not recreate or push to its merged branch. Use a fresh numeric
+retry branch such as `release/v<new-version>-retry-1` (incrementing the suffix
+for later attempts). The release contract accepts only the exact branch above
+or this numeric retry form; the PR title remains unchanged.
+
 The PR body must summarize the version, release notes, and gate results, and
 must end with the standard Bobbit footer. Wait for every required check and
 review before publishing:

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -4,7 +4,7 @@ This doc covers the Bobbit release checks that cannot be inferred from a normal 
 
 ## Automated root release
 
-A release is authorized by squash-merging a same-repository PR from `release/v<version>` into `main`. Merging is the irreversible publication approval.
+A release is authorized by squash-merging a same-repository PR from `release/v<version>` into `main`. If an earlier attempt merged but failed before npm accepted the package, a fresh `release/v<version>-retry-<number>` branch is also accepted; merged branches are never reused. Merging is the irreversible publication approval.
 
 **The trigger is the push to `main`, not the pull request.** Three things follow from that, and each of them is the reason for the choice:
 

--- a/scripts/release/release-contract.mjs
+++ b/scripts/release/release-contract.mjs
@@ -125,6 +125,13 @@ export function releaseBranchFor(version) {
 	return `release/v${version}`;
 }
 
+export function isReleaseBranchFor(ref, version) {
+	const expected = releaseBranchFor(version);
+	if (ref === expected) return true;
+	const retryPrefix = `${expected}-retry-`;
+	return typeof ref === "string" && ref.startsWith(retryPrefix) && /^[1-9]\d*$/.test(ref.slice(retryPrefix.length));
+}
+
 export function releaseTitleFor(version) {
 	return `chore(release): v${version}`;
 }
@@ -193,11 +200,11 @@ export function assertPullRequestContract(pr, { version, repository, sha }) {
 				`expected ${repository}. Release branches must live in this repository.`,
 		);
 	}
-	if (pr.head?.ref !== releaseBranchFor(version)) {
+	if (!isReleaseBranchFor(pr.head?.ref, version)) {
 		fail(
 			`release branch ${pr.head?.ref} does not match version ${version} ` +
-				`(expected ${releaseBranchFor(version)}). A release must be opened as a release, ` +
-				"not be the side effect of a version change.",
+				`(expected ${releaseBranchFor(version)} or ${releaseBranchFor(version)}-retry-<number>). ` +
+				"A release must be opened as a release, not be the side effect of a version change.",
 		);
 	}
 	if (pr.title !== releaseTitleFor(version)) {

--- a/tests2/core/release-skill-preflight-order.test.ts
+++ b/tests2/core/release-skill-preflight-order.test.ts
@@ -587,6 +587,14 @@ describe("release contract rules", () => {
 
 	it("requires the release to have been opened as a release", () => {
 		assertPullRequestContract(mergedPr, contract);
+		assertPullRequestContract(
+			{ ...mergedPr, head: { ...mergedPr.head, ref: "release/v0.16.0-retry-1" } },
+			contract,
+		);
+		assertPullRequestContract(
+			{ ...mergedPr, head: { ...mergedPr.head, ref: "release/v0.16.0-retry-12" } },
+			contract,
+		);
 
 		assert.throws(() => assertPullRequestContract(null, contract), /no merged pull request produced/);
 		assert.throws(
@@ -601,10 +609,19 @@ describe("release contract rules", () => {
 				),
 			/Release branches must live in this repository/,
 		);
-		assert.throws(
-			() => assertPullRequestContract({ ...mergedPr, head: { ...mergedPr.head, ref: "deps/bump" } }, contract),
-			/not be the side effect of a version change/,
-		);
+		for (const ref of [
+			"deps/bump",
+			"release/v0.16.0-retry",
+			"release/v0.16.0-retry-0",
+			"release/v0.16.0-retry-01",
+			"release/v0.16.0-retry-one",
+			"release/v0.16.1-retry-1",
+		]) {
+			assert.throws(
+				() => assertPullRequestContract({ ...mergedPr, head: { ...mergedPr.head, ref } }, contract),
+				/not be the side effect of a version change/,
+			);
+		}
 		assert.throws(
 			() => assertPullRequestContract({ ...mergedPr, title: "release 0.16.0" }, contract),
 			/title must be/,


### PR DESCRIPTION
## Summary

Allow a failed, unpublished release to retry from a fresh branch such as `release/v0.16.0-retry-1` instead of recreating a branch whose PR was already merged.

The contract remains fail-closed:

- the base branch must still be `main`
- the branch must still name the exact package version
- retry suffixes must be positive integers without leading zeroes
- the PR must still come from this repository with the exact release title
- npm provenance and all existing release checks remain unchanged

## Verification

- `npx vitest run tests2/core/release-skill-preflight-order.test.ts`
- `npm run check`

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)
