### PR TITLE
Bound Bobbit read output

### DIFF
--- a/defaults/tools/bobbit/bobbit_read.yaml
+++ b/defaults/tools/bobbit/bobbit_read.yaml
@@ -36,7 +36,7 @@ detail_docs: >-
   - Semantic filters: `q` (free-text list/search filter), `type` (search result
   type), `archived` (list_goals archive opt-in), `include` (list_sessions and
   search archive opt-in, e.g. `archived`), `includeArchived` (REST-style search
-  archive opt-in), `view` (gates/tasks projection), `probe`
+  archive opt-in), `view` (goal/Git detail or gates/tasks projection), `probe`
   (maintenance_inspect selector).
 
   - Shared paging: `limit`, `offset`, `after`, `cursor`. List-style operations
@@ -45,15 +45,14 @@ detail_docs: >-
   (`limit=20`, maximum `100`) unless you pass `limit` explicitly.
 
   - REST vs tool paging: paging is forwarded to REST for `list_sessions`,
-  `list_goals`, and `search`. Other list-style operations are paged in the tool
-  after the gateway applies semantic filters such as `projectId`, `goalId`, or
-  `view`. If a response already contains REST page fields (`total`, `hasMore`,
-  `nextOffset`, `nextCursor`, or `pagination`), the tool treats it as REST-paged
-  and does **not** slice the array again.
+  `list_goals`, `search`, and `list_gates`. Other list-style operations are
+  paged in the tool after the gateway applies semantic filters. REST-paged
+  responses are annotated rather than re-sliced; `list_gates` additionally
+  enforces the requested bound if an endpoint returns an unsliced array.
 
-  - Cursor aliases: `cursor` is the generic cursor input; `after` is the gateway
-  query name used by archived session/goal paths. If both cursor and offset
-  inputs are present for a cursor-backed call, the cursor form wins.
+  - Cursor aliases: `cursor` is the generic cursor input; `after` is also
+  accepted. For `list_gates`, both are numeric absolute positions translated
+  to REST `offset`; precedence is `cursor`, then `after`, then `offset`.
 
 
   ## Archive visibility (hidden by default)
@@ -97,9 +96,9 @@ detail_docs: >-
   List-style operations return the endpoint's normal fields plus a
   `pagination` object. The primary item key is preserved (`sessions`, `goals`,
   `projects`, `workflows`, `roles`, `tools`, `gates`, `tasks`, `staff`,
-  `servers`, `results`, or probe-specific keys such as `worktrees`/`sample`).
-  Fallback tool-side paging happens only after the gateway has applied semantic
-  filters, and REST-paged responses are annotated rather than re-sliced.
+  `servers`, `results`, or probe-specific keys such as `items`, `worktrees`,
+  and `sample`). Fallback tool-side paging happens after semantic filtering;
+  REST-paged responses are normally annotated rather than re-sliced.
 
 
   `pagination` includes:
@@ -123,6 +122,43 @@ detail_docs: >-
   bounded an unpaged endpoint response.
 
 
+  ### Bounded summary views
+
+
+  `get_goal` with `view: "summary"` returns only available `id`, `title`,
+  `state`, `projectId`, `workflowId`, `parentGoalId`, `rootGoalId`, `paused`,
+  `archived`, `archivedAt`, `setupStatus`, `setupError`, `createdAt`, and
+  `updatedAt`. It excludes `spec`, workflow detail, paths, config/provider data,
+  and branch/merge internals. Omitted and non-summary views, including `full`,
+  keep the established detail projection and untruncated spec.
+
+
+  `goal_git_status` with `view: "summary"` returns one scalar `aggregate` with
+  branch/upstream, ahead/behind, change-count, clean/merged/unpushed/partial/
+  untracked flags, textual `summary`, and derived `changedFiles`. Available
+  freshness fields (`observedAt`, `refreshedAt`, `stale`, `source`, `ageMs`) and
+  compact `lastError` remain. Per-file `status` and root/`repos`/`data` aliases
+  are omitted. Omitted and non-summary views, including `full`, retain the
+  legacy projection and compatibility aliases.
+
+
+  ### `list_gates` paging
+
+
+  Paging applies to summary, omitted, and full views; `view` changes item detail,
+  not page size. Root `gates` is the sole paged gate collection. Summary output
+  retains count-only progress metadata and omits `summary.gates`; `total` is the
+  full authorized, goal-scoped count.
+
+
+  Non-negative integer `cursor` and `after` values are absolute offsets;
+  precedence is `cursor`, then `after`, then `offset`. Offset pages return
+  `nextOffset` and equivalent `nextCursor` when more rows remain. Cursor pages
+  report `mode: "cursor"`, the
+  consumed `cursor`, and only `nextCursor`. Terminal pages set `hasMore: false`
+  and omit continuation markers. Calls without controls use the list defaults.
+
+
   ## Operation catalogue
 
   | operation | GET path | required | semantic filters / paging |
@@ -135,13 +171,13 @@ detail_docs: >-
 
   | `list_goals` | `/api/goals` (`?projectId`, `?archived`, `?q`, paging) | — | `projectId`, `q`, `limit`, `offset`; archived hidden unless `archived=true` (then `after`/`cursor`) |
 
-  | `get_goal` | `/api/goals/:goalId` | `goalId` | — |
+  | `get_goal` | `/api/goals/:goalId` | `goalId` | `view` (`summary` is bounded; omitted/`full` preserve detail) |
 
   | `goal_cost` | `/api/goals/:goalId/cost` | `goalId` | — |
 
-  | `goal_git_status` | `/api/goals/:goalId/git-status` | `goalId` | — |
+  | `goal_git_status` | `/api/goals/:goalId/git-status` | `goalId` | `view` (`summary` is scalar/deduplicated; omitted/`full` preserve legacy output) |
 
-  | `goal_commits` | `/api/goals/:goalId/commits` | `goalId` | — |
+  | `goal_commits` | `/api/goals/:goalId/commits` | `goalId` | `limit` (forwarded to REST) |
 
   | `goal_pr_status` | `/api/goals/:goalId/pr-status` | `goalId` | — |
 
@@ -165,7 +201,7 @@ detail_docs: >-
 
   | `list_tools` | `/api/tools` (`?projectId`) | — | `projectId`, `limit`, `offset` (tool-side fallback) |
 
-  | `list_gates` | `/api/goals/:goalId/gates` (`?view`) | `goalId` | `view`, `limit`, `offset` (tool-side fallback) |
+  | `list_gates` | `/api/goals/:goalId/gates` (`?view`, paging) | `goalId` | `view`, `limit`, `offset`, numeric `cursor`/`after`; root `gates` is canonical |
 
   | `list_tasks` | `/api/goals/:goalId/tasks` (`?view`) | `goalId` | `view`, `limit`, `offset` (tool-side fallback) |
 
