### PR TITLE
Improve history fork prompt actions

### DIFF
--- a/docs/design/archived-session-menu-ux.md
+++ b/docs/design/archived-session-menu-ux.md
@@ -34,7 +34,7 @@ Order:
 
 1. `Continue in new session` — only when the archived session satisfies the existing continue rules: non-goal, non-delegate, non-team, registered project, and transcript available. This uses `POST /api/sessions/:id/continue`, not the live Fork endpoint.
 2. `Copy link`
-3. `View System Prompt`
+3. `View system prompt`
 4. `Open in new window`
 
 If Continue is not eligible, hide it rather than disabling it. The remaining read-only actions keep the same order.

--- a/docs/design/extension-channels-host-channels.md
+++ b/docs/design/extension-channels-host-channels.md
@@ -449,7 +449,7 @@ not create a new process.
 
 For terminal, the preferred flow is:
 
-1. User clicks a session-menu entrypoint such as **Open Terminal**.
+1. User clicks a session-menu entrypoint such as **Open terminal**.
 2. `runLauncherEntrypoint()` recognizes a structured channel-panel target, e.g. `{ action:
    "open-channel-panel", channel: "terminal", panelId: "terminal.panel", singletonKey:
    "default" }`.

--- a/docs/design/extension-channels-terminal-ux.md
+++ b/docs/design/extension-channels-terminal-ux.md
@@ -52,10 +52,10 @@ Header control rules:
 
 ## Launchers and open/focus semantics
 
-### Session menu: `Open Terminal`
+### Session menu: `Open terminal`
 
 - Render as a normal session-menu entry in the existing session actions overflow, near other session-level actions.
-- Label: `Open Terminal`.
+- Label: `Open terminal`.
 - On click:
   1. Open or focus the terminal side-panel tab for the selected session.
   2. Resolve/open the session-persistent terminal channel for that session. The bridge asks the server for a one-shot open grant, and the server mints it only after validating the surface token and the pack's declared `terminal` channel.

--- a/docs/design/history-fork-prompt-actions.md
+++ b/docs/design/history-fork-prompt-actions.md
@@ -18,8 +18,8 @@ The design does **not** add a second endpoint, invoke a Pi fork/session-switch R
 
 | Area | In scope | Explicitly out of scope |
 |---|---|---|
-| Prompt rows | One always-visible compact overflow trigger on eligible durable historic user prompts, identical on desktop and mobile | Assistant/tool/synthetic/optimistic/pending/current-turn actions; hover-only action bars; long press |
-| Prompt actions | **Fork from history**, `(?)` explanation, trailing **New worktree** toggle, **Copy prompt** | Resend, edit, retry, rollback, replacement, delete, branch switching |
+| Prompt rows | One always-visible compact overflow trigger on eligible durable user prompts, including the current prompt once its transcript cursor is confirmed, identical on desktop and mobile | Assistant/tool/synthetic/optimistic/pending actions; hover-only action bars; long press |
+| Prompt actions | **Fork before this point** with a row tooltip, trailing **New worktree** toggle, **Copy prompt** | Resend, edit, retry, rollback, replacement, delete, branch switching |
 | Copy | Original user-visible text only; preserve line breaks, typed slash-skill syntax, and `@path`; exclude attachments and private author prefixes | Copying rendered DOM, attachment labels/data, expanded model prompt, author badge text |
 | Fork API | Optional durable `entryId` on the existing live-fork endpoint; authoritative active-branch validation; exact cut before the selected prompt | New clone endpoint; client index/message-array input; Pi mutating fork RPC |
 | Transcript | One immutable raw source read; exact retained raw JSONL records; selected and later records physically absent | Rewriting source JSONL; leaving discarded entries behind a synthetic leaf marker |
