### PR TITLE
Add --version CLI flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ bobbit [options]
 --no-ui             Gateway-only mode (no UI)
 --new-token         Force-generate a new auth token
 --show-token        Print the current token and exit
+--version           Print the installed Bobbit version and exit
 ```
 
 See the **[Networking guide](docs/networking.md#production-subpath-mounting)** for base-path normalization and reverse-proxy configuration.

--- a/src/server/cli.ts
+++ b/src/server/cli.ts
@@ -19,6 +19,11 @@ import { normalizeBasePath } from "../shared/base-path.js";
 
 export { isLoopbackHost, loopbackForBind };
 
+export function readPackageVersion(): string {
+	const cliDir = path.dirname(fileURLToPath(import.meta.url));
+	return (JSON.parse(fs.readFileSync(path.resolve(cliDir, "../../package.json"), "utf-8")) as { version: string }).version;
+}
+
 export interface CliArgs {
 	host: string;
 	port: number;
@@ -212,9 +217,15 @@ export function parseArgs(argv: string[], env: NodeJS.ProcessEnv = process.env):
 }
 
 async function main() {
+	const argv = process.argv.slice(2);
+	if (argv.includes("--version")) {
+		process.stdout.write(`v${readPackageVersion()}\n`);
+		return;
+	}
+
 	// Wall-clock anchor for boot instrumentation — process-start (approx) to listen.
 	const bootWallT0 = Date.now();
-	const args = parseArgs(process.argv.slice(2));
+	const args = parseArgs(argv);
 
 	// --show-token: print token and exit
 	if (args.showToken) {
@@ -342,8 +353,7 @@ async function main() {
 		forceAuth: args.forceAuth,
 	});
 
-	const __cliDir = path.dirname(fileURLToPath(import.meta.url));
-	const pkgVersion = JSON.parse(fs.readFileSync(path.resolve(__cliDir, "../../package.json"), "utf-8")).version;
+	const pkgVersion = readPackageVersion();
 	// Set terminal tab title
 	process.stdout.write(`\x1b]0;Bobbit Server\x07`);
 	console.log(formatStartupBanner({

--- a/src/server/cli.ts
+++ b/src/server/cli.ts
@@ -24,6 +24,24 @@ export function readPackageVersion(): string {
 	return (JSON.parse(fs.readFileSync(path.resolve(cliDir, "../../package.json"), "utf-8")) as { version: string }).version;
 }
 
+export function hasVersionFlag(argv: string[]): boolean {
+	for (let i = 0; i < argv.length; i++) {
+		switch (argv[i]) {
+			case "--version":
+				return true;
+			case "--host":
+			case "--port":
+			case "--cwd":
+			case "--static":
+			case "--agent-cli":
+			case "--base-path":
+				i++;
+				break;
+		}
+	}
+	return false;
+}
+
 export interface CliArgs {
 	host: string;
 	port: number;
@@ -218,7 +236,7 @@ export function parseArgs(argv: string[], env: NodeJS.ProcessEnv = process.env):
 
 async function main() {
 	const argv = process.argv.slice(2);
-	if (argv.includes("--version")) {
+	if (hasVersionFlag(argv)) {
 		process.stdout.write(`v${readPackageVersion()}\n`);
 		return;
 	}

--- a/tests2/core/base-path-cli.test.ts
+++ b/tests2/core/base-path-cli.test.ts
@@ -14,6 +14,7 @@ interface StartupUrls {
 }
 
 interface CliModule {
+	hasVersionFlag(argv: string[]): boolean;
 	parseArgs(argv: string[], env?: NodeJS.ProcessEnv): CliArgs;
 	buildStartupUrls(options: {
 		protocol: "http" | "https";
@@ -35,6 +36,33 @@ interface CliModule {
 async function cliModule(): Promise<CliModule> {
 	return await import("../../src/server/cli.ts") as unknown as CliModule;
 }
+
+describe("version CLI selection", () => {
+	it("recognizes the exact standalone version flag", async () => {
+		const { hasVersionFlag } = await cliModule();
+		assert.equal(hasVersionFlag(["--version"]), true);
+	});
+
+	it("recognizes a standalone version flag mixed with normal options", async () => {
+		const { hasVersionFlag } = await cliModule();
+		assert.equal(hasVersionFlag(["--no-ui", "--host", "127.0.0.1", "--version", "--auth"]), true);
+	});
+
+	it.each(["--host", "--port", "--cwd", "--static", "--agent-cli", "--base-path"])(
+		"does not treat --version as the value of %s as a version flag",
+		async (option) => {
+			const { hasVersionFlag } = await cliModule();
+			assert.equal(hasVersionFlag([option, "--version"]), false);
+		},
+	);
+
+	it("leaves a malformed base-path value for parseArgs to reject", async () => {
+		const { hasVersionFlag, parseArgs } = await cliModule();
+		const argv = ["--base-path", "--version"];
+		assert.equal(hasVersionFlag(argv), false);
+		assert.throws(() => parseArgs(argv, {}), /base.path.*value|value.*base.path/i);
+	});
+});
 
 describe("base-path CLI selection", () => {
 	it("defaults to root when neither flag nor environment is present", async () => {

--- a/tests2/integration/base-path-cli-entrypoint.test.ts
+++ b/tests2/integration/base-path-cli-entrypoint.test.ts
@@ -1,8 +1,10 @@
 import { spawn, type ChildProcess } from "node:child_process";
 import { existsSync, mkdtempSync, mkdirSync, readFileSync, symlinkSync, writeFileSync } from "node:fs";
+import { createServer, type Server } from "node:net";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { performance } from "node:perf_hooks";
 import { describe, expect, it } from "vitest";
 
 import { awaitableRm, pollUntil } from "../../tests/e2e/test-utils/cleanup.js";
@@ -42,11 +44,109 @@ async function forceStop(child: ChildProcess): Promise<void> {
 	await waitForExit(child, 5_000);
 }
 
+function listen(server: Server): Promise<number> {
+	return new Promise((resolvePort, reject) => {
+		server.once("error", reject);
+		server.listen(0, "127.0.0.1", () => {
+			server.off("error", reject);
+			const address = server.address();
+			if (!address || typeof address === "string") {
+				reject(new Error("port guard did not publish a TCP address"));
+				return;
+			}
+			resolvePort(address.port);
+		});
+	});
+}
+
+function close(server: Server): Promise<void> {
+	if (!server.listening) return Promise.resolve();
+	return new Promise((resolveClose, reject) => {
+		server.close((error) => error ? reject(error) : resolveClose());
+	});
+}
+
 function escapeRegExp(value: string): string {
 	return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
 describe("executable CLI root and nested base-path smoke", () => {
+	it("prints only the package version and exits before all gateway side effects", async () => {
+		const root = mkdtempSync(join(tmpdir(), "bobbit-cli-version-"));
+		const projectRoot = join(root, "project");
+		const headquartersDir = join(root, "headquarters");
+		const secretsTrapParent = join(root, "secrets-trap");
+		const agentTrapParent = join(root, "agent-trap");
+		const secretsDir = join(secretsTrapParent, "secrets");
+		const agentDir = join(agentTrapParent, "agent");
+		mkdirSync(projectRoot, { recursive: true });
+		// Any token or agent-dir initialization turns these regular-file parents into
+		// a deterministic ENOTDIR failure instead of silently touching host state.
+		writeFileSync(secretsTrapParent, "token access is forbidden\n", "utf8");
+		writeFileSync(agentTrapParent, "agent initialization is forbidden\n", "utf8");
+
+		const portGuard = createServer((socket) => socket.destroy());
+		const guardedPort = await listen(portGuard);
+		const packageVersion = JSON.parse(readFileSync(join(REPO_ROOT, "package.json"), "utf8")).version;
+		const childEnv: NodeJS.ProcessEnv = {
+			...process.env,
+			BOBBIT_DIR: headquartersDir,
+			BOBBIT_SECRETS_DIR: secretsDir,
+			BOBBIT_AGENT_DIR: agentDir,
+			BOBBIT_PI_DIR: join(root, "legacy-headquarters"),
+			PI_CODING_AGENT_DIR: join(root, "pi-agent"),
+			NODE_ENV: "production",
+		};
+		delete childEnv.BOBBIT_BASE_PATH;
+		delete childEnv.BOBBIT_NO_OPEN;
+
+		const startedAt = performance.now();
+		const child = spawn(process.execPath, [
+			"--import", "tsx",
+			CLI_ENTRY,
+			"--version",
+			"--cwd", projectRoot,
+			"--host", "127.0.0.1",
+			"--port", String(guardedPort),
+			"--no-tls",
+			"--no-ui",
+		], {
+			cwd: REPO_ROOT,
+			env: childEnv,
+			stdio: ["ignore", "pipe", "pipe"],
+			windowsHide: true,
+		});
+		let stdout = "";
+		let stderr = "";
+		child.stdout?.on("data", (chunk: Buffer) => { stdout += chunk.toString(); });
+		child.stderr?.on("data", (chunk: Buffer) => { stderr += chunk.toString(); });
+
+		try {
+			const exit = await waitForExit(child, 5_000);
+			const elapsedMs = performance.now() - startedAt;
+			expect(exit).toEqual({ code: 0, signal: null });
+			expect(elapsedMs, "--version must terminate promptly without starting a long-lived gateway").toBeLessThan(5_000);
+			expect(stdout).toBe(`v${packageVersion}\n`);
+			expect(stderr).toBe("");
+			expect(portGuard.listening, "the CLI must not replace or disturb the occupied gateway port").toBe(true);
+			for (const forbiddenPath of [
+				join(projectRoot, ".bobbit"),
+				headquartersDir,
+				secretsDir,
+				agentDir,
+				join(root, "legacy-headquarters"),
+				join(root, "pi-agent"),
+			]) {
+				expect(existsSync(forbiddenPath), `--version created forbidden Bobbit state: ${forbiddenPath}`).toBe(false);
+			}
+		} finally {
+			await forceStop(child);
+			await close(portGuard);
+			const cleanup = await awaitableRm(root, { maxAttempts: 3, backoffMs: 50 });
+			expect(cleanup.removed, `isolated CLI version cleanup failed: ${String(cleanup.lastError ?? "unknown error")}`).toBe(true);
+		}
+	});
+
 	it("binds an ephemeral mounted gateway, persists its URL, serves it, and exits cleanly", async () => {
 		const root = mkdtempSync(join(tmpdir(), "bobbit-cli-mount-smoke-"));
 		const projectRoot = join(root, "project");

--- a/tests2/integration/base-path-cli-entrypoint.test.ts
+++ b/tests2/integration/base-path-cli-entrypoint.test.ts
@@ -72,6 +72,15 @@ function escapeRegExp(value: string): string {
 
 describe("executable CLI root and nested base-path smoke", () => {
 	it("prints only the package version and exits before all gateway side effects", async () => {
+		const packageMetadata = JSON.parse(readFileSync(join(REPO_ROOT, "package.json"), "utf8")) as {
+			version: string;
+			bin: { bobbit: string };
+		};
+		expect(packageMetadata.bin.bobbit).toBe("dist/server/cli.js");
+		const packageBinEntry = resolve(REPO_ROOT, packageMetadata.bin.bobbit);
+		expect(packageBinEntry).toBe(BUILT_CLI_ENTRY);
+		expect(existsSync(packageBinEntry), "the package bin target must be built before executable coverage").toBe(true);
+
 		const root = mkdtempSync(join(tmpdir(), "bobbit-cli-version-"));
 		const projectRoot = join(root, "project");
 		const headquartersDir = join(root, "headquarters");
@@ -87,7 +96,6 @@ describe("executable CLI root and nested base-path smoke", () => {
 
 		const portGuard = createServer((socket) => socket.destroy());
 		const guardedPort = await listen(portGuard);
-		const packageVersion = JSON.parse(readFileSync(join(REPO_ROOT, "package.json"), "utf8")).version;
 		const childEnv: NodeJS.ProcessEnv = {
 			...process.env,
 			BOBBIT_DIR: headquartersDir,
@@ -95,6 +103,9 @@ describe("executable CLI root and nested base-path smoke", () => {
 			BOBBIT_AGENT_DIR: agentDir,
 			BOBBIT_PI_DIR: join(root, "legacy-headquarters"),
 			PI_CODING_AGENT_DIR: join(root, "pi-agent"),
+			BOBBIT_TEST_NO_EXTERNAL: "1",
+			BOBBIT_TEST_NO_REMOTE: "1",
+			PI_OFFLINE: "1",
 			NODE_ENV: "production",
 		};
 		delete childEnv.BOBBIT_BASE_PATH;
@@ -102,8 +113,7 @@ describe("executable CLI root and nested base-path smoke", () => {
 
 		const startedAt = performance.now();
 		const child = spawn(process.execPath, [
-			"--import", "tsx",
-			CLI_ENTRY,
+			packageBinEntry,
 			"--version",
 			"--cwd", projectRoot,
 			"--host", "127.0.0.1",
@@ -111,7 +121,7 @@ describe("executable CLI root and nested base-path smoke", () => {
 			"--no-tls",
 			"--no-ui",
 		], {
-			cwd: REPO_ROOT,
+			cwd: projectRoot,
 			env: childEnv,
 			stdio: ["ignore", "pipe", "pipe"],
 			windowsHide: true,
@@ -126,7 +136,7 @@ describe("executable CLI root and nested base-path smoke", () => {
 			const elapsedMs = performance.now() - startedAt;
 			expect(exit).toEqual({ code: 0, signal: null });
 			expect(elapsedMs, "--version must terminate promptly without starting a long-lived gateway").toBeLessThan(5_000);
-			expect(stdout).toBe(`v${packageVersion}\n`);
+			expect(stdout).toBe(`v${packageMetadata.version}\n`);
 			expect(stderr).toBe("");
 			expect(portGuard.listening, "the CLI must not replace or disturb the occupied gateway port").toBe(true);
 			for (const forbiddenPath of [

--- a/tests2/tests-map.json
+++ b/tests2/tests-map.json
@@ -302,7 +302,7 @@
     },
     {
       "path": "tests2/core/base-path-cli.test.ts",
-      "reason": "Focused CLI coverage for flag-over-environment base-path selection, unsafe input rejection, mounted startup URLs, persisted peers, and truthful authentication banners.",
+      "reason": "Focused CLI coverage for standalone version-flag recognition without consuming option values, flag-over-environment base-path selection, unsafe input rejection, mounted startup URLs, persisted peers, and truthful authentication banners.",
       "execution": {
         "runner": "vitest",
         "tier": "unit",
@@ -356,7 +356,7 @@
     },
     {
       "path": "tests2/integration/base-path-cli-entrypoint.test.ts",
-      "reason": "Real executable CLI entrypoint smoke in the E2E Vitest lane proving an isolated nested mount binds an ephemeral port, persists its mounted gateway URL, serves mounted health and static routes, prints the truthful loopback-auth banner, and terminates cleanly within a bound.",
+      "reason": "Real package-bin CLI entrypoint smoke in the E2E Vitest lane proving --version prints exact package metadata and exits without gateway state or port binding, while an isolated nested mount binds an ephemeral port, persists its mounted gateway URL, serves mounted health and static routes, prints the truthful loopback-auth banner, and terminates cleanly within a bound.",
       "execution": {
         "runner": "vitest",
         "tier": "e2e",


### PR DESCRIPTION
## Summary
- print the installed package version for `bobbit --version` before gateway startup
- preserve existing option-value parsing while handling the standalone flag
- cover the compiled package entrypoint, exact output, clean exit, and absence of gateway state or port binding
- document the flag in the README

## Validation
- implementation workflow: build, type-check, unit, browser, E2E, conformance, code, and security reviews passed
- focused core CLI tests: 23 passed
- focused executable-entrypoint tests: 2 passed, 1 platform-skipped

## Browser coverage
A browser journey is not applicable to this CLI-only early-exit path: the required behavior is that no gateway or browser starts. Executable-process coverage validates the user-facing command at the package `bin` target and asserts the browser/gateway startup path is never reached. The existing browser suite passed unchanged.

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)