@@ -202,9 +238,15 @@ detail_docs: >-
 
   `orphaned_worktrees` (paged `worktrees`), `orphaned_sessions` (paged
   `sessions`), `expired_archives`, `orphaned_index_rows` (`?projectId`, paged
-  `sample`), `worktrees`, `archived_session_worktrees` (paged `worktrees`),
-  `worktree_pool` (`?projectId`), `sandbox_pool`, `sandbox_status`
-  (`?projectId`), `search_stats` (`?projectId`).
+  `sample`), `worktrees` (paged root `items`), `archived_session_worktrees`
+  (paged root `items`), `worktree_pool` (`?projectId`), `sandbox_pool`,
+  `sandbox_status` (`?projectId`), `search_stats` (`?projectId`).
+
+
+  The compact archived-session worktree response uses root `items` as its sole
+  worktree collection. Nested session worktrees and worktree aliases are
+  suppressed while compact counts and session/group identity remain. Direct
+  REST responses are unchanged.
 
 
   ## Overlap policy (use the dedicated tool instead)
@@ -221,6 +263,11 @@ detail_docs: >-
   - List responses are compact discovery views with ids, state, relationships,
   concise diagnostics, timestamps, and pagination. Choose one id and use the
   matching `get_*` operation for useful detail about that exact entity.
+
+  - Intentional compact contract changes: `list_gates` is always bounded and no
+  longer repeats `summary.gates`; Git summary has one aggregate and no file
+  aliases; worktree inventory probes page canonical root `items`; archived
+  worktree output suppresses nested duplicates. Direct REST remains unchanged.
 
   - On failure, the tool surfaces `{ error, code }` as one readable line
   including the HTTP status.

--- a/defaults/tools/bobbit/compact-projection.ts
+++ b/defaults/tools/bobbit/compact-projection.ts
@@ -329,6 +329,86 @@ const LIST_SUMMARY_FIELDS = new Set([
 	"runningGateIds", "error", "code",
 ]);
 
