### PR TITLE
Fix panel tab overflow and preview routing

### DIFF
--- a/docs/preview-architecture.md
+++ b/docs/preview-architecture.md
@@ -154,8 +154,8 @@ between multiple preview tabs without re-mounting on every click. The
 active tab's `artifactId` is read off the panel-tab itself, not mirrored
 into global state, so SSE / bootstrap updates of `state.previewPanelEntry`
 can never desync the iframe `src` from the visible tab. The live mount
-slot remains the source for tabs without an `artifactId` (assistant /
-live preview).
+slot remains only as the fallback for tabs without an `artifactId`; a current
+or assistant-owned tab with an artifact still uses the stable artifact route.
 
 ### Reopen-tab decision flow
 
@@ -214,8 +214,9 @@ small metadata to render after restart:
 On gateway restart, `sidePanelWorkspace` is loaded with the session. When the
 browser reloads or returns to the session, the side-panel shell renders the
 active preview tab and the iframe derives `entry`, `mtime`, and `artifactId` from
-that tab before transient preview mirrors are repopulated. Live tabs point at
-`/preview/<sid>/<entry>?mtime=<n>`; artifact-backed historical tabs point at
+that tab before transient preview mirrors are repopulated. Tabs without an
+artifact point at `/preview/<sid>/<entry>?mtime=<n>`; every artifact-backed tab,
+including the current/live identity, points at
 `/preview/<sid>/_artifact/<artifactId>/<entry>?mtime=<n>`.
 
 Bootstrap (`GET /api/preview/mount`) and `preview-changed` SSE metadata may later

--- a/docs/side-panel-workspace.md
+++ b/docs/side-panel-workspace.md
@@ -61,6 +61,7 @@ Because those legacy files are superseded by pack artifact panels, they are excl
 `preview_open` still writes the per-session preview mount and streams updates via preview SSE. Workspace tab creation is separate:
 
 - explicit preview open/tool actions open or focus the current preview tab and persist render metadata such as `entry`, `mtime`, `contentHash`, `path`, `url`, and `artifactId` when available;
+- `live` describes the current tab's in-place update identity, not its transport: whenever that tab has an `artifactId`, iframe and popout navigation use the immutable artifact route so a later mount replacement cannot make an older filename transiently return `File not found`;
 - gateway restart restores the active preview iframe from that persisted workspace tab; the client does not need a fresh tool call or a mount bootstrap to recreate the tab;
 - historical card Open buttons explicitly open a versioned preview tab or focus an equivalent current tab when hashes match;
 - `GET /api/preview/mount` bootstrap, `preview-changed` SSE events, and mount metadata refreshes patch metadata only for already-open tabs;
@@ -148,6 +149,9 @@ The side-panel shell renders every tab kind with the same workspace chrome:
 
 - tab strip and close buttons;
 - active tab selection;
+- title-sized readable overflow: desktop and mobile tabs use their title-and-controls width up to the maximum instead of equal fixed slots; when the strip cannot keep longer titles readable, it moves excess tabs into a top-layer **More tabs** menu; mobile keeps Chat pinned while panel tabs overflow, and selecting an overflowed tab brings it into the visible window without changing canonical workspace order;
+- three tab-strip surface shades in every layout: muted strip background, an intermediate inactive-tab surface, and the content-background surface for the selected tab and its outward bottom curves;
+- active-tab actions share the tab-strip row: desktop retains its full panel/window controls, while mobile uses the trailing space for applicable controls such as preview refresh and pop-out instead of leaving it empty;
 - drag reorder;
 - fullscreen;
 - collapse and restore;
@@ -177,8 +181,8 @@ Keyboard shortcuts target the active side panel, regardless of kind, and use the
 
 Preview popout keeps the content-origin route:
 
-- live preview: `/preview/<sessionId>/<entry>`;
-- artifact preview: `/preview/<sessionId>/_artifact/<artifactId>/<entry>`.
+- preview without a persisted artifact: `/preview/<sessionId>/<entry>`;
+- any artifact-backed preview, including the current/live tab identity: `/preview/<sessionId>/_artifact/<artifactId>/<entry>`.
 
 All other panel kinds use the app deep link:
 

