### PR TITLE
chore(release): v0.16.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,18 @@
 Newest first. Each release appends a `## v<version>` section; the release
 workflow publishes that section as the GitHub release body.
 
+## v0.16.3
+
+Upgrading from v0.16.2. This release adds a command-line version flag and completes the automated release workflow fixes.
+
+### ✨ New Features
+
+* 🏷️ **Command-line version flag**: Run `bobbit --version` or `npx @gresearch/bobbit@latest --version` to print the installed Bobbit version and exit without starting the gateway or creating configuration state.
+
+### 🐛 Bug Fixes
+
+* 📦 **Reliable GitHub release creation**: The checkout-free release job now targets the repository explicitly, allowing it to create the GitHub release after npm publication and immutable tag creation.
+
 ## v0.16.2
 
 Upgrading from v0.16.1. This release fixes automated release completion.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gresearch/bobbit",
-  "version": "0.16.2",
+  "version": "0.16.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@gresearch/bobbit",
-      "version": "0.16.2",
+      "version": "0.16.3",
       "dependencies": {
         "@earendil-works/pi-agent-core": "0.82.1",
         "@earendil-works/pi-ai": "0.82.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gresearch/bobbit",
-  "version": "0.16.2",
+  "version": "0.16.3",
   "type": "module",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Release

Prepare `@gresearch/bobbit@0.16.3` for production publication to npm dist-tag `latest`.

This release adds the merged `--version` CLI flag and verifies the fully corrected automated path through npm publication, immutable tag creation, and checkout-free GitHub release creation.

The reviewed release notes are in the new top-level [`CHANGELOG.md`](https://github.com/G-Research/bobbit/blob/release/v0.16.3/CHANGELOG.md#v0163) section.

## Verification

- PR #1156 passed the hosted build, type-check, and unit matrix
- `npm run build`
- `npx vitest run tests2/core/base-path-cli.test.ts`
- `BOBBIT_V2_E2E_VITEST=1 npx vitest run --project v2-e2e-vitest tests2/integration/base-path-cli-entrypoint.test.ts`
- built `node dist/server/cli.js --version` prints exactly `v0.16.3`
- package dry-run validation passed for `gresearch-bobbit-0.16.3.tgz`
- `@gresearch/bobbit@0.16.3` is unused on npm
- binary versions remain unchanged; no binary package publication is required

Runtime audits remain optional diagnostics and are not release gates.

Merging this PR triggers the OIDC workflow to publish the root package, create immutable tag `v0.16.3`, and create the GitHub release.

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)
