### PR TITLE
Serialize workflow verification phases

### DIFF
--- a/.bobbit/config/project.yaml
+++ b/.bobbit/config/project.yaml
@@ -79,9 +79,9 @@ workflows:
               include an E2E test plan that validates the user journey
               end-to-end.
 
-              Treat this as a revision-ready content review. A FAIL is valid only
-              for an explicit unmet goal requirement or concrete regression and
-              is invalid without a complete author-ready revision packet for
+              Treat this as a revision-ready content review. A FAIL is valid
+              only for an explicit unmet goal requirement or concrete regression
+              and is invalid without a complete author-ready revision packet for
               every blocker. For each blocker, identify the exact artifact
               location; explain the goal-linked gap and practical consequence;
               provide concrete replacement wording, an outline, contract,
@@ -131,9 +131,9 @@ workflows:
               Use your tools to read the design document content from the
               signal.
 
-              Treat this as a revision-ready content review. A FAIL is valid only
-              for an explicit unmet goal requirement or concrete regression and
-              is invalid without a complete author-ready revision packet for
+              Treat this as a revision-ready content review. A FAIL is valid
+              only for an explicit unmet goal requirement or concrete regression
+              and is invalid without a complete author-ready revision packet for
               every blocker. For each blocker, identify the exact artifact
               location; explain the goal-linked gap and practical consequence;
               provide concrete replacement wording, an outline, contract,
@@ -167,20 +167,20 @@ workflows:
             command: unit
           - name: Browser tests
             type: command
-            phase: 1
+            phase: 2
             timeout: 900
             component: bobbit
             command: browser
           - name: E2E tests
             type: command
-            phase: 1
+            phase: 3
             timeout: 900
             component: bobbit
             command: e2e
           - name: Spec and regression conformance
             type: llm-review
             role: spec-auditor
-            phase: 2
+            phase: 3
             prompt: >-
               Compare the goal specification below, available upstream design or
               issue analysis, implementation, and tests on branch {{branch}}
@@ -190,23 +190,24 @@ workflows:
 
               Ignore documentation-only gaps. Identify unmet behavior,
               acceptance criteria, regressions, contradictions, and missing
-              regression coverage. Every blocker must include implementation-ready
-              remediation and focused tests that prove the fix.
+              regression coverage. Every blocker must include
+              implementation-ready remediation and focused tests that prove the
+              fix.
 
-              This phase-2 implementation review does not own optional phase-3 QA
-              or the downstream Ready-to-Merge gate. Defer QA when configured,
-              branch push, base synchronization, and PR creation to those stages.
-              Concrete implementation defects remain in scope.
+              This phase-3 implementation review does not own optional phase-4
+              QA or the downstream Ready-to-Merge gate. Defer QA when
+              configured, branch push, base synchronization, and PR creation to
+              those stages. Concrete implementation defects remain in scope.
           - name: Integrated implementation review
             type: llm-review
             role: code-reviewer
-            phase: 2
+            phase: 3
             prompt: >-
               Review the implementation on branch {{branch}} versus
-              origin/{{baseBranch}}. Cover correctness, error handling,
-              edge and mixed states, concurrency and lifecycle, cross-layer
-              interactions, maintainability, regression coverage, and
-              independently verifiable bugs.
+              origin/{{baseBranch}}. Cover correctness, error handling, edge and
+              mixed states, concurrency and lifecycle, cross-layer interactions,
+              maintainability, regression coverage, and independently verifiable
+              bugs.
 
               This review runs before the downstream Documentation gate. Ignore
               documentation-only gaps — including missing or outdated docs,
@@ -218,7 +219,7 @@ workflows:
           - name: Security review
             type: llm-review
             role: security-reviewer
-            phase: 2
+            phase: 3
             prompt: >-
               Review changed trust boundaries, authentication and authorization,
               validation and injection, secrets, destructive or resource
@@ -226,9 +227,9 @@ workflows:
               {{branch}} versus origin/{{baseBranch}}.
 
               This review runs before the downstream Documentation gate. Defer
-              documentation-only gaps — including missing or outdated docs, README
-              or design-document updates, and code comments — to that gate.
-              Concrete in-scope security defects remain in scope.
+              documentation-only gaps — including missing or outdated docs,
+              README or design-document updates, and code comments — to that
+              gate. Concrete in-scope security defects remain in scope.
 
               For each blocker, provide minimal remediation plus abuse and
               regression tests that verify the fix.
@@ -256,15 +257,15 @@ workflows:
 
               Treat this as a revision-ready documentation review. A FAIL is
               valid only for an explicit unmet goal requirement or concrete