@@ -114,7 +114,6 @@ interface ForkSessionError {
     | "HISTORY_FORK_CURSOR_NOT_FOUND"
     | "HISTORY_FORK_CURSOR_INACTIVE"
     | "HISTORY_FORK_CURSOR_NOT_USER"
-    | "HISTORY_FORK_CURSOR_IN_FLIGHT"
     | "HISTORY_FORK_TRANSCRIPT_INVALID"
     | "HISTORY_FORK_IN_PROGRESS";
   stack?: string; // existing development/error forwarding only
@@ -127,7 +126,6 @@ interface ForkSessionError {
 | `409 HISTORY_FORK_CURSOR_NOT_FOUND` | No id-bearing record in the immutable read: `This prompt is no longer available` |
 | `409 HISTORY_FORK_CURSOR_INACTIVE` | Entry exists but is not on the active branch: `This prompt is no longer on the active conversation branch` |
 | `422 HISTORY_FORK_CURSOR_NOT_USER` | Entry is not an ordinary `type:"message"` accountable user prompt, or is tool-result-only: `History forks must start before a user prompt` |
-| `409 HISTORY_FORK_CURSOR_IN_FLIGHT` | Entry is the current user prompt while the source is streaming: `The current prompt cannot be forked until the turn finishes` |
 | `409 HISTORY_FORK_TRANSCRIPT_INVALID` | Duplicate ids, cycle, missing parent, non-object JSON, malformed complete line, invalid header, or impossible ordering: `The session transcript changed or is not valid for history forking` |
 | `409 HISTORY_FORK_IN_PROGRESS` | Same source/cursor/worktree tuple already reserved: `A fork from this prompt is already being created` |
 
@@ -150,31 +148,17 @@ type BobbitMessage<T extends object> = T & {
 
 The reducer's normal `message.id` is not a history cursor. It may be Pi message identity, an optimistic id, a compaction id, or a synthesized render key. The only eligible pair is a bounded `entryId` plus `_entryIdSource:"pi-transcript"` on a server-origin row.
 
-### Live prompt echoes
+### Authoritative cursor snapshots
 
-`prepareVisibleAgentEvent()` in `src/server/agent/session-manager.ts` already calls `promptAuthorMessageId(message, event)` and records that id in an echoed prompt settlement. Extend this same terminal boundary:
+Live Pi events do not prove transcript cursor identity, so `prepareVisibleAgentEvent()` strips any claimed `_entryIdSource`. Cursor projection instead pairs one immutable `get_messages` response with Pi's transcript cursor snapshot, correlates accountable user rows against the active branch, and stamps only proven rows with `{ entryId, _entryIdSource: "pi-transcript" }`.
 
-```ts
-prepareVisibleAgentEvent(session, event, deps): unknown
-```
+Pi has appended the current user prompt by `agent_start`. Bobbit schedules this paired read behind that event's call stack and broadcasts a cursor-enriched replacement, making the ellipsis available while the assistant is working. The final `agent_end` refresh remains a fallback for transient persistence lag and is the only refresh that consumes pending skill-sidecar bindings.
 
-For `message_end` ordinary user prompts only, when `promptAuthorMessageId()` returns a valid authoritative Pi id, copy it onto the prepared visible `message` as:
-
-```ts
-{ entryId, _entryIdSource: "pi-transcript" }
-```
-
-Do not stamp `message_update`, `message_start`, assistant, tool result, keyless legacy echo, or optimistic client events. `src/app/remote-agent.ts` then receives the cursor as part of `event.message`; it needs no outer-event/index correlation and the reducer preserves the additive fields while reconciling the optimistic row.
-
-### Reload snapshots
-
-`transformMessages()` in `src/server/agent/visible-message-snapshot.ts` already performs author-sidecar correlation before user-facing skill/file projection. Extend `mergeAuthorSidecarIntoMessages()` in `src/server/agent/author-sidecar.ts` so a row assigned to an echoed binding with `settlement.messageId` receives the same `{ entryId, _entryIdSource }` pair. This uses the existing phased exact-id, timestamp/digest, and FIFO duplicate correlation. The cursor is attached only after the binding is transcript-confirmed; weak/unresolved/legacy rows without a settlement id fail closed and show no actions.
-
-This deliberately avoids a second Pi RPC, tail correlation, or reading JSONL on every message snapshot. The authoritative fork request still validates the cursor against its own immutable JSONL read. A forged or stale browser field cannot select an invalid boundary.
+Reload snapshots use the same paired projection. Weak, unresolved, unpersisted, or legacy rows fail closed and show no actions. The authoritative fork request still validates the cursor against its own immutable JSONL read, so a forged or stale browser field cannot select an invalid boundary.
 
 `src/server/agent/transcript-reader.ts` already exposes `entryId` for raw transcript projections. Pre-compaction expanded rows are intentionally ineligible: they are orphaned history, not entries on the current active branch. They must not gain `_entryIdSource:"pi-transcript"` for this surface.
 
-## Client eligibility and current-turn rule
+## Client eligibility
 
 Add a pure predicate at the `MessageList` row boundary:
 
@@ -183,8 +167,6 @@ export function isEligibleHistoryPrompt(
   message: BobbitMessage<AgentMessage>,
   context: {
     canForkSource: boolean;
-    isStreaming: boolean;
-    newestDurableUserEntryId?: string;
   },
 ): boolean;
 ```
@@ -195,7 +177,8 @@ It returns true only when all conditions hold:
 2. `isAccountablePromptMessage(message)` is true (`user` or `user-with-attachments`, not a tool-result-only provider row).
 3. Reducer provenance is `_origin === "server"`; `_origin:"optimistic"`, `"synthetic"`, or `"permission"` is rejected even if fields are malformed or injected.
 4. `entryId` is a bounded non-empty string and `_entryIdSource === "pi-transcript"`.
-5. While `isStreaming`, the row is not the last server-origin durable user row with a cursor. Older settled durable prompts remain actionable during a later turn; the current prompt becomes actionable after the session returns idle.
+
+A current streaming prompt is eligible as soon as the authoritative cursor refresh projects its durable entry id.
 
 No action is rendered for archived/read-only/non-interactive/terminated/delegate/child/team sessions because `canForkSession()` already rejects them. The server repeats the source and entry checks authoritatively.
 
@@ -257,52 +240,14 @@ Opening performs a dynamic import of `SidebarActionsPopover`, checks an incremen
 
 Items, in order:
 
-1. `history-fork`: label `Fork from history`, `GitFork` icon, optional help descriptor, trailing `New worktree` toggle.
+1. `history-fork`: label `Fork before this point`, `GitFork` icon, row `title` set to **“The new session will include the conversation up to, but not including, this prompt.”**, trailing `New worktree` toggle.
 2. `copy-prompt`: label `Copy prompt`, `Copy` icon.
 
-Selecting Fork dispatches a composed `prompt-history-fork` event with `{ entryId, newWorktree }`. Selecting Copy dispatches `prompt-copy` with the captured string. `AgentInterface` resolves the current `GatewaySession`, calls `forkSession()` or `copyTextToClipboard()`, and shows existing feedback. No prompt is put in the composer, prefetched, or resent.
-
-### Canonical help extension
-
-Extend the existing item model, not its callers' action models:
-
-```ts
-export interface SidebarActionsHelp {
-  id: string;
-  ariaLabel: string;
-  text: string;
-}
-
-export interface SidebarActionsPopoverItem {
-  // existing fields
-  help?: SidebarActionsHelp;
-}
-
-interface SidebarActionsFocusStop {
-  kind: "row" | "help" | "toggle";
-  itemIndex: number;
-}
-```
-
-A help-bearing item renders a `role="none"` flex wrapper containing three **siblings**: primary `role="menuitem"`, help button, and optional `role="menuitemcheckbox"`. A button is never nested in another button.
-
-The help button:
-
-- visibly says `(?)`;
-- has `aria-label="About Fork from history"`;
-- is associated by `aria-describedby` with a `role="tooltip"` node;
-- exposes exactly: **“The new session will include the conversation up to, but not including, this prompt.”**;
-- opens on pointer hover and focus;
-- toggles/pins on click/tap, Enter, or Space so touch and keyboard users can retain it;
-- closes on blur when unpinned, on a second activation, or when the popover closes;
-- calls `preventDefault()` and `stopPropagation()` for activation/pointer handling and never selects Fork, toggles the worktree choice, or dismisses the popover;
-- uses fixed, viewport-clamped positioning adjacent to the help control and flips independently if needed.
-
-Focus-stop order is Fork row → help → toggle → Copy row. ArrowDown/ArrowUp wrap; Home/End choose ends. Enter activates a row, help, or toggle according to the active stop. Space on the Fork row retains canonical behavior and toggles its trailing checkbox without forking; Space/Enter on help toggles the explanation; Space/Enter on the toggle changes `aria-checked` without selecting or closing.
+There is no separate `(?)` help control or focus stop. Selecting Fork dispatches a composed `prompt-history-fork` event with `{ entryId, newWorktree }`. Selecting Copy dispatches `prompt-copy` with the captured string. `AgentInterface` resolves the current `GatewaySession`, calls `forkSession()` or `copyTextToClipboard()`, and shows existing feedback. No prompt is put in the composer, prefetched, or resent.
 
 Pointer/touch activation of the toggle uses the existing `_handleToggle()` path. Its accessible label remains `New worktree (off) — reuse the source worktree` or `New worktree (on) — fork into a fresh worktree`; `aria-checked` is always current.
 
-Escape/outside pointer returns focus to the prompt trigger. Tab dismisses without forcibly moving focus. Successful selection closes the menu. Tooltip content counts as inside interaction for dismissal.
+Escape/outside pointer returns focus to the prompt trigger. Tab dismisses without forcibly moving focus. Successful selection closes the menu.
 
 ## Immutable JSONL branch materialization
 
@@ -365,7 +310,6 @@ export class HistoryForkValidationError extends Error {
 export function materializeHistoryForkTranscript(
   sourceContent: string,
   entryId: string,
-  options: { sourceStreaming: boolean },
 ): HistoryForkMaterialization;
 ```
 
@@ -374,10 +318,9 @@ Algorithm:
 1. Parse the immutable source string and validate exactly one usable session header and a strict tree.
 2. Resolve `entryId` in `byId`; distinguish missing from present-but-inactive.
 3. Require the selected active record to be `type:"message"` whose `message` is an accountable ordinary user prompt and not tool-result-only.
-4. Find the newest ordinary user entry on the active branch. If `sourceStreaming` and it is selected, reject as current/in-flight.
-5. Take the selected record's active-branch prefix; the selected record and every descendant are excluded.
-6. Emit the exact raw session header record(s), then exact raw records for those active ancestors in parent order. Preserve unknown/additive fields, model/thinking changes, assistant/tool records, compaction records, retained tails, timestamps, and each retained line's original terminator. Do not stringify parsed entries.
-7. Return retained ids and typed subsets for sidecar filtering.
+4. Take the selected record's active-branch prefix; the selected record and every descendant are excluded. This boundary is stable even while descendants are being appended.
+5. Emit the exact raw session header record(s), then exact raw records for those active ancestors in parent order. Preserve unknown/additive fields, model/thinking changes, assistant/tool records, compaction records, retained tails, timestamps, and each retained line's original terminator. Do not stringify parsed entries.
+6. Return retained ids and typed subsets for sidecar filtering.
 
 The destination for a first/root prompt therefore contains only the valid source session header. There is no user prompt prefill and no automatic dispatch.
 
@@ -517,7 +460,7 @@ Acquire it before the immutable read and release it in `finally`. A duplicate ge
 - The immutable `sessionFileRead()` snapshot defines the request. Appends completed after it are irrelevant.
 - A final partial append is ignored only under the strict unterminated-fragment rule.
 - If the selected entry is absent or inactive in that read, fail before allocating destination state.
-- Source status is captured/rechecked around materialization. If it becomes streaming and the selected entry is now its newest user entry, reject as in-flight; no destination has launched.
+- Source status is captured/rechecked around materialization for live-source eligibility, but streaming does not invalidate an exact cut before the selected prompt.
 - Server validation never relies on browser streaming state.
 
 ### Failure cleanup
@@ -552,7 +495,7 @@ If a failed create left a destination persisted-session record, use the establis
 | `src/app/session-manager.ts` | Add optional `entryId` to `forkSession()` body; retain global single-flight, refresh, navigation, and failure UI |
 | `src/ui/components/SidebarActionsPopover.ts` | Optional help descriptor, sibling help control/tooltip, `help` focus stop, positioning and non-bubbling interactions |
 | `src/ui/components/Messages.ts` | Export `userVisiblePromptText()`; render one eligible prompt trigger in both user-row markup branches |
-| `src/ui/components/MessageList.ts` | Pure eligibility/current-turn calculation; directly mount one canonical prompt popover; reset toggle off; dispatch fork/copy events |
+| `src/ui/components/MessageList.ts` | Pure durable-cursor eligibility; directly mount one canonical prompt popover; reset toggle off; dispatch fork/copy events |
 | `src/ui/components/AgentInterface.ts` | Pass source eligibility; handle prompt fork/copy composed events using existing app helpers |
 | `src/ui/app.css` | Trigger/bubble reservation and help hit-area styles; canonical variables/classes, same desktop/mobile content |
 | `docs/rest-api.md` | Optional `entryId`, history semantics, errors, worktree defaults |
@@ -598,7 +541,7 @@ All new tests live in `tests2/` and are registered in `tests2/tests-map.json`.
 - terminal leaf selection using existing semantics;
 - exact raw line/additive-field preservation for header/model/thinking/assistant/tool/compaction/custom entries;
 - duplicate text prompts selected by id, not text;
-- missing/stale/inactive/non-message/non-user/tool-result-only/current-turn errors;
+- missing/stale/inactive/non-message/non-user/tool-result-only errors; exact cut before newest streaming prompt;
 - duplicate ids, missing parent, cycle, out-of-order parent, malformed complete line;
 - safe ignore of only a final unterminated append fragment;
 - input/source string immutability.
@@ -643,8 +586,8 @@ Extend `tests2/integration/sidebar-actions-fork-github-link.test.ts` only where 
 
 `tests2/dom/prompt-history-actions.test.ts`
 
-- full eligible/ineligible role/origin/cursor/forkability/current-turn matrix;
-- absent on assistant, tool, synthetic, optimistic, pending, current streaming, pre-compaction orphan, archived, child/team/read-only rows;
+- full eligible/ineligible role/origin/cursor/forkability matrix;
+- absent on assistant, tool, synthetic, optimistic, pending, pre-compaction orphan, archived, child/team/read-only rows; present on the current streaming row once its cursor is proven;
 - one always-visible trigger and identical desktop/mobile item contents;
 - legacy and author-labelled bubble placement; no content/attachment overlap;
 - canonical icon/row/type/toggle classes and menu position behavior;

--- a/docs/extension-host-authoring.md
+++ b/docs/extension-host-authoring.md
@@ -1251,7 +1251,7 @@ is not loaded).
 # entrypoints/viewer-open.yaml
 id: my-pack.open
 kind: composer-slash          # composer-slash | session-menu
-label: My Viewer              # required for launcher kinds
+label: My viewer              # required for launcher kinds; use sentence case
 icon: zap                     # optional; stable launcher icon id
 target:
   route: my-pack              # OR { panelId: ... }
@@ -1285,7 +1285,7 @@ First-party launcher examples:
 # market-packs/terminal/entrypoints/terminal-session-menu.yaml
 id: terminal.session-menu
 kind: session-menu
-label: Open Terminal
+label: Open terminal
 icon: terminal
 target:
   action: channel-panel
@@ -1300,7 +1300,7 @@ target:
 # market-packs/file-explorer/entrypoints/file-explorer-session-menu.yaml
 id: file-explorer.session-menu
 kind: session-menu
-label: Open File Explorer
+label: Open file explorer
 icon: folder-tree
 target:
   panelId: file-explorer.panel
@@ -1310,7 +1310,7 @@ target:
 # market-packs/pr-walkthrough/entrypoints/pr-walkthrough-session-menu.yaml
 id: pr-walkthrough.session-menu
 kind: session-menu
-label: PR Walkthrough
+label: PR walkthrough
 icon: git-pull-request
 target:
   action: spawn
@@ -1348,7 +1348,7 @@ host.ui.navigate({ route: "artifacts", params: { artifactId } });
 # entrypoints/reviewer-launch.yaml
 id: my-pack.launch
 kind: session-menu            # any launcher kind
-label: Run Reviewer
+label: Run reviewer
 target:
   action: spawn               # discriminates a SpawnLaunchTarget
   route: run                  # pack route name; called POST with an empty body
@@ -1888,7 +1888,7 @@ file-explorer/
   pack.yaml                              # schema 2; entrypoints plus list/read/diff routes
   panels/file-explorer-panel.yaml        # singleton file-explorer.panel
   entrypoints/
-    file-explorer-session-menu.yaml      # Open File Explorer
+    file-explorer-session-menu.yaml      # Open file explorer
     file-explorer-slash.yaml             # /files
   lib/
     file-explorer-panel.js               # built browser panel

--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -386,7 +386,6 @@ History validation uses the standard `{ error, code }` response shape:
 | `409` | `HISTORY_FORK_CURSOR_NOT_FOUND` | `This prompt is no longer available` |
 | `409` | `HISTORY_FORK_CURSOR_INACTIVE` | `This prompt is no longer on the active conversation branch` |
 | `422` | `HISTORY_FORK_CURSOR_NOT_USER` | `History forks must start before a user prompt` |
-| `409` | `HISTORY_FORK_CURSOR_IN_FLIGHT` | `The current prompt cannot be forked until the turn finishes` |
 | `409` | `HISTORY_FORK_TRANSCRIPT_INVALID` | `The session transcript changed or is not valid for history forking` |
 | `409` | `HISTORY_FORK_IN_PROGRESS` | `A fork from this prompt is already being created` |
 

--- a/docs/session-actions.md
+++ b/docs/session-actions.md
@@ -49,7 +49,7 @@ Archived menus contain only these built-in actions, in this order:
 
 1. `continue-archived` — `Continue in new session`, hidden unless the session is eligible.
 2. `copy-link` — `Copy link` for the path-style `/session/<sessionId>` URL.
-3. `view-system-prompt` — `View System Prompt` for the archived session id.
+3. `view-system-prompt` — `View system prompt` for the archived session id.
 4. `open-new-window` — `Open in new window` using the same path-style session URL.
 
 `Continue in new session` uses `canContinueArchivedSession()` for client-side visibility. It is shown only for archived/read-only sources that are not goal sessions, delegates, child/delegate rows, team sessions, team leads, or non-interactive sessions; whose `projectId` still resolves to a registered project; and whose transcript is available (`agentSessionFile` is present when supplied, and `transcriptAvailable` is not `false`). Ineligible sessions hide Continue rather than rendering a disabled item, while the other read-only actions remain available.
@@ -134,21 +134,20 @@ The browser fails closed unless all of these are true:
 - the source passes the same live-fork rules as session-level Fork: live, interactive, writable, and not archived, terminated, delegated/child, or team-owned;
 - the row is an ordinary accountable `user` or `user-with-attachments` prompt, not an assistant or tool-result-only row;
 - the row is settled server data rather than synthetic, optimistic, permission, or pending UI state;
-- it carries a bounded `entryId` with Bobbit's `_entryIdSource: "pi-transcript"` provenance;
-- it is not the current durable user prompt while that turn is streaming.
+- it carries a bounded `entryId` with Bobbit's `_entryIdSource: "pi-transcript"` provenance.
 
-Older durable prompts remain actionable while a later optimistic or in-flight prompt is present. The current row becomes eligible after it settles. The server repeats source, cursor, user-role, active-branch, and in-flight validation; browser provenance never grants authority by itself.
+Older durable prompts remain actionable while a later optimistic or in-flight prompt is present. At `agent_start`, Bobbit refreshes the authoritative transcript cursor projection so the current row becomes eligible during the turn. A final refresh remains as a fallback if persistence lags. The server repeats source, cursor, user-role, and active-branch validation; browser provenance never grants authority by itself.
 
 ### Menu and keyboard behavior
 
 The prompt menu has exactly two rows, in order:
 
-1. **Fork from history**, with an adjacent `(?)` help stop and trailing **New worktree** toggle.
+1. **Fork before this point**, with the explanation in the row tooltip and a trailing **New worktree** toggle.
 2. **Copy prompt**.
 
 `MessageList` owns at most one prompt menu and body-mounts the canonical popover against the row trigger. Opening another row replaces the previous menu. Escape and outside-pointer dismissal restore trigger focus; Tab and route changes dismiss through the existing popover behavior. Arrow keys, Home/End, Enter/Space, responsive viewport clamping, and pointer/touch handling are inherited from the shared component.
 
-The `(?)` control is a sibling focus stop, not part of the Fork button. Its accessible name is `About Fork from history`, and its tooltip says exactly:
+The **Fork before this point** row tooltip says exactly:
 
 > The new session will include the conversation up to, but not including, this prompt.
 
@@ -174,7 +173,7 @@ Attachment prompts therefore copy only their textual prompt. A textless attachme
 
 ### Fork request, feedback, and navigation
 
-Selecting **Fork from history** sends only `{ entryId, newWorktree }` to the existing `POST /api/sessions/:id/fork` endpoint. It never sends a rendered message array/index and never prefills or resends the selected prompt. Prompt controls are disabled while the local/global session-creation guard is active, and the server independently reserves identical in-flight history requests.
+Selecting **Fork before this point** sends only `{ entryId, newWorktree }` to the existing `POST /api/sessions/:id/fork` endpoint. It never sends a rendered message array/index and never prefills or resends the selected prompt. Prompt controls are disabled while the local/global session-creation guard is active, and the server independently reserves identical in-flight history requests.
 
 On success, the initiating client refreshes sessions and connects to the returned session as an existing session so retained history is fetched before navigation settles. Other clients remain on the live source. The destination ends immediately before the selected prompt; the source stays listed and unchanged. On validation, clipboard, launch, or connection failure, the initiating client stays on the source and shows the existing toast or connection-error feedback.
 

--- a/market-packs/file-explorer/entrypoints/file-explorer-session-menu.yaml
+++ b/market-packs/file-explorer/entrypoints/file-explorer-session-menu.yaml
@@ -1,6 +1,6 @@
 id: file-explorer.session-menu
 kind: session-menu
-label: Open File Explorer
+label: Open file explorer
 icon: folder-tree
 target:
   panelId: file-explorer.panel

--- a/market-packs/pr-walkthrough/entrypoints/pr-walkthrough-session-menu.yaml
+++ b/market-packs/pr-walkthrough/entrypoints/pr-walkthrough-session-menu.yaml
@@ -1,6 +1,6 @@
 id: pr-walkthrough.session-menu
 kind: session-menu
-label: PR Walkthrough
+label: PR walkthrough
 icon: git-pull-request
 # A session-menu LAUNCHER (the sidebar/chat session actions overflow menu). Its
 # selection IS the user gesture. SPAWN-ON-CLICK model (launch UX correction): like

--- a/market-packs/terminal/entrypoints/terminal-session-menu.yaml
+++ b/market-packs/terminal/entrypoints/terminal-session-menu.yaml
@@ -1,6 +1,6 @@
 id: terminal.session-menu
 kind: session-menu
-label: Open Terminal
+label: Open terminal
 icon: terminal
 target:
   action: channel-panel

--- a/scripts/affected/impact-rules.mjs
+++ b/scripts/affected/impact-rules.mjs
@@ -1050,10 +1050,10 @@ export const UNRESOLVED_REPOSITORY_READ_AUDIT = Object.freeze([
 		consumer: "tests2/integration/history-fork-api.test.ts",
 		allowReason: "isolated integration gateway and test-owned transcript, proposal, and worktree artifacts",
 		reads: frozen([
-			{ expression: "seeded.file", count: 4 },
+			{ expression: "seeded.file", count: 5 },
 			{ expression: "sandboxFixture.filesystem.hostPath(persisted.agentSessionFile)", count: 1 },
 			{ expression: "stagedFile", count: 1 },
-			{ expression: "forkPersisted.agentSessionFile", count: 3 },
+			{ expression: "forkPersisted.agentSessionFile", count: 4 },
 			{ expression: "path.join(proposalFork, \"goal.md\")", count: 1 },
 			{ expression: "path.join(proposalFork, \"goal.history\", \"0001.md\")", count: 1 },
 			{ expression: "sentinel", count: 1 },

--- a/src/app/main.ts
+++ b/src/app/main.ts
@@ -1001,7 +1001,7 @@ async function initApp() {
 	});
 
 	registerShortcut({
-		id: "ui.toggle-show-archived", label: "Toggle Show Archived", category: "UI",
+		id: "ui.toggle-show-archived", label: "Toggle show archived", category: "UI",
 		defaultBindings: [{ key: "a", ctrlOrMeta: false, shift: true, alt: true }],
 		allowInInput: true,
 		handler: () => {
@@ -1010,7 +1010,7 @@ async function initApp() {
 	});
 
 	registerShortcut({
-		id: "ui.toggle-show-busy", label: "Toggle Show Busy", category: "UI",
+		id: "ui.toggle-show-busy", label: "Toggle show busy", category: "UI",
 		defaultBindings: [{ key: "b", ctrlOrMeta: false, shift: true, alt: true }],
 		allowInInput: true,
 		handler: () => {
@@ -1019,7 +1019,7 @@ async function initApp() {
 	});
 
 	registerShortcut({
-		id: "ui.toggle-show-read", label: "Toggle Show Read", category: "UI",
+		id: "ui.toggle-show-read", label: "Toggle show read", category: "UI",
 		defaultBindings: [{ key: "r", ctrlOrMeta: false, shift: true, alt: true }],
 		allowInInput: true,
 		handler: () => {

--- a/src/app/session-actions.ts
+++ b/src/app/session-actions.ts
@@ -206,8 +206,8 @@ export function buildArchivedSessionActions(input: BuildArchivedSessionActionsIn
 		},
 		{
 			id: "view-system-prompt",
-			label: "View System Prompt",
-			title: "View System Prompt",
+			label: "View system prompt",
+			title: "View system prompt",
 			icon: icon(FileText, "xs"),
 			priority: ARCHIVED_BUILTIN_PRIORITIES["view-system-prompt"],
 			quick: false,
@@ -354,8 +354,8 @@ export function buildSessionActions(input: BuildSessionActionsInput): SessionAct
 		},
 		{
 			id: "view-system-prompt",
-			label: "View System Prompt",
-			title: "View System Prompt",
+			label: "View system prompt",
+			title: "View system prompt",
 			icon: icon(FileText, "xs"),
 			priority: BUILTIN_PRIORITIES["view-system-prompt"],
 			quick: false,

--- a/src/server/agent/history-fork.ts
+++ b/src/server/agent/history-fork.ts
@@ -12,7 +12,6 @@ export type HistoryForkErrorCode =
 	| "HISTORY_FORK_CURSOR_NOT_FOUND"
 	| "HISTORY_FORK_CURSOR_INACTIVE"
 	| "HISTORY_FORK_CURSOR_NOT_USER"
-	| "HISTORY_FORK_CURSOR_IN_FLIGHT"
 	| "HISTORY_FORK_TRANSCRIPT_INVALID"
 	| "HISTORY_FORK_IN_PROGRESS";
 
@@ -21,7 +20,6 @@ const HISTORY_FORK_ERRORS: Record<HistoryForkErrorCode, { status: 400 | 409 | 42
 	HISTORY_FORK_CURSOR_NOT_FOUND: { status: 409, message: "This prompt is no longer available" },
 	HISTORY_FORK_CURSOR_INACTIVE: { status: 409, message: "This prompt is no longer on the active conversation branch" },
 	HISTORY_FORK_CURSOR_NOT_USER: { status: 422, message: "History forks must start before a user prompt" },
-	HISTORY_FORK_CURSOR_IN_FLIGHT: { status: 409, message: "The current prompt cannot be forked until the turn finishes" },
 	HISTORY_FORK_TRANSCRIPT_INVALID: { status: 409, message: "The session transcript changed or is not valid for history forking" },
 	HISTORY_FORK_IN_PROGRESS: { status: 409, message: "A fork from this prompt is already being created" },
 };
@@ -91,7 +89,6 @@ function isOrdinaryUserEntry(record: ParsedTranscriptLine): boolean {
 export function materializeHistoryForkTranscript(
 	sourceContent: string,
 	entryId: string,
-	options: { sourceStreaming: boolean },
 ): HistoryForkMaterialization {
 	if (
 		typeof entryId !== "string"
@@ -112,18 +109,6 @@ export function materializeHistoryForkTranscript(
 	if (selectedIndex < 0) throw new HistoryForkValidationError("HISTORY_FORK_CURSOR_INACTIVE");
 	if (!isOrdinaryUserEntry(selected)) {
 		throw new HistoryForkValidationError("HISTORY_FORK_CURSOR_NOT_USER");
-	}
-
-	if (options.sourceStreaming) {
-		let newestUser: ParsedTranscriptLine | undefined;
-		for (let index = branch.length - 1; index >= 0; index--) {
-			if (!isOrdinaryUserEntry(branch[index])) continue;
-			newestUser = branch[index];
-			break;
-		}
-		if (newestUser === selected) {
-			throw new HistoryForkValidationError("HISTORY_FORK_CURSOR_IN_FLIGHT");
-		}
 	}
 
 	const retained = branch.slice(0, selectedIndex);

--- a/src/server/agent/session-manager.ts
+++ b/src/server/agent/session-manager.ts
@@ -7948,17 +7948,18 @@ export class SessionManager {
 		const refreshGeneration = (session.promptCursorRefreshGeneration ?? 0) + 1;
 		session.promptCursorRefreshGeneration = refreshGeneration;
 		queueMicrotask(() => {
-			if (this.sessions.get(session.id) !== session
-				|| session.rpcClient !== rpcClient
-				|| session.promptCursorRefreshGeneration !== refreshGeneration) return;
+			if (this.sessions.get(session.id) !== session || session.rpcClient !== rpcClient) return;
+			// A newer refresh supersedes only the client replacement. A final-turn
+			// refresh must still settle its captured sidecar bindings from the exact
+			// authoritative snapshot pair, even if the next turn has already started.
+			if (!options.settleBindings
+				&& session.promptCursorRefreshGeneration !== refreshGeneration) return;
 			const pendingBindings = options.settleBindings
 				? [...(session.pendingSkillTranscriptBindings ?? [])]
 				: [];
 			void this.getMessagesSnapshotBase(session).then((response) => {
 				if (!response.success || response.data === undefined) return;
-				if (this.sessions.get(session.id) !== session
-					|| session.rpcClient !== rpcClient
-					|| session.promptCursorRefreshGeneration !== refreshGeneration) return;
+				if (this.sessions.get(session.id) !== session || session.rpcClient !== rpcClient) return;
 				if (options.settleBindings && pendingBindings.length > 0) {
 					session.pendingSkillTranscriptBindings = session.pendingSkillTranscriptBindings
 						?.filter((binding) => !pendingBindings.includes(binding));
@@ -7989,6 +7990,7 @@ export class SessionManager {
 						appendSkillSidecarTranscriptBinding(session.id, binding.recordId, transcriptEntryId);
 					}
 				}
+				if (session.promptCursorRefreshGeneration !== refreshGeneration) return;
 				if (session.clients.size > 0) {
 					const data = this.buildVisibleMessageSnapshot(session.id, response.data);
 					broadcast(session.clients, { type: "messages", data: data as unknown[] });

--- a/src/server/agent/session-manager.ts
+++ b/src/server/agent/session-manager.ts
@@ -7951,7 +7951,6 @@ export class SessionManager {
 			if (this.sessions.get(session.id) !== session
 				|| session.rpcClient !== rpcClient
 				|| session.promptCursorRefreshGeneration !== refreshGeneration) return;
-			const refreshSeq = session.eventBuffer.lastSeq;
 			const pendingBindings = options.settleBindings
 				? [...(session.pendingSkillTranscriptBindings ?? [])]
 				: [];
@@ -7959,8 +7958,7 @@ export class SessionManager {
 				if (!response.success || response.data === undefined) return;
 				if (this.sessions.get(session.id) !== session
 					|| session.rpcClient !== rpcClient
-					|| session.promptCursorRefreshGeneration !== refreshGeneration
-					|| session.eventBuffer.lastSeq !== refreshSeq) return;
+					|| session.promptCursorRefreshGeneration !== refreshGeneration) return;
 				if (options.settleBindings && pendingBindings.length > 0) {
 					session.pendingSkillTranscriptBindings = session.pendingSkillTranscriptBindings
 						?.filter((binding) => !pendingBindings.includes(binding));

--- a/src/server/agent/session-manager.ts
+++ b/src/server/agent/session-manager.ts
@@ -6427,6 +6427,9 @@ export class SessionManager {
 				manualRetryRequired: false,
 			});
 			broadcastStatus(session, "streaming", { streamingStartedAt: session.streamingStartedAt });
+			// Pi has durably appended the user prompt by agent_start. Refresh the
+			// authoritative cursor plane now so prompt actions appear during the turn.
+			this.schedulePromptCursorRefresh(session);
 			// Clear the inbox nudger's per-staff guard so a fresh batch can be
 			// delivered next time the staff goes idle with pending entries.
 			// Hook fires for every session that starts a turn; the nudger
@@ -6530,7 +6533,7 @@ export class SessionManager {
 			});
 			broadcastStatus(session, "idle");
 			this.resolveIdleWaiters(session.id);
-			this.scheduleSettledPromptCursorRefresh(session);
+			this.schedulePromptCursorRefresh(session, { settleBindings: true });
 			// Don't drain the queue if the turn ended with a model error —
 			// queued/steered messages should wait for a retry.
 			if (!session.lastTurnErrored) {
@@ -7927,19 +7930,24 @@ export class SessionManager {
 	}
 
 	/**
-	 * Pi emits id-less message events before its append step. After the final
-	 * agent_end, schedule one authoritative read-only snapshot behind the current
-	 * event call stack so persistence and the event-buffer sequence are both
-	 * settled. Replacing from this snapshot enriches existing rows rather than
-	 * emitting a second user message.
+	 * Pi emits id-less message events before its append step. At agent_start the
+	 * prompt is durable, so schedule an authoritative read-only snapshot behind
+	 * the current event call stack and enrich the existing row with its cursor.
+	 * The final refresh also settles sidecar bindings and remains a fallback for
+	 * transient persistence lag at turn start.
 	 */
-	private scheduleSettledPromptCursorRefresh(session: SessionInfo): void {
+	private schedulePromptCursorRefresh(
+		session: SessionInfo,
+		options: { settleBindings?: boolean } = {},
+	): void {
 		if (typeof session.rpcClient.getTranscriptCursorSnapshot !== "function"
 			|| (session.clients.size === 0 && !session.pendingSkillTranscriptBindings?.length)) return;
 		const rpcClient = session.rpcClient;
 		queueMicrotask(() => {
 			if (this.sessions.get(session.id) !== session || session.rpcClient !== rpcClient) return;
-			const pendingBindings = session.pendingSkillTranscriptBindings?.splice(0) ?? [];
+			const pendingBindings = options.settleBindings
+				? session.pendingSkillTranscriptBindings?.splice(0) ?? []
+				: [];
 			void this.getMessagesSnapshotBase(session).then((response) => {
 				if (!response.success || response.data === undefined) return;
 				if (this.sessions.get(session.id) !== session || session.rpcClient !== rpcClient) return;

--- a/src/server/agent/session-manager.ts
+++ b/src/server/agent/session-manager.ts
@@ -1032,6 +1032,8 @@ export interface SessionInfo {
 		seq: number;
 		promise: Promise<MessageSnapshotBaseResponse>;
 	};
+	/** Monotonic fence preventing an older cursor refresh from broadcasting after a newer one. */
+	promptCursorRefreshGeneration?: number;
 	/** Cursor ids aligned to one exact immutable get_messages base object. */
 	messagesSnapshotCursorProjection?: {
 		seq: number;
@@ -7943,14 +7945,26 @@ export class SessionManager {
 		if (typeof session.rpcClient.getTranscriptCursorSnapshot !== "function"
 			|| (session.clients.size === 0 && !session.pendingSkillTranscriptBindings?.length)) return;
 		const rpcClient = session.rpcClient;
+		const refreshGeneration = (session.promptCursorRefreshGeneration ?? 0) + 1;
+		session.promptCursorRefreshGeneration = refreshGeneration;
 		queueMicrotask(() => {
-			if (this.sessions.get(session.id) !== session || session.rpcClient !== rpcClient) return;
+			if (this.sessions.get(session.id) !== session
+				|| session.rpcClient !== rpcClient
+				|| session.promptCursorRefreshGeneration !== refreshGeneration) return;
+			const refreshSeq = session.eventBuffer.lastSeq;
 			const pendingBindings = options.settleBindings
-				? session.pendingSkillTranscriptBindings?.splice(0) ?? []
+				? [...(session.pendingSkillTranscriptBindings ?? [])]
 				: [];
 			void this.getMessagesSnapshotBase(session).then((response) => {
 				if (!response.success || response.data === undefined) return;
-				if (this.sessions.get(session.id) !== session || session.rpcClient !== rpcClient) return;
+				if (this.sessions.get(session.id) !== session
+					|| session.rpcClient !== rpcClient
+					|| session.promptCursorRefreshGeneration !== refreshGeneration
+					|| session.eventBuffer.lastSeq !== refreshSeq) return;
+				if (options.settleBindings && pendingBindings.length > 0) {
+					session.pendingSkillTranscriptBindings = session.pendingSkillTranscriptBindings
+						?.filter((binding) => !pendingBindings.includes(binding));
+				}
 				const messages = Array.isArray(response.data)
 					? response.data
 					: response.data && typeof response.data === "object" && Array.isArray((response.data as any).messages)

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -14249,7 +14249,6 @@ async function handleApiRoute(
 				historyForkReservations.add(historyReservationKey);
 				historyReservationAcquired = true;
 
-				const sourceWasStreaming = source.status === "streaming";
 				const sourceContent = await sessionFileRead(srcCtx, sourceJsonl, sandboxManager ?? null);
 				if (!sourceContent) {
 					json({ error: "source transcript missing or empty" }, 404);
@@ -14275,7 +14274,6 @@ async function handleApiRoute(
 					historyMaterialization = materializeHistoryForkTranscript(
 						sourceContent,
 						entryId,
-						{ sourceStreaming: sourceWasStreaming || source.status === "streaming" },
 					);
 					clonedTranscript = historyMaterialization.content;
 				} catch (err) {

--- a/src/ui/components/MessageList.ts
+++ b/src/ui/components/MessageList.ts
@@ -48,8 +48,6 @@ type HistoryPromptMessage = BobbitMessage<AgentMessage> & {
 
 export interface HistoryPromptEligibilityContext {
 	canForkSource: boolean;
-	isStreaming: boolean;
-	currentStreamingUserEntryId?: string;
 }
 
 /** Fail closed unless this is a server-settled, transcript-confirmed user prompt. */
@@ -61,11 +59,10 @@ export function isEligibleHistoryPrompt(
 	if (!context.canForkSource || !isAccountablePromptMessage(candidate)) return false;
 	if (candidate._pending === true) return false;
 	if (candidate._origin !== "server" || candidate._entryIdSource !== "pi-transcript") return false;
-	if (typeof candidate.entryId !== "string"
-		|| candidate.entryId.length === 0
-		|| candidate.entryId.length > HISTORY_ENTRY_ID_MAX_LENGTH
-		|| candidate.entryId.trim() !== candidate.entryId) return false;
-	return !(context.isStreaming && candidate.entryId === context.currentStreamingUserEntryId);
+	return typeof candidate.entryId === "string"
+		&& candidate.entryId.length > 0
+		&& candidate.entryId.length <= HISTORY_ENTRY_ID_MAX_LENGTH
+		&& candidate.entryId.trim() === candidate.entryId;
 }
 
 function durableUserEntryId(message: BobbitMessage<AgentMessage>): string | undefined {
@@ -251,26 +248,11 @@ export class MessageList extends LitElement {
 		super.updated(changedProperties);
 		const current = this._openPromptActions;
 		if (!current || (!changedProperties.has("messages")
-			&& !changedProperties.has("canForkSource")
-			&& !changedProperties.has("isStreaming"))) return;
-		const currentStreamingUserEntryId = this._currentStreamingUserEntryId();
+			&& !changedProperties.has("canForkSource"))) return;
 		const selected = this.messages.find((message) => durableUserEntryId(message) === current.entryId);
 		if (!selected || !isEligibleHistoryPrompt(selected, {
 			canForkSource: this.canForkSource,
-			isStreaming: this.isStreaming,
-			currentStreamingUserEntryId,
 		})) this._closePromptActions();
-	}
-
-	private _currentStreamingUserEntryId(): string | undefined {
-		if (!this.isStreaming) return undefined;
-		for (let index = this.messages.length - 1; index >= 0; index--) {
-			const message = this.messages[index];
-			// The final accountable row is the current turn. Do not scan past an
-			// optimistic or id-less row and misclassify the prior durable prompt.
-			if (isAccountablePromptMessage(message)) return durableUserEntryId(message);
-		}
-		return undefined;
 	}
 
 	private _closePromptActions(): void {
@@ -287,14 +269,10 @@ export class MessageList extends LitElement {
 		return [
 			{
 				id: "history-fork",
-				label: "Fork from history",
+				label: "Fork before this point",
+				title: HISTORY_FORK_HELP_TEXT,
 				icon: icon(GitFork, "sm"),
 				quick: false,
-				help: {
-					id: "history-fork-help",
-					ariaLabel: "About Fork from history",
-					text: HISTORY_FORK_HELP_TEXT,
-				},
 				trailingToggle: {
 					id: "history-fork-new-worktree",
 					checked: record.newWorktree,
@@ -332,8 +310,6 @@ export class MessageList extends LitElement {
 		const selected = this.messages.find((message) => durableUserEntryId(message) === entryId);
 		if (!selected || !isEligibleHistoryPrompt(selected, {
 			canForkSource: this.canForkSource,
-			isStreaming: this.isStreaming,
-			currentStreamingUserEntryId: this._currentStreamingUserEntryId(),
 		})) return;
 		if (this._openPromptActions?.entryId === entryId && this._openPromptActions.element.open) {
 			this._closePromptActions();
@@ -404,7 +380,6 @@ export class MessageList extends LitElement {
 		const items: Array<{ key: string; template: TemplateResult; eager?: boolean }> = [];
 		let i = 0;
 		const msgs = this.messages;
-		const currentStreamingUserEntryId = this._currentStreamingUserEntryId();
 
 		while (i < msgs.length) {
 			const msg = msgs[i];
@@ -494,8 +469,6 @@ export class MessageList extends LitElement {
 				const historyEntryId = durableUserEntryId(msg);
 				const showPromptActions = isEligibleHistoryPrompt(msg, {
 					canForkSource: this.canForkSource,
-					isStreaming: this.isStreaming,
-					currentStreamingUserEntryId,
 				});
 				items.push({
 					key: keyFor(msg),

--- a/src/ui/components/sidebar-filters.ts
+++ b/src/ui/components/sidebar-filters.ts
@@ -1,7 +1,7 @@
 /**
  * Sidebar Filters popover — replaces the legacy "See Archived" button.
  *
- * Contains three toggle switches (Show Archived, Show Busy, Show Read), each
+ * Contains three toggle switches (Show archived, Show busy, Show read), each
  * persisted to localStorage and wired to keyboard shortcuts.
  *
  *   - bobbit-show-archived (default OFF)
@@ -27,7 +27,7 @@ import { safeSetItem } from "../../app/safe-storage.js";
 // Shared toggle handlers (used by both popover clicks and keyboard shortcuts)
 // ---------------------------------------------------------------------------
 
-/** Toggle Show Archived. Persists, lazy-loads/clears archived data, re-renders. */
+/** Toggle Show archived. Persists, lazy-loads/clears archived data, re-renders. */
 export function toggleShowArchived(): void {
 	state.showArchived = !state.showArchived;
 	safeSetItem("bobbit-show-archived", String(state.showArchived));
@@ -44,14 +44,14 @@ export function toggleShowArchived(): void {
 	renderApp();
 }
 
-/** Toggle Show Busy. Persists, re-renders. */
+/** Toggle Show busy. Persists, re-renders. */
 export function toggleShowBusy(): void {
 	state.showBusy = !state.showBusy;
 	safeSetItem("bobbit-show-busy", String(state.showBusy));
 	renderApp();
 }
 
-/** Toggle Show Read. Persists, re-renders. */
+/** Toggle Show read. Persists, re-renders. */
 export function toggleShowRead(): void {
 	state.showRead = !state.showRead;
 	safeSetItem("bobbit-show-read", String(state.showRead));
@@ -172,7 +172,7 @@ function _renderPopover(): TemplateResult | "" {
 			${_renderToggleRow({
 				id: "archived",
 				icon: Archive,
-				label: "Show Archived",
+				label: "Show archived",
 				shortcut: shortcutHint("ui.toggle-show-archived", { prefix: "", suffix: "" }) || "Alt+Shift+A",
 				checked: state.showArchived,
 				onToggle: toggleShowArchived,
@@ -180,7 +180,7 @@ function _renderPopover(): TemplateResult | "" {
 			${_renderToggleRow({
 				id: "busy",
 				icon: Zap,
-				label: "Show Busy",
+				label: "Show busy",
 				shortcut: shortcutHint("ui.toggle-show-busy", { prefix: "", suffix: "" }) || "Alt+Shift+B",
 				checked: state.showBusy,
 				onToggle: toggleShowBusy,
@@ -188,7 +188,7 @@ function _renderPopover(): TemplateResult | "" {
 			${_renderToggleRow({
 				id: "read",
 				icon: Eye,
-				label: "Show Read",
+				label: "Show read",
 				shortcut: shortcutHint("ui.toggle-show-read", { prefix: "", suffix: "" }) || "Alt+Shift+R",
 				checked: state.showRead,
 				onToggle: toggleShowRead,

--- a/tests2/browser/e2e/file-explorer-pack.spec.ts
+++ b/tests2/browser/e2e/file-explorer-pack.spec.ts
@@ -131,7 +131,7 @@ async function openFromSessionMenu(page: Page): Promise<void> {
 	await trigger.click();
 	const menu = page.locator("sidebar-actions-popover [role=menu]");
 	await expect(menu).toBeVisible({ timeout: 5_000 });
-	const launcher = menu.getByRole("menuitem", { name: /Open File Explorer/ });
+	const launcher = menu.getByRole("menuitem", { name: /Open file explorer/ });
 	await expect(launcher, "the built-in explorer must contribute a session launcher").toBeVisible();
 	await launcher.click();
 	await expect(page.locator("sidebar-actions-popover")).toHaveCount(0, { timeout: 5_000 });
@@ -186,7 +186,7 @@ test.describe("Journey: built-in file explorer pack", () => {
 		const explorer = contributions.find((pack) => pack.packId === "file-explorer");
 		expect(explorer?.panels?.some((panel) => panel.id === "file-explorer.panel")).toBe(true);
 		expect(explorer?.entrypoints).toEqual(expect.arrayContaining([
-			expect.objectContaining({ kind: "session-menu", label: "Open File Explorer" }),
+			expect.objectContaining({ kind: "session-menu", label: "Open file explorer" }),
 			expect.objectContaining({ kind: "composer-slash", id: "files" }),
 		]));
 		expect(explorer?.routeNames).toEqual(expect.arrayContaining(["list", "read", "diff"]));
@@ -212,7 +212,7 @@ test.describe("Journey: built-in file explorer pack", () => {
 		await trigger.click();
 		const menu = page.locator("sidebar-actions-popover [role=menu]");
 		await expect(menu).toBeVisible();
-		await expect(menu.getByRole("menuitem", { name: /Open File Explorer/ }), "disabling the pack removes its session launcher").toHaveCount(0);
+		await expect(menu.getByRole("menuitem", { name: /Open file explorer/ }), "disabling the pack removes its session launcher").toHaveCount(0);
 		await page.keyboard.press("Escape");
 		const composer = page.locator("message-editor textarea").first();
 		await composer.fill("/files");

--- a/tests2/browser/e2e/pr-walkthrough-default-off.spec.ts
+++ b/tests2/browser/e2e/pr-walkthrough-default-off.spec.ts
@@ -99,7 +99,7 @@ async function expectPrwContributionsPresent(): Promise<void> {
 			if (!meta) return "absent";
 			const hasPanel = meta.panels?.some((p) => p.id === PANEL_ID);
 			const hasRoutes = ["bundle", "publish"].every((r) => meta.routeNames?.includes(r));
-			const hasLauncher = meta.entrypoints?.some((e) => e.kind === "session-menu" && e.label === "PR Walkthrough");
+			const hasLauncher = meta.entrypoints?.some((e) => e.kind === "session-menu" && e.label === "PR walkthrough");
 			return hasPanel && hasRoutes && hasLauncher ? "full" : "partial";
 		}, { timeout: 15_000 })
 		.toBe("full");

--- a/tests2/browser/e2e/pr-walkthrough-pack.spec.ts
+++ b/tests2/browser/e2e/pr-walkthrough-pack.spec.ts
@@ -402,7 +402,7 @@ test.describe("Built-in first-party pack — pr-walkthrough served by the built-
 		expect(packMeta, "the built-in pr-walkthrough pack must be resolved with NO install once enabled").toBeTruthy();
 		expect(packMeta?.panels?.some((p) => p.id === PANEL_ID)).toBe(true);
 		expect(packMeta?.routeNames).toEqual(expect.arrayContaining(["bundle", "publish"]));
-		expect(packMeta?.entrypoints?.some((e) => e.kind === "session-menu" && e.label === "PR Walkthrough")).toBe(true);
+		expect(packMeta?.entrypoints?.some((e) => e.kind === "session-menu" && e.label === "PR walkthrough")).toBe(true);
 		expect((packMeta?.entrypoints ?? []).map((e) => e.listName)).not.toEqual(expect.arrayContaining(["pr-walkthrough-git-widget", "pr-walkthrough-palette"]));
 		const builtinRow = (await listInstalled()).find((p) => p.packName === PACK && p.builtin);
 		expect(builtinRow, "the built-in pack must appear in the Installed list flagged builtin").toBeTruthy();
@@ -462,7 +462,7 @@ test.describe("Built-in first-party pack — pr-walkthrough served by the built-
 		const metaAfterToolDisable = (await listContributions()).find((p) => p.packId === PACK);
 		expect(metaAfterToolDisable?.panels?.some((p) => p.id === PANEL_ID), "tool disable must not remove the pack panel").toBe(true);
 		expect(metaAfterToolDisable?.routeNames, "tool disable must not remove pack routes").toEqual(expect.arrayContaining(["bundle", "publish"]));
-		expect(metaAfterToolDisable?.entrypoints?.some((e) => e.kind === "session-menu" && e.label === "PR Walkthrough"), "tool disable must not remove entrypoints").toBe(true);
+		expect(metaAfterToolDisable?.entrypoints?.some((e) => e.kind === "session-menu" && e.label === "PR walkthrough"), "tool disable must not remove entrypoints").toBe(true);
 
 		put = page.waitForResponse((r) => r.url().includes("/api/marketplace/pack-activation") && r.request().method() === "PUT");
 		await toolToggle.click();
@@ -553,7 +553,7 @@ test.describe("Built-in first-party pack — pr-walkthrough served by the built-
 		await expectRuntimePrwTools(PRW_TOOL_NAMES);
 		await expect.poll(async () => {
 			const meta = (await listContributions()).find((p) => p.packId === PACK);
-			return meta?.entrypoints?.some((e) => e.kind === "session-menu" && e.label === "PR Walkthrough") ? "ok" : "no";
+			return meta?.entrypoints?.some((e) => e.kind === "session-menu" && e.label === "PR walkthrough") ? "ok" : "no";
 		}, { timeout: 10_000 }).toBe("ok");
 		// The deep-link resolves again from a CLEAN context (re-open the session, then
 		// navigate the bare deep-link → the panel mounts via the re-registered route).
@@ -670,7 +670,7 @@ test.describe("PR walkthrough — launch UX (NO_PR error + child-session pane)",
 		await expect(trigger, "chat header session-actions menu must be available").toBeVisible({ timeout: 10_000 });
 		await trigger.click();
 		await expect(page.locator("sidebar-actions-popover [role='menu']")).toBeVisible({ timeout: 5_000 });
-		const launcher = page.locator('sidebar-actions-popover [role="menuitem"]', { hasText: "PR Walkthrough" }).first();
+		const launcher = page.locator('sidebar-actions-popover [role="menuitem"]', { hasText: "PR walkthrough" }).first();
 		await expect(launcher, "the PR Walkthrough launcher must render in the session menu").toBeVisible({ timeout: 10_000 });
 
 		const runResp = page.waitForResponse(
@@ -710,7 +710,7 @@ test.describe("PR walkthrough — launch UX (NO_PR error + child-session pane)",
 		await expect(trigger, "inactive row session-actions trigger must be available").toBeVisible({ timeout: 10_000 });
 		await trigger.click();
 		await expect(page.locator("sidebar-actions-popover [role='menu']")).toBeVisible({ timeout: 5_000 });
-		const launcher = page.locator('sidebar-actions-popover [role="menuitem"]', { hasText: "PR Walkthrough" }).first();
+		const launcher = page.locator('sidebar-actions-popover [role="menuitem"]', { hasText: "PR walkthrough" }).first();
 		await expect(launcher, "the PR Walkthrough launcher must render for inactive rows").toBeVisible({ timeout: 10_000 });
 
 		const runResp = page.waitForResponse(

--- a/tests2/browser/e2e/pr-walkthrough-trust-prompt.spec.ts
+++ b/tests2/browser/e2e/pr-walkthrough-trust-prompt.spec.ts
@@ -81,7 +81,7 @@ async function clickPrWalkthroughLauncher(page: Page): Promise<void> {
 	await expect(trigger).toBeVisible({ timeout: 10_000 });
 	await trigger.click();
 	await expect(page.locator("sidebar-actions-popover [role='menu']")).toBeVisible({ timeout: 5_000 });
-	const launcher = page.locator('sidebar-actions-popover [role="menuitem"]', { hasText: "PR Walkthrough" }).first();
+	const launcher = page.locator('sidebar-actions-popover [role="menuitem"]', { hasText: "PR walkthrough" }).first();
 	await expect(launcher).toBeVisible({ timeout: 10_000 });
 	await launcher.click();
 }

--- a/tests2/browser/e2e/sidebar-actions-menu.spec.ts
+++ b/tests2/browser/e2e/sidebar-actions-menu.spec.ts
@@ -691,7 +691,7 @@ test.describe("Sidebar actions menu", () => {
 		await expect(page.locator("sidebar-actions-popover [role='menu']")).toBeVisible({ timeout: 5_000 });
 		await expectQuickActionHiddenAndNonInteractive(sessionModify, "mobile sidebar modify quick action");
 		await expectQuickActionHiddenAndNonInteractive(sessionTerminate, "mobile sidebar terminate quick action");
-		expect(await menuLabels(page)).toEqual(expect.arrayContaining(["Refresh agent", "Fork", "Copy link", "View System Prompt", "Open in new window"]));
+		expect(await menuLabels(page)).toEqual(expect.arrayContaining(["Refresh agent", "Fork", "Copy link", "View system prompt", "Open in new window"]));
 		await expect.poll(() => page.evaluate(() => window.location.hash), { message: "session hamburger should not select/navigate its row" }).toBe(startingHash);
 		await page.keyboard.press("Escape");
 		await expectNoPopover(page);

--- a/tests2/browser/e2e/terminal-pack.spec.ts
+++ b/tests2/browser/e2e/terminal-pack.spec.ts
@@ -44,7 +44,7 @@ test.describe("terminal pack panel", () => {
 		const contributions = await listContributions();
 		const terminal = contributions.find((p) => p.packId === "terminal");
 		expect(terminal?.panels?.some((p) => p.id === "terminal.panel")).toBe(true);
-		expect(terminal?.entrypoints?.some((e) => e.kind === "session-menu" && e.label === "Open Terminal")).toBe(true);
+		expect(terminal?.entrypoints?.some((e) => e.kind === "session-menu" && e.label === "Open terminal")).toBe(true);
 
 		await openApp(page);
 		sessionId = await createSessionViaUI(page);
@@ -875,7 +875,7 @@ async function openTerminalFromSessionMenu(page: import("@playwright/test").Page
 	await expect(trigger, "chat header session-actions menu must be available").toBeVisible({ timeout: 10_000 });
 	await trigger.click();
 	await expect(page.locator("sidebar-actions-popover [role='menu']")).toBeVisible({ timeout: 5_000 });
-	const launcher = page.locator('sidebar-actions-popover [role="menuitem"]', { hasText: "Open Terminal" }).first();
+	const launcher = page.locator('sidebar-actions-popover [role="menuitem"]', { hasText: "Open terminal" }).first();
 	await expect(launcher, "the terminal launcher must render in the session menu").toBeVisible({ timeout: 10_000 });
 	await launcher.click();
 	await expect(page.locator("sidebar-actions-popover")).toHaveCount(0, { timeout: 5_000 });

--- a/tests2/browser/fixtures/archived-session-actions.spec.ts
+++ b/tests2/browser/fixtures/archived-session-actions.spec.ts
@@ -23,7 +23,7 @@ const ARCHIVED_SAFE_ACTION_IDS = [
 const ARCHIVED_ACTION_LABELS: Record<typeof ARCHIVED_SAFE_ACTION_IDS[number], string> = {
 	"continue-archived": "Continue in new session",
 	"copy-link": "Copy link",
-	"view-system-prompt": "View System Prompt",
+	"view-system-prompt": "View system prompt",
 	"open-new-window": "Open in new window",
 };
 const ARCHIVED_READ_ONLY_ACTION_IDS = ARCHIVED_SAFE_ACTION_IDS.filter((id) => id !== "continue-archived");
@@ -33,8 +33,8 @@ const FORBIDDEN_LABELS = [
 	"End team",
 	"Refresh agent",
 	"Fork",
-	"PR Walkthrough",
-	"Open Terminal",
+	"PR walkthrough",
+	"Open terminal",
 ] as const;
 
 function sessionRow(page: Page, sessionId: string): Locator {

--- a/tests2/browser/fixtures/sidebar-actions-menu-fixture.spec.ts
+++ b/tests2/browser/fixtures/sidebar-actions-menu-fixture.spec.ts
@@ -173,13 +173,13 @@ test("session and goal menus preserve popover ordering and title contracts", asy
 	const ids = await loadFixture(page);
 
 	await openMenu(page, "session", ids.session);
-	await expect.poll(() => menuLabels(page)).toEqual(["Modify", "Terminate", "Refresh agent", "Fork", "Copy link", "View System Prompt", "Open in new window"]);
+	await expect.poll(() => menuLabels(page)).toEqual(["Modify", "Terminate", "Refresh agent", "Fork", "Copy link", "View system prompt", "Open in new window"]);
 	await expect.poll(() => menuTitleMap(page)).toMatchObject({
 		modify: "Modify session. Edit the name, colour, and Role",
 		"refresh-agent": "Restart this agent with the latest prompt, tools, and auth state",
 		fork: "Create a new session from this session's history",
 		"copy-link": "Copy a link to this session",
-		"view-system-prompt": "View System Prompt",
+		"view-system-prompt": "View system prompt",
 		"open-new-window": "Open this session in a new browser window",
 	});
 	expect((await menuTitleMap(page)).terminate).toContain("Terminate this session");
@@ -355,7 +355,7 @@ test("mobile rows expose quick actions plus hamburger menus without row navigati
 	await openMenu(page, "session", ids.session);
 	await expectQuickActionHiddenAndNonInteractive(sessionModify, "mobile sidebar modify quick action");
 	await expectQuickActionHiddenAndNonInteractive(sessionTerminate, "mobile sidebar terminate quick action");
-	await expect.poll(() => menuLabels(page)).toEqual(["Modify", "Terminate", "Refresh agent", "Fork", "Copy link", "View System Prompt", "Open in new window"]);
+	await expect.poll(() => menuLabels(page)).toEqual(["Modify", "Terminate", "Refresh agent", "Fork", "Copy link", "View system prompt", "Open in new window"]);
 	await expect(item(page, "refresh-agent")).toBeVisible();
 	await expect(item(page, "fork")).toBeVisible();
 	await expect(item(page, "copy-link")).toBeVisible();

--- a/tests2/browser/journeys/history-fork-prompt-actions.journey.spec.ts
+++ b/tests2/browser/journeys/history-fork-prompt-actions.journey.spec.ts
@@ -77,7 +77,7 @@ async function clipboardText(page: Page): Promise<string> {
 }
 
 function forkRow(page: Page): Locator {
-	return popover(page).getByRole("menuitem", { name: /Fork from history/i }).first();
+	return popover(page).getByRole("menuitem", { name: "Fork before this point" }).first();
 }
 
 function worktreeToggle(page: Page): Locator {
@@ -193,10 +193,10 @@ function pathsEqual(left: string, right: string): boolean {
 		: resolvedLeft === resolvedRight;
 }
 
-test.describe("Journey: Fork from history prompt actions", () => {
+test.describe("Journey: Fork before this point prompt actions", () => {
 	test.use({ permissions: ["clipboard-read", "clipboard-write"], hasTouch: true });
 
-	test("desktop and mobile expose copy/help/toggle controls and a failed fork does not navigate", async ({ page }) => {
+	test("desktop and mobile expose copy/tooltip/toggle controls and a failed fork does not navigate", async ({ page }) => {
 		test.setTimeout(120_000);
 		const sourceId = await createSession();
 		const requests: Array<Record<string, unknown>> = [];
@@ -207,14 +207,14 @@ test.describe("Journey: Fork from history prompt actions", () => {
 			await navigateToHash(page, `#/session/${sourceId}`);
 			await expectSourceHistory(page);
 
-			// A real later turn keeps the immediately preceding durable prompt
-			// actionable while its optimistic/id-less user row is in flight.
+			// At agent_start the authoritative cursor refresh makes the current
+			// durable prompt actionable while the assistant is still working.
 			await sendMessage(page, `STAY_BUSY:4000 ${IN_FLIGHT}`);
 			await expect(page.locator("button[title='Stop streaming']")).toBeVisible({ timeout: 20_000 });
 			await expect(promptRow(page, IN_FLIGHT)).toBeVisible({ timeout: 10_000 });
-			await expect(promptTrigger(page, IN_FLIGHT)).toHaveCount(0);
+			await expect(promptTrigger(page, IN_FLIGHT)).toBeVisible({ timeout: 10_000 });
 			await expect(promptTrigger(page, LATER)).toBeVisible();
-			await openPromptActions(page, LATER);
+			await openPromptActions(page, IN_FLIGHT);
 			await page.keyboard.press("Escape");
 			await expect(popover(page)).toHaveCount(0);
 			await waitForSessionStatus(sourceId, "idle", 20_000);
@@ -233,19 +233,10 @@ test.describe("Journey: Fork from history prompt actions", () => {
 			// original prompt string, including newlines, slash syntax, and @path.
 			await expect(promptTrigger(page)).toBeVisible();
 			await openPromptActions(page);
-			const help = popover(page).getByRole("menuitem", { name: "About Fork from history" });
-			await help.hover();
-			await expect(page.getByRole("tooltip")).toHaveText(TOOLTIP);
-			await help.focus();
-			await expect(page.getByRole("tooltip")).toHaveText(TOOLTIP);
-			await page.keyboard.press("Escape");
-			await expect(popover(page)).toHaveCount(0);
-
-			await openPromptActions(page);
-			await page.keyboard.press("ArrowDown");
-			await expect(popover(page).getByRole("menuitem", { name: "About Fork from history" })).toBeFocused();
-			await page.keyboard.press("Enter");
-			await expect(page.getByRole("tooltip")).toHaveText(TOOLTIP);
+			await expect(forkRow(page)).toHaveText("Fork before this point");
+			await expect(forkRow(page)).toHaveAttribute("title", TOOLTIP);
+			await expect(popover(page).locator("[data-sidebar-actions-help]")).toHaveCount(0);
+			await expect(popover(page)).not.toContainText("(?)");
 			await page.keyboard.press("Escape");
 			await expect(popover(page)).toHaveCount(0);
 
@@ -254,15 +245,12 @@ test.describe("Journey: Fork from history prompt actions", () => {
 			await expect.poll(() => clipboardText(page)).toBe(SELECTED);
 			await expect(page.getByText("Prompt copied", { exact: true })).toBeVisible();
 
-			// Mobile uses the same overflow and menu. Clicking the help stop models
-			// the touch/pinned interaction and must neither fork nor dismiss.
+			// Mobile uses the same overflow, label, and native row tooltip.
 			await page.setViewportSize({ width: 390, height: 844 });
 			await expect(promptTrigger(page)).toBeVisible();
 			await openPromptActions(page);
-			const mobileHelp = popover(page).getByRole("menuitem", { name: "About Fork from history" });
-			await mobileHelp.click();
-			await expect(page.getByRole("tooltip")).toHaveText(TOOLTIP);
-			await expect(popover(page).getByRole("menu")).toBeVisible();
+			await expect(forkRow(page)).toHaveAttribute("title", TOOLTIP);
+			await expect(popover(page).locator("[data-sidebar-actions-help]")).toHaveCount(0);
 			await popover(page).getByRole("menuitem", { name: "Copy prompt" }).click();
 			await expect.poll(() => clipboardText(page)).toBe(SELECTED);
 			await openPromptActions(page);

--- a/tests2/browser/journeys/sidebar-nav.journey.spec.ts
+++ b/tests2/browser/journeys/sidebar-nav.journey.spec.ts
@@ -257,13 +257,14 @@ test.describe("Journey: Sidebar Navigation", () => {
 	});
 
 	// Ported from sidebar-filters.spec.ts (audit: sidebar-nav GAP / BR58): the
-	// Filters popover exposes a "Show Read" toggle row with its stable testid.
-	test("Filters popover exposes the Show Read toggle", async ({ page }) => {
+	// Filters popover exposes a sentence-cased "Show read" toggle row with its stable testid.
+	test("Filters popover exposes the Show read toggle", async ({ page }) => {
 		await openApp(page);
 		await expect(filtersButton(page)).toBeVisible({ timeout: 10_000 });
 		await openFiltersPopover(page);
 		const readToggle = page.locator("[data-testid='sidebar-filter-read']").first();
 		await expect(readToggle).toBeVisible({ timeout: 10_000 });
+		await expect(readToggle).toContainText("Show read");
 		await expect(readToggle.locator("input[type='checkbox']")).toHaveCount(1);
 	});
 

--- a/tests2/core/extension-host-terminal.test.ts
+++ b/tests2/core/extension-host-terminal.test.ts
@@ -34,7 +34,7 @@ describe("built-in terminal pack", () => {
 		const contributions = loadPackContributions(root, manifest);
 		assert.equal(contributions.panels[0]?.id, "terminal.panel");
 		const sessionMenu = contributions.entrypoints.find((e) => e.kind === "session-menu");
-		assert.equal(sessionMenu?.label, "Open Terminal");
+		assert.equal(sessionMenu?.label, "Open terminal");
 		assert.equal((sessionMenu as any)?.icon, "terminal");
 		assert.deepEqual(sessionMenu?.target, {
 			action: "channel-panel",

--- a/tests2/core/file-explorer-pack.test.ts
+++ b/tests2/core/file-explorer-pack.test.ts
@@ -74,7 +74,7 @@ describe("built-in file explorer pack shipping", () => {
 		});
 		expect(enabled.getEntrypoint(undefined, "file-explorer", "file-explorer.session-menu")).toMatchObject({
 			kind: "session-menu",
-			label: "Open File Explorer",
+			label: "Open file explorer",
 			icon: "folder-tree",
 			target: { panelId: "file-explorer.panel" },
 		});

--- a/tests2/core/history-fork-transcript.test.ts
+++ b/tests2/core/history-fork-transcript.test.ts
@@ -46,8 +46,8 @@ function jsonl(entries: TranscriptEntry[], trailingNewline = true): string {
 	return entries.map((entry) => JSON.stringify(entry)).join("\n") + (trailingNewline ? "\n" : "");
 }
 
-function materialize(source: string, entryId: string, sourceStreaming = false) {
-	return materializeHistoryForkTranscript(source, entryId, { sourceStreaming });
+function materialize(source: string, entryId: string) {
+	return materializeHistoryForkTranscript(source, entryId);
 }
 
 function expectValidationError(
@@ -55,11 +55,10 @@ function expectValidationError(
 	entryId: string,
 	code: string,
 	status: number,
-	sourceStreaming = false,
 ): HistoryForkValidationError {
 	let thrown: unknown;
 	try {
-		materialize(source, entryId, sourceStreaming);
+		materialize(source, entryId);
 	} catch (error) {
 		thrown = error;
 	}
@@ -244,7 +243,7 @@ describe("history fork transcript materialization", () => {
 		expectValidationError(source, "selected", "HISTORY_FORK_CURSOR_NOT_USER", 422);
 	});
 
-	it("rejects only the newest ordinary user entry while streaming", () => {
+	it("cuts safely before the newest ordinary user entry while streaming", () => {
 		const source = jsonl([
 			session(),
 			user("older-user", null),
@@ -253,10 +252,15 @@ describe("history fork transcript materialization", () => {
 			assistant("partial-reply", "current-user"),
 		]);
 
-		const older = materialize(source, "older-user", true);
+		const older = materialize(source, "older-user");
 		assert.equal(older.content, `${JSON.stringify(session())}\n`);
-		expectValidationError(source, "current-user", "HISTORY_FORK_CURSOR_IN_FLIGHT", 409, true);
-		assert.equal(materialize(source, "current-user", false).selected.id, "current-user");
+		const current = materialize(source, "current-user");
+		assert.equal(current.selected.id, "current-user");
+		assert.equal(current.content, jsonl([
+			session(),
+			user("older-user", null),
+			assistant("older-reply", "older-user"),
+		]));
 	});
 
 	it.each([

--- a/tests2/core/session-manager-snapshot-memo.test.ts
+++ b/tests2/core/session-manager-snapshot-memo.test.ts
@@ -456,6 +456,61 @@ describe("SessionManager snapshot memo", () => {
 		expect(live.messagesSnapshotCache.seq).toBe(1);
 	});
 
+	it("fences a stale cursor refresh after a newer snapshot wins", async () => {
+		const oldMessages = deferred<any>();
+		const oldCursors = deferred<any>();
+		const newMessages = deferred<any>();
+		const newCursors = deferred<any>();
+		const messageReads = [oldMessages, newMessages];
+		const cursorReads = [oldCursors, newCursors];
+		const getMessages = vi.fn(() => messageReads.shift()!.promise);
+		const getCursors = vi.fn(() => cursorReads.shift()!.promise);
+		const sends: string[] = [];
+		const client = { readyState: 1, send: (payload: string) => sends.push(payload) };
+		const value = manager();
+		const live = session(getMessages, getCursors);
+		live.clients.add(client);
+		live.pendingSkillTranscriptBindings = [{
+			recordId: "pending-record",
+			promptId: "pending-prompt",
+			modelText: "prompt",
+			messageIdentity: { id: "user-message" },
+		}];
+		value.sessions.set(live.id, live);
+
+		value.schedulePromptCursorRefresh(live, { settleBindings: true });
+		await vi.waitFor(() => expect(getMessages).toHaveBeenCalledOnce());
+		live.eventBuffer.push({ type: "message_update" });
+		value.schedulePromptCursorRefresh(live);
+		await vi.waitFor(() => expect(getMessages).toHaveBeenCalledTimes(2));
+
+		newMessages.resolve({ success: true, data: [
+			{ id: "user-message", role: "user", content: "prompt" },
+			{ id: "assistant-message", role: "assistant", content: "new answer" },
+		] });
+		newCursors.resolve({ success: true, data: {
+			entries: [userEntry("new-user", null, "prompt"), assistantEntry("new-answer", "new-user", "new answer")],
+			leafId: "new-answer",
+			forkMessages: [{ entryId: "new-user", text: "prompt" }],
+		} });
+		await vi.waitFor(() => expect(sends).toHaveLength(1));
+		const winningFrame = JSON.parse(sends[0]);
+		expect(winningFrame.data[0]).toMatchObject({ entryId: "new-user", _entryIdSource: "pi-transcript" });
+		expect(winningFrame.data[1]).toMatchObject({ content: "new answer" });
+
+		oldMessages.resolve({ success: true, data: [
+			{ id: "user-message", role: "user", content: "prompt" },
+		] });
+		oldCursors.resolve({ success: true, data: {
+			entries: [userEntry("old-user", null, "prompt")],
+			leafId: "old-user",
+			forkMessages: [{ entryId: "old-user", text: "prompt" }],
+		} });
+		await new Promise((resolve) => setImmediate(resolve));
+		expect(sends).toHaveLength(1);
+		expect(live.pendingSkillTranscriptBindings).toHaveLength(1);
+	});
+
 	it("refreshes compaction messages and cursors as one fresh authoritative pair", async () => {
 		const visibleMessages = [
 			{ role: "user", content: "same prompt" },

--- a/tests2/core/session-manager-snapshot-memo.test.ts
+++ b/tests2/core/session-manager-snapshot-memo.test.ts
@@ -324,7 +324,7 @@ describe("SessionManager snapshot memo", () => {
 		});
 		expect(live.pendingSkillTranscriptBindings).toHaveLength(1);
 
-		value.scheduleSettledPromptCursorRefresh(live);
+		value.schedulePromptCursorRefresh(live, { settleBindings: true });
 		await vi.waitFor(() => expect(readSkillSidecarEntries(live.id)[0]).toMatchObject({
 			recordId,
 			transcriptEntryId: "pi-user",
@@ -365,15 +365,40 @@ describe("SessionManager snapshot memo", () => {
 			message: { role: "user", content: "duplicate", timestamp: 7 },
 		});
 
-		value.scheduleSettledPromptCursorRefresh(live);
+		value.schedulePromptCursorRefresh(live, { settleBindings: true });
 		await vi.waitFor(() => expect(getCursors).toHaveBeenCalledOnce());
 		await new Promise((resolve) => setImmediate(resolve));
 		expect(readSkillSidecarEntries(live.id)[0]).not.toHaveProperty("transcriptEntryId");
 	});
 
-	it("schedules cursor enrichment only at the final agent lifecycle boundary", () => {
+	it("does not consume pending skill bindings during the agent-start cursor refresh", async () => {
+		const getCursors = vi.fn(async () => ({ success: true, data: {
+			entries: [userEntry("pi-user", null, "prompt")],
+			leafId: "pi-user",
+			forkMessages: [{ entryId: "pi-user", text: "prompt" }],
+		} }));
+		const value = manager();
+		const live = session(async () => ({ success: true, data: [
+			{ id: "inner-user", role: "user", content: "prompt" },
+		] }), getCursors);
+		live.pendingSkillTranscriptBindings = [{
+			recordId: "skill-record",
+			promptId: "prompt-id",
+			modelText: "prompt",
+			messageIdentity: { id: "inner-user" },
+		}];
+		value.sessions.set(live.id, live);
+
+		value.schedulePromptCursorRefresh(live);
+		await vi.waitFor(() => expect(getCursors).toHaveBeenCalledOnce());
+		expect(live.pendingSkillTranscriptBindings).toHaveLength(1);
+	});
+
+	it("schedules cursor enrichment at agent start and a settling fallback at final agent end", () => {
 		const value = manager();
 		value._sessionReplacementCoordinators = new Map();
+		value._bootRepromptedSessions = new Set();
+		value.clock = { now: () => 1 };
 		value._sessionWriterIsCurrent = () => true;
 		value._consumeSteerEcho = () => undefined;
 		value.resolveStoreForSession = () => ({
@@ -383,17 +408,19 @@ describe("SessionManager snapshot memo", () => {
 		value.resolveIdleWaiters = () => undefined;
 		value.drainQueue = () => undefined;
 		value._finishSessionSetup = async () => undefined;
-		value.scheduleSettledPromptCursorRefresh = vi.fn();
+		value.schedulePromptCursorRefresh = vi.fn();
 		const live = session(async () => ({ success: true, data: [] }));
 		live.status = "streaming";
 		live.promptQueue = { dequeueAllSteered: () => [] };
 		value.sessions.set(live.id, live);
 
+		value.handleAgentLifecycle(live, { type: "agent_start" });
+		expect(value.schedulePromptCursorRefresh).toHaveBeenCalledWith(live);
 		value.handleAgentLifecycle(live, { type: "agent_end", messages: [], willRetry: true });
-		expect(value.scheduleSettledPromptCursorRefresh).not.toHaveBeenCalled();
+		expect(value.schedulePromptCursorRefresh).toHaveBeenCalledOnce();
 		value.handleAgentLifecycle(live, { type: "agent_end", messages: [], willRetry: false });
-		expect(value.scheduleSettledPromptCursorRefresh).toHaveBeenCalledOnce();
-		expect(value.scheduleSettledPromptCursorRefresh).toHaveBeenCalledWith(live);
+		expect(value.schedulePromptCursorRefresh).toHaveBeenCalledTimes(2);
+		expect(value.schedulePromptCursorRefresh).toHaveBeenLastCalledWith(live, { settleBindings: true });
 	});
 
 	it("broadcasts a cursor-enriched replacement after the settled event sequence advances", async () => {
@@ -417,7 +444,7 @@ describe("SessionManager snapshot memo", () => {
 		live.clients.add(client);
 		value.sessions.set(live.id, live);
 
-		value.scheduleSettledPromptCursorRefresh(live);
+		value.schedulePromptCursorRefresh(live, { settleBindings: true });
 		live.eventBuffer.push({ type: "agent_end" });
 		await vi.waitFor(() => expect(sends.length).toBe(1));
 		const frame = JSON.parse(sends[0]);

--- a/tests2/core/session-manager-snapshot-memo.test.ts
+++ b/tests2/core/session-manager-snapshot-memo.test.ts
@@ -505,8 +505,15 @@ describe("SessionManager snapshot memo", () => {
 		const value = manager();
 		const live = session(getMessages, getCursors);
 		live.clients.add(client);
+		const recordId = appendIdentifiedSkillSidecarEntry(live.id, {
+			ts: 1,
+			modelText: "prompt",
+			originalText: "/pending",
+			skillExpansions: [],
+		});
+		assert.ok(recordId);
 		live.pendingSkillTranscriptBindings = [{
-			recordId: "pending-record",
+			recordId,
 			promptId: "pending-prompt",
 			modelText: "prompt",
 			messageIdentity: { id: "user-message" },
@@ -541,9 +548,12 @@ describe("SessionManager snapshot memo", () => {
 			leafId: "old-user",
 			forkMessages: [{ entryId: "old-user", text: "prompt" }],
 		} });
-		await new Promise((resolve) => setImmediate(resolve));
+		await vi.waitFor(() => expect(readSkillSidecarEntries(live.id)[0]).toMatchObject({
+			recordId,
+			transcriptEntryId: "old-user",
+		}));
 		expect(sends).toHaveLength(1);
-		expect(live.pendingSkillTranscriptBindings).toHaveLength(1);
+		expect(live.pendingSkillTranscriptBindings).toHaveLength(0);
 	});
 
 	it("refreshes compaction messages and cursors as one fresh authoritative pair", async () => {

--- a/tests2/core/session-manager-snapshot-memo.test.ts
+++ b/tests2/core/session-manager-snapshot-memo.test.ts
@@ -456,6 +456,41 @@ describe("SessionManager snapshot memo", () => {
 		expect(live.messagesSnapshotCache.seq).toBe(1);
 	});
 
+	it("keeps the sole mid-turn cursor refresh when streaming events advance", async () => {
+		const messages = deferred<any>();
+		const cursors = deferred<any>();
+		const getMessages = vi.fn(() => messages.promise);
+		const getCursors = vi.fn(() => cursors.promise);
+		const sends: string[] = [];
+		const client = { readyState: 1, send: (payload: string) => sends.push(payload) };
+		const value = manager();
+		const live = session(getMessages, getCursors);
+		live.clients.add(client);
+		value.sessions.set(live.id, live);
+
+		value.schedulePromptCursorRefresh(live);
+		await vi.waitFor(() => expect(getMessages).toHaveBeenCalledOnce());
+		live.latestMessageUpdate = {
+			id: "assistant-message",
+			message: { id: "assistant-message", role: "assistant", content: "live answer" },
+		};
+		live.eventBuffer.push({ type: "message_update" });
+		messages.resolve({ success: true, data: [
+			{ id: "user-message", role: "user", content: "prompt" },
+		] });
+		cursors.resolve({ success: true, data: {
+			entries: [userEntry("pi-user", null, "prompt")],
+			leafId: "pi-user",
+			forkMessages: [{ entryId: "pi-user", text: "prompt" }],
+		} });
+
+		await vi.waitFor(() => expect(sends).toHaveLength(1));
+		const frame = JSON.parse(sends[0]);
+		expect(frame.data[0]).toMatchObject({ entryId: "pi-user", _entryIdSource: "pi-transcript" });
+		expect(frame.data[1]).toMatchObject({ content: "live answer" });
+		expect(getMessages).toHaveBeenCalledOnce();
+	});
+
 	it("fences a stale cursor refresh after a newer snapshot wins", async () => {
 		const oldMessages = deferred<any>();
 		const oldCursors = deferred<any>();

--- a/tests2/dom/prompt-history-actions.test.ts
+++ b/tests2/dom/prompt-history-actions.test.ts
@@ -115,9 +115,9 @@ function menuLabels(popover: ParentNode): string[] {
 }
 
 describe("history prompt eligibility", () => {
-	it("fails closed across the role, provenance, cursor, forkability, pending, and current-turn matrix", () => {
+	it("fails closed across the role, provenance, cursor, forkability, and pending matrix", () => {
 		const eligible = durablePrompt("entry-eligible");
-		const context = { canForkSource: true, isStreaming: false, currentStreamingUserEntryId: "entry-newest" };
+		const context = { canForkSource: true };
 		expect(isEligibleHistoryPrompt(eligible, context)).toBe(true);
 
 		const ineligible = [
@@ -138,17 +138,7 @@ describe("history prompt eligibility", () => {
 		for (const message of ineligible) {
 			expect(isEligibleHistoryPrompt(message, context), JSON.stringify(message)).toBe(false);
 		}
-		expect(isEligibleHistoryPrompt(eligible, { ...context, canForkSource: false })).toBe(false);
-		expect(isEligibleHistoryPrompt(eligible, {
-			...context,
-			isStreaming: true,
-			currentStreamingUserEntryId: eligible.entryId,
-		})).toBe(false);
-		expect(isEligibleHistoryPrompt(eligible, {
-			...context,
-			isStreaming: true,
-			currentStreamingUserEntryId: "later-entry",
-		})).toBe(true);
+		expect(isEligibleHistoryPrompt(eligible, { canForkSource: false })).toBe(false);
 	});
 
 	it("renders actions only for eligible durable historic rows", async () => {
@@ -169,8 +159,8 @@ describe("history prompt eligibility", () => {
 			durablePrompt("older"),
 			durablePrompt("current"),
 		], { isStreaming: true });
-		expect(promptTriggers(streaming)).toHaveLength(1);
-		expect(promptTriggers(streaming)[0].closest("user-message")?.textContent).toContain("older");
+		expect(promptTriggers(streaming)).toHaveLength(2);
+		expect(promptTriggers(streaming)[1].closest("user-message")?.textContent).toContain("current");
 
 		document.body.innerHTML = "";
 		const nonForkable = await renderList([durablePrompt("archived-source")], { canForkSource: false });
@@ -204,22 +194,15 @@ describe("history prompt eligibility", () => {
 		expect(actionRow(reopened, "history-fork")).toBeTruthy();
 	});
 
-	it("excludes only a trusted durable current row while streaming and restores it when settled", async () => {
+	it("keeps a trusted durable current row actionable while streaming", async () => {
 		const prior = durablePrompt("prior-trusted");
 		const current = durablePrompt("current-trusted");
 		const list = await renderList([prior, current], { isStreaming: true });
 
-		expect(promptTriggers(list)).toHaveLength(1);
-		expect(promptTriggers(list)[0].closest("user-message")?.textContent).toContain("prior-trusted");
-		const popover = await openPromptMenu(promptTriggers(list)[0]);
-
-		list.isStreaming = false;
-		await list.updateComplete;
-		await settle();
-
 		expect(promptTriggers(list)).toHaveLength(2);
 		expect(promptTriggers(list)[1].closest("user-message")?.textContent).toContain("current-trusted");
-		expect(popover.isConnected).toBe(true);
+		const popover = await openPromptMenu(promptTriggers(list)[1]);
+		expect(actionRow(popover, "history-fork")).toBeTruthy();
 	});
 });
 
@@ -256,7 +239,7 @@ describe("history prompt trigger and canonical menu", () => {
 			});
 		}
 		expect(snapshots[0]).toEqual(snapshots[1]);
-		expect(snapshots[0].labels).toEqual(["Fork from history", "Copy prompt"]);
+		expect(snapshots[0].labels).toEqual(["Fork before this point", "Copy prompt"]);
 	});
 
 	it("places the same trigger beside both legacy and author-labelled bubbles", async () => {
@@ -302,30 +285,15 @@ describe("history prompt trigger and canonical menu", () => {
 		expect(forks).toEqual([{ entryId: "toggle-entry", newWorktree: false }]);
 	});
 
-	it("keeps help pointer/touch/keyboard interactions exact and nonactivating", async () => {
+	it("puts the fork explanation in the row tooltip without a separate help control", async () => {
 		const list = await renderList([durablePrompt("help-entry")]);
-		const forks: any[] = [];
-		list.addEventListener("prompt-history-fork", (event: Event) => forks.push((event as CustomEvent).detail));
 		const popover = await openPromptMenu(promptTriggers(list)[0]);
-		const help = popover.querySelector<HTMLElement>("[aria-label='About Fork from history']")!;
-		const toggle = popover.querySelector<HTMLElement>("[role='menuitemcheckbox']")!;
+		const fork = actionRow(popover, "history-fork");
 
-		help.dispatchEvent(new MouseEvent("mouseenter"));
-		await settle();
-		expect(popover.querySelector("[role='tooltip']")?.textContent?.trim()).toBe(HELP_TEXT);
-		help.click();
-		help.blur();
-		await settle();
-		expect(popover.querySelector("[role='tooltip']")?.textContent?.trim()).toBe(HELP_TEXT);
-		expect(forks).toEqual([]);
-		expect(toggle.getAttribute("aria-checked")).toBe("false");
-		expect((popover as any).open).toBe(true);
-
-		help.focus();
-		document.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true, cancelable: true }));
-		await settle();
-		expect(forks).toEqual([]);
-		expect((popover as any).open).toBe(true);
+		expect(fork.textContent?.trim()).toBe("Fork before this point");
+		expect(fork.getAttribute("title")).toBe(HELP_TEXT);
+		expect(popover.querySelector("[data-sidebar-actions-help]")).toBeNull();
+		expect(popover.textContent).not.toContain("(?)");
 	});
 
 	it("restores trigger focus after Escape and suppresses duplicate select dispatch", async () => {

--- a/tests2/integration/history-fork-api.test.ts
+++ b/tests2/integration/history-fork-api.test.ts
@@ -568,19 +568,23 @@ test.describe("history fork API", () => {
 		expect(gateway.sessionManager.getPersistedSession(unavailableId).agentSessionFile).toBe(maliciousStoredPath);
 	});
 
-	test("rejects the newest durable user cursor while the source is streaming", async ({ gateway }) => {
+	test("forks safely before the newest durable user cursor while the source is streaming", async ({ gateway }) => {
 		const sourceId = await createTrackedSession();
-		seedTranscript(gateway, sourceId, ordinaryHistory());
+		const seeded = seedTranscript(gateway, sourceId, ordinaryHistory());
 		const source = gateway.sessionManager.getSession(sourceId);
 		const previousStatus = source.status;
 		source.status = "streaming";
 		try {
 			const response = await historyFork(gateway, sourceId, "selected-user");
-			expect(response.status).toBe(409);
-			expect(await responseJson(response)).toEqual({
-				error: "The current prompt cannot be forked until the turn finishes",
-				code: "HISTORY_FORK_CURSOR_IN_FLIGHT",
-			});
+			expect(response.status, JSON.stringify(await responseJson(response))).toBe(201);
+			const fork = await response.json();
+			sessions.add(fork.id);
+			const forkPersisted = gateway.sessionManager.getPersistedSession(fork.id);
+			const forkTranscript = fs.readFileSync(forkPersisted.agentSessionFile, "utf8");
+			expect(forkTranscript).toContain("retained prompt");
+			expect(forkTranscript).not.toContain("selected prompt");
+			expect(fs.readFileSync(seeded.file, "utf8")).toBe(seeded.content);
+			expect(source.status).toBe("streaming");
 		} finally {
 			source.status = previousStatus;
 		}


### PR DESCRIPTION
## Summary
- rename the prompt action to `Fork before this point` and move its explanation into the row tooltip
- expose the newest durable prompt action at agent start and permit exact-before forks while the turn is streaming
- standardize related overflow, sidebar, header, and first-party pack menu labels to sentence case

## Testing
- `npm run test:unit` — 10,246 passed, 17 skipped
- `npm run test:browser` — 727 passed, 9 skipped, 1 flaky passed on retry
- `npm run test:e2e` — all four phases passed; 181 Vitest tests passed, 1 skipped
- `npm run check`

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)