### PR TITLE
fix(release): handle missing tags correctly

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -196,7 +196,10 @@ jobs:
           TAG: ${{ needs.verify.outputs.tag }}
         run: |
           set -euo pipefail
-          existing="$(gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$TAG" --jq .object.sha 2>/dev/null || true)"
+          existing=""
+          if found="$(gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$TAG" --jq .object.sha 2>/dev/null)"; then
+            existing="$found"
+          fi
           if [ -n "$existing" ]; then
             [ "$existing" = "$GITHUB_SHA" ] || {
               echo "::error::$TAG points at $existing, not $GITHUB_SHA"

--- a/tests2/core/release-skill-preflight-order.test.ts
+++ b/tests2/core/release-skill-preflight-order.test.ts
@@ -306,6 +306,9 @@ describe("push-triggered release workflow", () => {
 		assert.match(tagStep, /git\/ref\/tags\/\$TAG/);
 		assert.match(tagStep, /points at \$existing, not \$GITHUB_SHA/);
 		assert.match(tagStep, /-f ref="refs\/tags\/\$TAG" -f sha="\$GITHUB_SHA"/);
+		assert.match(tagStep, /existing=""/);
+		assert.match(tagStep, /if found="\$\(gh api/);
+		assert.doesNotMatch(tagStep, /gh api[^\n]*\|\| true/);
 
 		assert.match(releaseStep("release", "Create release").run ?? "", /--verify-tag/);
 


### PR DESCRIPTION
## Summary

Fix missing-tag detection in the release workflow.

`gh api` writes its 404 response body to stdout while returning a failure status. The previous `$(gh api ... || true)` therefore stored the JSON error as if it were an existing tag SHA. The workflow now assigns the SHA only when the API call succeeds.

Regression coverage rejects the old failure-swallowing pattern.

## Verification

- `npx vitest run tests2/core/release-skill-preflight-order.test.ts`
- `npm run check`

`v0.16.1` was manually completed at its npm provenance SHA after explicit maintainer approval. This fix contains no recovery mechanism and does not publish anything.

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)
