### PR TITLE
Fix mobile sidebar row alignment

### DIFF
--- a/src/app/app.css
+++ b/src/app/app.css
@@ -1303,9 +1303,21 @@ details.wf-proposal-workflow .wf-proposal-gates {
 	left: -5px;
 }
 
+/* Mobile rows keep status metadata and action controls in separate flex slots.
+   The extra cluster margin makes metadata→first-action spacing match the
+   icon-to-icon spacing between padded action buttons. */
+.sidebar-mobile-action-cluster {
+	display: inline-flex;
+	align-items: center;
+	gap: 0.25rem;
+	flex-shrink: 0;
+	margin-left: 0.25rem;
+}
+
 @media (max-width: 767px) {
 	.sidebar-active-dot {
-		left: 2px !important;
+		left: 0 !important;
+		align-self: center;
 	}
 }
 

--- a/src/app/render-helpers.ts
+++ b/src/app/render-helpers.ts
@@ -574,6 +574,12 @@ function renderSidebarQuickActions(actions: SidebarActionItem[], opts: { kind: S
 	})}`;
 }
 
+function wrapSidebarRowActions(buttons: TemplateResult, mobile: boolean): TemplateResult {
+	return mobile
+		? html`<span class="sidebar-mobile-action-cluster">${buttons}</span>`
+		: buttons;
+}
+
 function renderSidebarActionsTrigger(input: {
 	kind: SidebarActionEntityKind;
 	entityId: string;
@@ -673,7 +679,10 @@ export function renderStaffSidebarActions(staffId: string, displayTitle: string,
 		? buildSessionSidebarActions(session, displayTitle, staffId)
 		: [buildStaffEditSidebarAction(staffId)];
 	const actions = buildActions();
-	return html`${renderSidebarQuickActions(actions, { kind: "session", entityId, mobile, btnPad })}${renderSidebarActionsTrigger({ kind: "session", entityId, actions, mobile, btnPad, refresh: buildActions, onBeforeOpen: session ? resetSessionForkNewWorktree : undefined })}`;
+	return wrapSidebarRowActions(
+		html`${renderSidebarQuickActions(actions, { kind: "session", entityId, mobile, btnPad })}${renderSidebarActionsTrigger({ kind: "session", entityId, actions, mobile, btnPad, refresh: buildActions, onBeforeOpen: session ? resetSessionForkNewWorktree : undefined })}`,
+		mobile,
+	);
 }
 
 function buildArchivedSessionSidebarActions(session: GatewaySession, displayTitle: string): SidebarActionItem[] {
@@ -1036,7 +1045,10 @@ export function renderSessionRow(session: GatewaySession, treeOptionsOrIndex?: R
 
 	const actions = buildSessionSidebarActions(session, displayTitle);
 	const actionRefresh = () => buildSessionSidebarActions(session, displayTitle);
-	const buttons = html`${renderSidebarQuickActions(actions, { kind: "session", entityId: session.id, mobile, btnPad })}${renderSidebarActionsTrigger({ kind: "session", entityId: session.id, actions, mobile, btnPad, refresh: actionRefresh, onBeforeOpen: resetSessionForkNewWorktree })}`;
+	const buttons = wrapSidebarRowActions(
+		html`${renderSidebarQuickActions(actions, { kind: "session", entityId: session.id, mobile, btnPad })}${renderSidebarActionsTrigger({ kind: "session", entityId: session.id, actions, mobile, btnPad, refresh: actionRefresh, onBeforeOpen: resetSessionForkNewWorktree })}`,
+		mobile,
+	);
 
 	const navId = `session:${session.id}`;
 	// Keyboard nav can have moved the active row away from this session even
@@ -1191,7 +1203,10 @@ export function renderArchivedSessionRow(session: GatewaySession, extraChildren 
 	const btnPad = mobile ? "p-1" : "p-0.5";
 	const actions = buildArchivedSessionSidebarActions(session, displayTitle);
 	const actionRefresh = () => buildArchivedSessionSidebarActions(session, displayTitle);
-	const buttons = renderSidebarActionsTrigger({ kind: "session", entityId: session.id, actions, mobile, btnPad, refresh: actionRefresh });
+	const buttons = wrapSidebarRowActions(
+		renderSidebarActionsTrigger({ kind: "session", entityId: session.id, actions, mobile, btnPad, refresh: actionRefresh }),
+		mobile,
+	);
 	const archivedTime = session.archivedAt ? html`<span class="shrink-0 text-muted-foreground" style="${mobile ? "font-size: 1em;" : "font-size: 0.8333em;"}">${terseRelativeTime(session.archivedAt)}</span>` : "";
 	const archivedNavId = `session:${session.id}`;
 	return html`
