### PR TITLE
Speed up Vite development reloads

### DIFF
--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -2,6 +2,15 @@
 
 Scannable checklists for common issues. Each entry: symptom → where to look → key detail.
 
+## Dev UI stays grey after a source edit or pull
+
+- **Symptom**: after a TypeScript edit, `git pull`, or checkout, Vite reloads but the inline grey shell remains for tens of seconds. A proxy `ECONNABORTED` / `ECONNRESET` may appear during navigation.
+- **Cause**: Bobbit's large eager browser graph took one request per source module under Vite's unbundled dev server. Client timing showed `modules-evaluated` at 46.95 s while WebSocket auth plus a 1.1 MB transcript snapshot completed in the following 0.56 s; the gateway was not the bottleneck.
+- **Fix**: development enables Vite's bundled dev mode (`experimental.bundledDev`) so Rolldown serves a small set of in-memory chunks and performs incremental HMR. A separate-port proof reduced a warm full reload to 597 ms. Production keeps the normal mount-aware build configuration. Tailwind 4.3.3 needs the narrow `tailwindcssWithBundledDevGuard` compatibility shim from its merged upstream fix; remove that shim after upgrading to a release containing tailwindlabs/tailwindcss#20379.
+- **Service worker**: a production worker must never control Vite. In dev, `main.ts` unregisters the exact mounted worker and clears only that mount's Bobbit caches.
+- **Diagnostic**: enable Settings → Debug and inspect the latest `boot-timing.jsonl`. A long delay before `modules-evaluated` is Vite/browser loading; a delay after `ws-open` belongs to auth or snapshot recovery. Bundled dev requests `/assets/*.js`, not hundreds of `/src/**/*.ts` modules. Confirm `[boot]` / `[harness]` lifecycle logs before treating a proxy disconnect as a gateway restart.
+- **Pinning test**: `tests2/core/vite-bundled-dev.test.ts`.
+
 ## Project Settings save returns `PROJECT_CONFIG_LOAD_FAILED` or `PROJECT_CONFIG_PERSIST_FAILED`
 
 - **Symptom**: `PUT /api/projects/:id/config` or `PUT /api/project-config` returns 409 `PROJECT_CONFIG_LOAD_FAILED`, or 500 `PROJECT_CONFIG_PERSIST_FAILED`, instead of `{ ok: true }`.

--- a/docs/dev-workflow.md
+++ b/docs/dev-workflow.md
@@ -107,6 +107,8 @@ before changing `node_modules`.
 
 **Rule of thumb**: UI is hot. Server is compiled. If you touched anything under `src/server/`, you need a rebuild + restart.
 
+Development uses Vite's bundled dev mode: Rolldown serves the large eager browser graph as a small set of in-memory chunks instead of one request per source module, while preserving incremental HMR for edits and multi-file operations. Dev mode also unregisters Bobbit's production service worker and removes only the current mount's worker caches. A proxy `ECONNABORTED` during navigation means the page cancelled its API request; confirm separate `[harness]` or gateway `[boot]` logs before treating it as a server restart.
+
 ---
 
 ## `node_modules` gets wiped while the dev server is running