+const GOAL_SUMMARY_FIELDS = [
+	"id", "title", "state", "projectId", "workflowId", "parentGoalId", "rootGoalId",
+	"paused", "archived", "archivedAt", "setupStatus", "setupError", "createdAt", "updatedAt",
+] as const;
+
+const GIT_STATUS_SCALAR_FIELDS = [
+	"branch", "primaryBranch", "isOnPrimary", "primaryRef", "hasUpstream",
+	"ahead", "behind", "aheadOfPrimary", "behindPrimary", "mergedIntoPrimary",
+	"insertionsVsPrimary", "deletionsVsPrimary", "clean", "summary", "unpushed",
+	"partial", "untrackedIncluded",
+] as const;
+
+const GIT_STATUS_FRESHNESS_FIELDS = [
+	"observedAt", "refreshedAt", "stale", "source", "ageMs",
+] as const;
+
+function projectGoalSummary(value: unknown): unknown {
+	if (!isRecord(value)) return sanitizeGeneric(value);
+	const out: Record<string, unknown> = {};
+	for (const field of GOAL_SUMMARY_FIELDS) {
+		let child = value[field];
+		if (field === "workflowId" && typeof child !== "string" && isRecord(value.workflow)) child = value.workflow.id;
+		if (child !== undefined) out[field] = sanitizeGeneric(child, field);
+	}
+	return out;
+}
+
+function projectGitStatusSummary(value: unknown): unknown {
+	if (!isRecord(value)) return sanitizeGeneric(value);
+	const aggregateSource = isRecord(value.aggregate) ? value.aggregate : value;
+	const aggregate: Record<string, unknown> = {};
+	for (const field of GIT_STATUS_SCALAR_FIELDS) {
+		const child = aggregateSource[field];
+		if (typeof child === "string" || typeof child === "number" || typeof child === "boolean") {
+			aggregate[field] = sanitizeGeneric(child, field);
+		}
+	}
+	if (Array.isArray(aggregateSource.status)) aggregate.changedFiles = aggregateSource.status.length;
+
+	const out: Record<string, unknown> = { aggregate };
+	for (const field of GIT_STATUS_FRESHNESS_FIELDS) {
+		const child = value[field];
+		if (child !== undefined) out[field] = sanitizeGeneric(child, field);
+	}
+	if (value.lastError !== undefined) out.lastError = sanitizeGeneric(value.lastError, "lastError");
+	return out;
+}
+
+function pickCompactFields(value: unknown, fields: ReadonlySet<string>): unknown {
+	if (!isRecord(value)) return sanitizeGeneric(value);
+	const out: Record<string, unknown> = {};
+	for (const [key, child] of Object.entries(value)) {
+		if (fields.has(key)) out[key] = sanitizeGeneric(child, key);
+	}
+	return out;
+}
+
+const ARCHIVED_WORKTREE_SESSION_FIELDS = new Set([
+	"id", "sessionId", "title", "name", "projectId", "goalId", "status", "state", "count",
+]);
+const ARCHIVED_WORKTREE_GROUP_FIELDS = new Set([
+	"id", "key", "label", "name", "description", "count", "hasMore", "actionable", "status", "state",
+]);
+
+function projectArchivedSessionWorktrees(value: unknown): unknown {
+	if (!isRecord(value)) return sanitizeGeneric(value);
+	const out: Record<string, unknown> = {};
+	if (Array.isArray(value.items)) out.items = value.items.map((item) => sanitizeGeneric(item));
+	if (Array.isArray(value.sessions)) {
+		out.sessions = value.sessions.map((session) => pickCompactFields(session, ARCHIVED_WORKTREE_SESSION_FIELDS));
+	}
+	if (Array.isArray(value.groups)) {
+		out.groups = value.groups.map((group) => pickCompactFields(group, ARCHIVED_WORKTREE_GROUP_FIELDS));
+	}
+	for (const field of ["counts", "pagination", "generatedAt", "scannedAt", "checkedAt"] as const) {
+		if (value[field] !== undefined) out[field] = sanitizeGeneric(value[field], field);
+	}
+	return out;
+}
+
 function projectListEnvelope(
 	value: Record<string, unknown>,
 	collections: Readonly<Record<string, ProfileName>>,
@@ -393,7 +473,7 @@ export const BOBBIT_COMPACT_PROJECTIONS = {
 		get_workflow: { profile: "workflowDetail", mode: "detail" },
 		list_roles: { profile: "generic", mode: "list", collections: { roles: "role" } },
 		list_tools: { profile: "generic", mode: "list", collections: { tools: "tool" } },
-		list_gates: { profile: "generic", mode: "list", collections: { gates: "gate", "summary.gates": "gate" } },
+		list_gates: { profile: "generic", mode: "list", collections: { gates: "gate" } },
 		list_tasks: { profile: "generic", mode: "list", collections: { tasks: "task" } },
 		get_task: { profile: "task", mode: "detail" },
 		list_staff: { profile: "generic", mode: "list", collections: { staff: "staff" } },
@@ -441,9 +521,23 @@ export const BOBBIT_COMPACT_PROJECTIONS = {
 } as const satisfies Record<BobbitToolName, Record<string, ProjectionSpec>>;
 
 /** Apply the selected operation's compact projection. */
-export function projectBobbitResponse(tool: BobbitToolName, operation: string, data: unknown): unknown {
+export function projectBobbitResponse(
+	tool: BobbitToolName,
+	operation: string,
+	data: unknown,
+	params: Readonly<Record<string, unknown>> = {},
+): unknown {
 	const spec = (BOBBIT_COMPACT_PROJECTIONS[tool] as Record<string, ProjectionSpec>)[operation];
 	if (!spec) throw new Error(`missing compact projection for ${tool}.${operation}`);
+	if (tool === "bobbit_read" && operation === "get_goal" && params.view === "summary") {
+		return projectGoalSummary(data);
+	}
+	if (tool === "bobbit_read" && operation === "goal_git_status" && params.view === "summary") {
+		return projectGitStatusSummary(data);
+	}
+	if (tool === "bobbit_read" && operation === "maintenance_inspect" && params.probe === "archived_session_worktrees") {
+		return projectArchivedSessionWorktrees(data);
+	}
 	if (spec.profile === "identity") return data;
 
 	const mode = spec.mode ?? "compact";

--- a/defaults/tools/bobbit/extension.ts
+++ b/defaults/tools/bobbit/extension.ts
@@ -52,6 +52,10 @@ interface PageSpec {
 	maxLimit?: number;
 	/** Whether this operation should use cursor (`after`) pagination for these params. */
 	cursor?: boolean | ((p: Params) => boolean);
+	/** Translate a numeric cursor/after position to the endpoint's offset protocol. */
+	offsetCursor?: boolean;
+	/** Fall back to tool slicing if a supposedly paged REST response exceeds the requested limit. */
+	enforceBound?: boolean;
 }
 
 interface OpSpec {
@@ -108,17 +112,24 @@ function isCursorPaging(params: Params, spec: PageSpec): boolean {
 
 function normalizePaging(params: Params, spec: PageSpec): NormalizedPaging {
 	const limit = clampInteger(params.limit, spec.defaultLimit ?? DEFAULT_PAGE_LIMIT, 1, spec.maxLimit ?? MAX_PAGE_LIMIT);
-	const offset = Math.max(0, parseInteger(params.offset) ?? 0);
 	const rawCursor = params.cursor ?? params.after;
-	const cursor = rawCursor !== undefined && rawCursor !== null && rawCursor !== "" ? rawCursor as string | number : undefined;
-	const mode: PageMode = isCursorPaging(params, spec) ? "cursor" : "offset";
+	const numericCursor = spec.offsetCursor ? parseInteger(rawCursor) : undefined;
+	const cursor = spec.offsetCursor
+		? (numericCursor !== undefined ? Math.max(0, numericCursor) : undefined)
+		: (rawCursor !== undefined && rawCursor !== null && rawCursor !== "" ? rawCursor as string | number : undefined);
+	const offset = numericCursor !== undefined
+		? Math.max(0, numericCursor)
+		: Math.max(0, parseInteger(params.offset) ?? 0);
+	const mode: PageMode = spec.offsetCursor
+		? (numericCursor !== undefined ? "cursor" : "offset")
+		: (isCursorPaging(params, spec) ? "cursor" : "offset");
 	return { limit, offset, cursor, mode };
 }
 
 function appendPagingQuery(base: string, entries: Array<[string, unknown]>, params: Params, spec: PageSpec): string {
 	const paging = normalizePaging(params, spec);
 	const pagingEntries: Array<[string, unknown]> = [["limit", paging.limit]];
-	if (paging.mode === "cursor" && paging.cursor !== undefined) {
+	if (paging.mode === "cursor" && paging.cursor !== undefined && !spec.offsetCursor) {
 		pagingEntries.push(["after", paging.cursor]);
 	} else {
 		pagingEntries.push(["offset", paging.offset]);
@@ -187,12 +198,18 @@ function sliceByPath(data: unknown, spec: PageSpec, paging: NormalizedPaging): {
 	const sourceItems = Array.isArray(data) ? data : getAtPath(data, itemPath);
 	if (!Array.isArray(sourceItems)) return undefined;
 
-	const start = hasRestPagination ? 0 : paging.mode === "offset" ? paging.offset : 0;
+	// A domain-level `total` is not by itself proof that the endpoint honored its
+	// page size. Gate responses historically had such a count while returning the
+	// entire collection, so explicitly bounded operations fail closed to slicing.
+	const restIgnoredBound = hasRestPagination && spec.enforceBound === true && sourceItems.length > paging.limit;
+	const start = hasRestPagination && !restIgnoredBound
+		? 0
+		: (paging.mode === "offset" || spec.offsetCursor ? paging.offset : 0);
 	const end = start + paging.limit;
-	const shouldSlice = !hasRestPagination;
+	const shouldSlice = !hasRestPagination || restIgnoredBound;
 	const items = shouldSlice ? sourceItems.slice(start, end) : sourceItems;
 	const total = numberField(data, "total") ?? numberField(pagination, "total") ?? (hasRestPagination ? undefined : sourceItems.length);
-	const pagedBy = shouldSlice ? "tool" : "rest";
+	const pagedBy = hasRestPagination && !restIgnoredBound ? "rest" : "tool";
 	const result = Array.isArray(data)
 		? { [spec.itemKey]: items }
 		: setAtPath(data as Record<string, unknown>, itemPath, items);
@@ -205,15 +222,19 @@ function pageResult(data: unknown, params: Params, spec: PageSpec): unknown {
 	if (!sliced) return data;
 	const pagination = data && typeof data === "object" && !Array.isArray(data) ? (data as Record<string, unknown>).pagination : undefined;
 	const total = sliced.total;
-	const computedHasMore = (sliced.start + sliced.items.length) < (total ?? sliced.sourceLength);
+	const pagePosition = spec.offsetCursor ? paging.offset : sliced.start;
+	const computedHasMore = (pagePosition + sliced.items.length) < (total ?? sliced.sourceLength);
 	const topLevelHasMore = booleanField(data, "hasMore") ?? booleanField(pagination, "hasMore");
 	const hasMore = Boolean(sliced.pagedBy === "tool" ? (topLevelHasMore || computedHasMore) : (topLevelHasMore ?? computedHasMore));
+	const restNextOffset = numberField(data, "nextOffset") ?? numberField(pagination, "nextOffset");
 	const nextOffset = paging.mode === "offset" && hasMore
-		? numberField(data, "nextOffset") ?? numberField(pagination, "nextOffset") ?? paging.offset + sliced.items.length
+		? (spec.enforceBound && sliced.pagedBy === "tool" ? undefined : restNextOffset) ?? paging.offset + sliced.items.length
 		: undefined;
 	const nextCursor = paging.mode === "cursor"
-		? valueField(data, "nextCursor") ?? valueField(pagination, "nextCursor")
-		: undefined;
+		? (spec.offsetCursor
+			? (hasMore ? restNextOffset ?? paging.offset + sliced.items.length : undefined)
+			: valueField(data, "nextCursor") ?? valueField(pagination, "nextCursor"))
+		: (spec.offsetCursor && hasMore ? nextOffset : undefined);
 	return {
 		...(sliced.result as Record<string, unknown>),
 		pagination: {
@@ -308,7 +329,8 @@ const MAINTENANCE_PAGE_SPECS: Record<string, PageSpec | undefined> = {
 	orphaned_worktrees: { itemKey: "worktrees" },
 	orphaned_sessions: { itemKey: "sessions" },
 	orphaned_index_rows: { itemKey: "sample" },
-	archived_session_worktrees: { itemKey: "worktrees" },
+	worktrees: { itemKey: "items" },
+	archived_session_worktrees: { itemKey: "items" },
 };
 
 // POST maintenance/search actions for bobbit_admin.maintenance_cleanup.
@@ -339,7 +361,11 @@ const READ_OPS: Record<string, OpSpec> = {
 	get_goal: { method: "GET", buildPath: (p) => `/api/goals/${p.goalId}`, required: ["goalId"] },
 	goal_cost: { method: "GET", buildPath: (p) => `/api/goals/${p.goalId}/cost`, required: ["goalId"] },
 	goal_git_status: { method: "GET", buildPath: (p) => `/api/goals/${p.goalId}/git-status`, required: ["goalId"] },
-	goal_commits: { method: "GET", buildPath: (p) => `/api/goals/${p.goalId}/commits`, required: ["goalId"] },
+	goal_commits: {
+		method: "GET",
+		buildPath: (p) => withQuery(`/api/goals/${p.goalId}/commits`, [["limit", p.limit]]),
+		required: ["goalId"],
+	},
 	goal_pr_status: { method: "GET", buildPath: (p) => `/api/goals/${p.goalId}/pr-status`, required: ["goalId"] },
 	list_sessions: {
 		method: "GET",
@@ -381,9 +407,13 @@ const READ_OPS: Record<string, OpSpec> = {
 	list_tools: { method: "GET", buildPath: (p) => withQuery("/api/tools", [["projectId", p.projectId]]), required: [], page: { itemKey: "tools" } },
 	list_gates: {
 		method: "GET",
-		buildPath: (p) => withQuery(`/api/goals/${p.goalId}/gates`, [["view", p.view]]),
+		buildPath: (p) => appendPagingQuery(`/api/goals/${p.goalId}/gates`, [["view", p.view]], p, {
+			itemKey: "gates",
+			offsetCursor: true,
+			enforceBound: true,
+		}),
 		required: ["goalId"],
-		page: { itemKey: "gates" },
+		page: { itemKey: "gates", offsetCursor: true, enforceBound: true },
 	},
 	list_tasks: {
 		method: "GET",
@@ -671,7 +701,7 @@ export default function (pi: ExtensionAPI) {
 			const paged = pageSpec ? pageResult(processed, params, pageSpec) : processed;
 			const output = tool !== "bobbit_read" && params.verbose === true
 				? paged
-				: projectBobbitResponse(tool, params.operation, paged);
+				: projectBobbitResponse(tool, params.operation, paged, params);
 			return ok(output);
 		} catch (e: any) {
 			return err(e.message);

--- a/docs/bobbit-gateway-tool.md
+++ b/docs/bobbit-gateway-tool.md
@@ -93,7 +93,44 @@ relative import.
 
 ## Focused read output
 
-`bobbit_read` lists compact discovery fields, then uses matching `get_*` operations for exact detail; direct REST/UI and the admin/orchestrate tiers keep separate response policies.
+`bobbit_read` bounds agent-facing responses so discovery and status checks do not consume context with large or repeated payloads. These projections do not change direct REST/UI responses or the admin/orchestrate tiers.
+
+### Goal and Git status summaries
+
+`get_goal` with `view: "summary"` returns only this identity/status allowlist when fields are present:
+
+- `id`, `title`, `state`, `projectId`, `workflowId`
+- `parentGoalId`, `rootGoalId`
+- `paused`, `archived`, `archivedAt`
+- `setupStatus`, `setupError`
+- `createdAt`, `updatedAt`
+
+`workflowId` may be derived from the goal's workflow snapshot. The summary omits `spec`, workflow details, paths, configuration, provider data, and branch/merge internals. This exhaustive allowlist also keeps future unclassified detail fields out of summaries. With `view` omitted, `view: "full"`, or another non-summary value, the established detail projection remains available and `spec` is not truncated.
+
+`goal_git_status` with `view: "summary"` returns one `aggregate` object. It contains available scalar status fields — `branch`, `primaryBranch`, `isOnPrimary`, `primaryRef`, `hasUpstream`, `ahead`, `behind`, `aheadOfPrimary`, `behindPrimary`, `mergedIntoPrimary`, `insertionsVsPrimary`, `deletionsVsPrimary`, `clean`, `summary`, `unpushed`, `partial`, and `untrackedIncluded` — plus `changedFiles`, the aggregate status-entry count. Top-level freshness fields (`observedAt`, `refreshedAt`, `stale`, `source`, `ageMs`) and compact `lastError` remain when available. Per-file `status` and repeated root, `repos`, and `data` aliases are omitted. Omitted and non-summary views, including `view: "full"`, retain the legacy projection and its compatibility aliases.
+
+### Gate paging
+
+`list_gates` paging is independent of `view`. Summary, omitted, and full views all honor `limit`, `offset`, `cursor`, and `after`; calls without paging controls use the standard bounded list defaults. `view` controls per-gate field detail, not page cardinality.
+
+The root `gates` array is the sole paged gate collection. The `summary` object retains compact progress counts but no longer repeats gates under `summary.gates`. `total` describes the full authorized, goal-scoped collection before slicing.
+
+The gate endpoint uses offsets, so the tool treats each non-negative integer `cursor` or `after` as an absolute REST offset. Precedence is `cursor`, then `after`, then `offset`:
+
+- Offset pages return `nextOffset` and an equivalent `nextCursor` when `hasMore` is true.
+- Cursor pages report `mode: "cursor"` and the consumed `cursor`, then return only `nextCursor` when more rows remain.
+- Terminal pages report `hasMore: false` and omit both continuation markers.
+
+### Intentional agent response-contract changes
+
+These changes apply only to compact `bobbit_read` output:
+
+- `list_gates` is always bounded, exposes gates only at root `gates`, and removes `summary.gates`.
+- `goal_git_status(view: "summary")` removes repeated aliases and per-file status in favor of one scalar aggregate.
+- `maintenance_inspect(probe: "worktrees")` pages the canonical root `items` array while retaining aggregate counts and timestamps.
+- `maintenance_inspect(probe: "archived_session_worktrees")` also pages root `items`. Its compact response suppresses nested session worktree arrays and other worktree aliases while retaining compact session/group identity and count metadata.
+
+Direct REST responses are unchanged. `goal_commits(limit: N)` now forwards `N` to the REST endpoint, so callers can bound commit history at its source.
 
 ## Operation catalogue
 
@@ -105,9 +142,10 @@ mappings, methods, and body keys see each tool's `detail_docs`.
 
 All operations are GETs with no side effects. List-style operations are bounded
 by default (`limit=50`, `offset=0`, max `200`) and return a `pagination` object.
-`list_sessions`, `list_goals`, and `search` use REST pagination; other list
-operations page the already-filtered gateway response in the tool. REST-paged
-responses are annotated, not re-sliced.
+`list_sessions`, `list_goals`, `search`, and `list_gates` forward paging to REST;
+other list operations page the already-filtered gateway response in the tool.
+REST-paged responses are annotated rather than re-sliced, while `list_gates`
+also enforces the requested bound if an older endpoint returns an unsliced array.
 
 **Archived entities are hidden by default.** Every list/search read returns
 live rows only unless the caller explicitly opts in. This keeps stale, archived
@@ -137,9 +175,11 @@ opt-in.
 
 - `health`, `connection_info` — gateway liveness + network info.
 - `list_goals` (`archived=true` to include archived goals, `q`), `get_goal` —
-  enumerate / fetch goals.
+  enumerate / fetch goals; use `get_goal(view: "summary")` for bounded identity
+  and status metadata without the goal spec.
 - `goal_cost`, `goal_git_status`, `goal_commits`, `goal_pr_status` — per-goal
-  cost, git, commit, and PR details.
+  cost, git, commit, and PR details. Git status has a deduplicated summary view,
+  and `goal_commits` forwards `limit` to REST.
 - `list_sessions` (`include=archived` to include archived sessions, `q`,
   `projectId`), `get_session`, `session_cost` — enumerate / fetch sessions and
   their cost.
@@ -150,11 +190,12 @@ opt-in.
   requires `projectId`; `get_workflow` accepts it as a scope filter).
 - `list_roles`, `list_tools` — resolved roles and the tool catalogue.
 - `list_gates`, `list_tasks` (by arbitrary `goalId`), `get_task` — cross-goal
-  gate/task boards.
+  gate/task boards. Gate pages use root `gates` as their canonical collection
+  in every view.
 - `list_staff`, `list_mcp_servers` — staff agents and MCP servers.
 - `maintenance_inspect` (`probe=`) — the GET-only maintenance probes (orphaned
   worktrees/sessions, expired archives, orphaned index rows, worktree/sandbox
-  pools, search stats).
+  pools, search stats). Worktree inventory probes page canonical root `items`.
 
 ### `bobbit_orchestrate` — runtime state mutations
 

--- a/docs/design/bobbit-read-pagination.md
+++ b/docs/design/bobbit-read-pagination.md
@@ -1,5 +1,7 @@
 # Design: `bobbit_read` pagination
 
+> **Superseded contract notice:** This document records the original pagination rollout and is not the current agent-tool contract. See the authoritative [`bobbit` gateway tool reference](../bobbit-gateway-tool.md) and built-in [`bobbit_read` detail docs](../../defaults/tools/bobbit/bobbit_read.yaml).
+
 Status: **implemented** · Goal: Page Bobbit Tools · Author: coder-861a
 
 ## 1. Problem

--- a/tests2/core/bobbit-read-bounds.test.ts
+++ b/tests2/core/bobbit-read-bounds.test.ts
@@ -1,0 +1,472 @@
+// v2-native — focused bobbit_read response-bound regressions. Listed in tests-map.json `v2Native`.
+import { guardProcessEnv } from "./helpers/env-guard.js";
+guardProcessEnv();
+
+import { beforeAll, describe, expect, it } from "vitest";
+import { COMPACT_TEXT_PREVIEW_CHARS } from "../../defaults/tools/bobbit/compact-projection.ts";
+import { loadBobbitTools, stubFetch, type CapturedTool, type FetchCall } from "./helpers/bobbit-harness.ts";
+
+let tools: Map<string, CapturedTool>;
+
+beforeAll(() => {
+	process.env.BOBBIT_TOKEN = "tok";
+	process.env.BOBBIT_GATEWAY_URL = "https://gw.test";
+	tools = loadBobbitTools();
+});
+
+function json(result: any): any {
+	expect(result.isError).toBeFalsy();
+	return JSON.parse(result?.content?.[0]?.text ?? "");
+}
+
+async function read(params: Record<string, unknown>): Promise<any> {
+	return json(await tools.get("bobbit_read")!.execute("bounds-test", params));
+}
+
+function query(call: FetchCall): URLSearchParams {
+	return new URL(call.url).searchParams;
+}
+
+function occurrences(value: unknown, sentinel: string): number {
+	return JSON.stringify(value).split(sentinel).length - 1;
+}
+
+describe("bobbit_read — bounded goal detail", () => {
+	it("BOBBIT_READ_SUMMARY_BOUND: get_goal summary has only useful identity/status fields and no large detail", async () => {
+		const largeSpec = `SPEC_BOUND_SENTINEL_${"s".repeat(8_000)}`;
+		const largeWorkflow = `WORKFLOW_BOUND_SENTINEL_${"w".repeat(8_000)}`;
+		const goal = {
+			id: "goal-bounded",
+			title: "Bound Bobbit reads",
+			state: "in-progress",
+			projectId: "project-1",
+			workflowId: "workflow-1",
+			parentGoalId: "parent-1",
+			rootGoalId: "root-1",
+			paused: true,
+			archived: true,
+			archivedAt: "2026-08-01T00:00:00.000Z",
+			setupStatus: "failed",
+			setupError: "Actionable setup failure",
+			createdAt: "2026-07-01T00:00:00.000Z",
+			updatedAt: "2026-08-02T00:00:00.000Z",
+			spec: largeSpec,
+			workflow: { id: "workflow-1", raw: largeWorkflow, gates: [{ content: largeWorkflow }] },
+			cwd: `C:/private/${largeWorkflow}`,
+			worktreePath: largeWorkflow,
+			config: { private: largeWorkflow },
+			providerMetadata: { private: largeWorkflow },
+			branch: `goal/${largeWorkflow}`,
+			mergeTarget: "main",
+			futureUnclassifiedDetail: largeWorkflow,
+		};
+		stubFetch(() => ({ body: goal }));
+
+		const summary = await read({ operation: "get_goal", goalId: goal.id, view: "summary" });
+
+		const allowedFields = [
+			"id", "title", "state", "projectId", "workflowId", "parentGoalId", "rootGoalId",
+			"paused", "archived", "archivedAt", "setupStatus", "setupError", "createdAt", "updatedAt",
+		].sort();
+		expect(
+			Object.keys(summary).sort(),
+			"BOBBIT_READ_SUMMARY_BOUND: summary must use the exhaustive identity/status allowlist",
+		).toEqual(allowedFields);
+		expect(summary).toMatchObject({
+			id: goal.id, title: goal.title, state: goal.state, projectId: goal.projectId,
+			workflowId: goal.workflowId, parentGoalId: goal.parentGoalId, rootGoalId: goal.rootGoalId,
+			paused: goal.paused, archived: goal.archived, archivedAt: goal.archivedAt,
+			setupStatus: goal.setupStatus, setupError: goal.setupError,
+			createdAt: goal.createdAt, updatedAt: goal.updatedAt,
+		});
+		const serialized = JSON.stringify(summary);
+		expect(serialized).not.toContain("SPEC_BOUND_SENTINEL");
+		expect(serialized).not.toContain("WORKFLOW_BOUND_SENTINEL");
+		expect(serialized.length).toBeLessThan(1_000);
+	});
+
+	it.each([
+		["omitted view", undefined],
+		["explicit full view", "full"],
+	] as const)("keeps the untruncated goal spec for %s", async (_label, view) => {
+		const spec = `FULL_SPEC_SENTINEL_${"x".repeat(COMPACT_TEXT_PREVIEW_CHARS + 2_000)}`;
+		stubFetch(() => ({
+			body: {
+				id: "goal-full",
+				title: "Full goal",
+				state: "todo",
+				projectId: "project-1",
+				spec,
+				workflow: { id: "derived-workflow" },
+			},
+		}));
+		const params: Record<string, unknown> = { operation: "get_goal", goalId: "goal-full" };
+		if (view !== undefined) params.view = view;
+
+		const data = await read(params);
+
+		expect(data).toMatchObject({ id: "goal-full", workflowId: "derived-workflow", spec });
+		expect(data.spec).toHaveLength(spec.length);
+	});
+});
+
+const gateRows = Array.from({ length: 3 }, (_, index) => ({
+	id: `gate-row-${index + 1}`,
+	gateId: `gate-${index + 1}`,
+	goalId: "goal-gates",
+	name: `Gate ${index + 1} ${"n".repeat(250)}`,
+	type: "content",
+	status: index === 0 ? "passed" : "pending",
+	dependsOn: index === 0 ? [] : [`gate-${index}`],
+	assignedTo: `session-${index + 1}`,
+	signalCount: index + 1,
+	hasContent: true,
+	contentLength: 4_000 + index,
+	phase: "delivery",
+	updatedAt: `2026-08-0${index + 1}T00:00:00.000Z`,
+	currentContent: `GATE_BODY_SENTINEL_${index}_${"c".repeat(4_000)}`,
+}));
+
+function gateEndpointFixture(url: string, rows = gateRows): { body: unknown } {
+	const u = new URL(url);
+	const limitParam = u.searchParams.get("limit");
+	const offsetParam = u.searchParams.get("offset");
+	const pagingEnabled = limitParam !== null || offsetParam !== null;
+	const limit = Math.max(1, Number(limitParam ?? rows.length));
+	const offset = Math.max(0, Number(offsetParam ?? 0));
+	const page = pagingEnabled ? rows.slice(offset, offset + limit) : rows;
+	const hasMore = offset + page.length < rows.length;
+	return {
+		body: {
+			gates: page,
+			...(pagingEnabled ? {
+				total: rows.length,
+				limit,
+				offset,
+				hasMore,
+				...(hasMore ? { nextOffset: offset + page.length } : {}),
+			} : {}),
+			summary: {
+				passed: 1,
+				pending: rows.length - 1,
+				running: 0,
+				total: rows.length,
+				gates: page,
+			},
+		},
+	};
+}
+
+function expectCanonicalGatePage(data: any, expectedGateId: string, expectedOffset: number): void {
+	expect(data.gates).toHaveLength(1);
+	expect(data.gates[0]).toMatchObject({
+		gateId: expectedGateId,
+		goalId: "goal-gates",
+		assignedTo: `session-${expectedOffset + 1}`,
+		signalCount: expectedOffset + 1,
+		hasContent: true,
+		contentLength: 4_000 + expectedOffset,
+		phase: "delivery",
+	});
+	expect(data.summary).toMatchObject({ passed: 1, pending: 2, running: 0, total: 3 });
+	expect(data.summary.gates, "list_gates must expose only the canonical root gates collection").toBeUndefined();
+	expect(occurrences(data, `\"gateId\":\"${expectedGateId}\"`)).toBeLessThanOrEqual(1);
+}
+
+describe("bobbit_read — bounded gate pages", () => {
+	it.each([
+		["omitted view", undefined],
+		["summary view", "summary"],
+		["full view", "full"],
+	] as const)("honors limit=1 for %s and retains canonical paging plus legacy gate fields", async (_label, view) => {
+		const calls = stubFetch(gateEndpointFixture);
+		const params: Record<string, unknown> = { operation: "list_gates", goalId: "goal-gates", limit: 1 };
+		if (view !== undefined) params.view = view;
+
+		const data = await read(params);
+
+		expect(query(calls[0]).get("limit")).toBe("1");
+		expect(query(calls[0]).get("offset")).toBe("0");
+		if (view !== undefined) expect(query(calls[0]).get("view")).toBe(view);
+		expectCanonicalGatePage(data, "gate-1", 0);
+		expect(data.pagination).toMatchObject({
+			limit: 1,
+			offset: 0,
+			total: 3,
+			hasMore: true,
+			nextOffset: 1,
+			nextCursor: 1,
+			mode: "offset",
+			itemKey: "gates",
+			pagedBy: "rest",
+		});
+		if (view === "summary") {
+			expect(JSON.stringify(data)).not.toContain("GATE_BODY_SENTINEL");
+			expect(JSON.stringify(data).length).toBeLessThan(1_500);
+		}
+	});
+
+	it("supports non-overlapping offset continuation through a terminal page", async () => {
+		const calls = stubFetch(gateEndpointFixture);
+		const first = await read({ operation: "list_gates", goalId: "goal-gates", limit: 1 });
+		const second = await read({ operation: "list_gates", goalId: "goal-gates", limit: 1, offset: first.pagination.nextOffset });
+		const terminal = await read({ operation: "list_gates", goalId: "goal-gates", limit: 1, offset: second.pagination.nextOffset });
+
+		expect(first.gates[0].gateId).toBe("gate-1");
+		expect(second.gates[0].gateId).toBe("gate-2");
+		expect(terminal.gates[0].gateId).toBe("gate-3");
+		expect(query(calls[1]).get("offset")).toBe("1");
+		expect(query(calls[2]).get("offset")).toBe("2");
+		expect(terminal.pagination).toMatchObject({ total: 3, hasMore: false, offset: 2, mode: "offset" });
+		expect(terminal.pagination.nextOffset).toBeUndefined();
+		expect(terminal.pagination.nextCursor).toBeUndefined();
+	});
+
+	it.each(["cursor", "after"] as const)("translates numeric %s continuation into REST offset paging", async (cursorParam) => {
+		const calls = stubFetch(gateEndpointFixture);
+		const first = await read({ operation: "list_gates", goalId: "goal-gates", limit: 1 });
+		const second = await read({
+			operation: "list_gates",
+			goalId: "goal-gates",
+			limit: 1,
+			[cursorParam]: first.pagination.nextCursor,
+		});
+		const terminal = await read({
+			operation: "list_gates",
+			goalId: "goal-gates",
+			limit: 1,
+			[cursorParam]: second.pagination.nextCursor,
+		});
+
+		expect(query(calls[1]).get("offset")).toBe("1");
+		expect(query(calls[1]).has("cursor")).toBe(false);
+		expect(query(calls[1]).has("after")).toBe(false);
+		expect(second.gates[0].gateId).toBe("gate-2");
+		expect(second.pagination).toMatchObject({
+			limit: 1,
+			total: 3,
+			hasMore: true,
+			cursor: 1,
+			nextCursor: 2,
+			mode: "cursor",
+		});
+		expect(second.pagination.nextOffset).toBeUndefined();
+		expect(terminal.gates[0].gateId).toBe("gate-3");
+		expect(terminal.pagination).toMatchObject({ total: 3, hasMore: false, cursor: 2, mode: "cursor" });
+		expect(terminal.pagination.nextCursor).toBeUndefined();
+		expect(terminal.pagination.nextOffset).toBeUndefined();
+	});
+
+	it("gives cursor precedence over after and offset", async () => {
+		const calls = stubFetch(gateEndpointFixture);
+
+		const data = await read({
+			operation: "list_gates",
+			goalId: "goal-gates",
+			limit: 1,
+			offset: 0,
+			after: 1,
+			cursor: 2,
+		});
+
+		expect(query(calls[0]).get("offset")).toBe("2");
+		expect(data.gates.map((gate: any) => gate.gateId)).toEqual(["gate-3"]);
+		expect(data.pagination).toMatchObject({ mode: "cursor", cursor: 2, total: 3, hasMore: false });
+	});
+
+	it("applies the documented default bound even when paging controls are omitted", async () => {
+		const manyRows = Array.from({ length: 55 }, (_, index) => ({
+			...gateRows[index % gateRows.length],
+			id: `default-row-${index}`,
+			gateId: `default-gate-${index}`,
+			assignedTo: `default-session-${index}`,
+		}));
+		const calls = stubFetch((url) => gateEndpointFixture(url, manyRows));
+
+		const data = await read({ operation: "list_gates", goalId: "goal-gates" });
+
+		expect(query(calls[0]).get("limit")).toBe("50");
+		expect(query(calls[0]).get("offset")).toBe("0");
+		expect(data.gates).toHaveLength(50);
+		expect(data.gates[0]).toMatchObject({ assignedTo: "default-session-0", contentLength: 4_000 });
+		expect(data.pagination).toMatchObject({ limit: 50, total: 55, hasMore: true, nextOffset: 50, nextCursor: 50 });
+		expect(data.summary.gates).toBeUndefined();
+	});
+});
+
+function gitResult(label: string, fileCount: number) {
+	return {
+		branch: `goal/${label}`,
+		primaryBranch: "main",
+		primaryRef: "origin/main",
+		isOnPrimary: false,
+		hasUpstream: true,
+		ahead: 2,
+		behind: 1,
+		aheadOfPrimary: 3,
+		behindPrimary: 0,
+		mergedIntoPrimary: false,
+		insertionsVsPrimary: 40,
+		deletionsVsPrimary: 12,
+		clean: false,
+		unpushed: true,
+		partial: false,
+		untrackedIncluded: true,
+		summary: `${label} changes`,
+		status: Array.from({ length: fileCount }, (_, index) => ({
+			file: `GIT_FILE_SENTINEL_${label}_${index}_${"f".repeat(180)}`,
+			status: index % 2 === 0 ? "M" : "A",
+		})),
+	};
+}
+
+function gitEnvelope(repoCount: number) {
+	const aggregate = gitResult(`aggregate-${repoCount}`, 24);
+	const repos = Object.fromEntries(Array.from({ length: repoCount }, (_, index) => [
+		`repo-${index + 1}`,
+		gitResult(`repo-${index + 1}`, 12),
+	]));
+	return {
+		...aggregate,
+		aggregate,
+		repos,
+		data: { ...aggregate, aggregate, repos },
+		observedAt: 1_786_000_000_500,
+		refreshedAt: 1_786_000_000_000,
+		stale: false,
+		source: "repository",
+		ageMs: 500,
+		lastError: { kind: `transient-${"e".repeat(300)}`, observedAt: 1_785_999_000_000 },
+	};
+}
+
+describe("bobbit_read — bounded git status summary", () => {
+	it.each([
+		["single-repo", 1],
+		["multi-repo", 2],
+	] as const)("returns one scalar aggregate with freshness for %s status", async (_label, repoCount) => {
+		const fixture = gitEnvelope(repoCount);
+		stubFetch(() => ({ body: fixture }));
+
+		const data = await read({ operation: "goal_git_status", goalId: "goal-git", view: "summary" });
+		const { status: _status, ...aggregateScalars } = fixture.aggregate;
+
+		expect(data.aggregate).toEqual({ ...aggregateScalars, changedFiles: fixture.aggregate.status.length });
+		expect(data).toMatchObject({
+			observedAt: fixture.observedAt,
+			refreshedAt: fixture.refreshedAt,
+			stale: fixture.stale,
+			source: fixture.source,
+			ageMs: fixture.ageMs,
+		});
+		expect(Object.keys(data).sort()).toEqual([
+			"ageMs", "aggregate", "lastError", "observedAt", "refreshedAt", "source", "stale",
+		].sort());
+		expect(data.aggregate.status).toBeUndefined();
+		expect(data.status).toBeUndefined();
+		expect(data.repos).toBeUndefined();
+		expect(data.data).toBeUndefined();
+		expect(JSON.stringify(data)).not.toContain("GIT_FILE_SENTINEL");
+		expect(JSON.stringify(data).length).toBeLessThan(1_500);
+	});
+
+	it.each([
+		["omitted view", undefined],
+		["explicit full view", "full"],
+	] as const)("preserves the legacy repeated git-status projection for %s", async (_label, view) => {
+		const fixture = gitEnvelope(2);
+		stubFetch(() => ({ body: fixture }));
+		const params: Record<string, unknown> = { operation: "goal_git_status", goalId: "goal-git" };
+		if (view !== undefined) params.view = view;
+
+		const data = await read(params);
+
+		expect(data.status).toHaveLength(fixture.status.length);
+		expect(data.aggregate.status).toHaveLength(fixture.aggregate.status.length);
+		expect(Object.keys(data.repos)).toEqual(["repo-1", "repo-2"]);
+		expect(data.data.aggregate.status).toHaveLength(fixture.aggregate.status.length);
+	});
+});
+
+describe("bobbit_read — adjacent bounded operations", () => {
+	it("forwards goal_commits limit to the REST endpoint", async () => {
+		const calls = stubFetch((url) => {
+			const limit = Number(new URL(url).searchParams.get("limit") ?? 3);
+			return { body: { commits: Array.from({ length: limit }, (_, index) => ({ sha: `sha-${index}`, subject: `Commit ${index}` })) } };
+		});
+
+		const data = await read({ operation: "goal_commits", goalId: "goal-commits", limit: 1 });
+
+		expect(query(calls[0]).get("limit")).toBe("1");
+		expect(data.commits).toHaveLength(1);
+	});
+
+	it("pages maintenance worktree inventory on canonical root items and preserves authoritative metadata", async () => {
+		const counts = { total: 3, actionable: 2, troubleshooting: 1, byReason: { safe: 2, owned: 1 } };
+		const calls = stubFetch(() => ({
+			body: {
+				items: Array.from({ length: 3 }, (_, index) => ({ id: `worktree-${index}`, path: `/wt/${index}`, classification: "archived-owned" })),
+				counts,
+				generatedAt: 1_786_100_000_000,
+			},
+		}));
+
+		const data = await read({ operation: "maintenance_inspect", probe: "worktrees", limit: 1 });
+
+		expect(calls[0].url).toContain("/api/maintenance/worktrees");
+		expect(data.items).toEqual([{ id: "worktree-0", path: "/wt/0", classification: "archived-owned" }]);
+		expect(data.counts).toEqual(counts);
+		expect(data.generatedAt).toBe(1_786_100_000_000);
+		expect(data.pagination).toMatchObject({ limit: 1, offset: 0, total: 3, hasMore: true, nextOffset: 1, itemKey: "items" });
+	});
+
+	it("pages archived-session worktrees on sole canonical items and removes nested aliases", async () => {
+		const sentinel = "ARCHIVED_ITEM_SENTINEL_1";
+		const items = Array.from({ length: 3 }, (_, index) => ({
+			key: index === 0 ? sentinel : `archived-item-${index + 1}`,
+			sessionId: index < 2 ? "archived-session-1" : "archived-session-2",
+			path: `/archived/wt-${index + 1}`,
+			status: "removable",
+			disposition: "ready-to-clean",
+		}));
+		const calls = stubFetch(() => ({
+			body: {
+				items,
+				sessions: [
+					{ id: "archived-session-1", title: "First archived session", projectId: "project-1", worktrees: items.slice(0, 2) },
+					{ id: "archived-session-2", title: "Second archived session", projectId: "project-1", worktrees: items.slice(2) },
+				],
+				counts: { archivedSessions: 2, totalItems: 3, removableWorktrees: 3 },
+				groups: [{
+					key: "ready-to-clean",
+					label: "Ready to clean",
+					description: "Safe archived worktrees",
+					count: 3,
+					hasMore: false,
+					actionable: true,
+					sampleKeys: items.map((item) => item.key),
+					sampleItems: items,
+				}],
+				selectionPresets: [{ id: "all-removable", label: "All removable", count: 3, worktreeKeys: items.map((item) => item.key) }],
+				generatedAt: 1_786_200_000_000,
+			},
+		}));
+
+		const data = await read({ operation: "maintenance_inspect", probe: "archived_session_worktrees", limit: 1 });
+
+		expect(calls[0].url).toContain("/api/maintenance/archived-session-worktrees");
+		expect(data.items).toEqual([items[0]]);
+		expect(data.worktrees).toBeUndefined();
+		expect(data.pagination).toMatchObject({ limit: 1, offset: 0, total: 3, hasMore: true, nextOffset: 1, itemKey: "items" });
+		expect(data.counts).toEqual({ archivedSessions: 2, totalItems: 3, removableWorktrees: 3 });
+		expect(data.sessions).toEqual([
+			{ id: "archived-session-1", title: "First archived session", projectId: "project-1" },
+			{ id: "archived-session-2", title: "Second archived session", projectId: "project-1" },
+		]);
+		expect(data.groups[0]).toMatchObject({ key: "ready-to-clean", label: "Ready to clean", count: 3 });
+		expect(data.groups[0].sampleKeys).toBeUndefined();
+		expect(data.groups[0].sampleItems).toBeUndefined();
+		expect(occurrences(data, sentinel), "a worktree key must occur only in the canonical root items page").toBe(1);
+		expect(data.generatedAt).toBe(1_786_200_000_000);
+	});
+});

--- a/tests2/core/bobbit-read-bounds.test.ts
+++ b/tests2/core/bobbit-read-bounds.test.ts
@@ -179,7 +179,7 @@ describe("bobbit_read — bounded gate pages", () => {
 		["summary view", "summary"],
 		["full view", "full"],
 	] as const)("honors limit=1 for %s and retains canonical paging plus legacy gate fields", async (_label, view) => {
-		const calls = stubFetch(gateEndpointFixture);
+		const calls = stubFetch((url) => gateEndpointFixture(url));
 		const params: Record<string, unknown> = { operation: "list_gates", goalId: "goal-gates", limit: 1 };
 		if (view !== undefined) params.view = view;
 
@@ -207,7 +207,7 @@ describe("bobbit_read — bounded gate pages", () => {
 	});
 
 	it("supports non-overlapping offset continuation through a terminal page", async () => {
-		const calls = stubFetch(gateEndpointFixture);
+		const calls = stubFetch((url) => gateEndpointFixture(url));
 		const first = await read({ operation: "list_gates", goalId: "goal-gates", limit: 1 });
 		const second = await read({ operation: "list_gates", goalId: "goal-gates", limit: 1, offset: first.pagination.nextOffset });
 		const terminal = await read({ operation: "list_gates", goalId: "goal-gates", limit: 1, offset: second.pagination.nextOffset });
@@ -223,7 +223,7 @@ describe("bobbit_read — bounded gate pages", () => {
 	});
 
 	it.each(["cursor", "after"] as const)("translates numeric %s continuation into REST offset paging", async (cursorParam) => {
-		const calls = stubFetch(gateEndpointFixture);
+		const calls = stubFetch((url) => gateEndpointFixture(url));
 		const first = await read({ operation: "list_gates", goalId: "goal-gates", limit: 1 });
 		const second = await read({
 			operation: "list_gates",
@@ -258,7 +258,7 @@ describe("bobbit_read — bounded gate pages", () => {
 	});
 
 	it("gives cursor precedence over after and offset", async () => {
-		const calls = stubFetch(gateEndpointFixture);
+		const calls = stubFetch((url) => gateEndpointFixture(url));
 
 		const data = await read({
 			operation: "list_gates",

--- a/tests2/tests-map.json
+++ b/tests2/tests-map.json
@@ -1507,6 +1507,15 @@
       }
     },
     {
+      "path": "tests2/core/bobbit-read-bounds.test.ts",
+      "reason": "Focused regression coverage for bounded get_goal summaries, view-independent gate pagination and canonical collections, deduplicated git-status summaries, and adjacent commit/worktree response bounds.",
+      "execution": {
+        "runner": "vitest",
+        "tier": "unit",
+        "project": "core"
+      }
+    },
+    {
       "path": "tests2/core/bobbit-tool-verbosity.test.ts",
       "reason": "Acceptance coverage for focused bobbit_read discovery/detail projections, rejection of removed expansion fields, unchanged cost detail, unaffected nonpaged mutation/admin response behavior, and projection-catalogue drift.",
       "execution": {


### PR DESCRIPTION
## Summary
- add bounded summary projections for goals and Git status
- paginate and deduplicate gate and maintenance read collections
- add regression coverage for limits, cursors, response shape, and output size
- document the agent-facing response contracts and compatibility behavior

## Verification
- `npm run build`
- `npm run check`
- targeted Bobbit read tests
- workflow unit, browser, E2E, specification, code, and security reviews

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)