### PR TITLE
Fix team lead uptime display

### DIFF
--- a/src/app/goal-dashboard.ts
+++ b/src/app/goal-dashboard.ts
@@ -2674,7 +2674,7 @@ function renderAgentsTab(): TemplateResult {
 		const startedAt = Number.isFinite(agent.createdAt) && agent.createdAt > 0 && agent.createdAt <= now
 			? agent.createdAt
 			: now;
-		const hasValidArchivedAt = isArchived && Number.isFinite(agent.archivedAt) && agent.archivedAt! <= now;
+		const hasValidArchivedAt = isArchived && Number.isFinite(agent.archivedAt) && agent.archivedAt! > 0 && agent.archivedAt! <= now;
 		const endedAt = hasValidArchivedAt
 			? agent.archivedAt!
 			: isArchived && agent.role === "team-lead"

--- a/src/app/goal-dashboard.ts
+++ b/src/app/goal-dashboard.ts
@@ -2645,7 +2645,8 @@ function renderAgentsTab(): TemplateResult {
 			worktreePath: "",
 			branch: "",
 			task: "",
-			createdAt: 0,
+			createdAt: teamLeadSession.createdAt,
+			archivedAt: teamLeadSession.archivedAt,
 		});
 	}
 	allAgents.push(...agents);
@@ -2669,8 +2670,14 @@ function renderAgentsTab(): TemplateResult {
 				|| state.archivedSessions.find(gs => gs.id === agent.sessionId);
 			return s && c.author === (s.title || s.id.slice(0, 8));
 		}).length;
-		const elapsed = (isArchived && agent.archivedAt ? agent.archivedAt : Date.now()) - agent.createdAt;
-		const mins = Math.floor(elapsed / 60_000);
+		const now = Date.now();
+		const startedAt = Number.isFinite(agent.createdAt) && agent.createdAt > 0 && agent.createdAt <= now
+			? agent.createdAt
+			: now;
+		const endedAt = isArchived && Number.isFinite(agent.archivedAt) && agent.archivedAt! <= now
+			? agent.archivedAt!
+			: now;
+		const mins = Math.floor(Math.max(0, endedAt - startedAt) / 60_000);
 		const timeStr = mins < 60 ? `${mins}m` : `${Math.floor(mins / 60)}h ${mins % 60}m`;
 		const displayName = isArchived ? (agent.title || formatAgentName(agent)) : formatAgentName(agent);
 

