### PR TITLE
Await base-ref fixture cleanup

### DIFF
--- a/tests2/integration/base-ref-api.test.ts
+++ b/tests2/integration/base-ref-api.test.ts
@@ -173,11 +173,14 @@ test.afterEach(({ gateway }) => {
 	store?.remove("sandbox");
 });
 
-test.afterAll(() => {
+test.afterAll(async () => {
 	const pcm = fixtureGateway?.projectContextManager;
 	const registry = pcm?.getRegistry();
 	for (const id of cleanupProjectIds.splice(0).reverse()) {
-		pcm?.remove(id);
+		// remove() is the context shutdown barrier. Await it before unregistering
+		// or a following isolate:false suite can snapshot this closing fixture.
+		await pcm?.remove(id);
+		expect([...pcm.visible()].some((context: any) => context.project.id === id)).toBe(false);
 		try { registry?.remove(id); } catch { /* already removed */ }
 	}
 	for (const root of cleanupRoots) cleanupDir(root);


### PR DESCRIPTION
## Summary
- await the project-context shutdown barrier for base-ref integration fixtures
- verify each context is gone before teardown returns
- prevent later shared-worker suites from snapshotting closing projects

## Validation
- `VITEST_MAX_WORKERS=1 npx vitest run --project v2-integration tests2/integration/base-ref-api.test.ts tests2/integration/projects-no-default-workflows.test.ts`
- `npm run check`
- `git diff --check`

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)