### PR TITLE
Fix prompt metadata layout

### DIFF
--- a/src/app/settings-page.ts
+++ b/src/app/settings-page.ts
@@ -2760,7 +2760,7 @@ function renderGeneralTab() {
 					<span class="text-sm font-medium text-foreground">Show message timestamps</span>
 				</label>
 				<p class="text-xs text-muted-foreground ml-6">
-					Display timestamps next to user and assistant messages.
+					Display timestamps with user and assistant messages.
 				</p>
 			</div>
 			<div class="flex flex-col gap-1.5">

--- a/src/ui/app.css
+++ b/src/ui/app.css
@@ -4411,23 +4411,39 @@ html {
 	padding-left: 24px;
 	box-shadow: 0 1px 4px var(--user-msg-shadow), 0 2px 8px var(--user-msg-shadow2);
 }
-/* Historic prompt actions share one always-visible trigger on desktop and touch. */
+/* Prompt metadata sits below the bubble so it never reduces the readable width. */
 .prompt-row {
-	align-items: flex-end;
+	align-items: flex-start;
 	min-width: 0;
 	max-width: 100%;
 }
 
-.prompt-row > .user-message-container,
-user-message > div > .user-message-container {
+.prompt-content-column {
+	display: flex;
 	flex: 0 1 auto;
+	flex-direction: column;
+	align-items: flex-start;
+	width: fit-content;
+	min-width: 0;
+	max-width: 100%;
+}
+
+.prompt-content-column > .user-message-container {
+	flex: 0 1 auto;
+	min-width: 0;
+}
+
+.prompt-metadata-row {
+	display: flex;
+	align-items: center;
+	align-self: flex-end;
+	justify-content: flex-end;
 	min-width: 0;
 }
 
 .prompt-actions-trigger-wrap {
 	display: grid;
 	place-items: center;
-	align-self: flex-end;
 	flex: 0 0 32px;
 	width: 32px;
 	height: 32px;
@@ -4540,9 +4556,6 @@ user-message > div > .user-message-container {
 /* Prompt author attribution. The badge and bubble share one grid cell so the
    badge participates in intrinsic width while remaining over the top border. */
 .prompt-row--labelled {
-	align-items: flex-end;
-	min-width: 0;
-	max-width: 100%;
 	padding-top: 2px;
 }
 
@@ -4676,7 +4689,8 @@ user-message > div > .user-message-container {
 	letter-spacing: 0.07em;
 }
 
-.prompt-row--labelled > .message-timestamp {
+.prompt-metadata-row > .message-timestamp {
+	align-self: auto;
 	flex-shrink: 0;
 }
 

--- a/src/ui/components/Messages.ts
+++ b/src/ui/components/Messages.ts
@@ -361,15 +361,18 @@ export class UserMessage extends LitElement {
 			? presentPromptAuthor(this.message.author)
 			: undefined;
 		if (!presentation) {
-			// Keep the historical all-human/legacy markup and compact geometry exact.
 			return html`
-				<div class="flex justify-start mx-2 sm:mx-4 my-1">
-					<div class="user-message-container py-2 px-3 sm:px-4">
-						${body}
-						${attachments}
+				<div class="prompt-row flex justify-start mx-2 sm:mx-4 my-1">
+					<div class="prompt-content-column">
+						<div class="user-message-container py-2 px-3 sm:px-4">
+							${body}
+							${attachments}
+						</div>
+						<div class="prompt-metadata-row">
+							${this._renderPromptActionsTrigger()}
+							<span class="message-timestamp">${formatTimestamp(this.message.timestamp)}</span>
+						</div>
 					</div>
-					${this._renderPromptActionsTrigger()}
-					<span class="message-timestamp">${formatTimestamp(this.message.timestamp)}</span>
 				</div>
 			`;
 		}
@@ -414,15 +417,19 @@ export class UserMessage extends LitElement {
 		`;
 		return html`
 			<div class="prompt-row prompt-row--labelled flex justify-start mx-2 sm:mx-4 my-1">
-				<div class="prompt-bubble-shell">
-					${authorBadge}
-					<div class="user-message-container user-message-container--labelled py-2 px-3 sm:px-4">
-						${body}
-						${attachments}
+				<div class="prompt-content-column">
+					<div class="prompt-bubble-shell">
+						${authorBadge}
+						<div class="user-message-container user-message-container--labelled py-2 px-3 sm:px-4">
+							${body}
+							${attachments}
+						</div>
+					</div>
+					<div class="prompt-metadata-row">
+						${this._renderPromptActionsTrigger()}
+						<span class="message-timestamp">${formatTimestamp(this.message.timestamp)}</span>
 					</div>
 				</div>
-				${this._renderPromptActionsTrigger()}
-				<span class="message-timestamp">${formatTimestamp(this.message.timestamp)}</span>
 			</div>
 		`;
 	}

--- a/tests2/browser/journeys/author-metadata.journey.spec.ts
+++ b/tests2/browser/journeys/author-metadata.journey.spec.ts
@@ -185,8 +185,11 @@ async function expectAuthorBadgeGeometry(page: Page): Promise<void> {
 		rows: Array.from(document.querySelectorAll("user-message .prompt-row--labelled")).map((row) => {
 			const rowRect = row.getBoundingClientRect();
 			const badgeRect = row.querySelector(".prompt-author-badge")!.getBoundingClientRect();
+			const shellRect = row.querySelector(".prompt-bubble-shell")!.getBoundingClientRect();
 			const bubble = row.querySelector(".user-message-container--labelled")!;
 			const bubbleRect = bubble.getBoundingClientRect();
+			const footerRect = row.querySelector(".prompt-metadata-row")!.getBoundingClientRect();
+			const timestampRect = row.querySelector(".message-timestamp")!.getBoundingClientRect();
 			return {
 				left: rowRect.left,
 				right: rowRect.right,
@@ -196,6 +199,11 @@ async function expectAuthorBadgeGeometry(page: Page): Promise<void> {
 				rowTop: rowRect.top,
 				badgeBottom: badgeRect.bottom,
 				bubbleTop: bubbleRect.top,
+				bubbleBottom: bubbleRect.bottom,
+				shellRight: shellRect.right,
+				footerTop: footerRect.top,
+				footerRight: footerRect.right,
+				timestampRight: timestampRect.right,
 				chevronTop: getComputedStyle(bubble, "::before").top,
 			};
 		}),
@@ -209,6 +217,9 @@ async function expectAuthorBadgeGeometry(page: Page): Promise<void> {
 		expect(row.badgeTop).toBeGreaterThanOrEqual(row.rowTop);
 		expect(row.badgeBottom).toBeGreaterThan(row.bubbleTop);
 		expect(row.badgeHeight).toBeCloseTo(24, 1);
+		expect(row.footerTop).toBeGreaterThanOrEqual(row.bubbleBottom - 0.5);
+		expect(row.footerRight).toBeCloseTo(row.shellRight, 0);
+		expect(row.timestampRight).toBeCloseTo(row.footerRight, 0);
 		expect(row.chevronTop).toBe("19px");
 	}
 }

--- a/tests2/browser/journeys/history-fork-prompt-actions.journey.spec.ts
+++ b/tests2/browser/journeys/history-fork-prompt-actions.journey.spec.ts
@@ -93,6 +93,28 @@ async function openPromptActions(page: Page, marker?: string): Promise<void> {
 	await expect(popover(page).getByRole("menuitem", { name: "Copy prompt" })).toBeVisible();
 }
 
+async function expectPromptControlsBelowBubble(page: Page, marker?: string): Promise<void> {
+	const geometry = await promptRow(page, marker).evaluate((row) => {
+		const bubble = row.querySelector(".user-message-container")!.getBoundingClientRect();
+		const footer = row.querySelector(".prompt-metadata-row")!.getBoundingClientRect();
+		const trigger = row.querySelector("[data-prompt-actions-trigger]")!.getBoundingClientRect();
+		const timestamp = row.querySelector(".message-timestamp")!;
+		const timestampRect = getComputedStyle(timestamp).display === "none"
+			? undefined
+			: timestamp.getBoundingClientRect();
+		return {
+			bubbleBottom: bubble.bottom,
+			bubbleRight: bubble.right,
+			footerTop: footer.top,
+			footerRight: footer.right,
+			controlsRight: Math.max(trigger.right, timestampRect?.right ?? 0),
+		};
+	});
+	expect(geometry.footerTop).toBeGreaterThanOrEqual(geometry.bubbleBottom - 0.5);
+	expect(geometry.footerRight).toBeCloseTo(geometry.bubbleRight, 0);
+	expect(geometry.controlsRight).toBeCloseTo(geometry.footerRight, 0);
+}
+
 async function expectSourceHistory(page: Page): Promise<void> {
 	for (const marker of [RETAINED, "HISTORY_FORK_SELECTED_BRAVO", LATER]) {
 		await expect(promptRow(page, marker)).toBeVisible({ timeout: 20_000 });
@@ -206,6 +228,7 @@ test.describe("Journey: Fork before this point prompt actions", () => {
 			await openApp(page);
 			await navigateToHash(page, `#/session/${sourceId}`);
 			await expectSourceHistory(page);
+			await expectPromptControlsBelowBubble(page);
 
 			// At agent_start the authoritative cursor refresh makes the current
 			// durable prompt actionable while the assistant is still working.
@@ -248,6 +271,7 @@ test.describe("Journey: Fork before this point prompt actions", () => {
 			// Mobile uses the same overflow, label, and native row tooltip.
 			await page.setViewportSize({ width: 390, height: 844 });
 			await expect(promptTrigger(page)).toBeVisible();
+			await expectPromptControlsBelowBubble(page);
 			await openPromptActions(page);
 			await expect(forkRow(page)).toHaveAttribute("title", TOOLTIP);
 			await expect(popover(page).locator("[data-sidebar-actions-help]")).toHaveCount(0);

--- a/tests2/dom/message-author-labels.test.ts
+++ b/tests2/dom/message-author-labels.test.ts
@@ -135,7 +135,7 @@ describe("prompt author badge DOM", () => {
 		const list = await renderMessageList([prompt("human", USER)]);
 		expect(list.querySelector(".prompt-author-badge")).toBeNull();
 		expect(list.querySelector(".prompt-bubble-shell")).toBeNull();
-		expect(list.querySelector("user-message > div")?.className).toBe("flex justify-start mx-2 sm:mx-4 my-1");
+		expect(list.querySelector("user-message > div")?.className).toBe("prompt-row flex justify-start mx-2 sm:mx-4 my-1");
 	});
 
 	it("renders exact contextual User, exact System, and agent label/kind strings", async () => {

--- a/tests2/dom/prompt-history-actions.test.ts
+++ b/tests2/dom/prompt-history-actions.test.ts
@@ -242,11 +242,15 @@ describe("history prompt trigger and canonical menu", () => {
 		expect(snapshots[0].labels).toEqual(["Fork before this point", "Copy prompt"]);
 	});
 
-	it("places the same trigger beside both legacy and author-labelled bubbles", async () => {
+	it("places prompt actions and timestamps in a right-aligned footer beneath every bubble", async () => {
 		const legacy = await renderList([durablePrompt("legacy")]);
 		const legacyTrigger = promptTriggers(legacy)[0];
+		const legacyFooter = legacyTrigger.closest(".prompt-metadata-row");
 		expect(legacyTrigger.closest(".user-message-container")).toBeNull();
-		expect(legacyTrigger.closest("user-message")).toBeTruthy();
+		expect(legacyFooter?.querySelector(".message-timestamp")).toBeTruthy();
+		expect(legacyFooter?.previousElementSibling?.classList.contains("user-message-container")).toBe(true);
+		expect(legacyFooter?.closest(".prompt-content-column")).toBeTruthy();
+		expect(legacyFooter?.closest(".prompt-row")).toBeTruthy();
 
 		document.body.innerHTML = "";
 		const labelled = await renderList([
@@ -254,8 +258,12 @@ describe("history prompt trigger and canonical menu", () => {
 			durablePrompt("system", "system", { author: { kind: "system", id: "system:bobbit", label: "Bobbit" } }),
 		]);
 		const labelledTrigger = promptTriggers(labelled)[0];
+		const labelledFooter = labelledTrigger.closest(".prompt-metadata-row");
 		expect(labelledTrigger.closest(".user-message-container")).toBeNull();
-		expect(labelledTrigger.closest(".prompt-row--labelled")).toBeTruthy();
+		expect(labelledFooter?.querySelector(".message-timestamp")).toBeTruthy();
+		expect(labelledFooter?.previousElementSibling?.classList.contains("prompt-bubble-shell")).toBe(true);
+		expect(labelledFooter?.closest(".prompt-content-column")).toBeTruthy();
+		expect(labelledFooter?.closest(".prompt-row--labelled")).toBeTruthy();
 	});
 
 	it("resets New worktree off on every open and never fires Fork while toggling", async () => {


### PR DESCRIPTION
## Summary
- move prompt actions and timestamps beneath user prompt bubbles
- align metadata to the prompt bubble's right edge without reducing readable width
- cover legacy and author-labelled prompt layouts on desktop and mobile

## Tests
- `npm run check`
- `npm run test:unit` — 10,248 passed, 17 skipped
- `npm run test:browser` — 732 passed, 5 skipped
- `npm run test:e2e` — passed on retry after a transient busy-box streaming fixture failure

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)