--- a/src/app/goal-dashboard.ts
+++ b/src/app/goal-dashboard.ts
@@ -2674,9 +2674,12 @@ function renderAgentsTab(): TemplateResult {
 		const startedAt = Number.isFinite(agent.createdAt) && agent.createdAt > 0 && agent.createdAt <= now
 			? agent.createdAt
 			: now;
-		const endedAt = isArchived && Number.isFinite(agent.archivedAt) && agent.archivedAt! <= now
+		const hasValidArchivedAt = isArchived && Number.isFinite(agent.archivedAt) && agent.archivedAt! <= now;
+		const endedAt = hasValidArchivedAt
 			? agent.archivedAt!
-			: now;
+			: isArchived && agent.role === "team-lead"
+				? startedAt
+				: now;
 		const mins = Math.floor(Math.max(0, endedAt - startedAt) / 60_000);
 		const timeStr = mins < 60 ? `${mins}m` : `${Math.floor(mins / 60)}h ${mins % 60}m`;
 		const displayName = isArchived ? (agent.title || formatAgentName(agent)) : formatAgentName(agent);

--- a/tests2/browser/journeys/goal-dashboard-agent-duration.journey.spec.ts
+++ b/tests2/browser/journeys/goal-dashboard-agent-duration.journey.spec.ts
@@ -1,0 +1,73 @@
+import type { Locator, Page } from "@playwright/test";
+import {
+	apiFetch,
+	createGoal,
+	deleteGoal,
+	deleteSession,
+	expect,
+	navigateToHash,
+	openApp,
+	test,
+	waitForSessionStatus,
+} from "../_helpers/journey-fixture.js";
+import { startTeam, teardownTeam } from "../e2e-setup.js";
+
+function leadCard(page: Page): Locator {
+	return page.locator(".agent-card").filter({ hasText: "LEAD" }).first();
+}
+
+async function expectLiveLeadAge(page: Page, createdAt: number): Promise<void> {
+	const card = leadCard(page);
+	await expect(card).toBeVisible({ timeout: 20_000 });
+	const duration = (await card.locator(".agent-card-meta-item").last().textContent())?.trim() ?? "";
+	const actualMinutes = Math.floor(Math.max(0, Date.now() - createdAt) / 60_000);
+
+	expect(duration, "LEAD_UPTIME_BROWSER_EPOCH_REGRESSION: Agents tab must show the live lead's session age").toMatch(/^\d+m$/);
+	const renderedMinutes = Number.parseInt(duration, 10);
+	expect(renderedMinutes).toBeGreaterThanOrEqual(actualMinutes);
+	expect(renderedMinutes).toBeLessThanOrEqual(actualMinutes + 1);
+}
+
+test.describe("Journey: Goal dashboard team-lead duration", () => {
+	test("uses session age after Agents-tab navigation, dashboard navigation, and reload", async ({ page }) => {
+		test.setTimeout(90_000);
+		const stamp = Date.now();
+		const teamGoal = await createGoal({
+			title: `Lead uptime ${stamp}`,
+			team: true,
+			autoStartTeam: false,
+		});
+		const otherGoal = await createGoal({ title: `Lead uptime navigation ${stamp}` });
+		let teamLeadId: string | undefined;
+
+		try {
+			teamLeadId = await startTeam(teamGoal.id);
+			await waitForSessionStatus(teamLeadId, "idle", 30_000);
+			const sessionResponse = await apiFetch(`/api/sessions/${teamLeadId}`);
+			expect(sessionResponse.ok).toBe(true);
+			const session = await sessionResponse.json() as { createdAt: number };
+			expect(Number.isFinite(session.createdAt)).toBe(true);
+
+			await openApp(page);
+			await navigateToHash(page, `#/goal/${teamGoal.id}`);
+			await expect(page.locator("[data-testid='goal-dashboard']")).toBeVisible({ timeout: 20_000 });
+			await page.locator("[data-testid='tab-agents']").click();
+			await expectLiveLeadAge(page, session.createdAt);
+
+			await navigateToHash(page, `#/goal/${otherGoal.id}`);
+			await expect(page.getByText(String(otherGoal.title), { exact: true }).first()).toBeVisible({ timeout: 20_000 });
+			await navigateToHash(page, `#/goal/${teamGoal.id}?tab=agents`);
+			await expectLiveLeadAge(page, session.createdAt);
+
+			await page.reload({ waitUntil: "domcontentloaded" });
+			await expect(page.locator("[data-testid='goal-dashboard']")).toBeVisible({ timeout: 20_000 });
+			await expect(page.locator("[data-testid='tab-agents']")).toHaveAttribute("data-active", "true", { timeout: 20_000 });
+			await expectLiveLeadAge(page, session.createdAt);
+		} finally {
+			if (teamLeadId) await deleteSession(teamLeadId).catch(() => {});
+			await teardownTeam(teamGoal.id).catch(() => {});
+			await deleteGoal(teamGoal.id, true).catch(() => {});
+			await deleteGoal(otherGoal.id, true).catch(() => {});
+		}
+	});
+});

--- a/tests2/browser/journeys/goal-dashboard-agent-duration.journey.spec.ts
+++ b/tests2/browser/journeys/goal-dashboard-agent-duration.journey.spec.ts
@@ -24,7 +24,7 @@ async function expectLiveLeadAge(page: Page, createdAt: number): Promise<void> {
 
 	expect(duration, "LEAD_UPTIME_BROWSER_EPOCH_REGRESSION: Agents tab must show the live lead's session age").toMatch(/^\d+m$/);
 	const renderedMinutes = Number.parseInt(duration, 10);
-	expect(renderedMinutes).toBeGreaterThanOrEqual(actualMinutes);
+	expect(renderedMinutes).toBeGreaterThanOrEqual(actualMinutes - 1);
 	expect(renderedMinutes).toBeLessThanOrEqual(actualMinutes + 1);
 }
 

--- a/tests2/dom/goal-dashboard-agent-duration.test.ts
+++ b/tests2/dom/goal-dashboard-agent-duration.test.ts
@@ -1,0 +1,252 @@
+import { beforeAll as __syncBeforeAll } from "vitest";
+import { syncCustomElements as __syncCE } from "./_setup/custom-elements.js";
+__syncBeforeAll(() => __syncCE());
+
+import { render } from "lit";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import "../../src/ui/components/GitStatusWidget.js";
+import type { GatewaySession, Goal } from "../../src/app/state.js";
+import type { TeamAgent } from "../../src/app/goal-dashboard.js";
+
+type StateModule = typeof import("../../src/app/state.js");
+type DashboardModule = typeof import("../../src/app/goal-dashboard.js");
+
+const NOW = 1_750_000_000_000;
+const GOAL_ID = "11111111-2222-4333-8444-555555555555";
+
+let state!: StateModule["state"];
+let setRenderApp!: StateModule["setRenderApp"];
+let clearDashboardState!: DashboardModule["clearDashboardState"];
+let loadDashboardData!: DashboardModule["loadDashboardData"];
+let renderGoalDashboard!: DashboardModule["renderGoalDashboard"];
+let host!: HTMLElement;
+let goal!: Goal;
+let liveSessions: GatewaySession[] = [];
+let archivedSessions: GatewaySession[] = [];
+let teamAgents: TeamAgent[] = [];
+
+class MockWebSocket extends EventTarget {
+	static CONNECTING = 0;
+	static OPEN = 1;
+	static CLOSING = 2;
+	static CLOSED = 3;
+	readyState = MockWebSocket.OPEN;
+	send = vi.fn();
+	close = vi.fn(() => { this.readyState = MockWebSocket.CLOSED; });
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+	return new Response(JSON.stringify(body), {
+		status,
+		headers: { "Content-Type": "application/json" },
+	});
+}
+
+function makeGoal(): Goal {
+	return {
+		id: GOAL_ID,
+		title: "Agent duration regression",
+		cwd: "/repo",
+		projectId: "project-1",
+		state: "in-progress",
+		spec: "Verify team lead lifecycle durations on the real dashboard path.",
+		createdAt: NOW - 60_000,
+		updatedAt: NOW,
+		setupStatus: "ready",
+		team: true,
+	};
+}
+
+function makeLead(overrides: Partial<GatewaySession> = {}): GatewaySession {
+	return {
+		id: "lead-session",
+		title: "Team Lead",
+		cwd: "/repo",
+		projectId: "project-1",
+		status: "idle",
+		createdAt: NOW - 12 * 60_000,
+		lastActivity: NOW,
+		clientCount: 1,
+		goalId: GOAL_ID,
+		teamGoalId: GOAL_ID,
+		role: "team-lead",
+		...overrides,
+	};
+}
+
+function installFetchStub(): void {
+	const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+		const rawUrl = typeof input === "string" || input instanceof URL ? String(input) : input.url;
+		const url = new URL(rawUrl, window.location.origin);
+		const method = (init?.method || (input instanceof Request ? input.method : "GET") || "GET").toUpperCase();
+		if (method !== "GET") return Promise.resolve(jsonResponse({ ok: true }));
+
+		if (url.pathname === `/api/goals/${GOAL_ID}`) return Promise.resolve(jsonResponse(goal));
+		if (url.pathname === `/api/goals/${GOAL_ID}/tasks`) return Promise.resolve(jsonResponse({ tasks: [] }));
+		if (url.pathname === `/api/goals/${GOAL_ID}/commits`) return Promise.resolve(jsonResponse({ commits: [] }));
+		if (url.pathname === `/api/goals/${GOAL_ID}/gates`) return Promise.resolve(jsonResponse({ gates: [] }));
+		if (url.pathname === `/api/goals/${GOAL_ID}/git-status`) return Promise.resolve(jsonResponse({ error: "Not a git repository" }, 400));
+		if (url.pathname === `/api/goals/${GOAL_ID}/cost`) return Promise.resolve(jsonResponse({ totalCost: 0 }));
+		if (url.pathname === `/api/goals/${GOAL_ID}/pr-status`) return Promise.resolve(new Response(null, { status: 204 }));
+		if (url.pathname === `/api/goals/${GOAL_ID}/team`) return Promise.resolve(jsonResponse({ teamLeadSessionId: liveSessions[0]?.id ?? archivedSessions[0]?.id }));
+		if (url.pathname === `/api/goals/${GOAL_ID}/team/agents`) return Promise.resolve(jsonResponse({ agents: teamAgents }));
+		if (url.pathname === `/api/goals/${GOAL_ID}/tree-cost`) return Promise.resolve(jsonResponse({ totalCostUsd: 0, totalTokensIn: 0, totalTokensOut: 0, breakdown: [] }));
+		if (url.pathname === `/api/goals/${GOAL_ID}/descendants`) return Promise.resolve(jsonResponse({ goals: [] }));
+		if (url.pathname === `/api/goals/${GOAL_ID}/pending-mutations`) return Promise.resolve(jsonResponse({ pending: [] }));
+		if (url.pathname === `/api/goals/${GOAL_ID}/verifications/active`) return Promise.resolve(jsonResponse({ verifications: [] }));
+		if (url.pathname === "/api/sessions" && url.searchParams.get("include") === "archived") {
+			return Promise.resolve(jsonResponse({ sessions: archivedSessions, total: archivedSessions.length, hasMore: false }));
+		}
+		if (url.pathname === "/api/sessions") return Promise.resolve(jsonResponse({ sessions: liveSessions, generation: 1 }));
+		return Promise.resolve(jsonResponse({}));
+	});
+	vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+	(window as any).fetch = fetchMock;
+}
+
+async function nextFrame(): Promise<void> {
+	await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+	await Promise.resolve();
+}
+
+async function waitForAgentCards(count: number): Promise<HTMLElement[]> {
+	for (let i = 0; i < 30; i++) {
+		const cards = [...host.querySelectorAll<HTMLElement>(".agent-card")];
+		if (cards.length === count) return cards;
+		await nextFrame();
+	}
+	throw new Error(`Timed out waiting for ${count} agent cards`);
+}
+
+function cardDuration(card: HTMLElement): string {
+	const meta = [...card.querySelectorAll<HTMLElement>(".agent-card-meta-item")];
+	return meta.at(-1)?.textContent?.trim() ?? "";
+}
+
+function resetSharedState(): void {
+	clearDashboardState();
+	state.gatewaySessions = liveSessions;
+	state.archivedSessions = archivedSessions;
+	state.goals = [goal];
+	state.projects = [{ id: "project-1", name: "Project", rootPath: "/repo", colorLight: "#fff", colorDark: "#000" }];
+	state.activeProjectId = "project-1";
+	state.remoteAgent = null;
+	state.chatPanel = null;
+	state.selectedSessionId = null;
+	state.connectingSessionId = null;
+	state.appView = "authenticated";
+	state.connectionStatus = "connected" as any;
+	state.gateStatusCache.clear();
+	state.prStatusCache.clear();
+}
+
+async function renderAgentsDashboard(): Promise<HTMLElement[]> {
+	state.gatewaySessions = liveSessions;
+	state.archivedSessions = archivedSessions;
+	window.location.hash = `#/goal/${GOAL_ID}?tab=agents`;
+	setRenderApp(() => render(renderGoalDashboard(), host));
+	await loadDashboardData(GOAL_ID);
+	return waitForAgentCards((liveSessions.length + archivedSessions.length > 0 ? 1 : 0) + teamAgents.length);
+}
+
+beforeEach(async () => {
+	document.body.innerHTML = '<div id="host"></div>';
+	host = document.getElementById("host")!;
+	goal = makeGoal();
+	liveSessions = [];
+	archivedSessions = [];
+	teamAgents = [];
+	vi.spyOn(Date, "now").mockReturnValue(NOW);
+	const canvasContext = new Proxy({}, { get: () => () => {}, set: () => true });
+	vi.spyOn(HTMLCanvasElement.prototype, "getContext").mockReturnValue(canvasContext as CanvasRenderingContext2D);
+	vi.spyOn(HTMLCanvasElement.prototype, "toDataURL").mockReturnValue("data:image/png;base64,c3RhdGlj");
+	vi.stubGlobal("WebSocket", MockWebSocket as unknown as typeof WebSocket);
+	vi.spyOn(console, "warn").mockImplementation(() => {});
+
+	const stateMod = await import("../../src/app/state.js");
+	const dashboardMod = await import("../../src/app/goal-dashboard.js");
+	state = stateMod.state;
+	setRenderApp = stateMod.setRenderApp;
+	clearDashboardState = dashboardMod.clearDashboardState;
+	loadDashboardData = dashboardMod.loadDashboardData;
+	renderGoalDashboard = dashboardMod.renderGoalDashboard;
+	installFetchStub();
+	resetSharedState();
+});
+
+afterEach(async () => {
+	setRenderApp?.(() => {});
+	clearDashboardState?.();
+	await nextFrame();
+	if (host) render(null, host);
+	document.body.innerHTML = "";
+	vi.restoreAllMocks();
+	vi.unstubAllGlobals();
+});
+
+describe("Goal dashboard Agents-tab durations", () => {
+	it("derives a live team lead duration from the matching session createdAt", async () => {
+		liveSessions = [makeLead({ createdAt: NOW - 12 * 60_000 })];
+		const [leadCard] = await renderAgentsDashboard();
+
+		expect(cardDuration(leadCard), "LEAD_UPTIME_EPOCH_REGRESSION: live lead must use session.createdAt").toBe("12m");
+	});
+
+	it("freezes an archived team lead duration at its session archivedAt", async () => {
+		archivedSessions = [makeLead({
+			status: "archived",
+			archived: true,
+			createdAt: NOW - 3 * 60 * 60_000,
+			archivedAt: NOW - 2 * 60 * 60_000,
+		})];
+		const [leadCard] = await renderAgentsDashboard();
+
+		expect(cardDuration(leadCard), "LEAD_UPTIME_ARCHIVE_REGRESSION: archived lead must stop at session.archivedAt").toBe("1h 0m");
+	});
+
+	it.each([
+		["missing", undefined],
+		["non-finite", Number.NaN],
+		["future", NOW + 5 * 60_000],
+	])("uses a non-negative zero-age fallback for a %s lead createdAt", async (_case, createdAt) => {
+		liveSessions = [makeLead({ createdAt: createdAt as number })];
+		const [leadCard] = await renderAgentsDashboard();
+		const duration = cardDuration(leadCard);
+
+		expect(duration, "LEAD_UPTIME_INVALID_LIFECYCLE: invalid lead timestamps must not produce epoch or negative durations").toBe("0m");
+		expect(duration).not.toMatch(/^-|NaN|Infinity|\d{5,}h/);
+	});
+
+	it("preserves live and archived duration behavior for regular team agents", async () => {
+		teamAgents = [
+			{
+				sessionId: "live-coder",
+				role: "coder",
+				status: "idle",
+				worktreePath: "/repo/live",
+				branch: "agent/live",
+				task: "Live work",
+				createdAt: NOW - 70 * 60_000,
+			},
+			{
+				sessionId: "archived-reviewer",
+				role: "reviewer",
+				status: "archived",
+				worktreePath: "/repo/reviewer",
+				branch: "agent/reviewer",
+				task: "Review work",
+				createdAt: NOW - 3 * 60 * 60_000,
+				archivedAt: NOW - 75 * 60_000,
+				title: "Archived Reviewer",
+			},
+		];
+		const cards = await renderAgentsDashboard();
+		const live = cards.find((card) => card.textContent?.includes("CODER"));
+		const archived = cards.find((card) => card.textContent?.includes("REVIEWER"));
+
+		expect(live).toBeTruthy();
+		expect(archived).toBeTruthy();
+		expect(cardDuration(live!)).toBe("1h 10m");
+		expect(cardDuration(archived!)).toBe("1h 45m");
+	});
+});

