### PR TITLE
chore(release): v0.16.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 Newest first. Each release appends a `## v<version>` section; the release
 workflow publishes that section as the GitHub release body.
 
+## v0.16.2
+
+Upgrading from v0.16.1. This release fixes automated release completion.
+
+### 🐛 Bug Fixes
+
+* 📦 **Reliable release completion**: Automated releases now handle a missing version tag correctly after npm publication, allowing the immutable source tag and GitHub release to be created as intended.
+
 ## v0.16.1
 
 Upgrading from v0.15.1. This release adds shared Git and PR status, URL subpath hosting, keyboard steering, clearer workflow guidance, and broad improvements to authentication, recovery, and performance.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gresearch/bobbit",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@gresearch/bobbit",
-      "version": "0.16.1",
+      "version": "0.16.2",
       "dependencies": {
         "@earendil-works/pi-agent-core": "0.82.1",
         "@earendil-works/pi-ai": "0.82.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gresearch/bobbit",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "type": "module",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Release

Prepare `@gresearch/bobbit@0.16.2` for production publication to npm dist-tag `latest`.

This patch verifies the corrected automated release path after PR #1153 fixed missing-tag detection. The package's application code is unchanged from `v0.16.1`.

The reviewed release notes are in the new top-level [`CHANGELOG.md`](https://github.com/G-Research/bobbit/blob/release/v0.16.2/CHANGELOG.md#v0162) section.

## Verification

- PR #1153 passed the hosted build, type-check, and unit matrix
- targeted release workflow regression test passed
- `npm run check` passed
- package dry-run validation passed for `gresearch-bobbit-0.16.2.tgz`
- publish command uses the corrected explicit local tarball path
- post-publish missing-tag lookup uses the corrected exit-status handling
- `@gresearch/bobbit@0.16.2` is unused on npm
- binary versions remain unchanged; no binary package publication is required

Runtime audits remain optional diagnostics and are not release gates.

Merging this PR triggers the OIDC workflow to publish the root package, create immutable tag `v0.16.2`, and create the GitHub release.

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)