--- a/src/app/main.ts
+++ b/src/app/main.ts
@@ -1105,9 +1105,36 @@ async function initApp() {
 
 initApp();
 
-// Register the worker below the runtime mount so it cannot claim sibling apps.
+// Production registers the offline worker below the runtime mount. In dev,
+// unregister it instead: a worker controlling Vite intercepts and cache-writes
+// every source-module request, turning each full reload into a long grey boot.
 if ('serviceWorker' in navigator) {
-	navigator.serviceWorker.register(appUrl('/sw.js'), { scope: `${runtimeBasePath()}/` }).catch(() => {});
+	const scopePath = `${runtimeBasePath()}/`;
+	if ((globalThis as any).__BOBBIT_DEV__) {
+		const scopeUrl = new URL(scopePath, window.location.origin).href;
+		void navigator.serviceWorker.getRegistrations()
+			.then((registrations) => Promise.all(
+				registrations
+					.filter((registration) => registration.scope === scopeUrl)
+					.map((registration) => registration.unregister()),
+			))
+			.catch(() => {});
+
+		// Remove only this Bobbit mount's superseded worker caches. The current
+		// controller releases the page on the next navigation after unregister.
+		if ('caches' in window) {
+			const cachePrefix = `bobbit:${encodeURIComponent(runtimeBasePath() || "/")}:`;
+			void caches.keys()
+				.then((keys) => Promise.all(
+					keys
+						.filter((key) => key.startsWith(cachePrefix) || (!runtimeBasePath() && key.startsWith("bobbit-")))
+						.map((key) => caches.delete(key)),
+				))
+				.catch(() => {});
+		}
+	} else {
+		navigator.serviceWorker.register(appUrl('/sw.js'), { scope: scopePath }).catch(() => {});
+	}
 }
 
 // iOS PWA grey-screen recovery (frozen/killed standalone snapshot on relaunch).

--- a/tests2/core/base-path-pwa-cookie-guards.test.ts
+++ b/tests2/core/base-path-pwa-cookie-guards.test.ts
@@ -54,7 +54,16 @@ describe("service worker mount contracts", () => {
 		assert.match(worker, /cache\.match\(OFFLINE_NAVIGATION_URL\)/);
 	});
 
-	it("registers the worker script and scope below the runtime mount", () => {
-		assert.match(main, /serviceWorker\.register\(appUrl\('\/sw\.js'\), \{ scope: `\$\{runtimeBasePath\(\)\}\/` \}\)/);
+	it("registers the worker below the runtime mount only outside Vite dev mode", () => {
+		assert.match(main, /const scopePath = `\$\{runtimeBasePath\(\)\}\/`/);
+		assert.match(main, /if \(\(globalThis as any\)\.__BOBBIT_DEV__\)/);
+		assert.match(main, /serviceWorker\.register\(appUrl\('\/sw\.js'\), \{ scope: scopePath \}\)/);
+	});
+
+	it("unregisters the exact mounted worker and clears only its caches in dev", () => {
+		assert.match(main, /navigator\.serviceWorker\.getRegistrations\(\)/);
+		assert.match(main, /registration\.scope === scopeUrl/);
+		assert.match(main, /registration\.unregister\(\)/);
+		assert.match(main, /key\.startsWith\(cachePrefix\)/);
 	});
 });

--- a/tests2/core/vite-bundled-dev.test.ts
+++ b/tests2/core/vite-bundled-dev.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import type { UserConfig } from "vite";
+
+import viteConfig from "../../vite.config.ts";
+
+async function configFor(command: "serve" | "build", mode = "development"): Promise<UserConfig> {
+	const raw = typeof viteConfig === "function"
+		? viteConfig({ command, mode, isSsrBuild: false, isPreview: false })
+		: viteConfig;
+	return await Promise.resolve(raw) as UserConfig;
+}
+
+describe("Vite bundled development mode", () => {
+	it("bundles the browser graph during serve to avoid the native-ESM request waterfall", async () => {
+		const config = await configFor("serve");
+		const plugins = config.plugins?.flat() ?? [];
+
+		expect(config.experimental?.bundledDev).toBe(true);
+		expect(config.experimental?.renderBuiltUrl).toBeUndefined();
+		expect(plugins.map((plugin) => plugin && "name" in plugin ? plugin.name : ""))
+			.not.toContain("batch-client-full-reloads");
+	});
+
+	it("guards Tailwind's unreleased bundled-dev hot-update fix", async () => {
+		const config = await configFor("serve");
+		const plugin = config.plugins?.flat().find(
+			(candidate) => candidate && "name" in candidate && candidate.name === "@tailwindcss/vite:generate:serve",
+		);
+		expect(plugin).toBeDefined();
+		const hotUpdate = plugin && "hotUpdate" in plugin ? plugin.hotUpdate : undefined;
+		expect(hotUpdate).toEqual(expect.any(Function));
+
+		// Vite bundled dev currently omits server/timestamp/read. Tailwind 4.3.3
+		// dereferences server unless guarded (fixed upstream after that release).
+		const invokeHotUpdate = hotUpdate as unknown as (this: object, options: object) => unknown;
+		await expect(Promise.resolve(invokeHotUpdate.call({}, {
+			type: "update",
+			file: "src/app/main.ts",
+			modules: [{ type: "asset" }],
+		}))).resolves.toBeUndefined();
+	});
+
+	it("keeps production mount-aware URL rewriting separate from bundled dev", async () => {
+		const config = await configFor("build", "production");
+
+		expect(config.experimental?.bundledDev).toBeUndefined();
+		expect(config.experimental?.renderBuiltUrl).toEqual(expect.any(Function));
+	});
+});

--- a/tests2/tests-map.json
+++ b/tests2/tests-map.json
@@ -2514,6 +2514,15 @@
         "tier": "unit",
         "project": "core"
       }