--- a/tests2/dom/goal-dashboard-agent-duration.test.ts
+++ b/tests2/dom/goal-dashboard-agent-duration.test.ts
@@ -206,6 +206,7 @@ describe("Goal dashboard Agents-tab durations", () => {
 
 	it.each([
 		["missing", undefined],
+		["zero", 0],
 		["non-finite", Number.NaN],
 		["future", NOW + 24 * 60 * 60_000],
 	])("keeps an archived team lead at zero age when archivedAt is %s", async (_case, archivedAt) => {
@@ -243,7 +244,7 @@ describe("Goal dashboard Agents-tab durations", () => {
 		expect(duration).not.toMatch(/^-|NaN|Infinity|\d{5,}h/);
 	});
 
-	it("keeps the current-time fallback for a regular archived agent without archivedAt", async () => {
+	it("keeps the current-time fallback for a regular archived agent with zero archivedAt", async () => {
 		teamAgents = [{
 			sessionId: "archived-coder",
 			role: "coder",
@@ -252,6 +253,7 @@ describe("Goal dashboard Agents-tab durations", () => {
 			branch: "agent/coder",
 			task: "Archived work",
 			createdAt: NOW - 40 * 60_000,
+			archivedAt: 0,
 		}];
 		let [agentCard] = await renderAgentsDashboard();
 

--- a/tests2/dom/goal-dashboard-agent-duration.test.ts
+++ b/tests2/dom/goal-dashboard-agent-duration.test.ts
@@ -207,6 +207,32 @@ describe("Goal dashboard Agents-tab durations", () => {
 	it.each([
 		["missing", undefined],
 		["non-finite", Number.NaN],
+		["future", NOW + 24 * 60 * 60_000],
+	])("keeps an archived team lead at zero age when archivedAt is %s", async (_case, archivedAt) => {
+		archivedSessions = [makeLead({
+			status: "archived",
+			archived: true,
+			createdAt: NOW - 40 * 60_000,
+			archivedAt: archivedAt as number,
+		})];
+		let [leadCard] = await renderAgentsDashboard();
+		const durations = [cardDuration(leadCard)];
+
+		vi.mocked(Date.now).mockReturnValue(NOW + 25 * 60_000);
+		render(renderGoalDashboard(), host);
+		await nextFrame();
+		[leadCard] = await waitForAgentCards(1);
+		durations.push(cardDuration(leadCard));
+
+		expect(
+			durations,
+			"LEAD_UPTIME_INVALID_ARCHIVE_END: archived leads without a valid end time must not keep aging",
+		).toEqual(["0m", "0m"]);
+	});
+
+	it.each([
+		["missing", undefined],
+		["non-finite", Number.NaN],
 		["future", NOW + 5 * 60_000],
 	])("uses a non-negative zero-age fallback for a %s lead createdAt", async (_case, createdAt) => {
 		liveSessions = [makeLead({ createdAt: createdAt as number })];
@@ -215,6 +241,28 @@ describe("Goal dashboard Agents-tab durations", () => {
 
 		expect(duration, "LEAD_UPTIME_INVALID_LIFECYCLE: invalid lead timestamps must not produce epoch or negative durations").toBe("0m");
 		expect(duration).not.toMatch(/^-|NaN|Infinity|\d{5,}h/);
+	});
+
+	it("keeps the current-time fallback for a regular archived agent without archivedAt", async () => {
+		teamAgents = [{
+			sessionId: "archived-coder",
+			role: "coder",
+			status: "archived",
+			worktreePath: "/repo/coder",
+			branch: "agent/coder",
+			task: "Archived work",
+			createdAt: NOW - 40 * 60_000,
+		}];
+		let [agentCard] = await renderAgentsDashboard();
+
+		expect(cardDuration(agentCard)).toBe("40m");
+
+		vi.mocked(Date.now).mockReturnValue(NOW + 25 * 60_000);
+		render(renderGoalDashboard(), host);
+		await nextFrame();
+		[agentCard] = await waitForAgentCards(1);
+
+		expect(cardDuration(agentCard)).toBe("1h 5m");
 	});
 
 	it("preserves live and archived duration behavior for regular team agents", async () => {

--- a/tests2/tests-map.json
+++ b/tests2/tests-map.json
@@ -21,6 +21,24 @@
   },
   "v2Native": [
     {
+      "path": "tests2/dom/goal-dashboard-agent-duration.test.ts",
+      "reason": "Real dashboard-rendering regression coverage for live and archived team-lead lifecycle timestamps, safe invalid/future timestamp fallbacks, and unchanged regular-agent durations.",
+      "execution": {
+        "runner": "vitest",
+        "tier": "unit",
+        "project": "dom"
+      }
+    },
+    {
+      "path": "tests2/browser/journeys/goal-dashboard-agent-duration.journey.spec.ts",
+      "reason": "User-visible Agents-tab journey proving the team lead duration remains tied to its session age after tab navigation, cross-dashboard navigation, and page reload.",
+      "execution": {
+        "runner": "playwright",
+        "tier": "browser",
+        "project": "browser"
+      }
+    },
+    {
       "path": "tests2/core/file-explorer-model.test.ts",
       "reason": "Pure file explorer domain coverage for canonical relative paths, stable directory-first ordering, complete porcelain status combinations, retained-source copy augmentation, nested-root filtering, ancestor and virtual-deletion decoration, bounded file classification, and synthesized untracked diffs.",
       "execution": {
@@ -2685,6 +2703,10 @@
     },
     {
       "path": "tests2/browser/journeys/team-operations.journey.spec.ts",
+      "type": "smoke-journey"
+    },
+    {
+      "path": "tests2/browser/journeys/goal-dashboard-agent-duration.journey.spec.ts",
       "type": "smoke-journey"
     }
   ],


### PR DESCRIPTION
## Summary

- derive team lead duration from authoritative session lifecycle timestamps
- freeze archived lead duration and sanitize invalid timestamps
- add focused DOM and browser regressions for navigation and reload

## Validation

- `npm run check`
- focused DOM regression: 6 passed
- focused browser journey: 1 passed
- full implementation workflow verification passed

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)