### PR TITLE
Preserve retired verify-step types during goal-store SQLite migration

### DIFF
--- a/src/server/agent/goal-store.ts
+++ b/src/server/agent/goal-store.ts
@@ -262,12 +262,16 @@ function validateWorkflow(value: unknown, label: string): void {
 		if (gate.metadata !== undefined) validateStringRecord(gate.metadata, `${gateLabel} metadata`);
 		if (gate.verify !== undefined) {
 			if (!Array.isArray(gate.verify)) invalidGoal(gateLabel, "verify must be an array");
+				// Verify-step types have changed over time (for example the retired
+				// remote-state and integration-test types). A legacy goal stays valid as
+				// long as the step discriminator is a non-empty string — mirror the
+				// gate-store's tolerance so a retired type cannot brick the migration.
 			for (let stepIndex = 0; stepIndex < gate.verify.length; stepIndex++) {
 				const step = gate.verify[stepIndex];
 				const stepLabel = `${gateLabel} verify step at index ${stepIndex}`;
 				if (!isRecord(step) || typeof step.name !== "string"
-					|| !["command", "llm-review", "agent-qa", "subgoal", "human-signoff"].includes(String(step.type))) {
-					invalidGoal(stepLabel, "name and a supported type are required");
+					|| typeof step.type !== "string" || step.type.length === 0) {
+					invalidGoal(stepLabel, "name and a non-empty type are required");
 				}
 				for (const field of ["run", "prompt", "label", "optionalLabel", "role", "description", "failureGuidance", "component", "command"] as const) {
 					if (step[field] !== undefined && typeof step[field] !== "string") invalidGoal(stepLabel, `${field} must be a string`);

--- a/tests2/core/goal-store-sqlite.test.ts
+++ b/tests2/core/goal-store-sqlite.test.ts
@@ -161,6 +161,40 @@ describe("GoalStore SQLite persistence", () => {
 		expect(reopened.get("legacy-null")).toEqual(legacyGoal);
 	});
 
+	it("migrates a legacy verify step whose type was retired instead of failing the load", async () => {
+		const stateDir = tempRoot();
+		const legacyFile = path.join(stateDir, "goals.json");
+		// `remote-state` is a retired verify-step type still present in older
+		// goals.json (e.g. `{ type: "remote-state", operation: "publish-branch" }`).
+		// The migration must preserve it, not reject it against a current allow-list.
+		const legacyGoal = goal("legacy-retired-type", {
+			workflow: {
+				id: "wf-1",
+				name: "Legacy workflow",
+				description: "",
+				createdAt: 1,
+				updatedAt: 2,
+				gates: [{
+					id: "publish",
+					name: "Publish",
+					dependsOn: [],
+					verify: [{ name: "Branch pushed to remote", type: "remote-state", operation: "publish-branch" }],
+				}],
+			},
+		} as any);
+		fs.writeFileSync(legacyFile, JSON.stringify([legacyGoal]), "utf-8");
+
+		const migrated = openStore(stateDir);
+		const step = (migrated.get("legacy-retired-type")?.workflow as any)?.gates?.[0]?.verify?.[0];
+		expect(step?.type).toBe("remote-state");
+		expect(fs.existsSync(`${legacyFile}.sqlite-retired`)).toBe(true);
+
+		// The retired type is durable across a restart.
+		await closeTracked(migrated);
+		const reopened = openStore(stateDir);
+		expect(((reopened.get("legacy-retired-type")?.workflow as any)?.gates?.[0]?.verify?.[0])?.type).toBe("remote-state");
+	});
+
 	it("continues to reject non-null malformed workflow fields", async () => {
 		const sourceDir = tempRoot();
 		const sourceFile = path.join(sourceDir, "goals.json");


### PR DESCRIPTION
## Problem

The goal-store SQLite migration (#1174) crash-loops boot on upgrade:

```
Fatal: [goal-store] Invalid legacy goal at index 1 workflow gate at index 3 verify step at index 0: name and a supported type are required
```

`validateGoal` requires every verify step's `type` to be in a hardcoded allow-list (`command`/`llm-review`/`agent-qa`/`subgoal`/`human-signoff`). But verify-step types have changed over time: `remote-state` was retired from the code yet still lives in older `goals.json` (9 steps across 4 goals in a real store). The strict migration read throws before the transaction can commit, so the completion marker is never set and every restart re-fails identically.

Same failure class as the gate-store crash — whose validator comment already documents the lesson: *"Step types have changed over time (for example remote-state and integration-test)… valid as long as the discriminator is a non-empty string."* The goal-store migration reintroduced the allow-list.

## Fix

Accept any non-empty-string verify-step `type` (mirroring the gate-store) instead of allow-listing. Retired types are preserved verbatim, not rejected.

## Verification

- Replayed a real `goals.json` through the built code: all 4 goals migrate, the 9 `remote-state` steps preserved, `migration_complete` set, `goals.json` retired.
- New pinning test in `tests2/core/goal-store-sqlite.test.ts`: a legacy goal with a retired verify-step type migrates and round-trips across a restart.
- `npx vitest run tests2/core/goal-store-sqlite.test.ts` → 20/20 pass.

Regression fix for #1174.

> **Note:** `task-store` (also introduced in #1174) has the same all-or-nothing migration shape — a legacy task `state` outside `TASK_STATES` would crash-loop identically. A follow-up making these JSON→SQLite migrations resilient (quarantine unparseable records instead of `Fatal`, tolerate unknown-but-non-empty discriminators) is worth doing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