--- a/src/app/app.css
+++ b/src/app/app.css
@@ -1128,22 +1128,38 @@ details.wf-proposal-workflow .wf-proposal-gates {
 
 .panel-tab-overflow-menu {
 	position: fixed;
-	inset: auto;
+	inset: 0;
 	z-index: 100;
 	box-sizing: border-box;
-	max-height: min(420px, calc(100vh - 16px));
+	width: 100vw;
+	height: 100vh;
+	max-width: none;
+	max-height: none;
 	margin: 0;
+	padding: 0;
+	overflow: hidden;
+	border: 0;
+	background: transparent;
+	color: var(--popover-foreground, var(--foreground));
+}
+
+.panel-tab-overflow-menu::backdrop {
+	background: transparent;
+}
+
+.panel-tab-overflow-menu-card {
+	position: absolute;
+	left: var(--panel-tab-menu-left, 8px);
+	top: var(--panel-tab-menu-top, 8px);
+	box-sizing: border-box;
+	width: var(--panel-tab-menu-width, 220px);
+	max-height: min(420px, calc(100vh - var(--panel-tab-menu-top, 8px) - 8px));
 	padding: 4px;
 	overflow-y: auto;
 	border: 1px solid var(--border);
 	border-radius: 8px;
 	background: var(--popover, var(--card));
-	color: var(--popover-foreground, var(--foreground));
 	box-shadow: 0 8px 24px color-mix(in oklch, var(--foreground) 14%, transparent);
-}
-
-.panel-tab-overflow-menu::backdrop {
-	background: transparent;
 }
 
 .panel-tab-overflow-item {

--- a/src/app/app.css
+++ b/src/app/app.css
@@ -861,16 +861,28 @@ details.wf-proposal-workflow .wf-proposal-gates {
 	border-radius: 8px 8px 0 0;
 	border: none;
 	color: var(--color-muted-foreground, hsl(var(--muted-foreground)));
-	background: transparent;
+	/* Three deliberate surface shades: strip=muted, inactive=mixed middle,
+	   active=background/content surface. Shared by desktop and mobile. */
+	background: color-mix(in oklch, var(--background) 42%, var(--muted));
 	cursor: pointer;
 	transition: background 150ms ease, color 150ms ease;
 	line-height: 1.4;
 	position: relative;
 	box-sizing: border-box;
-	flex: 0 1 220px;
+	flex: 0 1 auto;
+	width: max-content;
 	max-width: 220px;
 	min-width: 0;
-	overflow: hidden;
+	overflow: visible;
+}
+
+/* In an overflowing strip, use the controller's per-tab allocation. It starts
+   at each title's readable floor, then shares spare width between truncated
+   titles so Chat is never crushed and no usable remainder is left idle. */
+.goal-tab-pill--constrained {
+	flex: 0 0 var(--panel-tab-readable-width);
+	width: var(--panel-tab-readable-width);
+	max-width: var(--panel-tab-readable-width);
 }
 
 /* Clicking a tab is the primary action; reordering is secondary. Keep the
@@ -934,6 +946,7 @@ details.wf-proposal-workflow .wf-proposal-gates {
 	gap: 5px;
 	flex: 1 1 auto;
 	min-width: 0;
+	overflow: hidden;
 	padding: 3px 2px 4px 12px;
 	border: 0;
 	background: transparent;
@@ -975,12 +988,13 @@ details.wf-proposal-workflow .wf-proposal-gates {
 }
 
 .goal-tab-pill:hover {
-	background: color-mix(in oklch, var(--background, hsl(var(--background))) 50%, transparent);
+	background: color-mix(in oklch, var(--background) 68%, var(--muted));
 	color: var(--color-foreground, hsl(var(--foreground)));
 }
 
 /* Active tab: matches the content background below so it visually merges. */
 .goal-tab-pill--active {
+	z-index: 1;
 	background: var(--color-background, hsl(var(--background)));
 	color: var(--color-foreground, hsl(var(--foreground)));
 }
@@ -1032,6 +1046,135 @@ details.wf-proposal-workflow .wf-proposal-gates {
 		transparent 8px,
 		var(--color-background, hsl(var(--background))) 8px
 	);
+}
+
+/* Off-screen natural-width probes let the overflow controller budget each tab
+   by its title instead of assigning every tab a fixed width. */
+.panel-tab-measurements {
+	position: absolute;
+	inset: 0 auto auto 0;
+	display: flex;
+	gap: 4px;
+	width: 0;
+	height: 0;
+	overflow: hidden;
+	visibility: hidden;
+	pointer-events: none;
+	contain: layout style;
+}
+
+.panel-tab-measure {
+	display: inline-flex;
+	align-items: center;
+	flex: 0 0 auto;
+	width: max-content;
+	max-width: 220px;
+	box-sizing: border-box;
+	padding: 3px 7px 4px 12px;
+	font-size: 13px;
+	font-weight: 500;
+	line-height: 1.4;
+	white-space: nowrap;
+	overflow: hidden;
+}
+
+.panel-tab-measure--direct-label {
+	padding-right: 15px;
+}
+
+.panel-tab-measure-label {
+	display: block;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+
+.panel-tab-measure .goal-tab-dot {
+	flex: 0 0 auto;
+	margin-left: 5px;
+}
+
+.panel-tab-measure-close {
+	flex: 0 0 20px;
+	width: 20px;
+	margin-left: 2px;
+}
+
+/* Desktop workspace-tab overflow. The trigger reserves one readable slot once
+   the ResizeObserver-backed renderer moves excess tabs into the top-layer menu. */
+.panel-tab-overflow-trigger {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	flex: 0 0 36px;
+	width: 36px;
+	min-width: 36px;
+	align-self: stretch;
+	padding: 0 8px 4px;
+	border: 0;
+	border-radius: 8px 8px 0 0;
+	background: transparent;
+	color: var(--color-muted-foreground, hsl(var(--muted-foreground)));
+	font: inherit;
+	font-size: 16px;
+	line-height: 1;
+	cursor: pointer;
+}
+
+.panel-tab-overflow-trigger:hover,
+.panel-tab-overflow-trigger[aria-expanded="true"] {
+	background: color-mix(in oklch, var(--background, hsl(var(--background))) 55%, transparent);
+	color: var(--color-foreground, hsl(var(--foreground)));
+}
+
+.panel-tab-overflow-menu {
+	position: fixed;
+	inset: auto;
+	z-index: 100;
+	box-sizing: border-box;
+	max-height: min(420px, calc(100vh - 16px));
+	margin: 0;
+	padding: 4px;
+	overflow-y: auto;
+	border: 1px solid var(--border);
+	border-radius: 8px;
+	background: var(--popover, var(--card));
+	color: var(--popover-foreground, var(--foreground));
+	box-shadow: 0 8px 24px color-mix(in oklch, var(--foreground) 14%, transparent);
+}
+
+.panel-tab-overflow-menu::backdrop {
+	background: transparent;
+}
+
+.panel-tab-overflow-item {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 8px;
+	width: 100%;
+	min-height: 32px;
+	padding: 6px 8px;
+	border: 0;
+	border-radius: 5px;
+	background: transparent;
+	color: inherit;
+	font: inherit;
+	font-size: 13px;
+	text-align: left;
+	cursor: pointer;
+}
+
+.panel-tab-overflow-item:hover,
+.panel-tab-overflow-item:focus-visible {
+	background: var(--muted);
+	outline: none;
+}
+
+.panel-tab-overflow-label {
+	min-width: 0;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
 }
 
 /* Notification dot on Preview tab */

--- a/src/app/panel-workspace.ts
+++ b/src/app/panel-workspace.ts
@@ -254,13 +254,23 @@ export function isPinnedPanelTab(_tab: PanelWorkspaceTab | undefined | null): bo
 	return false;
 }
 
+/** Return the immutable artifact backing a preview tab, regardless of whether
+ * the tab is the current/live identity. "Live" controls update semantics; once
+ * an artifact exists, its stable route is always safer than the mutable mount. */
+export function previewArtifactIdFromTab(tab: PanelWorkspaceTab | undefined | null): string {
+	if (!tab || tab.kind !== "preview") return "";
+	const source = tab.source as Record<string, unknown> | undefined;
+	const tabState = tab.state as Record<string, unknown> | undefined;
+	const stateArtifactId = typeof tabState?.artifactId === "string" ? tabState.artifactId.trim() : "";
+	const sourceArtifactId = typeof source?.artifactId === "string" ? source.artifactId.trim() : "";
+	return stateArtifactId || sourceArtifactId;
+}
+
 export function isLivePreviewTab(tab: PanelWorkspaceTab | undefined | null): boolean {
 	if (!tab || tab.kind !== "preview") return false;
 	if (tab.id === LIVE_PREVIEW_PANEL_TAB_ID || tab.id === LEGACY_LIVE_PREVIEW_PANEL_TAB_ID || tab.id.startsWith("preview:live")) return true;
 	const source = tab.source as Record<string, unknown> | undefined;
-	const tabState = tab.state as Record<string, unknown> | undefined;
-	const hasArtifact = typeof source?.artifactId === "string" && source.artifactId
-		|| typeof tabState?.artifactId === "string" && tabState.artifactId;
+	const hasArtifact = previewArtifactIdFromTab(tab);
 	const hasLiveSource = source?.live === true || source?.origin === "preview-bootstrap" || source?.origin === "preview-events";
 	// Current filename tabs are live when the preview event explicitly marks them
 	// live, even if the server also attached an immutable artifact for historical

--- a/src/app/render.ts
+++ b/src/app/render.ts
@@ -93,6 +93,7 @@ import {
 	panelContentTabs,
 	panelTabsForSession,
 	panelWorkspaceSessionKey,
+	previewArtifactIdFromTab,
 	previewContentHashFromTab,
 	previewTabDisplayTitle,
 	previewTabVersion,
@@ -1210,6 +1211,143 @@ let panelSortableStartIds: string[] = [];
 // its original vertical position (Chrome-style tab drag).
 let panelDragLockRaf = 0;
 
+// Desktop panel tabs remain readable down to this width. Once the strip cannot
+// provide it, excess tabs move into the More-tabs popover instead of collapsing
+// to a close button plus a few ambiguous characters.
+const PANEL_TAB_MIN_READABLE_WIDTH = 104;
+const PANEL_TAB_GAP = 4;
+const PANEL_TAB_OVERFLOW_TRIGGER_WIDTH = 36;
+const PANEL_TAB_OVERFLOW_MENU_ID = "side-panel-tab-overflow-menu";
+let panelTabVisibleCapacity = Number.POSITIVE_INFINITY;
+let panelTabOverflowHost: HTMLElement | null = null;
+let panelTabOverflowObserver: ResizeObserver | null = null;
+let panelTabOverflowHostWidth = 0;
+const panelTabNaturalWidths = new Map<string, number>();
+
+function readablePanelTabWidth(naturalWidth: number): number {
+	return Math.max(1, Math.min(PANEL_TAB_MIN_READABLE_WIDTH, naturalWidth || PANEL_TAB_MIN_READABLE_WIDTH));
+}
+
+function fittingPanelTabCount(widths: number[], budget: number, start: number, direction: 1 | -1): number {
+	let used = 0;
+	let count = 0;
+	for (let index = start; index >= 0 && index < widths.length; index += direction) {
+		const next = readablePanelTabWidth(widths[index]);
+		const required = next + (count > 0 ? PANEL_TAB_GAP : 0);
+		if (count > 0 && used + required > budget) break;
+		used += required;
+		count++;
+	}
+	return Math.max(1, count);
+}
+
+function panelTabCapacityForWidth(width: number, naturalWidths: number[], activeIndex: number): number {
+	const tabCount = naturalWidths.length;
+	if (tabCount <= 0) return 0;
+	const allReadableWidth = naturalWidths.reduce((sum, tabWidth) => sum + readablePanelTabWidth(tabWidth), 0)
+		+ Math.max(0, tabCount - 1) * PANEL_TAB_GAP;
+	if (allReadableWidth <= width) return tabCount;
+	const availableForTabs = Math.max(1, width - PANEL_TAB_OVERFLOW_TRIGGER_WIDTH - PANEL_TAB_GAP);
+	const prefixCount = fittingPanelTabCount(naturalWidths, availableForTabs, 0, 1);
+	if (activeIndex < prefixCount) return Math.min(tabCount - 1, prefixCount);
+	return Math.min(tabCount - 1, fittingPanelTabCount(naturalWidths, availableForTabs, activeIndex, -1));
+}
+
+/**
+ * Start every constrained tab at its readable floor, then share the remaining
+ * row width evenly between truncated titles (without exceeding natural width).
+ * This avoids both proportional flex crushing and an unused remainder before
+ * the More/actions controls.
+ */
+function allocatedPanelTabWidths(ids: string[], overflowing: boolean): Map<string, number> {
+	const result = new Map<string, number>();
+	if (!overflowing || ids.length === 0 || panelTabOverflowHostWidth <= 0) return result;
+	const natural = ids.map((id) => panelTabNaturalWidths.get(id) || PANEL_TAB_MIN_READABLE_WIDTH);
+	const widths = natural.map(readablePanelTabWidth);
+	const triggerAndGaps = PANEL_TAB_OVERFLOW_TRIGGER_WIDTH + ids.length * PANEL_TAB_GAP;
+	let remaining = Math.max(0, panelTabOverflowHostWidth - triggerAndGaps - widths.reduce((sum, value) => sum + value, 0));
+	let expandable = widths.map((width, index) => natural[index] > width + 0.01 ? index : -1).filter((index) => index >= 0);
+	while (remaining > 0.01 && expandable.length > 0) {
+		const share = remaining / expandable.length;
+		let used = 0;
+		const nextExpandable: number[] = [];
+		for (const index of expandable) {
+			const addition = Math.min(share, natural[index] - widths[index]);
+			widths[index] += addition;
+			used += addition;
+			if (natural[index] - widths[index] > 0.01) nextExpandable.push(index);
+		}
+		if (used <= 0.01) break;
+		remaining -= used;
+		expandable = nextExpandable;
+	}
+	ids.forEach((id, index) => result.set(id, widths[index]));
+	return result;
+}
+
+function syncPanelTabOverflowCapacity(host: HTMLElement): void {
+	const measurements = [...host.querySelectorAll<HTMLElement>(".panel-tab-measure")];
+	const naturalWidths = measurements.map((measurement) => measurement.getBoundingClientRect().width || measurement.offsetWidth);
+	let widthsChanged = false;
+	measurements.forEach((measurement, index) => {
+		const id = measurement.dataset.panelTabMeasureId || "";
+		const measuredWidth = naturalWidths[index] || PANEL_TAB_MIN_READABLE_WIDTH;
+		if (id && panelTabNaturalWidths.get(id) !== measuredWidth) {
+			panelTabNaturalWidths.set(id, measuredWidth);
+			widthsChanged = true;
+		}
+	});
+	const activeId = host.dataset.activePanelTabId || "";
+	const activeIndex = Math.max(0, measurements.findIndex((measurement) => measurement.dataset.panelTabMeasureId === activeId));
+	const width = host.getBoundingClientRect().width || host.clientWidth;
+	if (width <= 0 || naturalWidths.length === 0) return;
+	const hostWidthChanged = Math.abs(width - panelTabOverflowHostWidth) > 0.25;
+	panelTabOverflowHostWidth = width;
+	const next = panelTabCapacityForWidth(width, naturalWidths, activeIndex);
+	if (next === panelTabVisibleCapacity && !widthsChanged && !hostWidthChanged) return;
+	panelTabVisibleCapacity = next;
+	renderApp();
+}
+
+function ensurePanelTabOverflowObserver(host: HTMLElement | null): void {
+	if (host !== panelTabOverflowHost) {
+		panelTabOverflowObserver?.disconnect();
+		panelTabOverflowObserver = null;
+		panelTabOverflowHost = host;
+		panelTabVisibleCapacity = Number.POSITIVE_INFINITY;
+		if (host && typeof ResizeObserver !== "undefined") {
+			panelTabOverflowObserver = new ResizeObserver(() => syncPanelTabOverflowCapacity(host));
+			panelTabOverflowObserver.observe(host);
+		}
+	}
+	if (host) syncPanelTabOverflowCapacity(host);
+}
+
+function togglePanelTabOverflow(event: Event): void {
+	event.stopPropagation();
+	const trigger = event.currentTarget as HTMLButtonElement | null;
+	const menu = document.getElementById(PANEL_TAB_OVERFLOW_MENU_ID) as HTMLElement | null;
+	if (!trigger || !menu) return;
+	if (menu.matches(":popover-open")) {
+		menu.hidePopover();
+		trigger.setAttribute("aria-expanded", "false");
+		return;
+	}
+	const rect = trigger.getBoundingClientRect();
+	const menuWidth = Math.min(260, Math.max(180, window.innerWidth - 16));
+	menu.style.width = `${menuWidth}px`;
+	menu.style.left = `${Math.max(8, Math.min(window.innerWidth - menuWidth - 8, rect.right - menuWidth))}px`;
+	menu.style.top = `${Math.min(window.innerHeight - 8, rect.bottom + 4)}px`;
+	menu.showPopover();
+	trigger.setAttribute("aria-expanded", "true");
+}
+
+function syncPanelTabOverflowExpanded(event: Event): void {
+	const menu = event.currentTarget as HTMLElement | null;
+	const trigger = document.querySelector<HTMLButtonElement>(".panel-tab-overflow-trigger");
+	if (menu && trigger) trigger.setAttribute("aria-expanded", menu.matches(":popover-open") ? "true" : "false");
+}
+
 // Chrome-style axis lock: while the user drags a tab, SortableJS positions the
 // floating clone (Sortable.ghost) via `transform: matrix(a,b,c,d,e,f)` where
 // `e` is translateX and `f` is translateY. We run a requestAnimationFrame loop
@@ -1339,16 +1477,13 @@ function restoreHistoricalPreviewTab(tab: PanelWorkspaceTab): void {
 	const source = tab.source as Record<string, unknown>;
 	const entry = previewEntryFromTab(tab) || state.previewPanelEntry || "inline.html";
 	const contentHash = normalizePreviewContentHash(recordValue(tabState, "contentHash") || recordValue(source, "contentHash"));
-	const tabArtifactIdEarly = recordValue(tabState, "artifactId") || recordValue(source, "artifactId");
+	const tabArtifactIdEarly = previewArtifactIdFromTab(tab);
 
 	// Fast path: any preview tab that has a persisted artifact is served
-	// directly from `/preview/<sid>/_artifact/<artifactId>/...`. This bypasses
-	// the single-slot live mount entirely so switching between artifact-backed
-	// preview tabs is instant (no POST restore round-trip, no iframe blanking).
-	// We skip this only for the canonical live tab id, which intentionally
-	// follows the live mount slot's changing bytes.
-	const isLiveTab = isLivePreviewTab(tab);
-	if (!isLiveTab && tabArtifactIdEarly) {
+	// directly from `/preview/<sid>/_artifact/<artifactId>/...`. "Live" is the
+	// tab's update identity, not its transport: using the immutable bytes avoids
+	// racing a later preview_open that replaces the session's mutable mount.
+	if (tabArtifactIdEarly) {
 		if (state.previewPanelEntry === entry && state.previewPanelArtifactId === tabArtifactIdEarly && currentMountedPreviewTabId() === tab.id) {
 			clearPreviewTabRestoreError(sessionId, tab.id);
 			markPreviewTabMounted(tab);
@@ -1365,6 +1500,7 @@ function restoreHistoricalPreviewTab(tab: PanelWorkspaceTab): void {
 		return;
 	}
 
+	const isLiveTab = isLivePreviewTab(tab);
 	if (isLiveTab || !isHistoricalPreviewTab(tab)) {
 		const liveEntry = previewEntryFromTab(tab);
 		const liveHash = previewContentHashFromTab(tab);
@@ -1561,9 +1697,16 @@ function selectVisibleReviewGroup(reviewId: string): boolean {
 export function setUnifiedActiveTab(tab: PanelWorkspaceTab): void {
 	if ((tab as any).kind === "chat" || tab.id === CHAT_PANEL_TAB_ID) return;
 	const sid = workspaceSessionId();
-	setActivePanelTabIdForSession(state, sid, tab.id);
 	const workspace = getSidePanelWorkspace(sid);
-	if (sid !== "__no-session__" && workspace.tabs.some((candidate) => candidate.id === tab.id) && workspace.activeTabId !== tab.id) {
+	// Capture the authoritative comparison before updating compatibility mirrors:
+	// `state.panelWorkspace` aliases this workspace object, so the legacy setter
+	// mutates `workspace.activeTabId` in place and would otherwise suppress every
+	// user-driven `/active` persistence request.
+	const shouldPersistSelection = sid !== "__no-session__"
+		&& workspace.tabs.some((candidate) => candidate.id === tab.id)
+		&& workspace.activeTabId !== tab.id;
+	setActivePanelTabIdForSession(state, sid, tab.id);
+	if (shouldPersistSelection) {
 		void setServerActiveSidePanelTab(tab.id, { sessionId: sid });
 	}
 	(state as any).previewPanelTab = tab.legacyTab;
@@ -1977,20 +2120,20 @@ function ensurePanelSortable(container: HTMLElement | null): void {
 					return;
 				}
 
-				// Read the new tab id order directly off the DOM children.
+				// Read the visible tab order directly off the DOM. Overflowed tabs are
+				// absent from this strip; preserve their canonical slots while applying
+				// the dragged order to visible slots only.
 				const newIds = Array.from(host.querySelectorAll<HTMLElement>(".goal-tab-pill"))
 					.map((el) => el.getAttribute("data-panel-tab-id") || "")
 					.filter((id) => id.length > 0);
 				const byId = new Map(currentTabs.map((tab) => [tab.id, tab]));
-				const reordered: PanelWorkspaceTab[] = [];
-				for (const id of newIds) {
-					const tab = byId.get(id);
-					if (tab) reordered.push(tab);
-				}
-				// Append any tabs that weren't in the DOM order (defensive).
-				for (const tab of currentTabs) {
-					if (!newIds.includes(tab.id)) reordered.push(tab);
-				}
+				const visibleIds = new Set(newIds);
+				let visibleIndex = 0;
+				const reordered = currentTabs.map((tab) => {
+					if (!visibleIds.has(tab.id)) return tab;
+					const replacement = byId.get(newIds[visibleIndex++]);
+					return replacement || tab;
+				});
 
 				// Defense-in-depth: refuse to commit a reordering that places any
 				// non-pinned tab before any pinned tab. onMove should already have
@@ -2497,7 +2640,7 @@ export function doRenderApp(): void {
 		return tab.label || tab.title || (tab.kind === "preview" ? "Preview" : "");
 	};
 
-	const panelTabButton = (tab: UnifiedPanelTab, testId: string) => {
+	const panelTabButton = (tab: UnifiedPanelTab, testId: string, constrainedWidth?: number) => {
 		const label = panelTabButtonLabel(tab);
 		const sourceTitle = tab.kind === "preview" ? previewSourceTitle(tab) : "";
 		const tooltip = sourceTitle || label;
@@ -2512,7 +2655,8 @@ export function doRenderApp(): void {
 		const selectTab = () => { setUnifiedMobileTab(tab); renderApp(); };
 		return html`
 		<div
-			class="goal-tab-pill ${tabIsActive ? "goal-tab-pill--active" : ""} ${draggable ? "goal-tab-pill--draggable" : "goal-tab-pill--pinned"} ${draggingPanelTabId === tab.id ? "goal-tab-pill--dragging" : ""}"
+			class="goal-tab-pill ${tabIsActive ? "goal-tab-pill--active" : ""} ${draggable ? "goal-tab-pill--draggable" : "goal-tab-pill--pinned"} ${constrainedWidth ? "goal-tab-pill--constrained" : ""} ${draggingPanelTabId === tab.id ? "goal-tab-pill--dragging" : ""}"
+			style=${constrainedWidth ? `--panel-tab-readable-width:${constrainedWidth}px` : ""}
 			title=${tooltip}
 			data-panel-tab-id=${tab.id}
 			data-panel-tab-kind=${tab.kind}
@@ -2537,18 +2681,20 @@ export function doRenderApp(): void {
 	`;
 	};
 
-	const unifiedMobileTabButton = (tab: UnifiedPanelTab) => panelTabButton(
+	const unifiedMobileTabButton = (tab: UnifiedPanelTab, constrainedWidth?: number) => panelTabButton(
 		tab,
 		tab.kind === "inbox" ? "inbox-tab-pill" : "",
+		constrainedWidth,
 	);
 
-	const mobileChatTabPill = () => {
+	const mobileChatTabPill = (constrainedWidth?: number) => {
 		const isChatActive = mobileSelectedPaneIndex === 0;
 		return html`
 			<div
 				role="button"
 				tabindex="0"
-				class="goal-tab-pill goal-tab-pill--pinned ${isChatActive ? "goal-tab-pill--active" : ""}"
+				class="goal-tab-pill goal-tab-pill--pinned ${constrainedWidth ? "goal-tab-pill--constrained" : ""} ${isChatActive ? "goal-tab-pill--active" : ""}"
+				style=${constrainedWidth ? `--panel-tab-readable-width:${constrainedWidth}px` : ""}
 				title="Chat"
 				data-panel-tab-id="__mobile_chat_pane__"
 				data-panel-tab-kind="chat"
@@ -2559,6 +2705,18 @@ export function doRenderApp(): void {
 		`;
 	};
 
+	const partitionPanelTabs = <T extends UnifiedPanelTab>(tabs: T[], capacity: number, activeId: string): { visibleTabs: T[]; overflowTabs: T[] } => {
+		const boundedCapacity = Math.max(1, Math.min(tabs.length, capacity));
+		if (boundedCapacity >= tabs.length) return { visibleTabs: tabs, overflowTabs: [] };
+		const activeIndex = Math.max(0, tabs.findIndex((tab) => tab.id === activeId));
+		const start = activeIndex < boundedCapacity
+			? 0
+			: Math.min(tabs.length - boundedCapacity, activeIndex - boundedCapacity + 1);
+		const visibleTabs = tabs.slice(start, start + boundedCapacity);
+		const visibleIds = new Set(visibleTabs.map((tab) => tab.id));
+		return { visibleTabs, overflowTabs: tabs.filter((tab) => !visibleIds.has(tab.id)) };
+	};
+
 	const unifiedTabBar = () => {
 		if (!hasUnifiedPanel()) return "";
 		// Refresh mobileSelectedPaneIndex BEFORE rendering the tab bar so both
@@ -2567,20 +2725,64 @@ export function doRenderApp(): void {
 		// the slider then advances to the active panel tab — leaving both
 		// visually highlighted until the next render.
 		void unifiedMobilePaneIndex();
-		// Mirror the desktop tab strip: muted background, tabs flush at the
-		// bottom via items-end + pt-1 (no bottom padding), no border-b. The
-		// active tab's background matches the content panel below so the two
-		// merge seamlessly (Chrome-style), with the curve pseudo-elements
-		// providing the outward flare at the bottom corners.
+		const tabs = unifiedPanelTabs();
+		const measuredCapacity = Number.isFinite(panelTabVisibleCapacity) ? panelTabVisibleCapacity : tabs.length + 1;
+		const panelCapacity = Math.max(1, measuredCapacity - 1); // Chat remains pinned and visible.
+		const activePanelId = mobileSelectedPaneIndex === 0
+			? tabs[0]?.id || ""
+			: activeSidePanelTabIdForSession(state, workspaceSessionId());
+		const { visibleTabs, overflowTabs } = partitionPanelTabs(tabs, panelCapacity, activePanelId);
+		const measuredActiveId = mobileSelectedPaneIndex === 0 ? "__mobile_chat_pane__" : activePanelId;
+		const activeContentTab = mobileSelectedPaneIndex === 0
+			? null
+			: tabs.find((tab): tab is UnifiedContentTab => tab.id === activePanelId && tab.kind !== "chat") || null;
+		const visibleMobileIds = ["__mobile_chat_pane__", ...visibleTabs.map((tab) => tab.id)];
+		const allocatedWidths = allocatedPanelTabWidths(visibleMobileIds, overflowTabs.length > 0);
+
+		// Mobile uses the same title-sized tabs, active curves, three surface
+		// shades, and More-tabs overflow as desktop. Chat stays pinned so the
+		// conversation is always one tap away.
 		return html`
-			<div class="goal-tab-bar goal-tab-bar--mobile shrink-0 overflow-x-auto" style="scrollbar-width:thin; background: var(--muted, var(--color-muted));">
-				<div
-					class="flex items-end gap-1 px-3 pt-1 min-w-max"
-					data-panel-tab-bar="true"
-				>
-					${mobileChatTabPill()}
-					${repeat(unifiedPanelTabs(), (tab) => tab.id, (tab) => unifiedMobileTabButton(tab))}
+			<div class="goal-tab-bar goal-tab-bar--mobile shrink-0 flex items-end px-3 pt-1" style="background: var(--muted, var(--color-muted));">
+				<div class="relative flex-1 min-w-0" data-panel-tab-overflow-host="true" data-panel-tab-count=${tabs.length + 1} data-active-panel-tab-id=${measuredActiveId}>
+					<div class="flex items-end gap-1" data-panel-tab-bar="true">
+						${mobileChatTabPill(allocatedWidths.get("__mobile_chat_pane__"))}
+						${repeat(visibleTabs, (tab) => tab.id, (tab) => unifiedMobileTabButton(tab, allocatedWidths.get(tab.id)))}
+						${overflowTabs.length > 0 ? html`
+							<button type="button" class="panel-tab-overflow-trigger" aria-label="More tabs" title="More tabs" aria-haspopup="menu" aria-expanded="false" aria-controls=${PANEL_TAB_OVERFLOW_MENU_ID} @click=${togglePanelTabOverflow}>…</button>
+						` : ""}
+					</div>
+					${overflowTabs.length > 0 ? html`
+						<div id=${PANEL_TAB_OVERFLOW_MENU_ID} class="panel-tab-overflow-menu" role="menu" aria-label="More side-panel tabs" popover="auto" @toggle=${syncPanelTabOverflowExpanded}>
+							${overflowTabs.map((tab) => html`
+								<button type="button" role="menuitem" class="panel-tab-overflow-item" data-panel-tab-id=${tab.id} @click=${() => {
+									(document.getElementById(PANEL_TAB_OVERFLOW_MENU_ID) as HTMLElement | null)?.hidePopover();
+									(state as any).__lastSidePanelUserActiveSelection = { sessionId: workspaceSessionId(), tabId: tab.id, at: Date.now() };
+									setUnifiedMobileTab(tab);
+									renderApp();
+								}}>
+									<span class="panel-tab-overflow-label">${panelTabButtonLabel(tab)}</span>
+									${panelTabHasDot(tab) ? html`<span class="goal-tab-dot"></span>` : ""}
+								</button>
+							`)}
+						</div>
+					` : ""}
+					<div class="panel-tab-measurements" aria-hidden="true">
+						<span class="panel-tab-measure panel-tab-measure--direct-label" data-panel-tab-measure-id="__mobile_chat_pane__"><span class="panel-tab-measure-label">Chat</span></span>
+						${tabs.map((tab) => html`
+							<span class="panel-tab-measure" data-panel-tab-measure-id=${tab.id}>
+								<span class="panel-tab-measure-label">${panelTabButtonLabel(tab)}</span>
+								${panelTabHasDot(tab) ? html`<span class="goal-tab-dot"></span>` : ""}
+								${isPinnedPanelTab(tab) ? "" : html`<span class="panel-tab-measure-close"></span>`}
+							</span>
+						`)}
+					</div>
 				</div>
+				${activeContentTab ? html`
+					<div class="side-panel-mobile-actions flex items-center gap-0.5 shrink-0 pl-2 pb-1" aria-label="Active tab actions">
+						${sidePanelActionButtons(activeContentTab)}
+					</div>
+				` : ""}
 			</div>
 		`;
 	};
@@ -2616,11 +2818,10 @@ export function doRenderApp(): void {
 
 	/** Render the HTML preview iframe content (no header — unified panel provides it). */
 	//
-	// WP-E: single iframe pointing at the per-session preview mount. The agent
-	// writes into <stateDir>/preview/<sid>/, the gateway serves from
-	// `/preview/<sid>/<rel-path>` with cookie auth + theme-bridge injection on
-	// text/html responses. Hot reloads come via SSE bumping `previewPanelMtime`,
-	// which forces the iframe to reload via the `#mtime=<n>` hash.
+	// WP-E: one iframe for the active preview tab. Artifact-backed tabs use the
+	// immutable per-artifact route; only legacy/unpersisted tabs fall back to the
+	// mutable per-session mount. Both routes apply cookie auth + theme injection.
+	// SSE bumps `previewPanelMtime`, forcing the active iframe to reload.
 	const htmlPreviewContent = () => {
 		const sid = activeSessionId() || "";
 		// Derive artifactId, entry, and mtime from the active panel tab rather than
@@ -2635,12 +2836,10 @@ export function doRenderApp(): void {
 		let tabMtime = 0;
 		if (activeTab && activeTab.kind === "preview") {
 			const tabState = (activeTab.state || {}) as Record<string, unknown>;
-			const source = activeTab.source as Record<string, unknown>;
 			const tabEntry = previewEntryFromTab(activeTab);
 			if (tabEntry) entry = tabEntry;
 			if (typeof tabState.mtime === "number" && Number.isFinite(tabState.mtime)) tabMtime = tabState.mtime;
-			const isLiveTab = isLivePreviewTab(activeTab);
-			if (!isLiveTab) artifactId = recordValue(tabState, "artifactId") || recordValue(source, "artifactId");
+			artifactId = previewArtifactIdFromTab(activeTab);
 		}
 		const v = state.previewPanelMtime || tabMtime || 0;
 		if (!sid || !entry) {
@@ -2775,11 +2974,9 @@ export function doRenderApp(): void {
 		let entry = state.previewPanelEntry || "inline.html";
 		let artifactId = "";
 		if (tab?.kind === "preview") {
-			const tabState = (tab.state || {}) as Record<string, unknown>;
-			const source = tab.source as Record<string, unknown>;
 			const tabEntry = previewEntryFromTab(tab);
 			if (tabEntry) entry = tabEntry;
-			if (!isLivePreviewTab(tab)) artifactId = recordValue(tabState, "artifactId") || recordValue(source, "artifactId");
+			artifactId = previewArtifactIdFromTab(tab);
 		}
 		if (!gatewayNativeTransportSupport().supported) return "";
 		const route = gatewayRoute(artifactId
@@ -2925,9 +3122,10 @@ export function doRenderApp(): void {
 		return "";
 	};
 
-	const unifiedDesktopTabButton = (tab: UnifiedContentTab) => panelTabButton(
+	const unifiedDesktopTabButton = (tab: UnifiedContentTab, constrainedWidth?: number) => panelTabButton(
 		tab,
 		tab.kind === "inbox" ? "inbox-tab-unified" : "",
+		constrainedWidth,
 	);
 
 	const activeSidePanelContentTab = (): UnifiedContentTab | null => {
@@ -2949,6 +3147,9 @@ export function doRenderApp(): void {
 		const activeTab = activeSidePanelContentTab();
 		if (!activeTab) return "";
 
+		const { visibleTabs, overflowTabs } = partitionPanelTabs(contentTabs, panelTabVisibleCapacity, activeTab.id);
+		const allocatedWidths = allocatedPanelTabWidths(visibleTabs.map((tab) => tab.id), overflowTabs.length > 0);
+
 		return html`
 			<div class="side-panel-workspace goal-preview-panel flex-1 flex flex-col ${mode === "split" ? "border-l border-border" : ""} min-h-0" data-panel-workspace="content" data-side-panel-mode=${mode}>
 				<!-- Chrome-style tab strip: muted bg distinct from the panel below.
@@ -2957,9 +3158,58 @@ export function doRenderApp(): void {
 				     bridges the color boundary (curve pseudo-elements in CSS do
 				     the outward-curve flourish at the bottom corners). -->
 				<div class="flex items-end justify-between px-3 pt-1 shrink-0 min-w-0" style="background: var(--muted, var(--color-muted));">
-					<div class="flex-1 min-w-0">
+					<div class="flex-1 min-w-0 relative" data-panel-tab-overflow-host="true" data-panel-tab-count=${contentTabs.length} data-active-panel-tab-id=${activeTab.id}>
 						<div class="flex items-end gap-1" data-panel-tab-bar="true">
-							${repeat(contentTabs, (tab) => tab.id, (tab) => unifiedDesktopTabButton(tab))}
+							${repeat(visibleTabs, (tab) => tab.id, (tab) => unifiedDesktopTabButton(tab, allocatedWidths.get(tab.id)))}
+							${overflowTabs.length > 0 ? html`
+								<button
+									type="button"
+									class="panel-tab-overflow-trigger"
+									aria-label="More tabs"
+									title="More tabs"
+									aria-haspopup="menu"
+									aria-expanded="false"
+									aria-controls=${PANEL_TAB_OVERFLOW_MENU_ID}
+									@click=${togglePanelTabOverflow}
+								>…</button>
+							` : ""}
+						</div>
+						${overflowTabs.length > 0 ? html`
+							<div id=${PANEL_TAB_OVERFLOW_MENU_ID} class="panel-tab-overflow-menu" role="menu" aria-label="More side-panel tabs" popover="auto" @toggle=${syncPanelTabOverflowExpanded}>
+								${overflowTabs.map((tab) => html`
+									<button
+										type="button"
+										role="menuitem"
+										class="panel-tab-overflow-item"
+										data-panel-tab-id=${tab.id}
+										@click=${() => {
+											(document.getElementById(PANEL_TAB_OVERFLOW_MENU_ID) as HTMLElement | null)?.hidePopover();
+											// The delegated pointerdown guard in main.ts only sees visible
+											// `.goal-tab-pill` elements. Overflow menu items need the same
+											// user-selection marker so an in-flight workspace payload cannot
+											// immediately pull focus back to the previously active tab.
+											(state as any).__lastSidePanelUserActiveSelection = {
+												sessionId: workspaceSessionId(),
+												tabId: tab.id,
+												at: Date.now(),
+											};
+											setUnifiedDesktopTab(tab);
+										}}
+									>
+										<span class="panel-tab-overflow-label">${panelTabButtonLabel(tab)}</span>
+										${panelTabHasDot(tab) ? html`<span class="goal-tab-dot"></span>` : ""}
+									</button>
+								`)}
+							</div>
+						` : ""}
+						<div class="panel-tab-measurements" aria-hidden="true">
+							${contentTabs.map((tab) => html`
+								<span class="panel-tab-measure" data-panel-tab-measure-id=${tab.id}>
+									<span class="panel-tab-measure-label">${panelTabButtonLabel(tab)}</span>
+									${panelTabHasDot(tab) ? html`<span class="goal-tab-dot"></span>` : ""}
+									${isPinnedPanelTab(tab) ? "" : html`<span class="panel-tab-measure-close"></span>`}
+								</span>
+							`)}
 						</div>
 					</div>
 					<div class="flex items-center gap-0.5 shrink-0 pl-2 pb-1">
@@ -3233,4 +3483,5 @@ export function doRenderApp(): void {
 	// container is unchanged.
 	const tabBar = document.querySelector<HTMLElement>("[data-panel-tab-bar]");
 	ensurePanelSortable(tabBar);
+	ensurePanelTabOverflowObserver(document.querySelector<HTMLElement>("[data-panel-tab-overflow-host]"));
 }

--- a/src/app/render.ts
+++ b/src/app/render.ts
@@ -1335,9 +1335,9 @@ function togglePanelTabOverflow(event: Event): void {
 	}
 	const rect = trigger.getBoundingClientRect();
 	const menuWidth = Math.min(260, Math.max(180, window.innerWidth - 16));
-	menu.style.width = `${menuWidth}px`;
-	menu.style.left = `${Math.max(8, Math.min(window.innerWidth - menuWidth - 8, rect.right - menuWidth))}px`;
-	menu.style.top = `${Math.min(window.innerHeight - 8, rect.bottom + 4)}px`;
+	menu.style.setProperty("--panel-tab-menu-width", `${menuWidth}px`);
+	menu.style.setProperty("--panel-tab-menu-left", `${Math.max(8, Math.min(window.innerWidth - menuWidth - 8, rect.right - menuWidth))}px`);
+	menu.style.setProperty("--panel-tab-menu-top", `${Math.min(window.innerHeight - 8, rect.bottom + 4)}px`);
 	menu.showPopover();
 	trigger.setAttribute("aria-expanded", "true");
 }
@@ -1346,6 +1346,11 @@ function syncPanelTabOverflowExpanded(event: Event): void {
 	const menu = event.currentTarget as HTMLElement | null;
 	const trigger = document.querySelector<HTMLButtonElement>(".panel-tab-overflow-trigger");
 	if (menu && trigger) trigger.setAttribute("aria-expanded", menu.matches(":popover-open") ? "true" : "false");
+}
+
+function dismissPanelTabOverflowFromBackdrop(event: MouseEvent): void {
+	if (event.target !== event.currentTarget) return;
+	(event.currentTarget as HTMLElement).hidePopover();
 }
 
 // Chrome-style axis lock: while the user drags a tab, SortableJS positions the
@@ -2753,18 +2758,20 @@ export function doRenderApp(): void {
 						` : ""}
 					</div>
 					${overflowTabs.length > 0 ? html`
-						<div id=${PANEL_TAB_OVERFLOW_MENU_ID} class="panel-tab-overflow-menu" role="menu" aria-label="More side-panel tabs" popover="auto" @toggle=${syncPanelTabOverflowExpanded}>
-							${overflowTabs.map((tab) => html`
-								<button type="button" role="menuitem" class="panel-tab-overflow-item" data-panel-tab-id=${tab.id} @click=${() => {
-									(document.getElementById(PANEL_TAB_OVERFLOW_MENU_ID) as HTMLElement | null)?.hidePopover();
-									(state as any).__lastSidePanelUserActiveSelection = { sessionId: workspaceSessionId(), tabId: tab.id, at: Date.now() };
-									setUnifiedMobileTab(tab);
-									renderApp();
-								}}>
-									<span class="panel-tab-overflow-label">${panelTabButtonLabel(tab)}</span>
-									${panelTabHasDot(tab) ? html`<span class="goal-tab-dot"></span>` : ""}
-								</button>
-							`)}
+						<div id=${PANEL_TAB_OVERFLOW_MENU_ID} class="panel-tab-overflow-menu" popover="auto" @toggle=${syncPanelTabOverflowExpanded} @click=${dismissPanelTabOverflowFromBackdrop}>
+							<div class="panel-tab-overflow-menu-card" role="menu" aria-label="More side-panel tabs">
+								${overflowTabs.map((tab) => html`
+									<button type="button" role="menuitem" class="panel-tab-overflow-item" data-panel-tab-id=${tab.id} @click=${() => {
+										(document.getElementById(PANEL_TAB_OVERFLOW_MENU_ID) as HTMLElement | null)?.hidePopover();
+										(state as any).__lastSidePanelUserActiveSelection = { sessionId: workspaceSessionId(), tabId: tab.id, at: Date.now() };
+										setUnifiedMobileTab(tab);
+										renderApp();
+									}}>
+										<span class="panel-tab-overflow-label">${panelTabButtonLabel(tab)}</span>
+										${panelTabHasDot(tab) ? html`<span class="goal-tab-dot"></span>` : ""}
+									</button>
+								`)}
+							</div>
 						</div>
 					` : ""}
 					<div class="panel-tab-measurements" aria-hidden="true">
@@ -3175,31 +3182,33 @@ export function doRenderApp(): void {
 							` : ""}
 						</div>
 						${overflowTabs.length > 0 ? html`
-							<div id=${PANEL_TAB_OVERFLOW_MENU_ID} class="panel-tab-overflow-menu" role="menu" aria-label="More side-panel tabs" popover="auto" @toggle=${syncPanelTabOverflowExpanded}>
-								${overflowTabs.map((tab) => html`
-									<button
-										type="button"
-										role="menuitem"
-										class="panel-tab-overflow-item"
-										data-panel-tab-id=${tab.id}
-										@click=${() => {
-											(document.getElementById(PANEL_TAB_OVERFLOW_MENU_ID) as HTMLElement | null)?.hidePopover();
-											// The delegated pointerdown guard in main.ts only sees visible
-											// `.goal-tab-pill` elements. Overflow menu items need the same
-											// user-selection marker so an in-flight workspace payload cannot
-											// immediately pull focus back to the previously active tab.
-											(state as any).__lastSidePanelUserActiveSelection = {
-												sessionId: workspaceSessionId(),
-												tabId: tab.id,
-												at: Date.now(),
-											};
-											setUnifiedDesktopTab(tab);
-										}}
-									>
-										<span class="panel-tab-overflow-label">${panelTabButtonLabel(tab)}</span>
-										${panelTabHasDot(tab) ? html`<span class="goal-tab-dot"></span>` : ""}
-									</button>
-								`)}
+							<div id=${PANEL_TAB_OVERFLOW_MENU_ID} class="panel-tab-overflow-menu" popover="auto" @toggle=${syncPanelTabOverflowExpanded} @click=${dismissPanelTabOverflowFromBackdrop}>
+								<div class="panel-tab-overflow-menu-card" role="menu" aria-label="More side-panel tabs">
+									${overflowTabs.map((tab) => html`
+										<button
+											type="button"
+											role="menuitem"
+											class="panel-tab-overflow-item"
+											data-panel-tab-id=${tab.id}
+											@click=${() => {
+												(document.getElementById(PANEL_TAB_OVERFLOW_MENU_ID) as HTMLElement | null)?.hidePopover();
+												// The delegated pointerdown guard in main.ts only sees visible
+												// `.goal-tab-pill` elements. Overflow menu items need the same
+												// user-selection marker so an in-flight workspace payload cannot
+												// immediately pull focus back to the previously active tab.
+												(state as any).__lastSidePanelUserActiveSelection = {
+													sessionId: workspaceSessionId(),
+													tabId: tab.id,
+													at: Date.now(),
+												};
+												setUnifiedDesktopTab(tab);
+											}}
+										>
+											<span class="panel-tab-overflow-label">${panelTabButtonLabel(tab)}</span>
+											${panelTabHasDot(tab) ? html`<span class="goal-tab-dot"></span>` : ""}
+										</button>
+									`)}
+								</div>
 							</div>
 						` : ""}
 						<div class="panel-tab-measurements" aria-hidden="true">

--- a/src/app/side-panel-workspace.ts
+++ b/src/app/side-panel-workspace.ts
@@ -5,8 +5,8 @@ import {
 	INBOX_PANEL_TAB_ID,
 	assistantProposalType,
 	buildPanelWorkspaceTabs,
-	isLivePreviewTab,
 	panelWorkspaceSessionKey,
+	previewArtifactIdFromTab,
 	previewContentHashFromTab,
 	previewEntryLabel,
 	previewTabDisplayTitle,
@@ -353,9 +353,8 @@ function hydrateActivePreviewMirror(workspace: SidePanelWorkspace, legacyTabs: P
 	);
 	if (!entry) return;
 	const contentHash = previewContentHashFromTab(activeTab);
-	const artifactId = stringValue(tabState.artifactId) || stringValue(source.artifactId);
+	const artifactId = previewArtifactIdFromTab(activeTab);
 	const mtime = finiteNumber(tabState.mtime) ?? finiteNumber(source.mtime);
-	const isLiveTab = isLivePreviewTab(activeTab);
 
 	state.isPreviewSession = true;
 	state.previewPanelEntry = entry;
@@ -364,7 +363,7 @@ function hydrateActivePreviewMirror(workspace: SidePanelWorkspace, legacyTabs: P
 	if (mtime != null) state.previewPanelMtime = mtime;
 	else if (!state.previewPanelMtime) state.previewPanelMtime = now();
 	if (contentHash) (state as any).previewPanelContentHash = contentHash;
-	state.previewPanelArtifactId = !isLiveTab && artifactId ? artifactId : "";
+	state.previewPanelArtifactId = artifactId;
 	(state as any).previewPanelMountedTabId = activeTab.id;
 }
 

--- a/tests2/browser/fixtures/preview-durable-restart.spec.ts
+++ b/tests2/browser/fixtures/preview-durable-restart.spec.ts
@@ -59,18 +59,19 @@ async function enablePreviewSession(sessionId: string): Promise<void> {
 	expect(resp.status, `PATCH preview=true should succeed: ${text}`).toBe(200);
 }
 
-async function mountPreview(sessionId: string): Promise<{ entry: string; mtime: number; contentHash: string; url?: string }> {
+async function mountPreview(sessionId: string): Promise<{ entry: string; mtime: number; contentHash: string; artifactId: string; url?: string }> {
 	const resp = await apiFetch(`/api/preview/mount?sessionId=${sessionId}`, {
 		method: "POST",
 		body: JSON.stringify({ entry: ENTRY, html: previewHtml() }),
 	});
 	const text = await resp.text();
 	expect(resp.status, `POST /api/preview/mount should succeed: ${text}`).toBe(200);
-	const body = JSON.parse(text) as { entry?: string; mtime?: number; contentHash?: string; url?: string };
+	const body = JSON.parse(text) as { entry?: string; mtime?: number; contentHash?: string; artifactId?: string; url?: string };
 	expect(body.entry).toBe(ENTRY);
 	expect(body.mtime).toBeGreaterThan(0);
 	expect(body.contentHash).toMatch(/^[a-f0-9]{64}$/);
-	return body as { entry: string; mtime: number; contentHash: string; url?: string };
+	expect(body.artifactId).toBeTruthy();
+	return body as { entry: string; mtime: number; contentHash: string; artifactId: string; url?: string };
 }
 
 async function workspace(sessionId: string): Promise<any> {
@@ -127,7 +128,7 @@ async function previewDiagnostics(page: Page): Promise<string> {
 	});
 }
 
-async function expectPreviewIframeContains(page: Page, message: string, sessionId: string): Promise<void> {
+async function expectPreviewIframeContains(page: Page, message: string, sessionId: string, artifactId: string): Promise<void> {
 	await expect.poll(
 		() => previewDiagnostics(page),
 		{
@@ -140,7 +141,7 @@ async function expectPreviewIframeContains(page: Page, message: string, sessionI
 	await expect(iframe, `${message}: iframe should have an absolute preview content src`).toHaveAttribute("src", /^https?:\/\//, { timeout: 10_000 });
 	const src = new URL((await iframe.getAttribute("src"))!);
 	expect(src.origin, `${message}: iframe preview should stay on the gateway origin`).toBe(new URL(base()).origin);
-	expect(src.pathname, `${message}: iframe preview should target the restored session and entry`).toBe(`/preview/${encodeURIComponent(sessionId)}/${encodeURIComponent(ENTRY)}`);
+	expect(src.pathname, `${message}: iframe preview should target the restored immutable artifact and entry`).toBe(`/preview/${encodeURIComponent(sessionId)}/_artifact/${encodeURIComponent(artifactId)}/${encodeURIComponent(ENTRY)}`);
 	expect([...src.searchParams.keys()], `${message}: iframe preview should carry only the cache buster`).toEqual(["mtime"]);
 	expect(src.searchParams.get("mtime"), `${message}: iframe cache buster should be numeric`).toMatch(/^\d+$/);
 	expect(src.hash, `${message}: iframe preview should not carry a fragment`).toBe("");
@@ -222,7 +223,7 @@ test.describe("Durable HTML preview restart restore", () => {
 
 		await openSessionDirectly(page, sessionId);
 		await expectPreviewTabActive(page, "direct navigation restore");
-		await expectPreviewIframeContains(page, "direct navigation restore", sessionId);
+		await expectPreviewIframeContains(page, "direct navigation restore", sessionId, mount.artifactId);
 
 		// Recreate the restore race: the active server-persisted preview tab has
 		// the entry in its source/state, while the transient previewPanelEntry
@@ -238,7 +239,7 @@ test.describe("Durable HTML preview restart restore", () => {
 			() => page.evaluate(() => (window as any).bobbitState?.previewPanelEntry ?? ""),
 			{ timeout: 2_000, message: "test setup should leave the previewPanelEntry mirror empty" },
 		).toBe("");
-		await expectPreviewIframeContains(page, "direct navigation restore with empty preview mirror", sessionId);
+		await expectPreviewIframeContains(page, "direct navigation restore with empty preview mirror", sessionId, mount.artifactId);
 
 		await expect(
 			page.locator('button[title="Refresh preview"]').first(),
@@ -252,7 +253,7 @@ test.describe("Durable HTML preview restart restore", () => {
 		await expect(openPreview, "open-preview action should expose an absolute gateway URL").toHaveAttribute("href", /^https?:\/\//);
 		const openPreviewUrl = new URL((await openPreview.getAttribute("href"))!);
 		expect(openPreviewUrl.origin, "open-preview action should stay on the gateway origin").toBe(new URL(base()).origin);
-		expect(openPreviewUrl.pathname).toBe(`/preview/${encodedSessionId}/${encodedEntry}`);
+		expect(openPreviewUrl.pathname).toBe(`/preview/${encodedSessionId}/_artifact/${encodeURIComponent(mount.artifactId)}/${encodedEntry}`);
 		expect(openPreviewUrl.search, "open-preview action should not carry the iframe cache buster").toBe("");
 		expect(openPreviewUrl.hash).toBe("");
 	});
@@ -265,18 +266,18 @@ test.describe("Durable HTML preview restart restore", () => {
 		const sessionId = await createRegularSession(page);
 
 		await enablePreviewSession(sessionId);
-		await mountPreview(sessionId);
+		const mount = await mountPreview(sessionId);
 		await waitForWorkspacePreviewTab(sessionId);
 
 		await expectPreviewTabActive(page, "before restart");
-		await expectPreviewIframeContains(page, "before restart", sessionId);
+		await expectPreviewIframeContains(page, "before restart", sessionId, mount.artifactId);
 
 		await crashAndRestart(gateway, page);
 		await reloadAndReturnToSession(page, sessionId);
 
 		await waitForWorkspacePreviewTab(sessionId);
 		await expectPreviewTabActive(page, "after restart");
-		await expectPreviewIframeContains(page, "after restart", sessionId);
+		await expectPreviewIframeContains(page, "after restart", sessionId, mount.artifactId);
 
 		await closePreviewTab(page);
 		await expectWorkspaceHasNoPreviewTab(sessionId);

--- a/tests2/browser/fixtures/side-panel-tabs.spec.ts
+++ b/tests2/browser/fixtures/side-panel-tabs.spec.ts
@@ -247,9 +247,14 @@ test.describe("Side-panel tab contract", () => {
 		const menu = page.getByRole("menu", { name: "More side-panel tabs" });
 		await expect(menu).toBeVisible();
 		expect(await menu.evaluate((element) => ({
-			popover: element.hasAttribute("popover"),
+			popover: element.parentElement?.hasAttribute("popover") || false,
 			insideStrip: !!element.closest("[data-panel-tab-bar]"),
 		}))).toEqual({ popover: true, insideStrip: false });
+		await page.mouse.click(4, 760);
+		await expect(menu, "clicking the transparent area outside the menu card should dismiss it").toBeHidden();
+		await expect(more).toHaveAttribute("aria-expanded", "false");
+		await more.click();
+		await expect(menu).toBeVisible();
 		await page.keyboard.press("Escape");
 		const desktopSurfaces = await tabSurfaceColors(page);
 		expect(new Set(Object.values(desktopSurfaces)).size, `desktop selected, inactive, and strip surfaces should use three shades: ${JSON.stringify(desktopSurfaces)}`).toBe(3);
@@ -270,7 +275,12 @@ test.describe("Side-panel tab contract", () => {
 		const mobileBar = page.locator(".goal-tab-bar--mobile");
 		await expect(mobileBar).toBeVisible({ timeout: 10_000 });
 		await expect(mobileBar.locator('[data-panel-tab-kind="chat"]'), "mobile keeps Chat pinned beside desktop-style panel tabs").toBeVisible();
-		await expect(mobileBar.getByRole("button", { name: "More tabs" }), "mobile should use the same overflow menu instead of a compressed scrolling strip").toBeVisible();
+		const mobileMore = mobileBar.getByRole("button", { name: "More tabs" });
+		await expect(mobileMore, "mobile should use the same overflow menu instead of a compressed scrolling strip").toBeVisible();
+		await mobileMore.click();
+		await expect(page.getByRole("menu", { name: "More side-panel tabs" })).toBeVisible();
+		await page.mouse.click(4, 760);
+		await expect(page.getByRole("menu", { name: "More side-panel tabs" }), "mobile outside click should dismiss the overflow menu").toBeHidden();
 		const mobileOverflow = await mobileBar.evaluate((element) => element.scrollWidth - element.clientWidth);
 		expect(mobileOverflow, "mobile tab chrome should not create horizontal scrolling").toBeLessThanOrEqual(1);
 		const chatLabelGeometry = await mobileBar.locator('[data-panel-tab-kind="chat"] .goal-tab-pill-label').evaluate((label) => ({

--- a/tests2/browser/fixtures/side-panel-tabs.spec.ts
+++ b/tests2/browser/fixtures/side-panel-tabs.spec.ts
@@ -122,6 +122,54 @@ async function expectPreviewContains(page: Page, expectedText: string, message: 
 	await expect(page.frameLocator(".goal-preview-panel iframe").first().locator("body"), message).toContainText(expectedText, { timeout: 15_000 });
 }
 
+async function postPreviewHtml(page: Page, sessionId: string, entry: string, bodyText: string): Promise<{ artifactId: string }> {
+	const baseUrl = new URL(page.url()).origin;
+	const result = await page.evaluate(async ({ baseUrl, sessionId, entry, html }) => {
+		const response = await fetch(`${baseUrl}/api/preview/mount?sessionId=${sessionId}`, {
+			method: "POST",
+			credentials: "include",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ entry, html }),
+		});
+		return { status: response.status, text: await response.text() };
+	}, { baseUrl, sessionId, entry, html: previewHtml(bodyText) });
+	expect(result.status, `preview mount for ${entry} should succeed: ${result.text}`).toBe(200);
+	const parsed = JSON.parse(result.text);
+	expect(parsed.artifactId, `preview mount for ${entry} should return immutable artifact identity`).toBeTruthy();
+	return { artifactId: parsed.artifactId };
+}
+
+async function tabSurfaceColors(page: Page, mobile = false): Promise<{ strip: string; inactive: string; active: string }> {
+	const selector = mobile ? ".goal-tab-bar--mobile [data-panel-tab-bar]" : '[data-panel-workspace="content"] [data-panel-tab-bar]';
+	return page.locator(selector).evaluate((bar) => {
+		const strip = bar.closest(".goal-tab-bar") || bar.parentElement?.parentElement;
+		const inactive = bar.querySelector<HTMLElement>(".goal-tab-pill:not(.goal-tab-pill--active)");
+		const active = bar.querySelector<HTMLElement>(".goal-tab-pill--active");
+		return {
+			strip: strip ? getComputedStyle(strip).backgroundColor : "",
+			inactive: inactive ? getComputedStyle(inactive).backgroundColor : "",
+			active: active ? getComputedStyle(active).backgroundColor : "",
+		};
+	});
+}
+
+async function selectPanelTab(page: Page, tabId: string, sessionId?: string): Promise<void> {
+	const visibleTab = page.locator(`.goal-tab-pill[data-panel-tab-id="${tabId}"]`);
+	if (await visibleTab.isVisible().catch(() => false)) {
+		await visibleTab.click();
+	} else {
+		await page.getByRole("button", { name: "More tabs" }).click();
+		await page.locator(`[role="menuitem"][data-panel-tab-id="${tabId}"]`).click();
+	}
+	await expect(page.locator(`.goal-tab-pill--active[data-panel-tab-id="${tabId}"]`)).toBeVisible({ timeout: 10_000 });
+	if (sessionId) {
+		await expect.poll(async () => (await workspace(sessionId)).activeTabId, {
+			timeout: 10_000,
+			message: `selection of ${tabId} should persist before another tab mutation`,
+		}).toBe(tabId);
+	}
+}
+
 async function workspace(sessionId: string): Promise<any> {
 	const resp = await apiFetch(`/api/sessions/${sessionId}/side-panel-workspace`);
 	const text = await resp.text();
@@ -152,10 +200,115 @@ test.describe("Side-panel tab contract", () => {
 		await mountPreviewHtml(page, sessionId, "current.html", "Preview v2");
 		await expectPanelTabs(page, [previewId("current.html")], "refreshing a preview should reuse one tab");
 		await expectPreviewContains(page, "Preview v2", "refreshed preview tab should render updated content");
+		const curve = await page.locator(`${PANEL_TAB_SELECTOR}.goal-tab-pill--active`).first().evaluate((element) => {
+			const style = getComputedStyle(element);
+			const before = getComputedStyle(element, "::before");
+			const after = getComputedStyle(element, "::after");
+			return {
+				overflow: style.overflow,
+				before: { width: before.width, left: before.left, image: before.backgroundImage },
+				after: { width: after.width, right: after.right, image: after.backgroundImage },
+			};
+		});
+		expect(curve.overflow, "active tabs must not clip their outward bottom curves").toBe("visible");
+		expect(curve.before).toMatchObject({ width: "8px", left: "-8px" });
+		expect(curve.before.image).toContain("radial-gradient");
+		expect(curve.after).toMatchObject({ width: "8px", right: "-8px" });
+		expect(curve.after.image).toContain("radial-gradient");
+		const naturalTabWidth = await page.locator(`${PANEL_TAB_SELECTOR}.goal-tab-pill--active`).first().evaluate((element) => element.getBoundingClientRect().width);
+		expect(naturalTabWidth, "a lone tab should size to its title and controls instead of taking a fixed 220px slot").toBeLessThan(180);
 
 		await page.reload({ waitUntil: "domcontentloaded" });
 		await navigateToSession(page, sessionId);
 		await expectPanelTabs(page, [previewId("current.html")], "preview tab should survive reload");
 		await expectNoPersistedChatTab(page, sessionId);
+	});
+
+	test("sequential preview files keep stable artifact routes across tabs and reload", async ({ page }) => {
+		await page.setViewportSize({ width: 1280, height: 800 });
+		await openApp(page);
+		const sessionId = await createRegularSessionViaApi(page);
+		await enablePreview(page, sessionId);
+
+		const previews: Array<{ entry: string; body: string; artifactId: string }> = [];
+		for (let index = 1; index <= 6; index++) {
+			const entry = `sequential-${index}.html`;
+			const body = `SEQUENTIAL_PREVIEW_${index}`;
+			const { artifactId } = await postPreviewHtml(page, sessionId, entry, body);
+			previews.push({ entry, body, artifactId });
+		}
+		await expect.poll(async () => (await workspace(sessionId)).tabs.length, { timeout: 15_000 }).toBe(previews.length);
+		const more = page.getByRole("button", { name: "More tabs" });
+		await expect(more, "many preview tabs should expose overflow access").toBeVisible({ timeout: 10_000 });
+		const visibleWidths = await page.locator("[data-panel-tab-bar] > .goal-tab-pill").evaluateAll((tabs) => tabs.map((tab) => tab.getBoundingClientRect().width));
+		expect(visibleWidths.length).toBeLessThan(previews.length);
+		expect(Math.min(...visibleWidths), "visible tabs should retain a readable label beside the close button").toBeGreaterThanOrEqual(103);
+		await more.click();
+		const menu = page.getByRole("menu", { name: "More side-panel tabs" });
+		await expect(menu).toBeVisible();
+		expect(await menu.evaluate((element) => ({
+			popover: element.hasAttribute("popover"),
+			insideStrip: !!element.closest("[data-panel-tab-bar]"),
+		}))).toEqual({ popover: true, insideStrip: false });
+		await page.keyboard.press("Escape");
+		const desktopSurfaces = await tabSurfaceColors(page);
+		expect(new Set(Object.values(desktopSurfaces)).size, `desktop selected, inactive, and strip surfaces should use three shades: ${JSON.stringify(desktopSurfaces)}`).toBe(3);
+
+		const checkedPreviews = [previews[0], previews[3], previews[5], previews[1]];
+		for (const preview of checkedPreviews) {
+			await selectPanelTab(page, previewId(preview.entry), sessionId);
+			const iframe = page.locator(".goal-preview-panel iframe").first();
+			await expect(iframe, `${preview.entry} should use its immutable artifact rather than the mutable live mount`).toHaveAttribute(
+				"src",
+				new RegExp(`/_artifact/${preview.artifactId}/${preview.entry.replace(".", "\\.")}(?:\\?|$)`),
+				{ timeout: 10_000 },
+			);
+			await expectPreviewContains(page, preview.body, `${preview.entry} should never transiently show file not found`);
+		}
+
+		await page.setViewportSize({ width: 390, height: 780 });
+		const mobileBar = page.locator(".goal-tab-bar--mobile");
+		await expect(mobileBar).toBeVisible({ timeout: 10_000 });
+		await expect(mobileBar.locator('[data-panel-tab-kind="chat"]'), "mobile keeps Chat pinned beside desktop-style panel tabs").toBeVisible();
+		await expect(mobileBar.getByRole("button", { name: "More tabs" }), "mobile should use the same overflow menu instead of a compressed scrolling strip").toBeVisible();
+		const mobileOverflow = await mobileBar.evaluate((element) => element.scrollWidth - element.clientWidth);
+		expect(mobileOverflow, "mobile tab chrome should not create horizontal scrolling").toBeLessThanOrEqual(1);
+		const chatLabelGeometry = await mobileBar.locator('[data-panel-tab-kind="chat"] .goal-tab-pill-label').evaluate((label) => ({
+			clientWidth: label.clientWidth,
+			scrollWidth: label.scrollWidth,
+		}));
+		expect(chatLabelGeometry.clientWidth, "the pinned Chat tab should show its whole short title").toBeGreaterThanOrEqual(chatLabelGeometry.scrollWidth);
+		const constrainedPanelWidths = await mobileBar.locator('[data-panel-tab-bar] > .goal-tab-pill:not([data-panel-tab-kind="chat"])').evaluateAll((tabs) => tabs.map((tab) => tab.getBoundingClientRect().width));
+		expect(Math.max(...constrainedPanelWidths) - Math.min(...constrainedPanelWidths), "long visible mobile tabs should share the same readable cap instead of flex-shrinking proportionally").toBeLessThanOrEqual(1);
+
+		const mobileTarget = previews[5];
+		await selectPanelTab(page, previewId(mobileTarget.entry), sessionId);
+		await expectPreviewContains(page, mobileTarget.body, "mobile More-tabs selection should show the chosen preview");
+		const mobileActions = mobileBar.locator(".side-panel-mobile-actions");
+		const refreshPreview = mobileActions.getByTitle("Refresh preview");
+		await expect(refreshPreview, "mobile should use spare tab-strip space for active preview controls").toBeVisible();
+		await expect(mobileActions.getByTitle("Open preview in new tab")).toBeVisible();
+		const [mobileBarBox, mobileActionsBox, moreTabsBox] = await Promise.all([
+			mobileBar.boundingBox(),
+			mobileActions.boundingBox(),
+			mobileBar.getByRole("button", { name: "More tabs" }).boundingBox(),
+		]);
+		expect(mobileBarBox && mobileActionsBox ? mobileBarBox.x + mobileBarBox.width - (mobileActionsBox.x + mobileActionsBox.width) : Number.POSITIVE_INFINITY, "mobile controls should be right-aligned").toBeLessThanOrEqual(16);
+		const hasTruncatedVisibleTitle = await mobileBar.locator('[data-panel-tab-bar] > .goal-tab-pill:not([data-panel-tab-kind="chat"]) .goal-tab-pill-label').evaluateAll((labels) => labels.some((label) => label.scrollWidth > label.clientWidth + 0.5));
+		if (hasTruncatedVisibleTitle) {
+			expect(mobileActionsBox && moreTabsBox ? mobileActionsBox.x - (moreTabsBox.x + moreTabsBox.width) : Number.POSITIVE_INFINITY, "truncated tabs should consume the usable remainder before the active-tab controls").toBeLessThanOrEqual(12);
+		}
+		const activePreviewFrame = page.locator(`.side-panel-pane[data-panel-tab-id="${previewId(mobileTarget.entry)}"] iframe`);
+		const iframeSrcBeforeRefresh = await activePreviewFrame.getAttribute("src");
+		await refreshPreview.click();
+		await expect.poll(() => activePreviewFrame.getAttribute("src"), { message: "mobile Refresh preview should reload the active iframe" }).not.toBe(iframeSrcBeforeRefresh);
+		const mobileSurfaces = await tabSurfaceColors(page, true);
+		expect(new Set(Object.values(mobileSurfaces)).size, `mobile selected, inactive, and strip surfaces should use three shades: ${JSON.stringify(mobileSurfaces)}`).toBe(3);
+
+		await page.setViewportSize({ width: 1280, height: 800 });
+		await page.reload({ waitUntil: "domcontentloaded" });
+		await navigateToSession(page, sessionId);
+		await selectPanelTab(page, previewId(mobileTarget.entry), sessionId);
+		await expectPreviewContains(page, mobileTarget.body, "artifact-backed mobile selection should survive reload");
 	});
 });

--- a/tests2/browser/journeys/base-path-mounting.journey.spec.ts
+++ b/tests2/browser/journeys/base-path-mounting.journey.spec.ts
@@ -297,6 +297,7 @@ test.describe("Journey: production gateway mounted below a nested base path", ()
 			});
 			expect(mounted.response.status, mounted.text).toBe(200);
 			expect(mounted.body?.url).toBe(`/preview/${sessionId}/${ENTRY}`);
+			expect(mounted.body?.artifactId).toBeTruthy();
 
 			const snapshot = await adminRequest(gateway, `/api/preview/mount?sessionId=${sessionId}`);
 			expect(snapshot.response.status, snapshot.text).toBe(200);
@@ -313,9 +314,10 @@ test.describe("Journey: production gateway mounted below a nested base path", ()
 			expectExactlyOneMount(iframeSrc!, gateway, "/preview");
 			await expect(page.frameLocator(".goal-preview-panel iframe").locator("body")).toContainText(PREVIEW_TEXT, { timeout: 20_000 });
 			await expect(page.frameLocator(".goal-preview-panel iframe").locator("#sibling")).toHaveCSS("color", "rgb(12, 34, 56)");
+			const artifactBasePath = `${BASE_PATH}/preview/${sessionId}/_artifact/${encodeURIComponent(mounted.body.artifactId)}/`;
 			const injectedBase = await page.frameLocator(".goal-preview-panel iframe").locator("base[data-bobbit-preview-base]").getAttribute("href");
-			expect(injectedBase).toBe(`${BASE_PATH}/preview/${sessionId}/`);
-			const siblingRequest = requests.find(record => new URL(record.url).pathname === `${BASE_PATH}/preview/${sessionId}/sibling.css`);
+			expect(injectedBase).toBe(artifactBasePath);
+			const siblingRequest = requests.find(record => new URL(record.url).pathname === `${artifactBasePath}sibling.css`);
 			expect(siblingRequest, "preview sibling asset should resolve through the injected mounted base").toBeTruthy();
 
 			const newTabLink = page.locator('a[title="Open preview in new tab"]').first();

--- a/tests2/browser/journeys/misc.journey.spec.ts
+++ b/tests2/browser/journeys/misc.journey.spec.ts
@@ -221,9 +221,10 @@ test.describe("Journey: Preview Artifacts", () => {
 				body: JSON.stringify({ html: "<!DOCTYPE html><body>journey-preview</body>", entry: "journey.html" }),
 			});
 			expect(mountResp.status).toBe(200);
-			const mountBody = await mountResp.json() as { entry: string; mtime: number };
+			const mountBody = await mountResp.json() as { entry: string; mtime: number; artifactId: string };
 			expect(mountBody.entry).toBe("journey.html");
 			expect(mountBody.mtime).toBeGreaterThan(0);
+			expect(mountBody.artifactId).toBeTruthy();
 			await expect.poll(
 				() => page.evaluate(() => {
 					const s: any = (window as any).bobbitState ?? (window as any).__bobbitState;
@@ -238,7 +239,7 @@ test.describe("Journey: Preview Artifacts", () => {
 			const srcUrl = new URL(src!);
 			const gatewayOrigin = new URL(page.url()).origin;
 			expect(srcUrl.origin, "preview iframe should stay on the active gateway origin").toBe(gatewayOrigin);
-			expect(srcUrl.pathname).toBe(`/preview/${encodeURIComponent(sessionId)}/journey.html`);
+			expect(srcUrl.pathname).toBe(`/preview/${encodeURIComponent(sessionId)}/_artifact/${encodeURIComponent(mountBody.artifactId)}/journey.html`);
 			expect([...srcUrl.searchParams.keys()], "preview iframe should carry only the cache buster").toEqual(["mtime"]);
 			expect(srcUrl.searchParams.get("mtime")).toMatch(/^\d+$/);
 			expect(srcUrl.hash).toBe("");
@@ -250,7 +251,7 @@ test.describe("Journey: Preview Artifacts", () => {
 			const href = await link.getAttribute("href");
 			const hrefUrl = new URL(href!);
 			expect(hrefUrl.origin, "preview popout should stay on the active gateway origin").toBe(gatewayOrigin);
-			expect(hrefUrl.pathname).toBe(`/preview/${encodeURIComponent(sessionId)}/journey.html`);
+			expect(hrefUrl.pathname).toBe(`/preview/${encodeURIComponent(sessionId)}/_artifact/${encodeURIComponent(mountBody.artifactId)}/journey.html`);
 			expect(hrefUrl.search, "preview popout must not carry the iframe cache buster").toBe("");
 			expect(hrefUrl.hash).toBe("");
 			const refresh = page.locator('button[title="Refresh preview"]').first();

--- a/tests2/browser/stateless-cookie-upgrade.spec.ts
+++ b/tests2/browser/stateless-cookie-upgrade.spec.ts
@@ -26,6 +26,17 @@ function pathname(response: Response): string {
 	return new URL(response.url()).pathname;
 }
 
+function previewArtifactPath(sessionId: string, artifactId: string): string {
+	return `/preview/${encodeURIComponent(sessionId)}/_artifact/${encodeURIComponent(artifactId)}/${encodeURIComponent(ENTRY)}`;
+}
+
+function isArtifactPreviewDocument(response: Response, sessionId: string): boolean {
+	const path = pathname(response);
+	return path.startsWith(`/preview/${encodeURIComponent(sessionId)}/_artifact/`)
+		&& path.endsWith(`/${encodeURIComponent(ENTRY)}`)
+		&& response.request().resourceType() === "document";
+}
+
 async function setCookieHeader(response: Response): Promise<string | null> {
 	return response.headerValue("set-cookie");
 }
@@ -153,9 +164,11 @@ test.describe("Stateless browser cookie upgrade", () => {
 			});
 			const mountText = await mount.text();
 			expect(mount.status, `mount preview failed: ${mountText}`).toBe(200);
-			expect(JSON.parse(mountText)).toEqual(expect.objectContaining({
+			const mountBody = JSON.parse(mountText) as { entry: string; contentHash: string; artifactId: string };
+			expect(mountBody).toEqual(expect.objectContaining({
 				entry: ENTRY,
 				contentHash: expect.stringMatching(/^[a-f0-9]{64}$/),
+				artifactId: expect.any(String),
 			}));
 
 			await context.addCookies([{
@@ -179,7 +192,7 @@ test.describe("Stateless browser cookie upgrade", () => {
 				{ timeout: 20_000 },
 			);
 			const iframePromise = page.waitForResponse(
-				response => pathname(response) === `/preview/${sessionId}/${ENTRY}`
+				response => pathname(response) === previewArtifactPath(sessionId!, mountBody.artifactId)
 					&& response.request().resourceType() === "document",
 				{ timeout: 20_000 },
 			);
@@ -231,7 +244,7 @@ test.describe("Stateless browser cookie upgrade", () => {
 			await expect(iframe, "preview iframe should expose an absolute cookie-authenticated gateway URL").toHaveAttribute("src", /^https?:\/\//);
 			const iframeUrl = new URL((await iframe.getAttribute("src"))!);
 			expect(iframeUrl.origin, "preview iframe must stay on the cookie-bearing browser origin").toBe(browserOrigin);
-			expect(iframeUrl.pathname).toBe(`/preview/${sessionId}/${ENTRY}`);
+			expect(iframeUrl.pathname).toBe(previewArtifactPath(sessionId, mountBody.artifactId));
 			expect([...iframeUrl.searchParams.keys()], "preview iframe should carry only the cache buster").toEqual(["mtime"]);
 			expect(iframeUrl.searchParams.get("mtime")).toMatch(/^\d+$/);
 			expect(iframeUrl.hash).toBe("");
@@ -244,8 +257,7 @@ test.describe("Stateless browser cookie upgrade", () => {
 			// request performs this update, so the iframe can reach the new content
 			// only through the live preview-changed SSE event.
 			const sseIframePromise = page.waitForResponse(
-				response => pathname(response) === `/preview/${sessionId}/${ENTRY}`
-					&& response.request().resourceType() === "document",
+				response => isArtifactPreviewDocument(response, sessionId!),
 				{ timeout: 15_000 },
 			);
 			const sseMount = await apiFetch(`/api/preview/mount?sessionId=${sessionId}`, {
@@ -257,8 +269,9 @@ test.describe("Stateless browser cookie upgrade", () => {
 			});
 			const sseMountText = await sseMount.text();
 			expect(sseMount.status, `SSE preview update failed: ${sseMountText}`).toBe(200);
-			const sseMountBody = JSON.parse(sseMountText) as { contentHash?: string };
+			const sseMountBody = JSON.parse(sseMountText) as { contentHash?: string; artifactId?: string };
 			expect(sseMountBody.contentHash).toMatch(/^[a-f0-9]{64}$/);
+			expect(sseMountBody.artifactId).toBeTruthy();
 			const sseIframeResponse = await sseIframePromise;
 			expect(sseIframeResponse.status()).toBe(200);
 			await expectCookieAuthenticatedNavigation(sseIframeResponse);
@@ -272,7 +285,7 @@ test.describe("Stateless browser cookie upgrade", () => {
 			await expect(newTabLink, "preview popout should expose an absolute cookie-authenticated gateway URL").toHaveAttribute("href", /^https?:\/\//, { timeout: 15_000 });
 			const newTabUrl = new URL((await newTabLink.getAttribute("href"))!);
 			expect(newTabUrl.origin, "preview popout must stay on the cookie-bearing browser origin").toBe(browserOrigin);
-			expect(newTabUrl.pathname).toBe(`/preview/${sessionId}/${ENTRY}`);
+			expect(newTabUrl.pathname).toBe(previewArtifactPath(sessionId, sseMountBody.artifactId!));
 			expect(newTabUrl.search, "preview popout must not carry the iframe cache buster").toBe("");
 			expect(newTabUrl.hash).toBe("");
 			const popupPromise = page.waitForEvent("popup", { timeout: 15_000 });
@@ -302,7 +315,7 @@ test.describe("Stateless browser cookie upgrade", () => {
 				{ timeout: 20_000 },
 			);
 			const reloadIframePromise = page.waitForResponse(
-				response => pathname(response) === `/preview/${sessionId}/${ENTRY}`
+				response => pathname(response) === previewArtifactPath(sessionId!, sseMountBody.artifactId!)
 					&& response.request().resourceType() === "document",
 				{ timeout: 20_000 },
 			);

--- a/tests2/core/panel-workspace.test.ts
+++ b/tests2/core/panel-workspace.test.ts
@@ -21,6 +21,7 @@ import {
 	normalizeSidePanelTabs,
 	packPanelRefFromTabId,
 	packPanelTabId,
+	previewArtifactIdFromTab,
 	previewContentHashFromTab,
 	previewEntryLabel,
 	previewEntryTabId,
@@ -452,6 +453,12 @@ describe("panel workspace side-pane tab contract", () => {
 });
 
 describe("panel workspace preview tab compatibility", () => {
+	it("uses immutable artifact identity for current and historical preview tabs", () => {
+		assert.equal(previewArtifactIdFromTab(previewTab(previewEntryTabId("live.html"), { live: true, artifactId: "artifact-live" })), "artifact-live");
+		assert.equal(previewArtifactIdFromTab(previewTab(previewVersionedTabId("old.html", 1), { artifactId: "artifact-source" }, { artifactId: "artifact-state" })), "artifact-state");
+		assert.equal(previewArtifactIdFromTab(previewTab(previewEntryTabId("fallback.html"), { live: true })), "");
+	});
+
 	it("distinguishes current preview tabs from historical preview tool-card tabs", () => {
 		assert.equal(isLivePreviewTab(previewTab("preview")), true);
 		assert.equal(isLivePreviewTab(previewTab("preview:live")), true);


### PR DESCRIPTION
## Summary
- route every artifact-backed preview tab through its immutable artifact URL to prevent intermittent file-not-found races
- restore active-tab corner curves and add title-aware overflow menus on desktop and mobile
- use distinct tab-strip surfaces, preserve readable tab widths, and expose active preview controls on mobile
- persist active tab selections correctly across reloads

## Validation
- `npm run check`
- `tests2/core/panel-workspace.test.ts` — 18 passed
- `tests2/browser/fixtures/side-panel-tabs.spec.ts` — 3 passed
- `tests2/browser/fixtures/preview-panel.spec.ts` — passed
- `git diff --check`

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)