@@ -1267,7 +1282,10 @@ function renderTeamLeadRow(session: GatewaySession, childCount: number, expanded
 
 	const actions = buildTeamLeadSidebarActions(session, displayTitle, goalId);
 	const actionRefresh = () => buildTeamLeadSidebarActions(session, displayTitle, goalId);
-	const buttons = html`${renderSidebarQuickActions(actions, { kind: "session", entityId: session.id, mobile, btnPad })}${renderSidebarActionsTrigger({ kind: "session", entityId: session.id, actions, mobile, btnPad, refresh: actionRefresh, onBeforeOpen: resetSessionForkNewWorktree })}`;
+	const buttons = wrapSidebarRowActions(
+		html`${renderSidebarQuickActions(actions, { kind: "session", entityId: session.id, mobile, btnPad })}${renderSidebarActionsTrigger({ kind: "session", entityId: session.id, actions, mobile, btnPad, refresh: actionRefresh, onBeforeOpen: resetSessionForkNewWorktree })}`,
+		mobile,
+	);
 
 	const chevron = html`<span
 		class="sidebar-chevron-slot sidebar-chevron-slot--absolute text-muted-foreground select-none cursor-pointer"
@@ -1300,7 +1318,9 @@ function renderTeamLeadRow(session: GatewaySession, childCount: number, expanded
 					? html`<svg class="animate-spin" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 12a9 9 0 1 1-6.219-8.56"></path></svg>`
 					: statusBobbit(session.status, session.isCompacting, session.id, active, session.isAborting, true, false, session.accessory, false, false, true)}
 			</div>
