### PR TITLE
Refine sidebar status view and session header

### DIFF
--- a/docs/design/session-manager-sidebar-views.md
+++ b/docs/design/session-manager-sidebar-views.md
@@ -60,6 +60,7 @@ The control row MUST match the mock's density and labels:
 ```
 
 - The two view controls form one minimal segmented selector.
+- Control labels use a compact but clearly legible `0.8333em` size.
 - Filters remains a separate button in the same row.
 - Switching views closes an open filter popover but does not clear search.
 - There is no session-count or sort-summary row below the controls.
@@ -81,18 +82,18 @@ type SidebarSessionView = "project" | "status";
 
 ### 4.3 Status section headings
 
-By Status renders non-interactive headings in this exact order:
+By Status renders collapsible headings in this exact order:
 
 1. Pinned — includes the Lucide `Pin` icon.
-2. Unread.
-3. Read.
+2. Unread — includes a mail icon.
+3. Read — includes an opened-mail icon.
 
-Each visible heading contains its label and visible count. Headings use the mock's compact uppercase/tracking treatment and do not look like selectable tabs.
+Each visible heading contains a disclosure chevron, icon, label, and visible count. Its typography and base padding match the By Project group headings; Unread and Read add slight lower breathing room before their rows. A horizontal rule appears above every visible section except the first, never inline with the title. Expansion defaults on and persists locally per section.
 
 - Hide a heading when its section has no rows.
 - Do not reserve blank space for an empty section.
 - If no sessions remain after search and filters, render one compact empty state: `No sessions match this search and filter.`
-- Do not add project names, goal names, role labels, busy labels, tag chips, or status badges to the canonical session row.
+- In By Status only, goal-owned agents promote the uppercase goal title to the first line with a goal icon in the owning project's accent colour; the agent/session title moves to a quiet second line. The two-line text block is vertically centred against the sprite's layout box, with the pixel sprite optically nudged slightly upward, and Status rows retain clear whitespace between them. Standalone sessions remain single-line and carry a smaller identity icon in the owning project's accent colour, optically nudged slightly downward: ordinary sessions use the session/chat icon, while staff sessions use the staff icon. Do not add a `Goal` label, project names, role labels, busy labels, tag chips, or status badges.
 
 ## 5. Session tag contract
 
@@ -230,7 +231,7 @@ The flattened population includes each eligible session exactly once, including:
 
 Deduplicate by session ID. If a live and archived collection both contain the same ID, the live record wins.
 
-By Status has no tree indentation, chevrons, project/goal headers, team-child nesting, or expansion state. A child or delegate is a normal flat row in this view. Its row action eligibility and read-only behavior remain unchanged.
+By Status has no tree indentation, project/goal headers, or team-child nesting. Its three flat status sections have independent persisted expansion state. A child or delegate is a normal flat row in this view, with owning-goal membership inherited from its canonical tree ancestors when the session record does not carry a goal ID. Its row action eligibility and read-only behavior remain unchanged.
 
 ### 8.2 Filter order
 
@@ -263,9 +264,13 @@ The classification is independent of activity state. A busy session can be Pinne
 
 Sort each section independently by:
 
+Rows that visibly render a last-activity value use:
+
 1. `lastActivity` descending;
 2. `createdAt` descending;
 3. `id` ascending as a deterministic final tie-breaker.
+
+Rows showing the active/busy shimmer instead of a last-activity value form a stable cluster ahead of timestamp rows and sort by `createdAt` descending, then `id` ascending. Hidden `lastActivity` churn therefore does not rearrange several simultaneously active agents when the user has no visible timestamp change with which to understand that movement. When a row transitions between shimmer and timestamp presentation, it rejoins the corresponding ordering policy.
 
 Do not sort pinned rows by the time they were pinned. Do not sort unread ahead of pinned. Do not apply project, goal, title, role, or manual ordering inside a section.
 
@@ -276,6 +281,10 @@ Real-time activity, read-state, archive-state, team-state, or pin-state changes 
 - Opening an unread session uses the existing mark-read path and moves it to Read when the authoritative/optimistic state changes.
 - A newly unread non-pinned row moves to Unread.
 - Updated activity may change a row's position within its current section.
+
+Meaningful ordering changes use a 280 ms FLIP translation (`transform` only, ease-out) so rows preserve spatial continuity without delaying authoritative data. The row whose presentation signature changed also receives a subtle 650 ms project-identity trace: a 5% surface tint and a 24% two-pixel inset rail. Displaced rows that did not themselves change move without the trace.
+
+For the duration of a row's FLIP movement, pointer-generated `click` and `auxclick` events targeting that row or any descendant are canceled in the capture phase. This applies equally to the row body and its action buttons, preventing an element that moved under the pointer from accepting an unintended action. Keyboard-generated activation remains available. Reduced-motion users receive the immediate final ordering with no movement, trace, or temporary click suppression.
 
 ### 8.5 By Status filters
 

--- a/src/app/app.css
+++ b/src/app/app.css
@@ -326,7 +326,7 @@ bell-toggle button {
 	min-width: 0;
 	white-space: nowrap;
 	color: var(--muted-foreground);
-	font-size: 0.75em;
+	font-size: 0.8333em;
 	font-weight: 500;
 	transition: color 120ms ease, background-color 120ms ease;
 }
@@ -455,49 +455,103 @@ bell-toggle button {
 	gap: 0.125em;
 }
 
-.sidebar-status-heading {
-	display: flex;
-	align-items: center;
-	gap: 0.4167em;
-	height: 2.0833em;
-	padding: 0 0.5833em;
-	color: var(--muted-foreground);
-	font-size: 0.6667em;
-	font-weight: 650;
-	letter-spacing: 0.09em;
-	text-transform: uppercase;
+.sidebar-status-section--first {
+	margin-top: 0.125rem;
 }
 
-.sidebar-status-heading::after {
-	content: "";
-	flex: 1 1 auto;
-	height: 1px;
-	background: color-mix(in oklch, var(--border) 70%, transparent);
+.sidebar-status-heading {
+	width: 100%;
+}
+
+.sidebar-status-heading--lower-padding {
+	padding-bottom: 0.25rem;
+}
+
+.sidebar-status-heading:focus-visible {
+	outline: 2px solid var(--ring);
+	outline-offset: -2px;
 }
 
 .sidebar-status-heading-icon {
 	display: inline-flex;
-	width: 1em;
-	height: 1em;
-}
-
-.sidebar-status-heading-icon svg {
-	width: 100%;
-	height: 100%;
+	align-items: center;
+	flex: 0 0 auto;
 }
 
 .sidebar-status-count {
 	padding: 0 0.5em;
 	border-radius: 999px;
 	background: var(--muted);
-	font-size: 0.6667rem;
+	font-size: 0.6667em;
 	letter-spacing: 0;
 }
 
 .sidebar-status-rows {
 	display: flex;
 	flex-direction: column;
-	gap: 0.125em;
+	gap: 0.25rem;
+}
+
+.sidebar-status-goal-row {
+	/* Keep the two-line label centred against the sprite's layout box. */
+	align-items: center;
+}
+
+.sidebar-status-goal-sprite {
+	/* Pixel art reads slightly low beside uppercase text; optically correct it. */
+	position: relative;
+	top: -0.0625rem;
+}
+
+.sidebar-status-goal-copy {
+	row-gap: 0.0625rem;
+}
+
+.sidebar-status-goal-title {
+	line-height: 1.25;
+}
+
+.sidebar-status-goal-title-icon,
+.sidebar-status-session-title-icon {
+	display: inline-flex;
+}
+
+.sidebar-status-goal-title-icon {
+	width: 1em;
+	height: 1em;
+}
+
+.sidebar-status-session-title-icon {
+	width: 0.8em;
+	height: 0.8em;
+	position: relative;
+	top: 0.0625rem;
+}
+
+.sidebar-status-goal-title-icon svg,
+.sidebar-status-session-title-icon svg {
+	width: 100%;
+	height: 100%;
+}
+
+.sidebar-status-agent-title {
+	line-height: 1.25;
+	opacity: 0.78;
+}
+
+[data-status-motion-row="true"][data-status-moving="true"] {
+	will-change: transform;
+}
+
+.sidebar-status-change-trace {
+	position: absolute;
+	inset: 0;
+	border-radius: inherit;
+	background: color-mix(in oklch, var(--sidebar-status-motion-accent) 5%, transparent);
+	box-shadow: inset 2px 0 0 color-mix(in oklch, var(--sidebar-status-motion-accent) 24%, transparent);
+	opacity: 0;
+	pointer-events: none;
+	z-index: 3;
 }
 
 .sidebar-status-empty {

--- a/src/app/render-helpers.ts
+++ b/src/app/render-helpers.ts
@@ -1,6 +1,6 @@
 import { icon } from "@mariozechner/mini-lit";
 import { html, nothing, type TemplateResult } from "lit";
-import { Archive, Goal as GoalIcon, LayoutDashboard, Link, Menu, Pencil, RotateCcw, Trash2 } from "lucide";
+import { Archive, Bot, Goal as GoalIcon, LayoutDashboard, Link, Menu, MessagesSquare, Pencil, RotateCcw, Trash2 } from "lucide";
 import { buildNestedGoalForest } from "./sidebar-nesting.js";
 import { selectSpawnedChildren, isAncestorCycle, extendAncestors, computeTitleSuffixes } from "./sidebar-spawned-children.js";
 import type { GoalContext, SessionChildrenContext, SessionContext, SidebarTreeNode, TeamLeadContext } from "./sidebar-tree-builder.js";
@@ -23,7 +23,7 @@ import { startTeam, deleteGoal, gatewayFetch, copySidebarLink, fetchGoalGithubLi
 import { buildArchivedSessionActions, buildSessionActions, openSessionInNewWindow, resetSessionForkNewWorktree, type SessionActionDescriptor, type SessionActionTrailingToggle } from "./session-actions.js";
 import { getActiveNavId } from "./sidebar-nav.js";
 import { sanitizePullRequestUrl } from "../shared/pr-url-safety.js";
-import { isSessionReadFilterable } from "../shared/session-tags.js";
+import { isSessionReadFilterable, sessionShowsLastActivity } from "../shared/session-tags.js";
 import { needsHumanAttention, needsImmediateHumanAttention } from "./notification-policy.js";
 import type { SidebarActionsPopover, SidebarActionsPopoverItem } from "../ui/components/SidebarActionsPopover.js";
 import { captureSidebarActionSourceRects, type SidebarActionsFlipRect } from "../ui/components/sidebar-actions-flip.js";
@@ -411,8 +411,7 @@ export function renderSandboxIndicator(status: string) {
 
 /** Render terse relative time with optional unseen indicator dot. */
 export function renderSessionTime(session: GatewaySession, selected = false) {
-	const isActive = session.status === "streaming" || session.status === "busy" || session.isCompacting;
-	if (isActive) return renderActiveShimmer();
+	if (!sessionShowsLastActivity(session)) return renderActiveShimmer();
 	const time = terseRelativeTime(session.lastActivity);
 	if (!time) return "";
 	const unseen = hasUnseenActivity(session);
@@ -994,7 +993,41 @@ export type RenderSessionTreeOptions = {
 	childGroupNodes?: SidebarTreeNode<SessionChildrenContext>[];
 	/** Render canonical row content without tree chevrons, recursion, or child discovery. */
 	flat?: boolean;
+	/** Optional owning-goal context promoted above the agent title in flat Status rows. */
+	goalTitle?: string;
+	/** Owning-project accent used by the goal or standalone-session identity icon. */
+	projectColor?: string;
+	/** Flat Status rows distinguish staff agents from ordinary sessions. */
+	statusIdentity?: "session" | "staff";
+	/** Stable presentation signature used to trace meaningful live changes. */
+	statusMotionSignature?: string;
 };
+
+function renderStatusGoalTitle(goalTitle: string | undefined, projectColor: string | undefined, mobile: boolean): TemplateResult | typeof nothing {
+	if (!goalTitle) return nothing;
+	return html`
+		<div
+			class="sidebar-status-goal-title flex items-center gap-1 min-w-0 font-medium uppercase tracking-wider"
+			data-testid="sidebar-status-goal-title"
+			title=${goalTitle}
+			style=${`font-size:${mobile ? "1.1667em" : "0.8333em"};`}
+		>
+			<span class="sidebar-status-goal-title-icon shrink-0" style=${`color:${projectColor || "var(--muted-foreground)"};`}>${icon(GoalIcon, mobile ? "sm" : "xs")}</span>
+			<span class="truncate">${renderHighlightedText(goalTitle.toUpperCase(), state.searchQuery)}</span>
+		</div>
+	`;
+}
+
+function renderStatusIdentityIcon(identity: "session" | "staff" | undefined, projectColor: string | undefined, mobile: boolean): TemplateResult | typeof nothing {
+	if (!identity || !projectColor) return nothing;
+	const identityIcon = identity === "staff" ? Bot : MessagesSquare;
+	return html`<span
+		class="sidebar-status-session-title-icon shrink-0"
+		data-testid="sidebar-status-session-title-icon"
+		data-status-identity=${identity}
+		style=${`color:${projectColor};`}
+	>${icon(identityIcon, mobile ? "sm" : "xs")}</span>`;
+}
 
 function isSessionChildrenNode(node: SidebarTreeNode): node is SidebarTreeNode<SessionChildrenContext> {
 	return node.kind === "session-children";
@@ -1076,6 +1109,8 @@ export function renderSessionRow(session: GatewaySession, treeOptionsOrIndex?: R
 	return html`
 		<div
 			data-session-id="${session.id}"
