### PR TITLE
Backfill missing verification-step duration_ms during gate-store migration

### DIFF
--- a/src/server/agent/gate-store.ts
+++ b/src/server/agent/gate-store.ts
@@ -218,7 +218,12 @@ function validateDiagnostics(value: unknown, label: string): void {
 	}
 }
 
-/** Validate known GateState fields without normalizing away historical extensions. */
+/**
+ * Validate known GateState fields without normalizing away historical extensions.
+ * The one narrow exception is backfilling a missing verification-step `duration_ms`
+ * (see the step loop): human bypasses and hand-recorded manual passes mark a step
+ * passed without a timed command run and legitimately omit it.
+ */
 function validateGateState(value: unknown, label: string, expectedIdentity?: { goalId: string; gateId: string }): GateState {
 	if (!isRecord(value)) invalidGate(label, "must be an object");
 	if (typeof value.goalId !== "string" || value.goalId.length === 0) invalidGate(label, "goalId must be a non-empty string");
@@ -262,6 +267,11 @@ function validateGateState(value: unknown, label: string, expectedIdentity?: { g
 			// integration-test). Historical signal history remains valid as long as
 			// the persisted discriminator is a non-empty string.
 			if (typeof step.name !== "string" || typeof step.type !== "string" || step.type.length === 0) invalidGate(stepLabel, "name and type are required");
+			// Human bypasses and hand-recorded manual passes mark a step passed
+			// without running a timed command, so historical data legitimately omits
+			// duration_ms. Backfill the default instead of failing the whole load; a
+			// present-but-non-finite value is still corruption and stays rejected.
+			if (step.duration_ms === undefined) step.duration_ms = 0;
 			if (typeof step.passed !== "boolean" || typeof step.output !== "string" || !Number.isFinite(step.duration_ms)) {
 				invalidGate(stepLabel, "passed, output, and finite duration_ms are required");
 			}

--- a/tests2/core/gate-store-sqlite.test.ts
+++ b/tests2/core/gate-store-sqlite.test.ts
@@ -276,6 +276,27 @@ describe("GateStore SQLite persistence", () => {
 		expect(fs.existsSync(path.join(stateDir, "gates.json.pre-migration-recovered"))).toBe(true);
 	});
 
+	it("migrates a hand-recorded manual pass whose step omits duration_ms instead of failing the load", async () => {
+		const stateDir = tempRoot();
+		const manualPass = representativeGate("goal-bypass", "qualification");
+		// A human bypass / hand-recorded manual pass marks a step passed without a
+		// timed command run, so the persisted step legitimately has no duration_ms.
+		// The old JSON loader tolerated this; the strict migration must not fatal.
+		delete (manualPass.signals[0].verification.steps[0] as unknown as Record<string, unknown>).duration_ms;
+		fs.writeFileSync(path.join(stateDir, "gates.json"), JSON.stringify([manualPass]), "utf-8");
+
+		const store = openStore(stateDir);
+		expect(store.getGate("goal-bypass", "qualification")?.signals[0]?.verification.steps[0]?.duration_ms).toBe(0);
+		expect(fs.existsSync(path.join(stateDir, "gates.sqlite"))).toBe(true);
+		expect(fs.existsSync(path.join(stateDir, "gates.json.sqlite-retired"))).toBe(true);
+
+		// The backfilled default is durable across a restart.
+		await store.close();
+		stores.splice(stores.indexOf(store), 1);
+		const reloaded = openStore(stateDir);
+		expect(reloaded.getGate("goal-bypass", "qualification")?.signals[0]?.verification.steps[0]?.duration_ms).toBe(0);
+	});
+
 	it("rejects malformed authoritative recovery transactionally and releases the database handle", async () => {
 		const stateDir = tempRoot();
 		const authoritative = openStore(stateDir);


### PR DESCRIPTION
## Problem

After the SQLite gate-store migration (#1167), the gateway crash-loops on boot with:

```
Fatal: [gate-store] Invalid recovery gate at index 20 signal at index 3 verification step at index 0: passed, output, and finite duration_ms are required
```

`validateGateState` validates every persisted verification step strictly, requiring a finite `duration_ms`. But human gate bypasses and hand-recorded manual passes mark a step `passed` without running a timed command, so they legitimately omit `duration_ms`. The previous JSON persistence never validated payloads on load, so these records were tolerated for months. The strict migration read now throws before the migration transaction can commit — the completion marker is never set, so every restart re-reads the same legacy data and re-fails identically (permanent crash loop).

## Fix

Backfill a missing `duration_ms` to `0` at the single validation choke point (`validateGateState`), covering both the legacy-JSON migration read and SQLite payload reads. A *present-but-non-finite* value is still rejected, so genuine corruption is still caught. `0` is semantically honest for an untimed manual pass.

## Verification

- Replayed real `.bobbit/state` (3567 gates; 11 affected steps) through the built code: migration completes, all rows import, both markers set, legacy files retired — zero remaining invalid steps.
- New pinning test in `tests2/core/gate-store-sqlite.test.ts`: a manual-pass step missing `duration_ms` migrates and loads as `0`, durable across a restart.
- `npx vitest run tests2/core/gate-store-sqlite.test.ts` → 18/18 pass.

Regression fix for #1167.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