-              change-introduced regression and is invalid without an author-ready
-              revision packet for every blocker. For each blocker, name exact
-              documentation paths and sections; identify the stale or missing
-              claim and its goal-linked consequence; give proposed replacement
-              wording or outline with relevant examples or links; state related
-              cross-section edits and constraints; include credible alternatives
-              with tradeoffs only when they exist; separate required edits from
-              bounded improvements; and explain how to verify the documented
-              behavior against the implementation.
+              change-introduced regression and is invalid without an
+              author-ready revision packet for every blocker. For each blocker,
+              name exact documentation paths and sections; identify the stale or
+              missing claim and its goal-linked consequence; give proposed
+              replacement wording or outline with relevant examples or links;
+              state related cross-section edits and constraints; include
+              credible alternatives with tradeoffs only when they exist;
+              separate required edits from bounded improvements; and explain how
+              to verify the documented behavior against the implementation.
 
               This review is limited to documentation. Defer branch push, base
               synchronization, and PR creation to the downstream Ready-to-Merge
@@ -286,6 +287,21 @@ workflows:
             type: command
             run: gh pr list --head {{branch}} --base {{baseBranch}} --state open --json url
               -q ".[0].url" | grep -q .
+          - name: PR checks pass
+            type: command
+            phase: 1
+            timeout: 3600
+            run: gh pr checks "{{branch}}" --watch --interval 10
+            failureGuidance: >-
+              Inspect the failed checks before acting. If the failure was transient and
+              no repository change is required, retry and re-signal this gate. If changes
+              are required, fix them and re-signal the earliest passed gate whose
+              verified work is affected: Implementation for source code, tests, build
+              configuration, or runtime behaviour; Documentation for documentation-only
+              changes where that gate exists; or Design/Issue Analysis when accepted
+              assumptions change. Re-signalling a passed gate invalidates its downstream
+              gates. Choose based on the planned remediation, not merely the check
+              failure.
   pr-review:
     id: pr-review
     name: PR Review
@@ -468,9 +484,9 @@ workflows:
               include an E2E test plan that validates the user journey
               end-to-end.
 
-              Treat this as a revision-ready content review. A FAIL is valid only
-              for an explicit unmet goal requirement or concrete regression and
-              is invalid without a complete author-ready revision packet for
+              Treat this as a revision-ready content review. A FAIL is valid
+              only for an explicit unmet goal requirement or concrete regression
+              and is invalid without a complete author-ready revision packet for
               every blocker. For each blocker, identify the exact artifact
               location; explain the goal-linked gap and practical consequence;
               provide concrete replacement wording, an outline, contract,
@@ -500,9 +516,9 @@ workflows:
               to justify an abstraction or possible future reuse. Use your tools
               to read the design document content from the signal.
 
-              Treat this as a revision-ready content review. A FAIL is valid only
-              for an explicit unmet goal requirement or concrete regression and
-              is invalid without a complete author-ready revision packet for
+              Treat this as a revision-ready content review. A FAIL is valid
+              only for an explicit unmet goal requirement or concrete regression
+              and is invalid without a complete author-ready revision packet for
               every blocker. For each blocker, identify the exact artifact
               location; explain the goal-linked gap and practical consequence;
               provide concrete replacement wording, an outline, contract,
@@ -536,20 +552,20 @@ workflows:
             command: unit
           - name: Browser tests
             type: command
-            phase: 1
+            phase: 2
             timeout: 900
             component: bobbit
             command: browser
           - name: E2E tests
             type: command
-            phase: 1
+            phase: 3
             timeout: 900
             component: bobbit
             command: e2e
           - name: Spec and regression conformance
             type: llm-review
             role: spec-auditor
-            phase: 2
+            phase: 3
             prompt: >-
               Compare the goal specification below, available upstream design or
               issue analysis, implementation, and tests on branch {{branch}}
@@ -559,23 +575,24 @@ workflows:
 
               Ignore documentation-only gaps. Identify unmet behavior,
               acceptance criteria, regressions, contradictions, and missing
-              regression coverage. Every blocker must include implementation-ready
-              remediation and focused tests that prove the fix.
+              regression coverage. Every blocker must include
+              implementation-ready remediation and focused tests that prove the
+              fix.
 
-              This phase-2 implementation review does not own optional phase-3 QA
-              or the downstream Ready-to-Merge gate. Defer QA when configured,
-              branch push, base synchronization, and PR creation to those stages.
-              Concrete implementation defects remain in scope.
+              This phase-3 implementation review does not own optional phase-4
+              QA or the downstream Ready-to-Merge gate. Defer QA when
+              configured, branch push, base synchronization, and PR creation to
+              those stages. Concrete implementation defects remain in scope.
           - name: Integrated implementation review
             type: llm-review
             role: code-reviewer