+    },
+    {
+      "path": "tests2/core/vite-bundled-dev.test.ts",
+      "reason": "Vite config regression coverage proving development uses bundled browser chunks to avoid the large native-ESM request waterfall, guards Tailwind's unreleased bundled-dev hot-update fix, and keeps production asset URL rewriting separate.",
+      "execution": {
+        "runner": "vitest",
+        "tier": "unit",
+        "project": "core"
+      }
     }
   ],
   "journeys": [

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -266,6 +266,25 @@ function blockDangerousGlobs(): Plugin {
 }
 
 /**
+ * Tailwind 4.3.3 assumes Vite always supplies `server` to hotUpdate, while
+ * bundled dev intentionally supplies only type/file/modules. Mirror Tailwind's
+ * merged (but unreleased) fix until the next package release lands.
+ * https://github.com/tailwindlabs/tailwindcss/pull/20379
+ */
+function tailwindcssWithBundledDevGuard(): Plugin[] {
+	const plugins = tailwindcss();
+	const generator = plugins.find((plugin) => plugin.name === "@tailwindcss/vite:generate:serve");
+	const hotUpdate = generator?.hotUpdate;
+	if (generator && typeof hotUpdate === "function") {
+		generator.hotUpdate = function guardedTailwindHotUpdate(options) {
+			if (!options.server) return;
+			return hotUpdate.call(this, options);
+		};
+	}
+	return plugins;
+}
+
+/**
  * Defense-in-depth: Reject requests from non-localhost IPs when Vite is
  * bound to localhost, and block Docker bridge subnet IPs in all modes.
  * Prevents sandbox containers from reaching the Vite dev server even if
@@ -566,7 +585,13 @@ function dynamicGatewayProxy(): Plugin {
 }
 
 export default defineConfig(({ command, mode }) => ({
-	plugins: [tailwindcss(), blockDangerousGlobs(), localhostGuard(), bobbitSwVersion(), dynamicGatewayProxy()],
+	plugins: [
+		tailwindcssWithBundledDevGuard(),
+		blockDangerousGlobs(),
+		localhostGuard(),
+		bobbitSwVersion(),
+		dynamicGatewayProxy(),
+	],
 	// Expose a dev-mode boolean via globalThis so code that needs to gate
 	// dev-only behaviour can read `(globalThis as any).__BOBBIT_DEV__` without
 	// touching `import.meta.env` — important for test fixtures that bundle
@@ -574,8 +599,10 @@ export default defineConfig(({ command, mode }) => ({
 	define: {
 		"globalThis.__BOBBIT_DEV__": JSON.stringify(mode !== "production"),
 	},
-	// Runtime URL expressions are a production-build concern only. The Vite
-	// development UI, HMR client, and source modules remain rooted at `/`.
+	// Bundle the browser graph during development. Bobbit's large eager graph
+	// takes tens of seconds to traverse as one request per source module; Vite's
+	// bundled mode keeps HMR while serving a small set of in-memory chunks.
+	// Production retains its mount-aware runtime URL rewriting instead.
 	experimental: command === "build"
 		? {
 			renderBuiltUrl(filename, { hostType }) {
@@ -591,7 +618,7 @@ export default defineConfig(({ command, mode }) => ({
 				return { relative: hostType === "css" };
 			},
 		}
-		: undefined,
+		: { bundledDev: true },
 	build: {
 		outDir: "dist/ui",
 		// Emit modern JS — the supported browser matrix (iOS 17+, modern Chrome/Edge/Firefox)


### PR DESCRIPTION
## Summary

- enable Vite's bundled development mode to replace the large native-ESM request waterfall with in-memory chunks
- guard Tailwind 4.3.3's unreleased bundled-dev hot-update fix
- unregister mount-scoped production workers and clear only their Bobbit caches during development
- keep the production build and service-worker registration paths unchanged

## Performance

An instrumented reload improved from 46.95 seconds before module evaluation to 100 ms. First paint occurred at 114 ms and a 1.38 MB session snapshot finished rendering at 744 ms.

## Testing

- `npm run build`
- targeted Vitest coverage: 8 tests passed
- server, web, and tests2 TypeScript checks
- live bundled-dev browser reload with no Tailwind error overlay
- production output checked for absence of bundled-dev client and cleanup code

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)