+			data-status-motion-row=${flat ? "true" : nothing}
+			data-status-motion-signature=${flat ? treeOptions?.statusMotionSignature ?? "" : nothing}
 			data-tree-key=${treeOptions?.treeNode?.key ?? nothing}
 			data-tree-parent-key=${treeOptions?.treeNode?.parentKey ?? nothing}
 			data-tree-depth=${treeOptions?.treeNode?.logicalDepth ?? nothing}
@@ -1083,9 +1118,9 @@ export function renderSessionRow(session: GatewaySession, treeOptionsOrIndex?: R
 			data-sidebar-actions-row-root
 			data-nav-id=${navId}
 			data-nav-active=${navActive ? "true" : "false"}
-			class="${mobile ? "" : "group relative"} relative flex items-center gap-1 pr-1 ${rowPy} rounded-md cursor-pointer transition-colors
+			class="${mobile ? "" : "group relative"} ${treeOptions?.goalTitle ? "sidebar-status-goal-row" : ""} relative flex items-center gap-1 pr-1 ${rowPy} rounded-md cursor-pointer transition-colors
 				${navActive ? `bg-secondary text-foreground sidebar-session-active${hasChildren && !flat ? "" : " sidebar-active-no-chevron"}` : connecting ? "bg-secondary/30 text-muted-foreground" : mobile ? "text-muted-foreground active:bg-secondary/50" : "text-muted-foreground hover:bg-secondary/50 hover:text-foreground"}"
-			style="padding-left:var(--sidebar-chevron-w);"
+			style=${`padding-left:var(--sidebar-chevron-w);${flat ? `--sidebar-status-motion-accent:${treeOptions?.projectColor || "var(--muted-foreground)"};` : ""}`}
 			${mobile ? "" : html``}
 			@click=${() => { if (!active && !connecting) connectToSession(session.id, true); }}
 			@auxclick=${(e: MouseEvent) => { if (e.button === 1) { e.preventDefault(); e.stopPropagation(); openSessionInNewWindow(session.id); } }}
@@ -1094,13 +1129,18 @@ export function renderSessionRow(session: GatewaySession, treeOptionsOrIndex?: R
 				class="sidebar-chevron-slot sidebar-chevron-slot--absolute text-muted-foreground select-none cursor-pointer"
 				@click=${(e: Event) => { e.stopPropagation(); if (hasFirstClassChild) toggleFirstClassParentExpanded(session.id); else toggleArchivedParentExpanded(session.id); renderApp(); }}
 			><span class="sidebar-chevron-glyph">${childrenExpanded ? "▾" : "▸"}</span></span>` : ""}
-			<div class="shrink-0 flex items-center justify-center ${!active && hasUnseenActivity(session) ? "bobbit-unread-pulse" : ""}">
+			<div class="${treeOptions?.goalTitle ? "sidebar-status-goal-sprite" : ""} shrink-0 flex items-center justify-center ${!active && hasUnseenActivity(session) ? "bobbit-unread-pulse" : ""}">
 				${connecting || preparing
 					? html`<svg class="animate-spin" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 12a9 9 0 1 1-6.219-8.56"></path></svg>`
 					: statusBobbit(session.status, session.isCompacting, session.id, active, session.isAborting, session.role === "team-lead", session.role === "coder", session.accessory, false, !active && hasUnseenActivity(session), true)}
 			</div>
-			<div class="flex-1 min-w-0 flex flex-col justify-center">
-				<div class="flex items-center gap-1 min-w-0 font-normal"><span class="flex-1 min-w-0 truncate ${preparing ? "text-muted-foreground/60 italic" : ""}" data-testid="sidebar-session-title-text" style="${mobile ? "font-size: 1.3333em;" : ""}">${preparing ? "preparing…" : renderSessionTitle(displayTitle, isActive, state.searchQuery)}</span>${mobile ? html`<span class="shrink-0 text-muted-foreground/40" style="font-size: 0.9167em;">·</span>${renderSessionTime(session)}` : ""}</div>
+			<div class="${treeOptions?.goalTitle ? "sidebar-status-goal-copy" : ""} flex-1 min-w-0 flex flex-col justify-center">
+				${treeOptions?.goalTitle ? html`
+					<div class="flex items-center gap-1 min-w-0">${renderStatusGoalTitle(treeOptions.goalTitle, treeOptions.projectColor, mobile)}${mobile ? html`<span class="flex-1"></span>${renderSessionTime(session)}` : ""}</div>
+					<div class="sidebar-status-agent-title min-w-0 truncate ${preparing ? "text-muted-foreground/60 italic" : ""}" data-testid="sidebar-session-title-text" style=${`font-size:${mobile ? "1em" : "0.75em"};`}>${preparing ? "preparing…" : renderSessionTitle(displayTitle, isActive, state.searchQuery)}</div>
+				` : html`
+					<div class="flex items-center gap-1 min-w-0 font-normal">${flat ? renderStatusIdentityIcon(treeOptions?.statusIdentity, treeOptions?.projectColor, mobile) : nothing}<span class="flex-1 min-w-0 truncate ${preparing ? "text-muted-foreground/60 italic" : ""}" data-testid="sidebar-session-title-text" style="${mobile ? "font-size: 1.3333em;" : ""}">${preparing ? "preparing…" : renderSessionTitle(displayTitle, isActive, state.searchQuery)}</span>${mobile ? html`<span class="shrink-0 text-muted-foreground/40" style="font-size: 0.9167em;">·</span>${renderSessionTime(session)}` : ""}</div>
+				`}
 			</div>
 			${mobile
 				? buttons
@@ -1109,6 +1149,7 @@ export function renderSessionRow(session: GatewaySession, treeOptionsOrIndex?: R
 					<div class="sidebar-actions sidebar-action-cluster absolute right-0 top-0 bottom-0 flex opacity-0 pointer-events-none group-hover:opacity-100 group-hover:pointer-events-auto group-focus-within:opacity-100 group-focus-within:pointer-events-auto items-center pr-1 pl-8 rounded-r-md" style="background:linear-gradient(to right, transparent 0%, var(--sidebar) 50%);">
 						${buttons}
 					</div>`}
+			${flat ? html`<span class="sidebar-status-change-trace" aria-hidden="true"></span>` : nothing}
 		</div>
 		${shouldRenderChildArea ? (treeChildGroups
 			? renderTreeSessionChildrenGroups(treeChildGroups, { showArchivedGroupHeader: liveChildren.length > 0 && hasArchivedChildGroup })
@@ -1224,6 +1265,8 @@ export function renderArchivedSessionRow(session: GatewaySession, extraChildren 
 	return html`
 		<div
 			data-session-id="${session.id}"
+			data-status-motion-row=${flat ? "true" : nothing}
+			data-status-motion-signature=${flat ? treeOptions?.statusMotionSignature ?? "" : nothing}
 			data-tree-key=${treeOptions?.treeNode?.key ?? nothing}
 			data-tree-parent-key=${treeOptions?.treeNode?.parentKey ?? nothing}
 			data-tree-depth=${treeOptions?.treeNode?.logicalDepth ?? nothing}
@@ -1231,9 +1274,9 @@ export function renderArchivedSessionRow(session: GatewaySession, extraChildren 
 			data-sidebar-actions-row-root
 			data-nav-id=${archivedNavId}
 			data-nav-active=${active ? "true" : "false"}
-			class="group relative flex items-center gap-1 pr-1 ${rowPy} rounded-md cursor-pointer transition-colors
+			class="group ${treeOptions?.goalTitle ? "sidebar-status-goal-row" : ""} relative flex items-center gap-1 pr-1 ${rowPy} rounded-md cursor-pointer transition-colors
 				${active ? `bg-secondary text-foreground sidebar-session-active${hasChildren ? "" : " sidebar-active-no-chevron"}` : "text-muted-foreground hover:bg-secondary/50 hover:text-foreground"}"
-			style="padding-left:var(--sidebar-chevron-w); filter:grayscale(1); opacity:0.75;"
+			style=${`padding-left:var(--sidebar-chevron-w);filter:grayscale(1);opacity:0.75;${flat ? `--sidebar-status-motion-accent:${treeOptions?.projectColor || "var(--muted-foreground)"};` : ""}`}
 			@click=${() => connectToSession(session.id, true, { readOnly: true })}
 		>
 			${hasChildren ? html`<span
@@ -1241,10 +1284,15 @@ export function renderArchivedSessionRow(session: GatewaySession, extraChildren 
 				@click=${(e: Event) => { e.stopPropagation(); if (treeOptions?.treeNode?.kind === "team-lead") toggleTeamLeadExpanded(session.id); else toggleArchivedParentExpanded(session.id); renderApp(); }}
 				title="${expanded ? "Collapse" : "Expand"}"
 			><span class="sidebar-chevron-glyph">${expanded ? "▾" : "▸"}</span></span>` : ""}
-			<div class="shrink-0 flex items-center justify-center">
+			<div class="${treeOptions?.goalTitle ? "sidebar-status-goal-sprite" : ""} shrink-0 flex items-center justify-center">
 				${statusBobbit("terminated", false, session.id, active, false, session.role === "team-lead", session.role === "coder", session.accessory, false, false, true)}
 			</div>
-			<div class="flex-1 min-w-0 font-normal truncate" style="${mobile ? "font-size: 1.3333em;" : ""}">${renderHighlightedText(displayTitle, state.searchQuery)}</div>
+			<div class="${treeOptions?.goalTitle ? "sidebar-status-goal-copy" : ""} flex-1 min-w-0 flex flex-col justify-center font-normal">
+				${treeOptions?.goalTitle ? html`
+					${renderStatusGoalTitle(treeOptions.goalTitle, treeOptions.projectColor, mobile)}
+					<div class="sidebar-status-agent-title truncate" style=${`font-size:${mobile ? "1em" : "0.75em"};`}>${renderHighlightedText(displayTitle, state.searchQuery)}</div>
+				` : html`<div class="flex items-center gap-1 min-w-0" style="${mobile ? "font-size: 1.3333em;" : ""}">${flat ? renderStatusIdentityIcon(treeOptions?.statusIdentity, treeOptions?.projectColor, mobile) : nothing}<span class="truncate">${renderHighlightedText(displayTitle, state.searchQuery)}</span></div>`}
+			</div>
 			${mobile
 				? html`${archivedTime}${buttons}`
 				: html`
@@ -1252,6 +1300,7 @@ export function renderArchivedSessionRow(session: GatewaySession, extraChildren 
 					<div class="sidebar-actions sidebar-action-cluster absolute right-0 top-0 bottom-0 flex opacity-0 pointer-events-none group-hover:opacity-100 group-hover:pointer-events-auto group-focus-within:opacity-100 group-focus-within:pointer-events-auto items-center pr-1 pl-8 rounded-r-md" style="background:linear-gradient(to right, transparent 0%, var(--sidebar) 50%);">
 						${buttons}
 					</div>`}
+			${flat ? html`<span class="sidebar-status-change-trace" aria-hidden="true"></span>` : nothing}
 		</div>
 	`;
 }

--- a/src/app/render.ts
+++ b/src/app/render.ts
@@ -51,6 +51,7 @@ import { buildSidebarTree, type GoalContext, type SidebarProjectTree, type Sideb
 import { loadSidebarTreeLayoutPreference, sidebarTreeBaseIndentStyle, sidebarTreeHalfIndentStyle, sidebarTreeNodeIndentStyle } from "./sidebar-tree-layout.js";
 import { isClientDebugEnabled, dumpClientDebugToComposer, registerDebugSection } from "./client-debug.js";
 import { setArchivedSectionExpanded, setUngroupedExpanded, sidebarTreeExpansionInput, toggleProjectExpanded } from "./sidebar-tree-state.js";
+import { animateSidebarStatusChanges, captureSidebarStatusMotion, installSidebarStatusMotionClickGuard } from "./sidebar-status-motion.js";
 // Register search web components
 // <search-box> + <search-results> appear in the mobile landing + search
 // route. Lazy-load via the shared widgets registrar so their combined
@@ -579,8 +580,8 @@ function renderMobileLanding() {
 	return html`
 		<div class="flex-1 flex flex-col overflow-y-auto sidebar-root" data-project-reordering=${isProjectReordering() ? "true" : "false"}>
 			${renderProjectReorderLiveRegion()}
-			<div class="w-full max-w-xl mx-auto px-2 py-2 pb-16 flex flex-col gap-0.5">
-				<div class="flex flex-col gap-1 px-1 pb-2 mb-1 border-b border-border/30">
+			<div class="w-full max-w-xl mx-auto px-2 pt-1 pb-16 flex flex-col gap-0.5">
+				<div class="flex flex-col gap-0.5 px-1 pb-1 mb-0.5 border-b border-border/30">
 					${(() => {
 						const isRolesActive = isRouteActive("roles", "role-edit");
 						const isToolsActive = isRouteActive("tools", "tool-edit");
@@ -2234,6 +2235,8 @@ function renderArchivedBanner() {
 export function doRenderApp(): void {
 	const app = document.getElementById("app");
 	if (!app) return;
+	installSidebarStatusMotionClickGuard();
+	const sidebarStatusMotion = captureSidebarStatusMotion(app);
 
 	// Dynamic page title.
 	// In a regular browser tab, suffix with " · Bobbit" so the tab tells you which app.
@@ -2444,9 +2447,14 @@ export function doRenderApp(): void {
 			const deskGoalTitle = deskGoalId ? state.goals.find(g => g.id === deskGoalId)?.title : undefined;
 			return html`
 				<div class="flex items-center gap-2 px-3 min-w-0 flex-1">
-					<div class="flex flex-col min-w-0 py-1">
-						<span class="text-sm font-medium text-foreground inline-flex items-center gap-1 min-w-0" title=${headerTitle}><span class="truncate">${headerTitle}</span>${deskSession?.sandboxed ? renderSandboxIndicator(deskSession.status) : ""}${(deskSession?.status === "preparing" || deskSession?.status === "starting") ? html`<span class="shrink-0 text-muted-foreground/70 italic" style="font-size:0.85em;">preparing…</span>` : ""}</span>
-						${deskGoalTitle ? html`<span class="text-[10px] text-muted-foreground/60 truncate uppercase tracking-wider">${deskGoalTitle}</span>` : ""}
+					<div class="flex items-center gap-1 min-w-0 py-1" data-testid="desktop-session-header-title-line">
+						<span class="text-sm font-medium text-foreground inline-flex items-center gap-1 min-w-0" data-testid="desktop-session-header-title" title=${headerTitle}><span class="truncate">${headerTitle}</span>${deskSession?.sandboxed ? renderSandboxIndicator(deskSession.status) : ""}${(deskSession?.status === "preparing" || deskSession?.status === "starting") ? html`<span class="shrink-0 text-muted-foreground/70 italic" style="font-size:0.85em;">preparing…</span>` : ""}</span>
+						${deskGoalTitle ? html`
+							<span class="inline-flex items-center gap-1 min-w-0 leading-none" style="position:relative;top:1px;">
+								<span class="shrink-0 text-muted-foreground/40" style="margin-inline:2px;position:relative;top:-2px;" aria-hidden="true" data-testid="desktop-session-header-goal-separator">·</span>
+								<span class="min-w-0 text-[10px] text-muted-foreground/60 truncate uppercase tracking-wider" data-testid="desktop-session-header-goal-title" title=${deskGoalTitle}>${deskGoalTitle}</span>
+							</span>
+						` : ""}
 					</div>
 				</div>
 			`;
@@ -3489,6 +3497,8 @@ export function doRenderApp(): void {
 			</div>
 		`, app);
 	}
+
+	animateSidebarStatusChanges(sidebarStatusMotion, app);
 
 	// Attach SortableJS to the panel tab bar (if present). We look up the
 	// element after each render rather than relying on lit's ref directive

--- a/src/app/sidebar-status-motion.ts
+++ b/src/app/sidebar-status-motion.ts
@@ -1,0 +1,148 @@
+const STATUS_MOTION_ROW_SELECTOR = "[data-status-motion-row='true'][data-session-id]";
+const STATUS_MOTION_MOVING_ATTRIBUTE = "data-status-moving";
+const STATUS_MOTION_TRACE_ATTRIBUTE = "data-status-change-tracing";
+
+export const SIDEBAR_STATUS_MOVE_DURATION_MS = 280;
+export const SIDEBAR_STATUS_TRACE_DURATION_MS = 650;
+export const SIDEBAR_STATUS_MOVE_EASING = "cubic-bezier(.2,.8,.2,1)";
+
+interface StatusMotionEntry {
+	rect: DOMRectReadOnly;
+	signature: string;
+}
+
+export interface SidebarStatusMotionSnapshot {
+	rows: Map<string, StatusMotionEntry>;
+	viewportWidth: number;
+	viewportHeight: number;
+}
+
+function statusMotionRows(root: ParentNode): HTMLElement[] {
+	return [...root.querySelectorAll<HTMLElement>(STATUS_MOTION_ROW_SELECTOR)];
+}
+
+function sessionIdForRow(row: HTMLElement): string | undefined {
+	return row.dataset.sessionId || undefined;
+}
+
+function prefersReducedMotion(): boolean {
+	return typeof window.matchMedia === "function" && window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+}
+
+/** Capture the visible Status-row geometry immediately before Lit updates the DOM. */
+export function captureSidebarStatusMotion(root: ParentNode = document): SidebarStatusMotionSnapshot | null {
+	const rows = statusMotionRows(root);
+	if (rows.length === 0) return null;
+	const entries = new Map<string, StatusMotionEntry>();
+	for (const row of rows) {
+		const sessionId = sessionIdForRow(row);
+		if (!sessionId) continue;
+		entries.set(sessionId, {
+			rect: row.getBoundingClientRect(),
+			signature: row.dataset.statusMotionSignature || "",
+		});
+	}
+	return {
+		rows: entries,
+		viewportWidth: window.innerWidth,
+		viewportHeight: window.innerHeight,
+	};
+}
+
+function clearRowMotion(row: HTMLElement): void {
+	for (const animation of row.getAnimations()) animation.cancel();
+	row.removeAttribute(STATUS_MOTION_MOVING_ATTRIBUTE);
+	row.removeAttribute(STATUS_MOTION_TRACE_ATTRIBUTE);
+	const trace = row.querySelector<HTMLElement>(".sidebar-status-change-trace");
+	if (trace) for (const animation of trace.getAnimations()) animation.cancel();
+}
+
+function animateChangeTrace(row: HTMLElement): void {
+	const trace = row.querySelector<HTMLElement>(".sidebar-status-change-trace");
+	if (!trace || typeof trace.animate !== "function") return;
+	row.setAttribute(STATUS_MOTION_TRACE_ATTRIBUTE, "true");
+	const animation = trace.animate([
+		{ opacity: 1 },
+		{ opacity: 0 },
+	], {
+		duration: SIDEBAR_STATUS_TRACE_DURATION_MS,
+		easing: "ease-out",
+		fill: "forwards",
+	});
+	const clear = () => {
+		if (row.isConnected) row.removeAttribute(STATUS_MOTION_TRACE_ATTRIBUTE);
+	};
+	animation.addEventListener("finish", clear, { once: true });
+	animation.addEventListener("cancel", clear, { once: true });
+}
+
+function animateMovement(row: HTMLElement, dx: number, dy: number): void {
+	if (typeof row.animate !== "function") return;
+	row.setAttribute(STATUS_MOTION_MOVING_ATTRIBUTE, "true");
+	const animation = row.animate([
+		{ transform: `translate(${dx}px, ${dy}px)` },
+		{ transform: "translate(0, 0)" },
+	], {
+		duration: SIDEBAR_STATUS_MOVE_DURATION_MS,
+		easing: SIDEBAR_STATUS_MOVE_EASING,
+		fill: "backwards",
+	});
+	const clear = () => {
+		if (row.isConnected) row.removeAttribute(STATUS_MOTION_MOVING_ATTRIBUTE);
+	};
+	animation.addEventListener("finish", clear, { once: true });
+	animation.addEventListener("cancel", clear, { once: true });
+}
+
+/**
+ * Apply FLIP motion after Lit renders the next Status ordering. Rows whose
+ * presentation signature changed receive a deliberately subtle identity trace.
+ */
+export function animateSidebarStatusChanges(
+	snapshot: SidebarStatusMotionSnapshot | null,
+	root: ParentNode = document,
+): void {
+	if (!snapshot) return;
+	const rows = statusMotionRows(root);
+	for (const row of rows) clearRowMotion(row);
+	if (prefersReducedMotion()) return;
+	if (snapshot.viewportWidth !== window.innerWidth || snapshot.viewportHeight !== window.innerHeight) return;
+
+	for (const row of rows) {
+		const sessionId = sessionIdForRow(row);
+		const previous = sessionId ? snapshot.rows.get(sessionId) : undefined;
+		if (!previous) continue;
+		const nextRect = row.getBoundingClientRect();
+		const dx = previous.rect.left - nextRect.left;
+		const dy = previous.rect.top - nextRect.top;
+		if (Math.abs(dx) > 0.5 || Math.abs(dy) > 0.5) animateMovement(row, dx, dy);
+		if (previous.signature !== (row.dataset.statusMotionSignature || "")) animateChangeTrace(row);
+	}
+}
+
+function movingStatusRowFromEvent(event: Event): HTMLElement | null {
+	if (!(event instanceof MouseEvent) || event.detail === 0) return null;
+	for (const target of event.composedPath()) {
+		if (!(target instanceof HTMLElement)) continue;
+		const row = target.closest<HTMLElement>(STATUS_MOTION_ROW_SELECTOR);
+		if (row?.getAttribute(STATUS_MOTION_MOVING_ATTRIBUTE) === "true") return row;
+	}
+	return null;
+}
+
+/** Block pointer-generated click/auxclick events on rows while FLIP is moving them. */
+export function guardMovingSidebarStatusClick(event: Event): boolean {
+	if (!movingStatusRowFromEvent(event)) return false;
+	event.preventDefault();
+	event.stopImmediatePropagation();
+	return true;
+}
+
+const clickGuardDocuments = new WeakSet<Document>();
+
+export function installSidebarStatusMotionClickGuard(target: Document = document): void {
+	if (clickGuardDocuments.has(target)) return;
+	clickGuardDocuments.add(target);
+	target.addEventListener("click", guardMovingSidebarStatusClick, true);
+	target.addEventListener("auxclick", guardMovingSidebarStatusClick, true);
+}

--- a/src/app/sidebar-status.ts
+++ b/src/app/sidebar-status.ts
@@ -1,6 +1,7 @@
-import { isSessionReadFilterable } from "../shared/session-tags.js";
+import { isSessionReadFilterable, sessionShowsLastActivity } from "../shared/session-tags.js";
 import type { GatewaySession } from "./state.js";
 import type {
+	GoalContext,
 	SessionContext,
 	SidebarTreeModel,
 	SidebarTreeNode,
@@ -18,6 +19,8 @@ export interface StatusCandidate<TSession extends StatusSession = StatusSession>
 	/** Archived-safe presentation, including terminal records and archived child placement. */
 	archived: boolean;
 	staff: boolean;
+	/** Owning goal resolved from the canonical tree, including inherited child/delegate membership. */
+	goalId?: string;
 }
 
 export interface StatusStaffLike {
@@ -49,6 +52,20 @@ function isArchivedCandidate(session: StatusSession, node?: SidebarTreeNode): bo
 	return false;
 }
 
+function nodeGoalId(model: Pick<SidebarTreeModel, "flatByKey">, node: SidebarTreeNode): string | undefined {
+	let current: SidebarTreeNode | undefined = node;
+	const seen = new Set<string>();
+	while (current) {
+		const context = current.context as Partial<SessionContext & TeamLeadContext & GoalContext>;
+		if (current.kind === "goal") return (current.context as GoalContext).goal.id;
+		if (context.goalId || context.teamGoalId) return context.goalId || context.teamGoalId;
+		if (!current.parentKey || seen.has(current.parentKey)) return undefined;
+		seen.add(current.parentKey);
+		current = model.flatByKey.get(current.parentKey);
+	}
+	return undefined;
+}
+
 /**
  * Flatten the already-eligible tree population without consulting expansion.
  * The supplied staff synthesizer is the existing production adapter; injecting
@@ -64,7 +81,7 @@ export function collectEligibleStatusSessions<TSession extends StatusSession = S
 	const add = (candidate: StatusCandidate<TSession>) => {
 		const existing = byId.get(candidate.session.id);
 		if (!existing || (existing.archived && !candidate.archived) || (candidate.staff && !existing.staff && existing.archived === candidate.archived)) {
-			byId.set(candidate.session.id, candidate);
+			byId.set(candidate.session.id, { ...candidate, goalId: candidate.goalId ?? existing?.goalId });
 		}
 	};
 
@@ -73,13 +90,13 @@ export function collectEligibleStatusSessions<TSession extends StatusSession = S
 		const context = node.context as SessionContext | TeamLeadContext;
 		const session = context.session as TSession;
 		if (!session?.id) continue;
-		add({ session, archived: isArchivedCandidate(session, node), staff: false });
+		add({ session, archived: isArchivedCandidate(session, node), staff: false, goalId: nodeGoalId(model, node) });
 	}
 
 	for (const staffAgent of staff) {
 		const session = synthesizeStaffSession(staffAgent);
 		if (!session?.id) continue;
-		add({ session, archived: isArchivedCandidate(session), staff: true });
+		add({ session, archived: isArchivedCandidate(session), staff: true, goalId: session.goalId || session.teamGoalId });
 	}
 
 	return [...byId.values()];
@@ -93,6 +110,15 @@ export function compareStatusCandidatesNewestFirst<TSession extends StatusSessio
 	a: StatusCandidate<TSession>,
 	b: StatusCandidate<TSession>,
 ): number {
+	const aShowsActivity = sessionShowsLastActivity(a.session);
+	const bShowsActivity = sessionShowsLastActivity(b.session);
+	// Active rows render a shimmer instead of a timestamp. Keep them in one
+	// deterministic cluster so hidden lastActivity churn cannot reshuffle them.
+	if (aShowsActivity !== bShowsActivity) return aShowsActivity ? 1 : -1;
+	if (!aShowsActivity) {
+		return finiteTimestamp(b.session.createdAt) - finiteTimestamp(a.session.createdAt)
+			|| a.session.id.localeCompare(b.session.id);
+	}
 	return finiteTimestamp(b.session.lastActivity) - finiteTimestamp(a.session.lastActivity)
 		|| finiteTimestamp(b.session.createdAt) - finiteTimestamp(a.session.createdAt)
 		|| a.session.id.localeCompare(b.session.id);

--- a/src/app/sidebar-view-preferences.ts
+++ b/src/app/sidebar-view-preferences.ts
@@ -1,6 +1,7 @@
 import { safeGetItem, safeSetItem } from "./safe-storage.js";
 
 export type SidebarSessionView = "project" | "status";
+export type SidebarStatusSectionKey = "pinned" | "unread" | "read";
 export type SidebarViewFilterKey = "showArchived" | "showBusy" | "showRead" | "showTeams";
 
 export interface SidebarViewFilters {
@@ -20,10 +21,12 @@ export interface SidebarViewPreferenceState {
 	statusShowBusy: boolean;
 	statusShowRead: boolean;
 	statusShowTeams: boolean;
+	statusCollapsedSections?: Set<SidebarStatusSectionKey>;
 	filtersPopoverOpen?: boolean;
 }
 
 export const SIDEBAR_SESSION_VIEW_STORAGE_KEY = "bobbit-sidebar-session-view";
+export const SIDEBAR_STATUS_COLLAPSED_SECTIONS_STORAGE_KEY = "bobbit-status-collapsed-sections";
 export const SIDEBAR_PROJECT_FILTER_STORAGE_KEYS = {
 	showArchived: "bobbit-show-archived",
 	showBusy: "bobbit-show-busy",
@@ -59,6 +62,30 @@ export function loadSidebarSessionView(): SidebarSessionView {
 export function loadSidebarStatusFilter(key: keyof typeof SIDEBAR_STATUS_FILTER_STORAGE_KEYS): boolean {
 	const value = safeGetItem(SIDEBAR_STATUS_FILTER_STORAGE_KEYS[key]);
 	return SIDEBAR_STATUS_FILTER_DEFAULTS[key] ? value !== "false" : value === "true";
+}
+
+export function loadSidebarStatusCollapsedSections(): Set<SidebarStatusSectionKey> {
+	const value = safeGetItem(SIDEBAR_STATUS_COLLAPSED_SECTIONS_STORAGE_KEY);
+	if (!value) return new Set();
+	try {
+		const parsed = JSON.parse(value);
+		if (!Array.isArray(parsed)) return new Set();
+		return new Set(parsed.filter((key): key is SidebarStatusSectionKey => key === "pinned" || key === "unread" || key === "read"));
+	} catch {
+		return new Set();
+	}
+}
+
+export function setSidebarStatusSectionExpanded(
+	preferenceState: SidebarViewPreferenceState,
+	key: SidebarStatusSectionKey,
+	expanded: boolean,
+): void {
+	const collapsed = preferenceState.statusCollapsedSections ?? new Set<SidebarStatusSectionKey>();
+	if (expanded) collapsed.delete(key);
+	else collapsed.add(key);
+	preferenceState.statusCollapsedSections = collapsed;
+	safeSetItem(SIDEBAR_STATUS_COLLAPSED_SECTIONS_STORAGE_KEY, JSON.stringify([...collapsed].sort()));
 }
 
 export function getSidebarViewFilters(

--- a/src/app/sidebar.ts
+++ b/src/app/sidebar.ts
@@ -1,6 +1,6 @@
 import { icon } from "@mariozechner/mini-lit";
 import { html, nothing, type TemplateResult } from "lit";
-import { Archive, Bot, ChevronDown, FolderTree, Goal as GoalIcon, GripVertical, List, ListFilter, MessagesSquare, PanelLeftClose, PanelLeftOpen, Pin, Plus, Settings, Store, Users, Workflow, Wrench, Zap } from "lucide";
+import { Archive, Bot, ChevronDown, FolderTree, Goal as GoalIcon, GripVertical, List, ListFilter, Mail, MailOpen, MessagesSquare, PanelLeftClose, PanelLeftOpen, Pin, Plus, Settings, Store, Users, Workflow, Wrench, Zap } from "lucide";
 // Register search web components (self-registering via @customElement)
 // Lazy-load via the shared widgets registrar; see render.ts for
 // rationale. Both modules ship in one shared chunk fetched in parallel
@@ -52,8 +52,8 @@ import {
 } from "./sidebar-tree-state.js";
 import { loadSidebarTreeLayoutPreference, sidebarTreeBaseIndentStyle, sidebarTreeCollapsedIndentStyle, sidebarTreeHalfIndentStyle, sidebarTreeNodeIndentStyle, sidebarTreeTruncationIndentStyle } from "./sidebar-tree-layout.js";
 import { collectEligibleStatusSessions, selectSidebarStatusSections, type SidebarStatusSections, type StatusCandidate } from "./sidebar-status.js";
-import { getSidebarViewFilters, setSidebarView, sidebarNeedsArchivedSessions, type SidebarSessionView, type SidebarViewFilters } from "./sidebar-view-preferences.js";
-import { isPinned, isSessionBusy, sessionTeamKind } from "../shared/session-tags.js";
+import { getSidebarViewFilters, setSidebarStatusSectionExpanded, setSidebarView, sidebarNeedsArchivedSessions, type SidebarSessionView, type SidebarStatusSectionKey, type SidebarViewFilters } from "./sidebar-view-preferences.js";
+import { isPinned, isSessionBusy, sessionShowsLastActivity, sessionTeamKind } from "../shared/session-tags.js";
 
 export { isProjectExpanded, toggleProjectExpanded };
 
@@ -1836,22 +1836,80 @@ export function renderSidebarViewControls(variant: "desktop" | "mobile" = "deskt
 	`;
 }
 
-function renderStatusHeading(key: "pinned" | "unread" | "read", count: number): TemplateResult {
-	const label = key === "pinned" ? "Pinned" : key === "unread" ? "Unread" : "Read";
+function renderStatusHeading(key: SidebarStatusSectionKey, count: number, expanded: boolean): TemplateResult {
+	const { label, headingIcon } = key === "pinned"
+		? { label: "Pinned", headingIcon: Pin }
+		: key === "unread"
+			? { label: "Unread", headingIcon: Mail }
+			: { label: "Read", headingIcon: MailOpen };
 	const headingId = `sidebar-status-${key}-heading`;
+	const rowsId = `sidebar-status-${key}-rows`;
+	const desktop = isDesktop();
+	const headingLayout = desktop
+		? "gap-1 pr-1 py-0.5 hover:bg-secondary/30"
+		: "gap-1.5 pl-0.5 pr-2 py-0.5 active:bg-secondary/50";
+	const toggle = () => {
+		setSidebarStatusSectionExpanded(state, key, !expanded);
+		renderApp();
+	};
 	return html`
-		<div class="sidebar-status-heading" id=${headingId}>
-			${key === "pinned" ? html`<span class="sidebar-status-heading-icon">${icon(Pin, "xs")}</span>` : nothing}
-			<span>${label}</span>
+		<div
+			class="sidebar-status-heading ${key === "pinned" ? "" : "sidebar-status-heading--lower-padding"} relative flex items-center ${headingLayout} rounded-md cursor-pointer transition-colors"
+			style=${desktop ? "padding-left:var(--sidebar-header-chevron-w);" : ""}
+			id=${headingId}
+			role="button"
+			tabindex="0"
+			aria-controls=${rowsId}
+			aria-expanded=${expanded ? "true" : "false"}
+			@click=${toggle}
+			@keydown=${(event: KeyboardEvent) => {
+				if (event.key !== "Enter" && event.key !== " ") return;
+				event.preventDefault();
+				toggle();
+			}}
+		>
+			<span class="sidebar-chevron-slot ${desktop ? "sidebar-chevron-slot--header sidebar-chevron-slot--absolute" : "sidebar-chevron-slot--inline"} text-muted-foreground shrink-0 select-none"><span class="sidebar-chevron-glyph">${expanded ? "▾" : "▸"}</span></span>
+			<span class="sidebar-status-heading-icon shrink-0 text-muted-foreground">${icon(headingIcon, desktop ? "xs" : "sm")}</span>
+			<span class="sidebar-status-heading-label flex-1 min-w-0 truncate text-muted-foreground uppercase tracking-wider font-medium" style=${`font-size:${desktop ? "0.75em" : "1.1667em"};`}>${label}</span>
 			<span class="sidebar-status-count">${count}</span>
 		</div>
 	`;
 }
 
+function statusCandidateMotionSignature(candidate: StatusCandidate, goalTitle: string | undefined): string {
+	const session = candidate.session;
+	return JSON.stringify([
+		session.title,
+		session.status,
+		sessionShowsLastActivity(session) ? session.lastActivity : 0,
+		sessionShowsLastActivity(session) ? session.lastReadAt ?? 0 : 0,
+		session.isCompacting === true,
+		session.isAborting === true,
+		session.lastTurnErrored === true,
+		session.consecutiveErrorTurns ?? 0,
+		session.archived === true,
+		session.archivedAt ?? 0,
+		candidate.staff,
+		goalTitle || "",
+		session.server_tags || [],
+		session.user_tags || [],
+	]);
+}
+
 function renderStatusCandidate(candidate: StatusCandidate): TemplateResult {
+	const goal = candidate.goalId ? state.goals.find(item => item.id === candidate.goalId) : undefined;
+	const projectId = goal?.projectId || candidate.session.projectId;
+	const project = projectId ? state.projects.find(item => item.id === projectId) : undefined;
+	const rowOptions = {
+		flat: true,
+		goalTitle: goal?.title,
+		projectColor: project ? getProjectAccentColor(project) : undefined,
+		statusIdentity: candidate.staff ? "staff" : "session",
+		statusMotionSignature: statusCandidateMotionSignature(candidate, goal?.title),
+	} as const;
 	return candidate.archived
-		? renderArchivedSessionRow(candidate.session, false, { flat: true })
-		: renderSessionRow(candidate.session, { flat: true });
+		? renderArchivedSessionRow(candidate.session, false, rowOptions)
+		: renderSessionRow(candidate.session, rowOptions);
 }
 
 /** Canonical flat rows grouped into the three exact Status sections. */
@@ -1870,16 +1928,21 @@ export function renderSidebarStatusContent(
 	if (count === 0) {
 		return html`<div class="sidebar-status-empty">No sessions match this search and filter.</div>${archiveControls}`;
 	}
-	return html`${entries.map(([key, rows]) => rows.length === 0 ? nothing : html`
-		<section
-			class="sidebar-status-section"
-			aria-labelledby=${`sidebar-status-${key}-heading`}
-			data-status-section=${key}
-		>
-			${renderStatusHeading(key, rows.length)}
-			<div class="sidebar-status-rows">${rows.map(renderStatusCandidate)}</div>
-		</section>
-	`)}${archiveControls}`;
+	const visibleEntries = entries.filter((entry) => entry[1].length > 0);
+	return html`${visibleEntries.map(([key, rows], index) => {
+		const expanded = !state.statusCollapsedSections.has(key);
+		return html`
+			${index > 0 ? html`<div class="sidebar-status-separator border-t border-border/30 ${isDesktop() ? "my-1" : "my-0.5"} mx-2"></div>` : nothing}
+			<section
+				class="sidebar-status-section ${index === 0 ? "sidebar-status-section--first" : ""}"
+				aria-labelledby=${`sidebar-status-${key}-heading`}
+				data-status-section=${key}
+			>
+				${renderStatusHeading(key, rows.length, expanded)}
+				${expanded ? html`<div class="sidebar-status-rows" id=${`sidebar-status-${key}-rows`}>${rows.map(renderStatusCandidate)}</div>` : nothing}
+			</section>
+		`;
+	})}${archiveControls}`;
 }
 
 export function renderSidebar() {

--- a/src/app/state.ts
+++ b/src/app/state.ts
@@ -6,7 +6,7 @@ import type { SidePanelWorkspace } from "./side-panel-workspace.js";
 import { isConfigPageRoute } from "./routing.js";
 import { type ProjectKind } from "./headquarters.js";
 import { safeSetItem, safeGetItem, safeGetJSON } from "./safe-storage.js";
-import { loadSidebarSessionView, loadSidebarStatusFilter } from "./sidebar-view-preferences.js";
+import { loadSidebarSessionView, loadSidebarStatusCollapsedSections, loadSidebarStatusFilter } from "./sidebar-view-preferences.js";
 import {
 	clearSidebarTreePreference,
 	getSidebarTreePreference,
@@ -486,6 +486,8 @@ export const state = {
 	statusShowBusy: loadSidebarStatusFilter("showBusy"),
 	statusShowRead: loadSidebarStatusFilter("showRead"),
 	statusShowTeams: loadSidebarStatusFilter("showTeams"),
+	/** Independently persisted expansion state for the three By Status groups. */
+	statusCollapsedSections: loadSidebarStatusCollapsedSections(),
 	/** Whether the sidebar filters popover is open */
 	filtersPopoverOpen: false,
 	/** Whether the archived section is expanded */

--- a/src/shared/session-tags.ts
+++ b/src/shared/session-tags.ts
@@ -106,6 +106,13 @@ export function isSessionBusy(session: SessionTagSource): boolean {
 		|| session.status === "starting";
 }
 
+/** Whether the canonical sidebar row shows a timestamp rather than active shimmer. */
+export function sessionShowsLastActivity(session: SessionTagSource): boolean {
+	return session.isCompacting !== true
+		&& session.status !== "streaming"
+		&& session.status !== "busy";
+}
+
 /**
  * Whether a read session is eligible for suppression by production Show Read.
  * Other states, including serialized `archived` records and active work, remain

--- a/tests/ui-fixtures/sidebar-status-journey-fixture-entry.ts
+++ b/tests/ui-fixtures/sidebar-status-journey-fixture-entry.ts
@@ -2,12 +2,14 @@ import { html, render } from "lit";
 import { commitGatewayConnection } from "../../src/app/gateway-fetch.js";
 import { doRenderApp } from "../../src/app/render.js";
 import { markSessionVisited } from "../../src/app/render-helpers.js";
+import { animateSidebarStatusChanges, captureSidebarStatusMotion, installSidebarStatusMotionClickGuard } from "../../src/app/sidebar-status-motion.js";
 import { buildSidebarStatusSections, renderSidebarStatusContent, renderSidebarViewControls } from "../../src/app/sidebar.js";
 import {
 	setProjects,
 	setRenderApp,
 	state,
 	type GatewaySession,
+	type Goal,
 	type Project,
 } from "../../src/app/state.js";
 import {
@@ -17,8 +19,10 @@ import {
 } from "../../src/app/sidebar-tree-state.js";
 import {
 	SIDEBAR_SESSION_VIEW_STORAGE_KEY,
+	SIDEBAR_STATUS_COLLAPSED_SECTIONS_STORAGE_KEY,
 	SIDEBAR_STATUS_FILTER_STORAGE_KEYS,
 	loadSidebarSessionView,
+	loadSidebarStatusCollapsedSections,
 	loadSidebarStatusFilter,
 } from "../../src/app/sidebar-view-preferences.js";
 
@@ -29,6 +33,17 @@ const PROJECT: Project = {
 	rootPath: "/tmp/sidebar-status-journey",
 	colorLight: "#2563eb",
 	colorDark: "#60a5fa",
+};
+const GOAL_ID = "sidebar-status-goal";
+const GOAL: Goal = {
+	id: GOAL_ID,
+	title: "Improve session manager sidebar",
+	cwd: PROJECT.rootPath,
+	projectId: PROJECT_ID,
+	state: "in-progress",
+	spec: "Status fixture goal",
+	createdAt: 1,
+	updatedAt: 1,
 };
 
 const IDS = {
@@ -52,6 +67,7 @@ const STAFF_RUNTIME_TITLE = "Underlying Staff Runtime";
 
 const VIEW_KEYS = [
 	SIDEBAR_SESSION_VIEW_STORAGE_KEY,
+	SIDEBAR_STATUS_COLLAPSED_SECTIONS_STORAGE_KEY,
 	...Object.values(SIDEBAR_STATUS_FILTER_STORAGE_KEYS),
 	"bobbit-show-archived",
 	"bobbit-show-busy",
@@ -180,7 +196,7 @@ function fixtureSessions(): GatewaySession[] {
 	return [
 		createSession({ id: IDS.pinnedNew, title: "Pinned Newest", status: "idle", createdAt: 91, lastActivity: 9_100, user_tags: persistedPinTags.get(IDS.pinnedNew) ?? ["pinned=true"] }),
 		createSession({ id: IDS.pinnedOld, title: "Pinned Older", status: "idle", createdAt: 81, lastActivity: 8_100, user_tags: persistedPinTags.get(IDS.pinnedOld) ?? ["pinned=true"] }),
-		createSession({ id: IDS.unreadNew, title: "Unread Newest", status: "idle", createdAt: 71, lastActivity: 7_100, lastReadAt: 1, lastTurnErrored: true, consecutiveErrorTurns: 3 }),
+		createSession({ id: IDS.unreadNew, title: "Unread Newest", status: "idle", createdAt: 71, lastActivity: 7_100, lastReadAt: 1, lastTurnErrored: true, consecutiveErrorTurns: 3, goalId: GOAL_ID }),
 		createSession({ id: IDS.unreadOld, title: "Unread Older", status: "idle", createdAt: 61, lastActivity: 6_100, lastReadAt: 1, lastTurnErrored: true, consecutiveErrorTurns: 3 }),
 		createSession({ id: IDS.readNew, title: "Read Newest", status: "idle", createdAt: 51, lastActivity: 5_100 }),
 		createSession({ id: IDS.readOld, title: "Read Older", status: "idle", createdAt: 41, lastActivity: 4_100 }),
@@ -209,6 +225,7 @@ function loadPreferences(): void {
 	state.statusShowBusy = loadSidebarStatusFilter("showBusy");
 	state.statusShowRead = loadSidebarStatusFilter("showRead");
 	state.statusShowTeams = loadSidebarStatusFilter("showTeams");
+	state.statusCollapsedSections = loadSidebarStatusCollapsedSections();
 	state.showArchived = localStorage.getItem("bobbit-show-archived") === "true";
 	state.showBusy = localStorage.getItem("bobbit-show-busy") !== "false";
 	state.showRead = localStorage.getItem("bobbit-show-read") !== "false";
@@ -253,7 +270,7 @@ async function resetFixture(options: {
 		connectionStatus: "connected",
 		gatewaySessions: fixtureSessions(),
 		archivedSessions: [fixtureArchivedSession()],
-		goals: [],
+		goals: [{ ...GOAL }],
 		selectedSessionId: null,
 		connectingSessionId: null,
 		remoteAgent: null,
@@ -300,13 +317,22 @@ function markFixtureSessionRead(sessionId: string): void {
 	renderFixture();
 }
 
+function reorderUnreadFixtureRows(): void {
+	const session = state.gatewaySessions.find((candidate) => candidate.id === IDS.unreadOld);
+	if (session) session.lastActivity = 7_200;
+	renderFixture();
+}
+
 function renderMobileStatusFixture(): void {
 	setRenderApp(renderMobileStatusFixture);
 	state.sidebarSessionView = "status";
 	localStorage.setItem(SIDEBAR_SESSION_VIEW_STORAGE_KEY, "status");
 	const app = document.getElementById("app");
 	if (!app) throw new Error("#app missing");
+	installSidebarStatusMotionClickGuard();
+	const motion = captureSidebarStatusMotion(app);
 	render(html`<div class="sidebar-root">${renderSidebarViewControls("mobile")}${renderSidebarStatusContent(buildSidebarStatusSections(undefined, "mobile"))}</div>`, app);
+	animateSidebarStatusChanges(motion, app);
 }
 
 setRenderApp(renderFixture);
@@ -316,6 +342,7 @@ setRenderApp(renderFixture);
 (window as any).__resetSidebarStatusJourney = resetFixture;
 (window as any).__reloadSidebarStatusJourney = simulateReload;
 (window as any).__markSidebarStatusSessionRead = markFixtureSessionRead;
+(window as any).__reorderSidebarStatusUnreadRows = reorderUnreadFixtureRows;
 (window as any).__renderMobileSidebarStatusJourney = renderMobileStatusFixture;
 (window as any).__releaseSidebarStatusStaffResponse = () => {
 	releaseStaffResponse?.();

--- a/tests2/browser/journeys/app-smoke.journey.spec.ts
+++ b/tests2/browser/journeys/app-smoke.journey.spec.ts
@@ -71,6 +71,45 @@ test.describe("Journey: Session Sharing", () => {
 		}
 	});
 
+	test("desktop session header keeps goal context inline without changing height", async ({ page }) => {
+		const goalTitle = `Header goal ${Date.now()}`;
+		const goal = await createGoal({ title: goalTitle, team: false, worktree: false });
+		const goalSessionId = await createSession({ goalId: goal.id as string });
+		const standaloneSessionId = await createSession();
+		await Promise.all([
+			waitForSessionStatus(goalSessionId, "idle"),
+			waitForSessionStatus(standaloneSessionId, "idle"),
+		]);
+		try {
+			await page.setViewportSize({ width: 1280, height: 800 });
+			await openApp(page);
+			await navigateToHash(page, `#/session/${goalSessionId}`);
+			await expect(page.locator("message-editor textarea").first()).toBeVisible({ timeout: 15_000 });
+
+			const titleLine = page.getByTestId("desktop-session-header-title-line");
+			await expect(titleLine).toBeVisible();
+			await expect(page.getByTestId("desktop-session-header-goal-separator")).toHaveText("·");
+			await expect(page.getByTestId("desktop-session-header-goal-title")).toHaveText(goalTitle);
+			const goalHeaderHeight = await page.getByTestId("app-header-row").evaluate(element => element.getBoundingClientRect().height);
+			const titleAndGoalShareLine = await titleLine.evaluate(element => {
+				const sessionTitle = element.querySelector<HTMLElement>("[data-testid='desktop-session-header-title']")!.getBoundingClientRect();
+				const goalTitleRect = element.querySelector<HTMLElement>("[data-testid='desktop-session-header-goal-title']")!.getBoundingClientRect();
+				return Math.abs((sessionTitle.top + sessionTitle.height / 2) - (goalTitleRect.top + goalTitleRect.height / 2)) < 2;
+			});
+			expect(titleAndGoalShareLine, "session and goal titles should share one desktop header line").toBe(true);
+
+			await navigateToHash(page, `#/session/${standaloneSessionId}`);
+			await expect(page.locator("message-editor textarea").first()).toBeVisible({ timeout: 15_000 });
+			await expect(page.getByTestId("desktop-session-header-goal-title")).toHaveCount(0);
+			const standaloneHeaderHeight = await page.getByTestId("app-header-row").evaluate(element => element.getBoundingClientRect().height);
+			expect(Math.abs(goalHeaderHeight - standaloneHeaderHeight), "goal context must not change desktop header height").toBeLessThanOrEqual(1);
+		} finally {
+			await deleteSession(goalSessionId);
+			await deleteSession(standaloneSessionId);
+			await deleteGoal(goal.id as string);
+		}
+	});
+
 	test("copy-link button is present in session header", async ({ page }) => {
 		const sessionId = await createSession();
 		await waitForSessionStatus(sessionId, "idle");

--- a/tests2/browser/journeys/sidebar-status.journey.spec.ts
+++ b/tests2/browser/journeys/sidebar-status.journey.spec.ts
@@ -28,6 +28,7 @@ const DEPS = [
 	ENTRY,
 	path.resolve("src/app/sidebar.ts"),
 	path.resolve("src/app/sidebar-status.ts"),
+	path.resolve("src/app/sidebar-status-motion.ts"),
 	path.resolve("src/app/sidebar-view-preferences.ts"),
 	path.resolve("src/app/render.ts"),
 	path.resolve("src/app/render-helpers.ts"),
@@ -88,6 +89,23 @@ async function sessionIdsInSection(page: Page, key: "pinned" | "unread" | "read"
 	return section(page, key).locator("[data-session-id]").evaluateAll((elements) =>
 		elements.map((element) => (element as HTMLElement).dataset.sessionId || "").filter(Boolean),
 	);
+}
+
+async function headingMetrics(heading: Locator, labelSelector: string) {
+	return heading.evaluate((element, selector) => {
+		const label = element.querySelector<HTMLElement>(selector);
+		if (!label) throw new Error(`Missing heading label: ${selector}`);
+		const headingStyle = getComputedStyle(element);
+		const labelStyle = getComputedStyle(label);
+		return {
+			height: element.getBoundingClientRect().height,
+			contentHeight: label.getBoundingClientRect().height + Number.parseFloat(headingStyle.paddingTop) + Number.parseFloat(headingStyle.paddingBottom),
+			padding: [headingStyle.paddingTop, headingStyle.paddingRight, headingStyle.paddingBottom, headingStyle.paddingLeft],
+			fontSize: labelStyle.fontSize,
+			fontWeight: labelStyle.fontWeight,
+			letterSpacing: labelStyle.letterSpacing,
+		};
+	}, labelSelector);
 }
 
 function filtersButton(page: Page): Locator {
@@ -169,8 +187,11 @@ test.describe("Journey: Sidebar status views", () => {
 		// Clean profile: one search, By Project selected, and canonical tree intact.
 		await expect(page.locator("input[data-search]")).toHaveCount(1);
 		await expect(page.getByTestId("sidebar-view-project")).toHaveAttribute("aria-pressed", "true");
-		await expect(page.getByTestId("project-header").filter({ hasText: "Status Journey Project" })).toBeVisible();
-		await expect(page.getByTestId("sidebar-sessions-header")).toBeVisible();
+		const projectHeader = page.getByTestId("project-header").filter({ hasText: "Status Journey Project" });
+		await expect(projectHeader).toBeVisible();
+		const projectGroupingHeader = page.getByTestId("sidebar-sessions-header");
+		await expect(projectGroupingHeader).toBeVisible();
+		const projectHeadingMetrics = await headingMetrics(projectGroupingHeader, ":scope > .flex-1");
 		await expect(row(page, ids.readNew)).toBeVisible();
 
 		// Shared search and Full Search remain available in Project mode.
@@ -193,7 +214,79 @@ test.describe("Journey: Sidebar status views", () => {
 		)).toEqual(["pinned", "unread", "read"]);
 		await expect.poll(() => sessionIdsInSection(page, "pinned")).toEqual([ids.pinnedNew, ids.pinnedOld]);
 		await expect.poll(() => sessionIdsInSection(page, "unread")).toEqual([ids.unreadNew, ids.unreadOld]);
-		await expect.poll(() => sessionIdsInSection(page, "read")).toEqual([ids.readNew, ids.readOld, ids.busy, ids.teamLead, ids.staffSession]);
+		await expect.poll(() => sessionIdsInSection(page, "read")).toEqual([ids.busy, ids.readNew, ids.readOld, ids.teamLead, ids.staffSession]);
+		const goalOwnedRow = row(page, ids.unreadNew);
+		await expect(goalOwnedRow.getByTestId("sidebar-status-goal-title")).toHaveText("IMPROVE SESSION MANAGER SIDEBAR");
+		await expect(goalOwnedRow.getByTestId("sidebar-session-title-text"), `${MARK}: agent title moves to the quiet second line`).toHaveText("Unread Newest");
+		const goalIconColor = await goalOwnedRow.locator(".sidebar-status-goal-title-icon").evaluate(element => getComputedStyle(element).color);
+		expect(["rgb(37, 99, 235)", "rgb(96, 165, 250)"], `${MARK}: goal icon uses the owning project colour`).toContain(goalIconColor);
+		await expect(goalOwnedRow.getByTestId("sidebar-status-session-title-icon"), `${MARK}: goal rows do not duplicate the session identity icon`).toHaveCount(0);
+		const standaloneRow = row(page, ids.unreadOld);
+		await expect(standaloneRow.getByTestId("sidebar-status-goal-title"), `${MARK}: standalone sessions stay single-line`).toHaveCount(0);
+		await expect(standaloneRow.getByTestId("sidebar-status-session-title-icon"), `${MARK}: standalone Status rows show a session icon`).toHaveAttribute("data-status-identity", "session");
+		const staffRow = row(page, ids.staffSession);
+		await expect(staffRow.getByTestId("sidebar-status-session-title-icon"), `${MARK}: staff Status rows use the staff icon instead of the session icon`).toHaveAttribute("data-status-identity", "staff");
+		const sessionIconColor = await standaloneRow.getByTestId("sidebar-status-session-title-icon").evaluate(element => getComputedStyle(element).color);
+		expect(["rgb(37, 99, 235)", "rgb(96, 165, 250)"], `${MARK}: session icon uses the owning project colour`).toContain(sessionIconColor);
+
+		const motionResult = await page.evaluate((sessionId) => {
+			(window as any).__reorderSidebarStatusUnreadRows();
+			const movingRow = document.querySelector<HTMLElement>(`[data-session-id="${sessionId}"]`)!;
+			const clickTarget = movingRow.querySelector<HTMLElement>("[data-testid='sidebar-session-title-text']")!;
+			const clickDispatched = clickTarget.dispatchEvent(new MouseEvent("click", {
+				bubbles: true,
+				cancelable: true,
+				detail: 1,
+			}));
+			return {
+				moving: movingRow.dataset.statusMoving,
+				tracing: movingRow.dataset.statusChangeTracing,
+				clickDispatched,
+				selectedSessionId: (window as any).__bobbitState.selectedSessionId,
+			};
+		}, ids.unreadOld);
+		expect(motionResult, `${MARK}: FLIP rows trace changes and suppress pointer clicks while moving`).toEqual({
+			moving: "true",
+			tracing: "true",
+			clickDispatched: false,
+			selectedSessionId: null,
+		});
+		await expect.poll(() => sessionIdsInSection(page, "unread")).toEqual([ids.unreadOld, ids.unreadNew]);
+		await expect(row(page, ids.unreadOld)).not.toHaveAttribute("data-status-moving", "true", { timeout: 2_000 });
+
+		for (const key of ["pinned", "unread", "read"] as const) {
+			const heading = section(page, key).locator(".sidebar-status-heading");
+			await expect(heading.locator(".sidebar-status-heading-icon svg"), `${MARK}: ${key} heading needs an icon`).toHaveCount(1);
+			await expect(heading.locator(".sidebar-chevron-glyph"), `${MARK}: ${key} heading needs a disclosure chevron`).toHaveText("▾");
+			const metrics = await headingMetrics(heading, ".sidebar-status-heading-label");
+			expect(metrics.contentHeight, `${MARK}: ${key} heading content height should match By Project`).toBeCloseTo(projectHeadingMetrics.contentHeight, 2);
+			expect(metrics.padding, `${MARK}: ${key} heading padding should match By Project`).toEqual(projectHeadingMetrics.padding);
+			expect(
+				{ fontSize: metrics.fontSize, fontWeight: metrics.fontWeight, letterSpacing: metrics.letterSpacing },
+				`${MARK}: ${key} heading typography should match By Project`,
+			).toEqual({
+				fontSize: projectHeadingMetrics.fontSize,
+				fontWeight: projectHeadingMetrics.fontWeight,
+				letterSpacing: projectHeadingMetrics.letterSpacing,
+			});
+		}
+		await expect(page.locator(".sidebar-status-separator"), `${MARK}: rules belong only between Status sections`).toHaveCount(2);
+		expect(await section(page, "pinned").evaluate((element) => element.previousElementSibling?.classList.contains("sidebar-status-separator") ?? false)).toBe(false);
+		for (const key of ["unread", "read"] as const) {
+			expect(await section(page, key).evaluate((element) => element.previousElementSibling?.classList.contains("sidebar-status-separator") ?? false)).toBe(true);
+		}
+
+		// Status headings collapse like project groups and persist independently.
+		const unreadHeading = section(page, "unread").locator(".sidebar-status-heading");
+		await unreadHeading.click();
+		await expect(unreadHeading).toHaveAttribute("aria-expanded", "false");
+		await expect(section(page, "unread").locator("[data-session-id]")).toHaveCount(0);
+		await expect(section(page, "pinned").locator("[data-session-id]")).toHaveCount(2);
+		await page.evaluate(() => (window as any).__reloadSidebarStatusJourney());
+		await expect(section(page, "unread").locator(".sidebar-status-heading")).toHaveAttribute("aria-expanded", "false");
+		await section(page, "unread").locator(".sidebar-status-heading").press("Enter");
+		await expect.poll(() => sessionIdsInSection(page, "unread")).toEqual([ids.unreadNew, ids.unreadOld]);
+
 		const allIds = await page.locator("[data-status-section] [data-session-id]").evaluateAll((elements) =>
 			elements.map((element) => (element as HTMLElement).dataset.sessionId),
 		);
@@ -286,6 +379,7 @@ test.describe("Journey: Sidebar status views", () => {
 		await expect(filterCheckbox(page, "archived")).toBeChecked();
 		await closeFiltersWithEscape(page);
 		await expect(row(page, ids.archived)).toBeVisible();
+		await expect(row(page, ids.archived).getByTestId("sidebar-status-session-title-icon"), `${MARK}: archived standalone rows retain the session identity icon`).toHaveCount(1);
 		await expect(row(page, ids.archived)).toHaveCSS("filter", "grayscale(1)");
 		await openSessionMenu(page, ids.archived);
 		expect((await menuItemIds(page)).slice(0, 3)).toEqual(["continue-archived", "copy-link", "pin"]);
@@ -323,6 +417,9 @@ test.describe("Journey: Sidebar status views", () => {
 		await page.setViewportSize({ width: 390, height: 844 });
 		await page.evaluate(() => (window as any).__renderMobileSidebarStatusJourney());
 		await expect(page.getByTestId("sidebar-view-status")).toHaveAttribute("aria-pressed", "true", { timeout: 10_000 });
+		const mobileGoalFontSize = await row(page, ids.unreadNew).getByTestId("sidebar-status-goal-title").evaluate(element => parseFloat(getComputedStyle(element).fontSize));
+		const mobileSessionFontSize = await row(page, ids.unreadOld).getByTestId("sidebar-session-title-text").evaluate(element => parseFloat(getComputedStyle(element).fontSize));
+		expect(mobileGoalFontSize, `${MARK}: mobile goal title is deliberately smaller than a standard session title`).toBeLessThan(mobileSessionFontSize);
 
 		const targetRow = row(page, ids.readNew);
 		await expect(targetRow).toBeVisible();

--- a/tests2/core/session-tags.test.ts
+++ b/tests2/core/session-tags.test.ts
@@ -9,6 +9,7 @@ import {
 	projectServerTags,
 	removeTag,
 	replaceTag,
+	sessionShowsLastActivity,
 	sessionTeamKind,
 } from "../../src/shared/session-tags.js";
 
@@ -95,6 +96,16 @@ describe("canonical session tag classifiers", () => {
 		["busy", false, false],
 	] as const)("classifies status=%s compacting=%s as busy=%s", (status, isCompacting, expected) => {
 		expect(isSessionBusy({ status, isCompacting })).toBe(expected);
+	});
+
+	it.each([
+		["streaming", false, false],
+		["busy", false, false],
+		["idle", true, false],
+		["idle", false, true],
+		["terminated", false, true],
+	] as const)("classifies status=%s compacting=%s as showing last activity=%s", (status, isCompacting, expected) => {
+		expect(sessionShowsLastActivity({ status, isCompacting })).toBe(expected);
 	});
 
 	it.each([

--- a/tests2/core/sidebar-status.test.ts
+++ b/tests2/core/sidebar-status.test.ts
@@ -72,6 +72,9 @@ describe("collectEligibleStatusSessions", () => {
 			() => staffSession,
 		);
 		assert.deepEqual(new Set(ids(collected)), new Set(["lead", "member", "child", "staff-live"]));
+		assert.equal(collected.find(value => value.session.id === "lead")?.goalId, "g");
+		assert.equal(collected.find(value => value.session.id === "member")?.goalId, "g");
+		assert.equal(collected.find(value => value.session.id === "child")?.goalId, "g", "child membership inherits from its tree ancestors");
 		assert.equal(collected.find(value => value.session.id === "staff-live")?.staff, true);
 	});
 
@@ -84,7 +87,7 @@ describe("collectEligibleStatusSessions", () => {
 		} as SidebarTreeNode;
 		const liveNode = {
 			kind: "session",
-			context: { session: live },
+			context: { session: live, goalId: "goal-live" },
 		} as SidebarTreeNode;
 		const model = { flatByKey: new Map([["archived", archivedNode], ["live", liveNode]]) } as Pick<SidebarTreeModel, "flatByKey">;
 		const collected = collectEligibleStatusSessions(model, [{ currentSessionId: "same" }], () => ({ ...live, title: "Staff name", staffId: "staff" }));
@@ -92,6 +95,7 @@ describe("collectEligibleStatusSessions", () => {
 		assert.equal(collected[0].archived, false);
 		assert.equal(collected[0].staff, true);
 		assert.equal(collected[0].session.title, "Staff name");
+		assert.equal(collected[0].goalId, "goal-live", "staff display replacement preserves canonical tree membership");
 	});
 });
 
@@ -108,14 +112,22 @@ describe("selectSidebarStatusSections", () => {
 		assert.equal([...sections.pinned, ...sections.unread, ...sections.read].length, 3);
 	});
 
-	it("sorts each section by activity, creation, then id", () => {
+	it("sorts timestamp rows by activity and keeps shimmer-only active rows stable", () => {
 		const sections = select([
 			candidate("z", { lastActivity: 20, createdAt: 5, server_tags: ["read-state=unread"] }),
 			candidate("b", { lastActivity: 20, createdAt: 10, server_tags: ["read-state=unread"] }),
 			candidate("a", { lastActivity: 20, createdAt: 10, server_tags: ["read-state=unread"] }),
 			candidate("newest", { lastActivity: 30, createdAt: 1, server_tags: ["read-state=unread"] }),
+			candidate("active-new", { status: "streaming", lastActivity: 100, createdAt: 40, server_tags: ["read-state=unread"] }),
+			candidate("active-old", { status: "busy", lastActivity: 200, createdAt: 35, server_tags: ["read-state=unread"] }),
 		]);
-		assert.deepEqual(ids(sections.unread), ["newest", "a", "b", "z"]);
+		assert.deepEqual(ids(sections.unread), ["active-new", "active-old", "newest", "a", "b", "z"]);
+
+		const afterHiddenActivityChurn = select([
+			candidate("active-new", { status: "streaming", lastActivity: 500, createdAt: 40, server_tags: ["read-state=unread"] }),
+			candidate("active-old", { status: "busy", lastActivity: 900, createdAt: 35, server_tags: ["read-state=unread"] }),
+		]);
+		assert.deepEqual(ids(afterHiddenActivityChurn.unread), ["active-new", "active-old"], "hidden timestamps must not reorder shimmer-only rows");
 	});
 
 	it("applies Archived, teams, Busy, and Read gates with only Busy/Read active exemptions", () => {

--- a/tests2/core/sidebar-view-preferences.test.ts
+++ b/tests2/core/sidebar-view-preferences.test.ts
@@ -3,13 +3,16 @@ import { afterAll, beforeEach, describe, it } from "vitest";
 import {
 	SIDEBAR_PROJECT_FILTER_STORAGE_KEYS,
 	SIDEBAR_SESSION_VIEW_STORAGE_KEY,
+	SIDEBAR_STATUS_COLLAPSED_SECTIONS_STORAGE_KEY,
 	SIDEBAR_STATUS_FILTER_STORAGE_KEYS,
 	getSidebarViewFilters,
 	isSidebarViewFilterActive,
 	loadSidebarSessionView,
+	loadSidebarStatusCollapsedSections,
 	loadSidebarStatusFilter,
 	parseSidebarSessionView,
 	setActiveSidebarViewFilter,
+	setSidebarStatusSectionExpanded,
 	setSidebarView,
 	setSidebarViewFilter,
 	sidebarNeedsArchivedSessions,
@@ -47,6 +50,7 @@ function preferenceState(): SidebarViewPreferenceState {
 		statusShowBusy: true,
 		statusShowRead: true,
 		statusShowTeams: false,
+		statusCollapsedSections: new Set(),
 		filtersPopoverOpen: false,
 	};
 }
@@ -73,6 +77,20 @@ describe("sidebar view preference validation", () => {
 		assert.equal(loadSidebarStatusFilter("showBusy"), false);
 		assert.equal(loadSidebarStatusFilter("showRead"), true);
 		assert.equal(loadSidebarStatusFilter("showTeams"), false);
+	});
+
+	it("persists only valid collapsed Status sections", () => {
+		const state = preferenceState();
+		setSidebarStatusSectionExpanded(state, "unread", false);
+		setSidebarStatusSectionExpanded(state, "pinned", false);
+		assert.deepEqual([...state.statusCollapsedSections!].sort(), ["pinned", "unread"]);
+		assert.equal(storage.getItem(SIDEBAR_STATUS_COLLAPSED_SECTIONS_STORAGE_KEY), '["pinned","unread"]');
+		assert.deepEqual([...loadSidebarStatusCollapsedSections()].sort(), ["pinned", "unread"]);
+
+		storage.setItem(SIDEBAR_STATUS_COLLAPSED_SECTIONS_STORAGE_KEY, '["read","invalid",3]');
+		assert.deepEqual([...loadSidebarStatusCollapsedSections()], ["read"]);
+		storage.setItem(SIDEBAR_STATUS_COLLAPSED_SECTIONS_STORAGE_KEY, "corrupt");
+		assert.deepEqual([...loadSidebarStatusCollapsedSections()], []);
 	});
 });
 


### PR DESCRIPTION
## Summary
- add the By Status sidebar view with persisted filters, collapsible sections, goal/staff identity, and meaningful activity ordering
- animate meaningful row changes with reduced-motion support and suppress pointer clicks while rows move
- keep desktop session headers stable by placing goal context inline after an interpunct

## Tests
- npm run check
- 50 focused core tests
- 6 focused browser journeys

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)