-            phase: 2
+            phase: 3
             prompt: >-
               Review the implementation on branch {{branch}} versus
-              origin/{{baseBranch}}. Cover correctness, error handling,
-              edge and mixed states, concurrency and lifecycle, cross-layer
-              interactions, maintainability, regression coverage, and
-              independently verifiable bugs.
+              origin/{{baseBranch}}. Cover correctness, error handling, edge and
+              mixed states, concurrency and lifecycle, cross-layer interactions,
+              maintainability, regression coverage, and independently verifiable
+              bugs.
 
               This review runs before the downstream Documentation gate. Ignore
               documentation-only gaps — including missing or outdated docs,
@@ -587,7 +604,7 @@ workflows:
           - name: Security review
             type: llm-review
             role: security-reviewer
-            phase: 2
+            phase: 3
             prompt: >-
               Review changed trust boundaries, authentication and authorization,
               validation and injection, secrets, destructive or resource
@@ -595,16 +612,16 @@ workflows:
               {{branch}} versus origin/{{baseBranch}}.
 
               This review runs before the downstream Documentation gate. Defer
-              documentation-only gaps — including missing or outdated docs, README
-              or design-document updates, and code comments — to that gate.
-              Concrete in-scope security defects remain in scope.
+              documentation-only gaps — including missing or outdated docs,
+              README or design-document updates, and code comments — to that
+              gate. Concrete in-scope security defects remain in scope.
 
               For each blocker, provide minimal remediation plus abuse and
               regression tests that verify the fix.
           - name: QA testing
             type: agent-qa
             role: qa-tester
-            phase: 3
+            phase: 4
             optional: true
             optionalLabel: Enable QA Testing
             description: Spawn a QA agent that builds the project, starts an ephemeral
@@ -622,7 +639,8 @@ workflows:
         verify:
           - name: Documentation coverage
             type: llm-review
-            prompt: Review documentation for the changes on branch {{branch}} vs
+            prompt: >-
+              Review documentation for the changes on branch {{branch}} vs
               origin/{{baseBranch}}. Verify user-facing
               features/API/config/behavior changes are documented, existing docs
               are updated, placement is appropriate, and documentation quality
@@ -630,15 +648,15 @@ workflows:
 
               Treat this as a revision-ready documentation review. A FAIL is
               valid only for an explicit unmet goal requirement or concrete
-              change-introduced regression and is invalid without an author-ready
-              revision packet for every blocker. For each blocker, name exact
-              documentation paths and sections; identify the stale or missing
-              claim and its goal-linked consequence; give proposed replacement
-              wording or outline with relevant examples or links; state related
-              cross-section edits and constraints; include credible alternatives
-              with tradeoffs only when they exist; separate required edits from
-              bounded improvements; and explain how to verify the documented
-              behavior against the implementation.
+              change-introduced regression and is invalid without an
+              author-ready revision packet for every blocker. For each blocker,
+              name exact documentation paths and sections; identify the stale or
+              missing claim and its goal-linked consequence; give proposed
+              replacement wording or outline with relevant examples or links;
+              state related cross-section edits and constraints; include
+              credible alternatives with tradeoffs only when they exist;
+              separate required edits from bounded improvements; and explain how
+              to verify the documented behavior against the implementation.
 
               This review is limited to documentation. Defer branch push, base
               synchronization, and PR creation to the downstream Ready-to-Merge
@@ -660,6 +678,21 @@ workflows:
             type: command
             run: gh pr list --head {{branch}} --base {{baseBranch}} --state open --json url
               -q ".[0].url" | grep -q .
+          - name: PR checks pass
+            type: command
+            phase: 1
+            timeout: 3600
+            run: gh pr checks "{{branch}}" --watch --interval 10
+            failureGuidance: >-
+              Inspect the failed checks before acting. If the failure was transient and
+              no repository change is required, retry and re-signal this gate. If changes
+              are required, fix them and re-signal the earliest passed gate whose
+              verified work is affected: Implementation for source code, tests, build
+              configuration, or runtime behaviour; Documentation for documentation-only
+              changes where that gate exists; or Design/Issue Analysis when accepted
+              assumptions change. Re-signalling a passed gate invalidates its downstream
+              gates. Choose based on the planned remediation, not merely the check
+              failure.
   bug-fix:
     id: bug-fix
     name: Bug Fix
@@ -678,9 +711,9 @@ workflows:
 
               This review is limited to the Issue Analysis artifact. Defer
               reproducing-test execution, implementation fixes, executed tests,