-			<div class="flex-1 min-w-0 ${mobile ? "flex items-center gap-1" : "truncate"} font-normal" style="${mobile ? "font-size: 1.3333em;" : ""}"><span class="${mobile ? "truncate" : ""}">${renderSessionTitle(displayTitle, isActive, state.searchQuery)}</span>${mobile ? html`<span class="shrink-0 text-muted-foreground/40" style="font-size: 0.9167em;">·</span>${renderSessionTime(session)}` : ""}</div>
+			<div class="flex-1 min-w-0 flex flex-col justify-center">
+				<div class="flex items-center gap-1 min-w-0 font-normal"><span class="flex-1 min-w-0 truncate" data-testid="sidebar-session-title-text" style="${mobile ? "font-size: 1.3333em;" : ""}">${renderSessionTitle(displayTitle, isActive, state.searchQuery)}</span>${mobile ? html`<span class="shrink-0 text-muted-foreground/40" style="font-size: 0.9167em;">·</span>${renderSessionTime(session)}` : ""}</div>
+			</div>
 			${mobile
 				? buttons
 				: html`
@@ -1610,7 +1630,10 @@ export function renderGoalGroup(goal: Goal, opts?: { descendantCount?: number; r
 	const hasActiveSession = goalSessions.some((s) => s.status !== "terminated");
 	const goalActions = buildGoalSidebarActions(goal, { hasActiveSession, showArchive });
 	const goalActionRefresh = () => buildGoalSidebarActions(goal, { hasActiveSession, showArchive });
-	const goalButtons = html`${renderSidebarQuickActions(goalActions, { kind: "goal", entityId: goal.id, mobile, btnPad })}${renderSidebarActionsTrigger({ kind: "goal", entityId: goal.id, actions: goalActions, mobile, btnPad, refresh: goalActionRefresh, onBeforeOpen: () => prefetchGoalGithubLink(goal.id) })}`;
+	const goalButtons = wrapSidebarRowActions(
+		html`${renderSidebarQuickActions(goalActions, { kind: "goal", entityId: goal.id, mobile, btnPad })}${renderSidebarActionsTrigger({ kind: "goal", entityId: goal.id, actions: goalActions, mobile, btnPad, refresh: goalActionRefresh, onBeforeOpen: () => prefetchGoalGithubLink(goal.id) })}`,
+		mobile,
+	);
 
 	const emptyState = html`
 		<div class="pl-2 py-1 text-muted-foreground" style="${mobile ? "" : "font-size: 0.9167em;"}">

--- a/tests2/browser/fixtures/session-actions.spec.ts
+++ b/tests2/browser/fixtures/session-actions.spec.ts
@@ -304,6 +304,98 @@ test.describe("unified session actions", () => {
 		expectCanonicalActionsPresentInPriorityOrder(sidebarIds);
 	});
 
+	test("mobile sidebar aligns team-lead activity, active spinner, and action spacing", async ({ page }) => {
+		test.slow();
+		const referenceSessionId = await createSession();
+		sessionsToDelete.add(referenceSessionId);
+		await waitForSessionStatus(referenceSessionId, "idle");
+
+		const goal = await createGoal({
+			title: `Mobile sidebar alignment ${Date.now()}`,
+			team: true,
+			autoStartTeam: false,
+			worktree: false,
+		});
+		goalsToDelete.add(goal.id as string);
+		const teamLeadId = await startTeam(goal.id as string);
+		teamsToTeardown.add(goal.id as string);
+		sessionsToDelete.add(teamLeadId);
+		await waitForSessionStatus(teamLeadId, "idle", 30_000);
+
+		await page.setViewportSize({ width: 390, height: 844 });
+		await openApp(page);
+		await page.evaluate((goalId) => {
+			(window as any).__bobbitExpandedGoals?.add(goalId);
+			(window as any).__bobbitRenderApp?.();
+		}, goal.id);
+
+		const referenceRow = sessionRow(page, referenceSessionId);
+		const leadRow = sessionRow(page, teamLeadId);
+		await expect(referenceRow, "reference session row should be visible on the mobile landing page").toBeVisible({ timeout: 20_000 });
+		await expect(leadRow, "expanded team goal should expose its team-lead row").toBeVisible({ timeout: 20_000 });
+		await expect(referenceRow.locator('[data-testid="sidebar-session-last-activity"]')).toBeVisible();
+		await expect(leadRow.locator('[data-testid="sidebar-session-last-activity"]')).toBeVisible();
+
+		type MobileRowMetrics = {
+			indicatorLeft: number;
+			indicatorRight: number;
+			indicatorCenterY: number;
+			firstIconLeft: number;
+			firstIconCenterY: number;
+			firstIconRight: number;
+			secondIconLeft: number;
+		};
+		const measure = (row: Locator, indicatorSelector: string) => row.evaluate((element, selector): MobileRowMetrics => {
+			const indicator = element.querySelector<HTMLElement>(selector);
+			const cluster = element.querySelector<HTMLElement>(".sidebar-mobile-action-cluster");
+			const icons = cluster
+				? Array.from(cluster.querySelectorAll<HTMLElement>("button .sidebar-scale-icon"))
+				: [];
+			if (!indicator || icons.length < 2) throw new Error("Missing mobile row indicator or action icons");
+			const indicatorRect = indicator.getBoundingClientRect();
+			const firstRect = icons[0]!.getBoundingClientRect();
+			const secondRect = icons[1]!.getBoundingClientRect();
+			return {
+				indicatorLeft: indicatorRect.left,
+				indicatorRight: indicatorRect.right,
+				indicatorCenterY: indicatorRect.top + indicatorRect.height / 2,
+				firstIconLeft: firstRect.left,
+				firstIconCenterY: firstRect.top + firstRect.height / 2,
+				firstIconRight: firstRect.right,
+				secondIconLeft: secondRect.left,
+			};
+		}, indicatorSelector);
+
+		const referenceIdle = await measure(referenceRow, '[data-testid="sidebar-session-last-activity"]');
+		const leadIdle = await measure(leadRow, '[data-testid="sidebar-session-last-activity"]');
+		expect(Math.abs(leadIdle.indicatorRight - referenceIdle.indicatorRight), "team-lead activity should share the ordinary session metadata column").toBeLessThanOrEqual(1);
+		expect(Math.abs(leadIdle.indicatorCenterY - leadIdle.firstIconCenterY), "team-lead activity should be vertically centered with its actions").toBeLessThanOrEqual(1);
+		expect(
+			Math.abs((leadIdle.firstIconLeft - leadIdle.indicatorRight) - (leadIdle.secondIconLeft - leadIdle.firstIconRight)),
+			"activity-to-first-action whitespace should match the whitespace between action icons",
+		).toBeLessThanOrEqual(1);
+
+		await page.evaluate((sessionId) => {
+			const state = (window as any).__bobbitState;
+			const session = state?.gatewaySessions?.find((candidate: { id?: string }) => candidate.id === sessionId);
+			if (!session) throw new Error(`Missing client session ${sessionId}`);
+			session.status = "busy";
+			(window as any).__bobbitRenderApp?.();
+		}, referenceSessionId);
+		await expect(referenceRow.locator(".sidebar-active-dot")).toBeVisible();
+		const active = await measure(referenceRow, ".sidebar-active-dot");
+		expect(Math.abs(active.indicatorCenterY - referenceIdle.indicatorCenterY), "active spinner should occupy the last-activity vertical center").toBeLessThanOrEqual(1);
+		expect(Math.abs(active.indicatorCenterY - active.firstIconCenterY), "active spinner should be vertically centered with its actions").toBeLessThanOrEqual(1);
+		expect(
+			Math.abs((active.firstIconLeft - active.indicatorRight) - (active.secondIconLeft - active.firstIconRight)),
+			"spinner-to-first-action whitespace should match the whitespace between action icons",
+		).toBeLessThanOrEqual(1);
+		expect(await referenceRow.locator(".sidebar-active-dot").evaluate((element) => ({
+			left: getComputedStyle(element).left,
+			alignSelf: getComputedStyle(element).alignSelf,
+		}))).toEqual({ left: "0px", alignSelf: "center" });
+	});
+
 	test("staff and team-lead sessions keep canonical labels and visibility", async ({ page }) => {
 		test.slow(); // staff-session sidebar lookup: extend timeout for concurrent verification load
 		await page.setViewportSize({ width: 900, height: 900 });

--- a/tests2/dom/sidebar-mobile.test.ts
+++ b/tests2/dom/sidebar-mobile.test.ts
@@ -6,20 +6,7 @@ __syncBeforeAll(() => __syncCE());
 // (getMobileSidebarBehavior). There is no exported src counterpart — the mobile
 // behaviour is expressed inline at the sidebar render sites — so this port keeps
 // a byte-identical replica of the fixture helper and preserves every assertion.
-import { readFileSync } from "node:fs";
-import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
-
-const renderHelpersSource = readFileSync(resolve(process.cwd(), "src/app/render-helpers.ts"), "utf8");
-const appCssSource = readFileSync(resolve(process.cwd(), "src/app/app.css"), "utf8");
-
-function sourceBetween(source: string, start: string, end: string): string {
-	const startIndex = source.indexOf(start);
-	const endIndex = source.indexOf(end, startIndex + start.length);
-	expect(startIndex, `missing source marker: ${start}`).toBeGreaterThanOrEqual(0);
-	expect(endIndex, `missing source marker: ${end}`).toBeGreaterThan(startIndex);
-	return source.slice(startIndex, endIndex);
-}
 
 function getMobileSidebarBehavior(isDesktop: boolean): {
 	buttonsAlwaysVisible: boolean;
@@ -56,31 +43,5 @@ describe("SB-33: Mobile sidebar behavior", () => {
 
 	it("mobile: hamburger menu shown", () => {
 		expect(getMobileSidebarBehavior(false).showHamburgerMenu).toBe(true);
-	});
-});
-
-describe("Mobile sidebar row layout regression", () => {
-	it("gives the team-lead title the same flexible slot as ordinary session titles", () => {
-		const teamLeadSource = sourceBetween(
-			renderHelpersSource,
-			"function renderTeamLeadRow(",
-			"// ============================================================================\n// UNIFIED GOAL GROUP",
-		);
-		expect(teamLeadSource).toContain('class="flex-1 min-w-0 truncate" data-testid="sidebar-session-title-text"');
-		expect(teamLeadSource).toContain("${renderSessionTime(session)}");
-	});
-
-	it("groups mobile actions with one extra row-gap before the first button", () => {
-		const clusterCss = sourceBetween(appCssSource, ".sidebar-mobile-action-cluster {", "@media (max-width: 767px)");
-		expect(clusterCss).toContain("gap: 0.25rem;");
-		expect(clusterCss).toContain("margin-left: 0.25rem;");
-		expect(renderHelpersSource).toContain('html`<span class="sidebar-mobile-action-cluster">${buttons}</span>`');
-	});
-
-	it("does not shift the mobile active spinner toward the first action", () => {
-		const mobileCss = sourceBetween(appCssSource, "/* Mobile rows keep status metadata", ".sidebar-active-dot::after");
-		expect(mobileCss).toContain("left: 0 !important;");
-		expect(mobileCss).toContain("align-self: center;");
-		expect(mobileCss).not.toContain("left: 2px");
 	});
 });

--- a/tests2/dom/sidebar-mobile.test.ts
+++ b/tests2/dom/sidebar-mobile.test.ts
@@ -6,7 +6,20 @@ __syncBeforeAll(() => __syncCE());
 // (getMobileSidebarBehavior). There is no exported src counterpart — the mobile
 // behaviour is expressed inline at the sidebar render sites — so this port keeps
 // a byte-identical replica of the fixture helper and preserves every assertion.
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
+
+const renderHelpersSource = readFileSync(resolve(process.cwd(), "src/app/render-helpers.ts"), "utf8");
+const appCssSource = readFileSync(resolve(process.cwd(), "src/app/app.css"), "utf8");
+
+function sourceBetween(source: string, start: string, end: string): string {
+	const startIndex = source.indexOf(start);
+	const endIndex = source.indexOf(end, startIndex + start.length);
+	expect(startIndex, `missing source marker: ${start}`).toBeGreaterThanOrEqual(0);
+	expect(endIndex, `missing source marker: ${end}`).toBeGreaterThan(startIndex);
+	return source.slice(startIndex, endIndex);
+}
 
 function getMobileSidebarBehavior(isDesktop: boolean): {
 	buttonsAlwaysVisible: boolean;
@@ -43,5 +56,31 @@ describe("SB-33: Mobile sidebar behavior", () => {
 
 	it("mobile: hamburger menu shown", () => {
 		expect(getMobileSidebarBehavior(false).showHamburgerMenu).toBe(true);
+	});
+});
+
+describe("Mobile sidebar row layout regression", () => {
+	it("gives the team-lead title the same flexible slot as ordinary session titles", () => {
+		const teamLeadSource = sourceBetween(
+			renderHelpersSource,
+			"function renderTeamLeadRow(",
+			"// ============================================================================\n// UNIFIED GOAL GROUP",
+		);
+		expect(teamLeadSource).toContain('class="flex-1 min-w-0 truncate" data-testid="sidebar-session-title-text"');
+		expect(teamLeadSource).toContain("${renderSessionTime(session)}");
+	});
+
+	it("groups mobile actions with one extra row-gap before the first button", () => {
+		const clusterCss = sourceBetween(appCssSource, ".sidebar-mobile-action-cluster {", "@media (max-width: 767px)");
+		expect(clusterCss).toContain("gap: 0.25rem;");
+		expect(clusterCss).toContain("margin-left: 0.25rem;");
+		expect(renderHelpersSource).toContain('html`<span class="sidebar-mobile-action-cluster">${buttons}</span>`');
+	});
+
+	it("does not shift the mobile active spinner toward the first action", () => {
+		const mobileCss = sourceBetween(appCssSource, "/* Mobile rows keep status metadata", ".sidebar-active-dot::after");
+		expect(mobileCss).toContain("left: 0 !important;");
+		expect(mobileCss).toContain("align-self: center;");
+		expect(mobileCss).not.toContain("left: 2px");
 	});
 });


### PR DESCRIPTION
## Summary
- right-align team lead activity like other session rows
- align the active-session spinner with activity metadata
- make metadata-to-action spacing match spacing between action buttons
- add mobile sidebar layout regression coverage

## Tests
- npm run check
- npm run test:unit (9,823 passed, 20 skipped)

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)