### PR TITLE
fix(release): target repository explicitly

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -237,6 +237,7 @@ jobs:
           PRERELEASE=()
           if [ "$DIST_TAG" = next ]; then PRERELEASE=(--prerelease); fi
           gh release create "$TAG" \
+            --repo "$GITHUB_REPOSITORY" \
             --verify-tag \
             --title "Bobbit $TAG" \
             --notes-file release-artifact/release-notes.md \

--- a/tests2/core/release-skill-preflight-order.test.ts
+++ b/tests2/core/release-skill-preflight-order.test.ts
@@ -378,6 +378,7 @@ describe("push-triggered release workflow", () => {
 		assert.deepEqual(releaseJob("release").needs, ["verify", "tag"]);
 		const release = releaseStep("release", "Create release").run ?? "";
 		assert.match(release, /gh release create "\$TAG"/);
+		assert.match(release, /--repo "\$GITHUB_REPOSITORY"/);
 		assert.match(release, /--notes-file release-artifact\/release-notes\.md/);
 		assert.match(release, /--generate-notes/);
 		assert.match(release, /PRERELEASE=\(\)/);


### PR DESCRIPTION
## Summary

Pass `--repo "$GITHUB_REPOSITORY"` to `gh release create`.

The least-privileged release job intentionally does not check out repository code. Without an explicit repository, `gh` tried to discover one from `.git` and failed after npm publication and tag creation. Regression coverage now pins the explicit repository argument.

## Verification

- `npx vitest run tests2/core/release-skill-preflight-order.test.ts`
- `npm run check`

`v0.16.2` was manually completed after explicit maintainer approval and now has npm provenance, the immutable source tag, and the GitHub release. This PR does not publish anything.

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)