-              documentation, and publication — branch push, base synchronization,
-              and PR creation — to their downstream gates. Concrete analysis
-              defects remain in scope.
+              documentation, and publication — branch push, base
+              synchronization, and PR creation — to their downstream gates.
+              Concrete analysis defects remain in scope.
 
               Treat this as a revision-ready content review. A FAIL is valid
               only for an explicit unmet goal requirement or concrete regression
@@ -760,20 +793,20 @@ workflows:
             command: unit
           - name: Browser tests
             type: command
-            phase: 1
+            phase: 2
             timeout: 900
             component: bobbit
             command: browser
           - name: E2E tests
             type: command
-            phase: 1
+            phase: 3
             timeout: 900
             component: bobbit
             command: e2e
           - name: Spec and regression conformance
             type: llm-review
             role: spec-auditor
-            phase: 2
+            phase: 3
             prompt: >-
               Compare the goal specification below, available upstream design or
               issue analysis, implementation, and tests on branch {{branch}}
@@ -783,23 +816,24 @@ workflows:
 
               Ignore documentation-only gaps. Identify unmet behavior,
               acceptance criteria, regressions, contradictions, and missing
-              regression coverage. Every blocker must include implementation-ready
-              remediation and focused tests that prove the fix.
+              regression coverage. Every blocker must include
+              implementation-ready remediation and focused tests that prove the
+              fix.
 
-              This phase-2 implementation review does not own optional phase-3 QA
-              or the downstream Ready-to-Merge gate. Defer QA when configured,
-              branch push, base synchronization, and PR creation to those stages.
-              Concrete implementation defects remain in scope.
+              This phase-3 implementation review does not own optional phase-4
+              QA or the downstream Ready-to-Merge gate. Defer QA when
+              configured, branch push, base synchronization, and PR creation to
+              those stages. Concrete implementation defects remain in scope.
           - name: Integrated implementation review
             type: llm-review
             role: code-reviewer
-            phase: 2
+            phase: 3
             prompt: >-
               Review the implementation on branch {{branch}} versus
-              origin/{{baseBranch}}. Cover correctness, error handling,
-              edge and mixed states, concurrency and lifecycle, cross-layer
-              interactions, maintainability, regression coverage, and
-              independently verifiable bugs.
+              origin/{{baseBranch}}. Cover correctness, error handling, edge and
+              mixed states, concurrency and lifecycle, cross-layer interactions,
+              maintainability, regression coverage, and independently verifiable
+              bugs.
 
               This review runs before the downstream Documentation gate. Ignore
               documentation-only gaps — including missing or outdated docs,
@@ -811,7 +845,7 @@ workflows:
           - name: Security review
             type: llm-review
             role: security-reviewer
-            phase: 2
+            phase: 3
             prompt: >-
               Review changed trust boundaries, authentication and authorization,
               validation and injection, secrets, destructive or resource
@@ -819,16 +853,16 @@ workflows:
               {{branch}} versus origin/{{baseBranch}}.
 
               This review runs before the downstream Documentation gate. Defer
-              documentation-only gaps — including missing or outdated docs, README
-              or design-document updates, and code comments — to that gate.
-              Concrete in-scope security defects remain in scope.
+              documentation-only gaps — including missing or outdated docs,
+              README or design-document updates, and code comments — to that
+              gate. Concrete in-scope security defects remain in scope.
 
               For each blocker, provide minimal remediation plus abuse and
               regression tests that verify the fix.
           - name: QA testing
             type: agent-qa
             role: qa-tester
-            phase: 3
+            phase: 4
             optional: true
             optionalLabel: Enable QA Testing
             description: Spawn a QA agent that builds the project, starts an ephemeral
@@ -847,22 +881,23 @@ workflows:
         verify:
           - name: Documentation coverage
             type: llm-review
-            prompt: Review documentation for the changes on branch {{branch}} vs
+            prompt: >-
+              Review documentation for the changes on branch {{branch}} vs
               {{baseBranch}}. Verify user-facing features/API/config/behavior
               changes are documented, existing docs are updated, placement is
               appropriate, and documentation quality standards are met.
 
               Treat this as a revision-ready documentation review. A FAIL is
               valid only for an explicit unmet goal requirement or concrete
-              change-introduced regression and is invalid without an author-ready
-              revision packet for every blocker. For each blocker, name exact
-              documentation paths and sections; identify the stale or missing
-              claim and its goal-linked consequence; give proposed replacement
-              wording or outline with relevant examples or links; state related
-              cross-section edits and constraints; include credible alternatives
-              with tradeoffs only when they exist; separate required edits from
-              bounded improvements; and explain how to verify the documented
-              behavior against the implementation.
+              change-introduced regression and is invalid without an
+              author-ready revision packet for every blocker. For each blocker,
+              name exact documentation paths and sections; identify the stale or
+              missing claim and its goal-linked consequence; give proposed
+              replacement wording or outline with relevant examples or links;
+              state related cross-section edits and constraints; include
+              credible alternatives with tradeoffs only when they exist;
+              separate required edits from bounded improvements; and explain how
+              to verify the documented behavior against the implementation.
 
               This review is limited to documentation. Defer branch push, base
               synchronization, and PR creation to the downstream Ready-to-Merge
