### PR TITLE
Deduplicate goal dashboard agents

### DIFF
--- a/src/app/goal-dashboard.ts
+++ b/src/app/goal-dashboard.ts
@@ -1082,6 +1082,63 @@ let agents: TeamAgent[] = [];
 let agentPollTimer: ReturnType<typeof setInterval> | null = null;
 let taskPollTimer: ReturnType<typeof setInterval> | null = null;
 
+function reconciledDashboardAgents(): TeamAgent[] {
+	const agentsBySessionId = new Map<string, TeamAgent>();
+	const orderedSessionIds: string[] = [];
+	for (const agent of agents) {
+		const existing = agentsBySessionId.get(agent.sessionId);
+		if (!existing) {
+			agentsBySessionId.set(agent.sessionId, agent);
+			orderedSessionIds.push(agent.sessionId);
+		} else if (existing.status === "archived" && agent.status !== "archived") {
+			// Polling can briefly expose both lifecycle records. Keep the original
+			// position, but prefer the live record until archival is authoritative.
+			agentsBySessionId.set(agent.sessionId, agent);
+		}
+	}
+
+	const teamLeadSession = currentGoal?.team
+		? (state.gatewaySessions.find(s => (s.goalId === currentGoal!.id || s.teamGoalId === currentGoal!.id) && s.role === "team-lead")
+			|| state.archivedSessions.find(s => (s.goalId === currentGoal!.id || s.teamGoalId === currentGoal!.id) && s.role === "team-lead"))
+		: null;
+	if (!teamLeadSession) {
+		return orderedSessionIds.map(sessionId => agentsBySessionId.get(sessionId)!);
+	}
+
+	const fallbackLead: TeamAgent = {
+		sessionId: teamLeadSession.id,
+		role: "team-lead",
+		status: teamLeadSession.status,
+		worktreePath: "",
+		branch: "",
+		task: "",
+		createdAt: teamLeadSession.createdAt,
+		archivedAt: teamLeadSession.archivedAt,
+	};
+	const responseLead = agentsBySessionId.get(teamLeadSession.id);
+	if (!responseLead) {
+		return [fallbackLead, ...orderedSessionIds.map(sessionId => agentsBySessionId.get(sessionId)!)];
+	}
+
+	// The response carries richer card metadata, so retain it when both paths
+	// contain the lead. A live session-state record wins only the lifecycle
+	// fields when teardown polling still reports the same lead as archived.
+	const reconciledLead = fallbackLead.status !== "archived" && responseLead.status === "archived"
+		? {
+			...responseLead,
+			status: fallbackLead.status,
+			createdAt: fallbackLead.createdAt,
+			archivedAt: fallbackLead.archivedAt,
+		}
+		: responseLead;
+	return [
+		reconciledLead,
+		...orderedSessionIds
+			.filter(sessionId => sessionId !== teamLeadSession.id)
+			.map(sessionId => agentsBySessionId.get(sessionId)!),
+	];
+}
+
 async function fetchAgents(goalId: string): Promise<TeamAgent[]> {
 	try {
 		const res = await gatewayFetch(`/api/goals/${goalId}/team/agents?include=archived`);
@@ -2478,12 +2535,13 @@ function currentGateSummaryCounts(): { passed: number; total: number } {
 function renderTabBar(): TemplateResult {
 	const gateSummary = currentGateSummaryCounts();
 	const gateCountStr = gateSummary.total > 0 ? `${gateSummary.passed}/${gateSummary.total}` : String(gates.length);
+	const dashboardAgents = reconciledDashboardAgents();
 
 	const tabs: Array<{ id: DashboardTabId; label: string; icon: TemplateResult; countStr: string }> = [
 		{ id: "spec", label: "Spec", icon: svgDoc, countStr: "" },
 		{ id: "gates", label: "Gates", icon: svgGate, countStr: gateCountStr },
 		{ id: "tasks", label: "Tasks", icon: svgTasks, countStr: String(tasks.length) },
-		{ id: "agents", label: "Agents", icon: svgAgents, countStr: String(agents.length + (currentGoal?.team && (state.gatewaySessions.some(s => (s.goalId === currentGoal!.id || s.teamGoalId === currentGoal!.id) && s.role === "team-lead") || state.archivedSessions.some(s => (s.goalId === currentGoal!.id || s.teamGoalId === currentGoal!.id) && s.role === "team-lead")) ? 1 : 0)) },
+		{ id: "agents", label: "Agents", icon: svgAgents, countStr: String(dashboardAgents.length) },
 		{ id: "commits", label: "Commits", icon: svgCommit, countStr: String(commits.length) },
 	];
 
@@ -2631,25 +2689,7 @@ function renderTasksTab(): TemplateResult {
 // ============================================================================
 
 function renderAgentsTab(): TemplateResult {
-	// Build combined list: team lead (if any) + spawned agents
-	const allAgents: TeamAgent[] = [];
-	const teamLeadSession = currentGoal?.team
-		? (state.gatewaySessions.find(s => (s.goalId === currentGoal!.id || s.teamGoalId === currentGoal!.id) && s.role === "team-lead")
-			|| state.archivedSessions.find(s => (s.goalId === currentGoal!.id || s.teamGoalId === currentGoal!.id) && s.role === "team-lead"))
-		: null;
-	if (teamLeadSession) {
-		allAgents.push({
-			sessionId: teamLeadSession.id,
-			role: "team-lead",
-			status: teamLeadSession.status,
-			worktreePath: "",
-			branch: "",
-			task: "",
-			createdAt: teamLeadSession.createdAt,
-			archivedAt: teamLeadSession.archivedAt,
-		});
-	}
-	allAgents.push(...agents);
+	const allAgents = reconciledDashboardAgents();
 
 	if (allAgents.length === 0) {
 		return html`<div class="tab-empty">${svgAgents}<span>No active agents</span></div>`;

--- a/tests2/browser/journeys/goal-dashboard-agent-dedupe.journey.spec.ts
+++ b/tests2/browser/journeys/goal-dashboard-agent-dedupe.journey.spec.ts
@@ -1,0 +1,81 @@
+import type { Page } from "@playwright/test";
+import {
+	apiFetch,
+	createGoal,
+	deleteGoal,
+	deleteSession,
+	expect,
+	navigateToHash,
+	openApp,
+	test,
+	waitForSessionStatus,
+} from "../_helpers/journey-fixture.js";
+import { startTeam, teardownTeam } from "../e2e-setup.js";
+
+const REGRESSION = "GOAL_AGENT_DEDUPE_BROWSER_REGRESSION";
+
+async function expectArchivedLeadFromBothSources(page: Page, sessionId: string): Promise<void> {
+	await expect.poll(() => page.evaluate((id) => {
+		const state = (window as any).bobbitState;
+		return {
+			live: Array.isArray(state?.gatewaySessions) && state.gatewaySessions.some((session: { id?: string }) => session.id === id),
+			archived: Array.isArray(state?.archivedSessions) && state.archivedSessions.some((session: { id?: string }) => session.id === id),
+		};
+	}, sessionId), {
+		timeout: 20_000,
+		message: `${REGRESSION}: archived team lead must hydrate into dashboard session state`,
+	}).toEqual({ live: false, archived: true });
+
+	const agentsTab = page.locator("[data-testid='tab-agents']");
+	await expect(agentsTab.locator(".tab-count"), `${REGRESSION}: Agents badge must count the unique archived lead once`).toHaveText("1", { timeout: 20_000 });
+
+	const panel = page.locator("[data-testid='goal-dashboard-tab-panel'][data-tab-id='agents']");
+	const cards = panel.locator(".agent-card");
+	await expect(cards, `${REGRESSION}: Agents tab must render one card for the archived lead returned by both lifecycle sources`).toHaveCount(1, { timeout: 20_000 });
+	await expect(cards.first().locator(".role-tag").filter({ hasText: /^LEAD$/ })).toHaveCount(1);
+	await expect(cards.first()).toContainText("Dismissed");
+}
+
+test.describe("Journey: Goal dashboard archived team-lead dedupe", () => {
+	test("shows one lead card and a matching badge after teardown, navigation, and reload", async ({ page }) => {
+		test.setTimeout(90_000);
+		const goal = await createGoal({
+			title: `Archived lead dedupe ${Date.now()}`,
+			team: true,
+			autoStartTeam: false,
+		});
+		let teamLeadId: string | undefined;
+
+		try {
+			teamLeadId = await startTeam(goal.id);
+			await waitForSessionStatus(teamLeadId, "idle", 30_000);
+			await teardownTeam(goal.id);
+
+			await expect.poll(async () => {
+				const response = await apiFetch(`/api/goals/${goal.id}/team/agents?include=archived`);
+				if (!response.ok) return -1;
+				const body = await response.json() as { agents?: Array<{ sessionId?: string; status?: string }> };
+				return (body.agents ?? []).filter((agent) => agent.sessionId === teamLeadId && agent.status === "archived").length;
+			}, {
+				timeout: 20_000,
+				message: `${REGRESSION}: team-agents response must expose the archived lead before UI hydration`,
+			}).toBe(1);
+
+			await openApp(page);
+			await navigateToHash(page, `#/goal/${goal.id}`);
+			await expect(page.locator("[data-testid='goal-dashboard']")).toBeVisible({ timeout: 20_000 });
+			await page.locator("[data-testid='tab-agents']").click();
+			await expect(page.locator("[data-testid='tab-agents']")).toHaveAttribute("data-active", "true");
+			await expectArchivedLeadFromBothSources(page, teamLeadId);
+
+			await page.reload({ waitUntil: "domcontentloaded" });
+			await expect(page.locator("[data-testid='goal-dashboard']")).toBeVisible({ timeout: 20_000 });
+			await expect(page.locator("[data-testid='tab-agents']")).toHaveAttribute("data-active", "true", { timeout: 20_000 });
+			await expectArchivedLeadFromBothSources(page, teamLeadId);
+		} finally {
+			await teardownTeam(goal.id).catch(() => {});
+			if (teamLeadId) await deleteSession(teamLeadId).catch(() => {});
+			await deleteGoal(goal.id, true).catch(() => {});
+		}
+	});
+});

--- a/tests2/dom/goal-dashboard-agents-dedupe.test.ts
+++ b/tests2/dom/goal-dashboard-agents-dedupe.test.ts
@@ -1,0 +1,280 @@
+import { beforeAll as __syncBeforeAll } from "vitest";
+import { syncCustomElements as __syncCE } from "./_setup/custom-elements.js";
+__syncBeforeAll(() => __syncCE());
+
+import { render } from "lit";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import "../../src/ui/components/GitStatusWidget.js";
+import type { GatewaySession, Goal } from "../../src/app/state.js";
+import type { TeamAgent } from "../../src/app/goal-dashboard.js";
+
+type StateModule = typeof import("../../src/app/state.js");
+type DashboardModule = typeof import("../../src/app/goal-dashboard.js");
+
+const NOW = 1_750_000_000_000;
+const GOAL_ID = "11111111-2222-4333-8444-555555555555";
+
+let state!: StateModule["state"];
+let setRenderApp!: StateModule["setRenderApp"];
+let clearDashboardState!: DashboardModule["clearDashboardState"];
+let loadDashboardData!: DashboardModule["loadDashboardData"];
+let renderGoalDashboard!: DashboardModule["renderGoalDashboard"];
+let host!: HTMLElement;
+let goal!: Goal;
+let liveSessions: GatewaySession[] = [];
+let archivedSessions: GatewaySession[] = [];
+let teamAgents: TeamAgent[] = [];
+
+class MockWebSocket extends EventTarget {
+	static CONNECTING = 0;
+	static OPEN = 1;
+	static CLOSING = 2;
+	static CLOSED = 3;
+	readyState = MockWebSocket.OPEN;
+	send = vi.fn();
+	close = vi.fn(() => { this.readyState = MockWebSocket.CLOSED; });
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+	return new Response(JSON.stringify(body), {
+		status,
+		headers: { "Content-Type": "application/json" },
+	});
+}
+
+function makeGoal(): Goal {
+	return {
+		id: GOAL_ID,
+		title: "Agent dedupe regression",
+		cwd: "/repo",
+		projectId: "project-1",
+		state: "in-progress",
+		spec: "Render each team session once.",
+		createdAt: NOW - 60_000,
+		updatedAt: NOW,
+		setupStatus: "ready",
+		team: true,
+	};
+}
+
+function makeLead(id: string, overrides: Partial<GatewaySession> = {}): GatewaySession {
+	return {
+		id,
+		title: `Lead ${id}`,
+		cwd: "/repo",
+		projectId: "project-1",
+		status: "idle",
+		createdAt: NOW - 12 * 60_000,
+		lastActivity: NOW,
+		clientCount: 1,
+		goalId: GOAL_ID,
+		teamGoalId: GOAL_ID,
+		role: "team-lead",
+		...overrides,
+	};
+}
+
+function makeAgent(sessionId: string, role: string, overrides: Partial<TeamAgent> = {}): TeamAgent {
+	return {
+		sessionId,
+		role,
+		status: "idle",
+		worktreePath: `/repo/${sessionId}`,
+		branch: `agent/${sessionId}`,
+		task: `${role} work`,
+		createdAt: NOW - 10 * 60_000,
+		...overrides,
+	};
+}
+
+function installFetchStub(): void {
+	const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+		const rawUrl = typeof input === "string" || input instanceof URL ? String(input) : input.url;
+		const url = new URL(rawUrl, window.location.origin);
+		const method = (init?.method || (input instanceof Request ? input.method : "GET") || "GET").toUpperCase();
+		if (method !== "GET") return Promise.resolve(jsonResponse({ ok: true }));
+
+		if (url.pathname === `/api/goals/${GOAL_ID}`) return Promise.resolve(jsonResponse(goal));
+		if (url.pathname === `/api/goals/${GOAL_ID}/tasks`) return Promise.resolve(jsonResponse({ tasks: [] }));
+		if (url.pathname === `/api/goals/${GOAL_ID}/commits`) return Promise.resolve(jsonResponse({ commits: [] }));
+		if (url.pathname === `/api/goals/${GOAL_ID}/gates`) return Promise.resolve(jsonResponse({ gates: [] }));
+		if (url.pathname === `/api/goals/${GOAL_ID}/git-status`) return Promise.resolve(jsonResponse({ error: "Not a git repository" }, 400));
+		if (url.pathname === `/api/goals/${GOAL_ID}/cost`) return Promise.resolve(jsonResponse({ totalCost: 0 }));
+		if (url.pathname === `/api/goals/${GOAL_ID}/pr-status`) return Promise.resolve(new Response(null, { status: 204 }));
+		if (url.pathname === `/api/goals/${GOAL_ID}/team`) return Promise.resolve(jsonResponse({ teamLeadSessionId: liveSessions[0]?.id ?? archivedSessions[0]?.id }));
+		if (url.pathname === `/api/goals/${GOAL_ID}/team/agents`) return Promise.resolve(jsonResponse({ agents: teamAgents }));
+		if (url.pathname === `/api/goals/${GOAL_ID}/tree-cost`) return Promise.resolve(jsonResponse({ totalCostUsd: 0, totalTokensIn: 0, totalTokensOut: 0, breakdown: [] }));
+		if (url.pathname === `/api/goals/${GOAL_ID}/descendants`) return Promise.resolve(jsonResponse({ goals: [] }));
+		if (url.pathname === `/api/goals/${GOAL_ID}/pending-mutations`) return Promise.resolve(jsonResponse({ pending: [] }));
+		if (url.pathname === `/api/goals/${GOAL_ID}/verifications/active`) return Promise.resolve(jsonResponse({ verifications: [] }));
+		if (url.pathname === "/api/sessions" && url.searchParams.get("include") === "archived") {
+			return Promise.resolve(jsonResponse({ sessions: archivedSessions, total: archivedSessions.length, hasMore: false }));
+		}
+		if (url.pathname === "/api/sessions") return Promise.resolve(jsonResponse({ sessions: liveSessions, generation: 1 }));
+		return Promise.resolve(jsonResponse({}));
+	});
+	vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+	(window as any).fetch = fetchMock;
+}
+
+async function nextFrame(): Promise<void> {
+	await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+	await Promise.resolve();
+}
+
+async function waitForAgentView(expectedCount: number): Promise<HTMLElement[]> {
+	for (let i = 0; i < 30; i++) {
+		const cards = [...host.querySelectorAll<HTMLElement>(".agent-card")];
+		const badge = host.querySelector<HTMLElement>("[data-testid='tab-agents'] .tab-count");
+		if (cards.length === expectedCount && badge?.textContent?.trim() === String(expectedCount)) return cards;
+		await nextFrame();
+	}
+	const actualCards = host.querySelectorAll(".agent-card").length;
+	const actualBadge = host.querySelector("[data-testid='tab-agents'] .tab-count")?.textContent?.trim();
+	throw new Error(`Timed out waiting for ${expectedCount} cards/badge; found ${actualCards}/${actualBadge}`);
+}
+
+async function renderAgentsDashboard(expectedCount: number): Promise<HTMLElement[]> {
+	state.gatewaySessions = liveSessions;
+	state.archivedSessions = archivedSessions;
+	window.location.hash = `#/goal/${GOAL_ID}?tab=agents`;
+	setRenderApp(() => render(renderGoalDashboard(), host));
+	await loadDashboardData(GOAL_ID);
+	return waitForAgentView(expectedCount);
+}
+
+beforeEach(async () => {
+	document.body.innerHTML = '<div id="host"></div>';
+	host = document.getElementById("host")!;
+	goal = makeGoal();
+	liveSessions = [];
+	archivedSessions = [];
+	teamAgents = [];
+	vi.spyOn(Date, "now").mockReturnValue(NOW);
+	const canvasContext = new Proxy({}, { get: () => () => {}, set: () => true });
+	vi.spyOn(HTMLCanvasElement.prototype, "getContext").mockReturnValue(canvasContext as CanvasRenderingContext2D);
+	vi.spyOn(HTMLCanvasElement.prototype, "toDataURL").mockReturnValue("data:image/png;base64,c3RhdGlj");
+	vi.stubGlobal("WebSocket", MockWebSocket as unknown as typeof WebSocket);
+	vi.spyOn(console, "warn").mockImplementation(() => {});
+
+	const stateMod = await import("../../src/app/state.js");
+	const dashboardMod = await import("../../src/app/goal-dashboard.js");
+	state = stateMod.state;
+	setRenderApp = stateMod.setRenderApp;
+	clearDashboardState = dashboardMod.clearDashboardState;
+	loadDashboardData = dashboardMod.loadDashboardData;
+	renderGoalDashboard = dashboardMod.renderGoalDashboard;
+	installFetchStub();
+	clearDashboardState();
+	state.goals = [goal];
+	state.projects = [{ id: "project-1", name: "Project", rootPath: "/repo", colorLight: "#fff", colorDark: "#000" }];
+	state.activeProjectId = "project-1";
+	state.remoteAgent = null;
+	state.chatPanel = null;
+	state.selectedSessionId = null;
+	state.connectingSessionId = null;
+	state.appView = "authenticated";
+	state.connectionStatus = "connected" as any;
+	state.gateStatusCache.clear();
+	state.prStatusCache.clear();
+});
+
+afterEach(async () => {
+	setRenderApp?.(() => {});
+	clearDashboardState?.();
+	await nextFrame();
+	if (host) render(null, host);
+	document.body.innerHTML = "";
+	vi.restoreAllMocks();
+	vi.unstubAllGlobals();
+});
+
+describe("Goal dashboard Agents-tab reconciliation", () => {
+	it("renders an archived lead once when session state and the agents response overlap", async () => {
+		archivedSessions = [makeLead("archived-lead", {
+			status: "archived",
+			archived: true,
+			archivedAt: NOW - 60_000,
+		})];
+		teamAgents = [makeAgent("archived-lead", "team-lead", {
+			status: "archived",
+			archivedAt: NOW - 60_000,
+			title: "Archived Team Lead",
+		})];
+
+		const cards = await renderAgentsDashboard(1);
+
+		expect(cards).toHaveLength(1);
+		expect(cards[0].textContent).toContain("Archived Team Lead");
+		expect(cards[0].textContent).toContain("Dismissed");
+	});
+
+	it("adds a live lead fallback when the agents response omits it", async () => {
+		liveSessions = [makeLead("live-lead", { title: "Current Team Lead" })];
+
+		const cards = await renderAgentsDashboard(1);
+
+		expect(cards[0].textContent).toContain("Current Team Lead");
+		expect(cards[0].classList.contains("opacity-70")).toBe(false);
+	});
+
+	it("prefers a live lead during live and archived lifecycle overlap", async () => {
+		liveSessions = [makeLead("overlap-lead", { title: "Live Team Lead", status: "streaming" })];
+		archivedSessions = [makeLead("overlap-lead", {
+			title: "Stale Archived Lead",
+			status: "archived",
+			archived: true,
+			archivedAt: NOW - 60_000,
+		})];
+		teamAgents = [makeAgent("overlap-lead", "team-lead", {
+			status: "archived",
+			archivedAt: NOW - 60_000,
+			task: "Preserved response task",
+		})];
+
+		const cards = await renderAgentsDashboard(1);
+
+		expect(cards[0].classList.contains("opacity-70")).toBe(false);
+		expect(cards[0].textContent).toContain("Live Team Lead");
+		expect(cards[0].textContent).toContain("Preserved response task");
+		expect(cards[0].textContent).not.toContain("Dismissed");
+	});
+
+	it("keeps regular agents alongside the reconciled lead", async () => {
+		liveSessions = [makeLead("live-lead")];
+		teamAgents = [makeAgent("coder-session", "coder", { title: "Coder Agent" })];
+
+		const cards = await renderAgentsDashboard(2);
+
+		expect(cards.map(card => card.textContent)).toEqual([
+		expect.stringContaining("Lead live-lead"),
+		expect.stringContaining("CODER"),
+		]);
+	});
+
+	it("preserves distinct historical team leads with different session IDs", async () => {
+		archivedSessions = [makeLead("historical-lead-1", {
+			status: "archived",
+			archived: true,
+			archivedAt: NOW - 60_000,
+		})];
+		teamAgents = [
+			makeAgent("historical-lead-1", "team-lead", {
+				status: "archived",
+				archivedAt: NOW - 60_000,
+				title: "Historical Lead One",
+			}),
+			makeAgent("historical-lead-2", "team-lead", {
+				status: "archived",
+				archivedAt: NOW - 120_000,
+				title: "Historical Lead Two",
+			}),
+		];
+
+		const cards = await renderAgentsDashboard(2);
+		const text = cards.map(card => card.textContent).join(" ");
+
+		expect(text).toContain("Historical Lead One");
+		expect(text).toContain("Historical Lead Two");
+	});
+});

--- a/tests2/tests-map.json
+++ b/tests2/tests-map.json
@@ -21,6 +21,24 @@
   },
   "v2Native": [
     {
+      "path": "tests2/dom/goal-dashboard-agents-dedupe.test.ts",
+      "reason": "DOM regression coverage for unique session-ID reconciliation across API agents and live/archived team-lead fallbacks, including overlap and distinct historical leads, with the Agents badge derived from the rendered collection.",
+      "execution": {
+        "runner": "vitest",
+        "tier": "unit",
+        "project": "dom"
+      }
+    },
+    {
+      "path": "tests2/browser/journeys/goal-dashboard-agent-dedupe.journey.spec.ts",
+      "reason": "User-visible teardown journey proving an archived team lead returned by both the team-agents API and hydrated session state renders once with a matching Agents badge after navigation and reload.",
+      "execution": {
+        "runner": "playwright",
+        "tier": "browser",
+        "project": "browser"
+      }
+    },
+    {
       "path": "tests2/dom/goal-dashboard-agent-duration.test.ts",
       "reason": "Real dashboard-rendering regression coverage for live and archived team-lead lifecycle timestamps, safe invalid/future timestamp fallbacks, and unchanged regular-agent durations.",
       "execution": {
@@ -2707,6 +2725,10 @@
     },
     {
       "path": "tests2/browser/journeys/goal-dashboard-agent-duration.journey.spec.ts",
+      "type": "smoke-journey"
+    },
+    {
+      "path": "tests2/browser/journeys/goal-dashboard-agent-dedupe.journey.spec.ts",
       "type": "smoke-journey"
     }
   ],


### PR DESCRIPTION
## Summary
- reconcile API-provided agents and team-lead session fallbacks by session ID
- use the same unique collection for Agents cards and badge counts
- add DOM coverage for lifecycle overlap and browser coverage for teardown, navigation, and reload

## Verification
- build
- type check
- unit tests
- browser tests
- E2E tests
- implementation, conformance, and security review

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)