@@ -884,6 +919,21 @@ workflows:
             type: command
             run: gh pr list --head {{branch}} --base {{baseBranch}} --state open --json url
               -q ".[0].url" | grep -q .
+          - name: PR checks pass
+            type: command
+            phase: 1
+            timeout: 3600
+            run: gh pr checks "{{branch}}" --watch --interval 10
+            failureGuidance: >-
+              Inspect the failed checks before acting. If the failure was transient and
+              no repository change is required, retry and re-signal this gate. If changes
+              are required, fix them and re-signal the earliest passed gate whose
+              verified work is affected: Implementation for source code, tests, build
+              configuration, or runtime behaviour; Documentation for documentation-only
+              changes where that gate exists; or Design/Issue Analysis when accepted
+              assumptions change. Re-signalling a passed gate invalidates its downstream
+              gates. Choose based on the planned remediation, not merely the check
+              failure.
   quick-fix:
     id: quick-fix
     name: Quick Fix
@@ -911,20 +961,20 @@ workflows:
             command: unit
           - name: Browser tests
             type: command
-            phase: 1
+            phase: 2
             timeout: 900
             component: bobbit
             command: browser
           - name: E2E tests
             type: command
-            phase: 1
+            phase: 3
             timeout: 900
             component: bobbit
             command: e2e
           - name: Spec and regression conformance
             type: llm-review
             role: spec-auditor
-            phase: 2
+            phase: 3
             prompt: >-
               Compare the goal specification below, available upstream design or
               issue analysis, implementation, and tests on branch {{branch}}
@@ -934,30 +984,31 @@ workflows:
 
               Ignore documentation-only gaps. Identify unmet behavior,
               acceptance criteria, regressions, contradictions, and missing
-              regression coverage. Every blocker must include implementation-ready
-              remediation and focused tests that prove the fix.
+              regression coverage. Every blocker must include
+              implementation-ready remediation and focused tests that prove the
+              fix.
 
-              This phase-2 implementation review does not own optional phase-3 QA
-              or the downstream Ready-to-Merge gate. Defer QA when configured,
-              branch push, base synchronization, and PR creation to those stages.
-              Concrete implementation defects remain in scope.
+              This phase-3 implementation review does not own optional phase-4
+              QA or the downstream Ready-to-Merge gate. Defer QA when
+              configured, branch push, base synchronization, and PR creation to
+              those stages. Concrete implementation defects remain in scope.
           - name: Integrated implementation review
             type: llm-review
             role: code-reviewer
-            phase: 2
+            phase: 3
             prompt: >-
               Review the implementation on branch {{branch}} versus
-              origin/{{baseBranch}}. Cover correctness, error handling,
-              edge and mixed states, concurrency and lifecycle, cross-layer
-              interactions, maintainability, regression coverage, and
-              independently verifiable bugs.
+              origin/{{baseBranch}}. Cover correctness, error handling, edge and
+              mixed states, concurrency and lifecycle, cross-layer interactions,
+              maintainability, regression coverage, and independently verifiable
+              bugs.
 
               Deduplicate findings by root cause. For each blocker, provide an
               exact minimal fix and focused tests that independently verify it.
           - name: Security review
             type: llm-review
             role: security-reviewer
-            phase: 2
+            phase: 3
             prompt: >-
               Review changed trust boundaries, authentication and authorization,
               validation and injection, secrets, destructive or resource
@@ -983,6 +1034,21 @@ workflows:
             type: command
             run: gh pr list --head {{branch}} --base {{baseBranch}} --state open --json url
               -q ".[0].url" | grep -q .
+          - name: PR checks pass
+            type: command
+            phase: 1
+            timeout: 3600
+            run: gh pr checks "{{branch}}" --watch --interval 10
+            failureGuidance: >-
+              Inspect the failed checks before acting. If the failure was transient and
+              no repository change is required, retry and re-signal this gate. If changes
+              are required, fix them and re-signal the earliest passed gate whose
+              verified work is affected: Implementation for source code, tests, build
+              configuration, or runtime behaviour; Documentation for documentation-only
+              changes where that gate exists; or Design/Issue Analysis when accepted
+              assumptions change. Re-signalling a passed gate invalidates its downstream
+              gates. Choose based on the planned remediation, not merely the check
+              failure.
     createdAt: 1774734770196
     updatedAt: 1774734770196
   human-signoff-test:
@@ -1040,8 +1106,7 @@ workflows:
             type: llm-review
             role: systems-reviewer
             phase: 1
-            prompt: >-
-              Perform the complete Systems Interaction Review defined by the
+            prompt: Perform the complete Systems Interaction Review defined by the
               systems-reviewer role for branch {{branch}} versus {{baseBranch}}.
               Inspect every changed cross-layer state and action path, continue
               after the first finding, and submit the verification result.

--- a/tests2/browser/e2e/source-vite-runtime-helpers.ts
+++ b/tests2/browser/e2e/source-vite-runtime-helpers.ts
@@ -232,6 +232,9 @@ export function startSourceVite(options: SourceViteOptions): RunningSourceProces
 	env.NODE_ENV = "development";
 	env.GATEWAY_URL = options.gatewayUrl;
 	env.VITE_HOST = "localhost";
+	// This smoke proves the canonical bridge is loaded from Vite's source module
+	// graph. The normal dev server remains bundled; only this owned fixture opts out.
+	env.BOBBIT_VITE_SOURCE_GRAPH = "1";
 	const child = spawn(process.execPath, [
 		viteCli,
 		"--host", "127.0.0.1",

--- a/tests2/core/seed-default-workflows.test.ts
+++ b/tests2/core/seed-default-workflows.test.ts
@@ -20,6 +20,8 @@ type VerifyStep = {
 	expect?: string;
 	optional?: boolean;
 	prompt?: string;
+	timeout?: number;
+	failureGuidance?: string;
 };
 
 type Workflow = {
@@ -42,6 +44,21 @@ const EXPECTED_REVIEWS = [
 	{ name: "Integrated implementation review", role: "code-reviewer" },
 	{ name: "Security review", role: "security-reviewer" },
 ];
+type ImplementationPhasePolicy = {
+	commands: Record<"check" | "unit" | "browser" | "e2e", number>;
+	reviews: number;
+	qa: number;
+};
+const DEFAULT_IMPLEMENTATION_PHASES: ImplementationPhasePolicy = {
+	commands: { check: 1, unit: 1, browser: 1, e2e: 1 },
+	reviews: 2,
+	qa: 3,
+};
+const PROJECT_IMPLEMENTATION_PHASES: ImplementationPhasePolicy = {
+	commands: { check: 1, unit: 1, browser: 2, e2e: 3 },
+	reviews: 3,
+	qa: 4,
+};
 const SUPERSEDED_REVIEW_NAMES = [
 	/code quality/i,
 	/bug hunt/i,
@@ -140,14 +157,19 @@ function assertDeferredToLaterStage(prompt: string, artifact: RegExp, source: st
 	assert.match(policy, new RegExp(`${genericOrContrast}.{0,${policyWindow}}${artifactPattern}|${artifactPattern}.{0,${policyWindow}}${genericOrContrast}|${explicitHandoff}`, "i"), message);
 }
 
-function assertCompleteGateStageOwnership(workflows: Record<string, Workflow>, source: string): void {
+function assertCompleteGateStageOwnership(
+	workflows: Record<string, Workflow>,
+	source: string,
+	optionalQaPhase = DEFAULT_IMPLEMENTATION_PHASES.qa,
+): void {
 	for (const workflowId of IMPLEMENTATION_WORKFLOW_IDS) {
 		const implementation = findGate(workflows[workflowId], "implementation");
 		const specPrompt = implementation.verify?.find((step) => step.role === "spec-auditor")?.prompt ?? "";
 		const securityPrompt = implementation.verify?.find((step) => step.role === "security-reviewer")?.prompt ?? "";
 
-		// Phase-2 reviews must not block on work owned by optional QA or publication.
-		assertDeferredToLaterStage(specPrompt, /(?:optional.{0,100}(?:phase[- ]?3|later).{0,100}(?:QA|agent QA)|(?:QA|agent QA).{0,100}optional.{0,100}(?:phase[- ]?3|later))/i, `${source}.${workflowId}.implementation Spec review optional QA`);
+		// Implementation reviews must not block on work owned by optional QA or publication.
+		const optionalQa = new RegExp(`(?:optional.{0,100}(?:phase[- ]?${optionalQaPhase}|later).{0,100}(?:QA|agent QA)|(?:QA|agent QA).{0,100}optional.{0,100}(?:phase[- ]?${optionalQaPhase}|later))`, "i");
+		assertDeferredToLaterStage(specPrompt, optionalQa, `${source}.${workflowId}.implementation Spec review optional QA`);
 		assertDeferredToLaterStage(specPrompt, /(?:ready[- ]to[- ]merge|publication).{0,160}(?:push|base(?:[- ]sync)?|pull request|PR)|(?:push|base(?:[- ]sync)?|pull request|PR).{0,160}(?:ready[- ]to[- ]merge|publication)/i, `${source}.${workflowId}.implementation Spec review publication`);
 
 		const hasDocumentationGate = workflowId !== "quick-fix";
@@ -191,7 +213,33 @@ function assertUnconditionalSpecDocumentationScope(workflows: Record<string, Wor
 	}
 }
 
-function assertImplementationReviewPolicy(workflows: Record<string, Workflow>, source: string) {
+function assertProjectReadyToMergeChecks(workflows: Record<string, Workflow>, source: string): void {
+	for (const workflowId of IMPLEMENTATION_WORKFLOW_IDS) {
+		const verify = findGate(workflows[workflowId], "ready-to-merge").verify ?? [];
+		const prRaisedIndex = verify.findIndex((step) => step.name === "PR raised");
+		const checksIndex = verify.findIndex((step) => step.name === "PR checks pass");
+		assert.ok(prRaisedIndex >= 0, `${source}.${workflowId}.ready-to-merge must verify that the PR was raised`);
+		assert.ok(checksIndex > prRaisedIndex, `${source}.${workflowId}.ready-to-merge must wait for PR checks after verifying that the PR was raised`);
+
+		const checks = verify[checksIndex];
+		assert.equal(checks.type, "command");
+		assert.equal(checks.phase, 1);
+		assert.equal(checks.timeout, 3600);
+		assert.equal(checks.run, 'gh pr checks "{{branch}}" --watch --interval 10');
+		const guidance = checks.failureGuidance?.replace(/\s+/g, " ") ?? "";
+		assert.match(guidance, /transient.{0,120}retry and re-signal/i);
+		assert.match(guidance, /re-signal.{0,120}earliest passed gate/i);
+		assert.match(guidance, /Implementation.{0,100}source code.{0,100}tests/i);
+		assert.match(guidance, /Documentation.{0,100}documentation-only/i);
+		assert.match(guidance, /Design\/Issue Analysis.{0,100}assumptions change/i);
+	}
+}
+
+function assertImplementationReviewPolicy(
+	workflows: Record<string, Workflow>,
+	source: string,
+	phases = DEFAULT_IMPLEMENTATION_PHASES,
+) {
 	for (const workflowId of IMPLEMENTATION_WORKFLOW_IDS) {
 		const implementation = findGate(workflows[workflowId], "implementation");
 		const verify = implementation.verify ?? [];
@@ -199,8 +247,8 @@ function assertImplementationReviewPolicy(workflows: Record<string, Workflow>, s
 
 		assert.deepEqual(
 			reviews.map(({ name, role, phase }) => ({ name, role, phase })),
-			EXPECTED_REVIEWS.map(({ name, role }) => ({ name, role, phase: 2 })),
-			`${source}.${workflowId}.implementation must contain exactly the three consolidated phase-2 reviews in policy order`,
+			EXPECTED_REVIEWS.map(({ name, role }) => ({ name, role, phase: phases.reviews })),
+			`${source}.${workflowId}.implementation must contain exactly the three consolidated reviews in policy order and phase`,
 		);
 
 		for (const step of verify) {
@@ -215,15 +263,15 @@ function assertImplementationReviewPolicy(workflows: Record<string, Workflow>, s
 		assert.equal(build.type, "command");
 		assert.ok(build.phase === undefined || build.phase === 0, `${source}.${workflowId}.implementation Build must run in phase 0`);
 
-		for (const command of ["check", "unit", "browser", "e2e"]) {
+		for (const [command, phase] of Object.entries(phases.commands)) {
 			const step = verify.find((candidate) => candidate.type === "command" && candidate.command === command);
 			assert.ok(step, `${source}.${workflowId}.implementation must run ${command}`);
-			assert.equal(step.phase, 1, `${source}.${workflowId}.implementation ${command} must run in phase 1`);
+			assert.equal(step.phase, phase, `${source}.${workflowId}.implementation ${command} must run in phase ${phase}`);
 		}
 
 		for (const qaStep of verify.filter((step) => step.type === "agent-qa")) {
 			assert.equal(qaStep.optional, true, `${source}.${workflowId}.implementation QA must be optional`);
-			assert.equal(qaStep.phase, 3, `${source}.${workflowId}.implementation QA must run in phase 3`);
+			assert.equal(qaStep.phase, phases.qa, `${source}.${workflowId}.implementation QA must run in phase ${phases.qa}`);
 		}
 	}
 
@@ -285,13 +333,14 @@ describe("consolidated implementation review defaults", () => {
 		}
 	});
 
-	it("keeps the active project workflow config parseable and on the same review policy", () => {
+	it("keeps the active project workflow config parseable with serialized expensive verification phases", () => {
 		const repoRoot = path.resolve(import.meta.dirname, "..", "..");
 		const project = YAML.parse(fs.readFileSync(path.join(repoRoot, ".bobbit", "config", "project.yaml"), "utf8")) as {
 			workflows?: Record<string, Workflow>;
 		};
 		assert.ok(project.workflows, "project.yaml must define workflows");
-		assertImplementationReviewPolicy(project.workflows, ".bobbit/config/project.yaml");
+		assertImplementationReviewPolicy(project.workflows, ".bobbit/config/project.yaml", PROJECT_IMPLEMENTATION_PHASES);
+		assertProjectReadyToMergeChecks(project.workflows, ".bobbit/config/project.yaml");
 
 		const prReview = project.workflows["pr-review"];
 		assert.ok(prReview, "PR Review must remain a purpose-built workflow");
@@ -318,7 +367,7 @@ describe("consolidated implementation review defaults", () => {
 			workflows?: Record<string, Workflow>;
 		};
 		assert.ok(project.workflows, "project.yaml must define workflows");
-		assertCompleteGateStageOwnership(project.workflows, ".bobbit/config/project.yaml");
+		assertCompleteGateStageOwnership(project.workflows, ".bobbit/config/project.yaml", PROJECT_IMPLEMENTATION_PHASES.qa);
 	});
 
 	it("keeps the phase-2 prompts implementation-ready", () => {

--- a/tests2/core/vite-bundled-dev.test.ts
+++ b/tests2/core/vite-bundled-dev.test.ts
@@ -21,6 +21,19 @@ describe("Vite bundled development mode", () => {
 			.not.toContain("batch-client-full-reloads");
 	});
 
+	it("allows the owned source-runtime smoke to inspect the native module graph", async () => {
+		const previous = process.env.BOBBIT_VITE_SOURCE_GRAPH;
+		process.env.BOBBIT_VITE_SOURCE_GRAPH = "1";
+		try {
+			const config = await configFor("serve");
+			expect(config.experimental?.bundledDev).toBeUndefined();
+			expect(config.experimental?.renderBuiltUrl).toBeUndefined();
+		} finally {
+			if (previous === undefined) delete process.env.BOBBIT_VITE_SOURCE_GRAPH;
+			else process.env.BOBBIT_VITE_SOURCE_GRAPH = previous;
+		}
+	});
+
 	it("guards Tailwind's unreleased bundled-dev hot-update fix", async () => {
 		const config = await configFor("serve");
 		const plugin = config.plugins?.flat().find(

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -602,7 +602,9 @@ export default defineConfig(({ command, mode }) => ({
 	// Bundle the browser graph during development. Bobbit's large eager graph
 	// takes tens of seconds to traverse as one request per source module; Vite's
 	// bundled mode keeps HMR while serving a small set of in-memory chunks.
-	// Production retains its mount-aware runtime URL rewriting instead.
+	// Production retains its mount-aware runtime URL rewriting instead. The
+	// source-runtime E2E owns an explicit opt-out because it verifies the actual
+	// source module graph rather than the normal bundled development runtime.
 	experimental: command === "build"
 		? {
 			renderBuiltUrl(filename, { hostType }) {
@@ -618,7 +620,9 @@ export default defineConfig(({ command, mode }) => ({
 				return { relative: hostType === "css" };
 			},
 		}
-		: { bundledDev: true },
+		: process.env.BOBBIT_VITE_SOURCE_GRAPH === "1"
+			? undefined
+			: { bundledDev: true },
 	build: {
 		outDir: "dist/ui",
 		// Emit modern JS — the supported browser matrix (iOS 17+, modern Chrome/Edge/Firefox)


### PR DESCRIPTION
## Summary

- serialize browser, E2E, review, and optional QA verification phases in the active project workflows
- require GitHub PR checks to pass in Ready-to-Merge gates, with remediation guidance for failures
- pin the project-specific phase policy and PR-check contract in unit tests
- keep the source-runtime E2E on Vite's native module graph while normal development retains bundled mode

## Testing

- `npm run check`
- `npm run test:unit` — 9,773 passed, 19 skipped
- `npm run test:unit -- vite-bundled-dev` — 4 passed
- `npm run test:browser` — 715 passed, 8 skipped
- source Vite E2E spec — 3 passed
- E2E groups A, B, and D passed; Group C rerun after the fix — 89 passed, 12 skipped

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)
