### PR TITLE
Fix sidebar accessory occlusion

### DIFF
--- a/docs/bobbit-sprites.md
+++ b/docs/bobbit-sprites.md
@@ -8,7 +8,7 @@ The **Bobbit** is a squishy green pixel-art blob — think Stardew Valley slime 
 - **Chat blob** — a larger 3.5× scale animated character in the `StreamingMessageContainer`, expressing the agent's activity state through Disney-style animations
 - **Role page** — inline blobs at arbitrary sizes inside role cards and the accessory picker
 
-The bobbit uses one canonical pixel grid across renderers. Sidebar sprites and accessories use CSS `box-shadow`; chat and inline body sprites use a device-pixel canvas so eye frames can be swapped atomically without resampling artifacts. There are no image or SVG assets. Accessories remain separate overlay `<div>`s and are counter-hue-rotated to maintain color stability across session identities.
+The bobbit uses one canonical pixel grid across renderers. Sidebar sprites and accessories are cached device-pixel canvas images; chat accessories use CSS `box-shadow`, while chat and inline body sprites use canvas so eye frames can be swapped atomically without resampling artifacts. There are no image or SVG assets. Accessories remain separate overlays and are counter-hue-rotated to maintain color stability across session identities.
 
 ---
 
@@ -405,6 +405,7 @@ The second bubble is offset by 1s delay for a staggered effect.
 | `bobbit-squish` | 1.5s | ScaleX/scaleY oscillation during compaction |
 | `bobbit-eyes` | 6s | Blink + look right cycle for selected sessions |
 | `bobbit-eyes-squash` | 6s | Same as above but with squash transform for compacting state |
+| `bobbit-sidebar-accessory-turn-front` / `-right` | 6s | Compositor-only opacity swap for headset/ponytail right-facing frames, synchronized with the selected eye cycle |
 | `blob-shimmer` | 8s | Reused from chat blob for streaming sidebar bobbits |
 
 ---
@@ -415,23 +416,27 @@ The second bubble is offset by 1s delay for a staggered effect.
 
 **File**: `src/app/session-colors.ts`
 
-The `statusBobbit()` function generates a self-contained `html` template literal with inline styles. No external CSS classes — everything is inline for simplicity.
+`statusBobbit()` resolves identity/status and delegates to `renderSidebarBobbitCanvas()`. Each pixel layer is encoded once at high resolution, cached as a data URL, and displayed at the 1.6× CSS size.
 
 **Structure**:
 ```
-<span container>          ← flex container, filter (hue-rotate + saturation), non-idle status animation
-  <span sprite>           ← box-shadow pixel art, base transform, shimmer animation
-  <span eyeLayer?>        ← separate eye overlay for selected sessions (enables independent eye animation)
-  <span accessoryLayer?>  ← counter-hue-rotated accessory overlay
+<span container>                ← filter and status animation
+  <img bodyLayer>               ← cached body bitmap
+  <img blinkLayer?>             ← unread blink bitmap
+  <img eyeLayer?>               ← selected-session eye overlay
+  <img accessoryFront?>         ← cached normal accessory bitmap
+  <img accessoryRightFacing?>   ← optional cached occluded bitmap
 </span>
 ```
 
 **Key behaviors**:
-- Scale: 1.6× via `transform: scale(1.6)`
+- Scale: high-resolution canvas bitmap displayed at 1.6×
 - Idle sessions: `saturate(0.4)` filter and sleeping/idle styling, but no continuous `bobbit-breathe` animation
 - Streaming sessions: `bobbit-bob` animation + `blob-shimmer`
 - Compacting: `bobbit-squish` animation with squash transform
 - Selected session: Eye layer shown with `bobbit-eyes` animation (blink + look right)
+- Headset/ponytail selected session: two immutable accessory bitmaps swap opacity on the same CSS clock; this adds no JS timer or per-frame canvas work
+- Headset/ponytail unread inactive row: only the right-facing bitmap is rendered because the unread gaze is statically right
 - Unread inactive rows: the outer row wrapper may still run the unread pulse/tap animation, even when the bobbit itself is idle
 - Aborting: `saturate(0.3)` + `bobbit-cancel-fade` opacity pulse
 - Status colors: Yellow for starting, red for terminated (applied via different box-shadow colors, not hue-rotate)
@@ -613,7 +618,7 @@ In `idleBlob()`, the div is already rendered because it's in the chat blob DOM. 
 
 #### 6. Sidebar support (`src/app/session-colors.ts`)
 
-The sidebar `statusBobbit()` function automatically resolves accessories via `getAccessory(id)` and renders the box-shadow. No additional code needed unless the accessory requires special positioning logic (check the bandana/crown handling for reference).
+The sidebar `statusBobbit()` function automatically resolves accessories via `getAccessory(id)` and renders the cached canvas bitmap. Accessories needing right-facing occlusion may provide `sidebarRightFacingPixels`; the renderer swaps that cached frame in sync with the selected eye cycle and uses it directly for unread right-gazing rows.
 
 #### 7. Role assistant description (`src/server/agent/role-assistant.ts`)
 

--- a/src/app/app.css
+++ b/src/app/app.css
@@ -1034,6 +1034,25 @@ details.wf-proposal-workflow .wf-proposal-gates {
 	90%, 100% { transform: scaleY(0.75) translateY(7.2px); opacity: 1; transform-origin: 0 14.4px; }
 }
 
+/* Sidebar headset/ponytail right-facing occlusion. Two immutable canvas
+ * bitmaps swap opacity on the existing 6s eye clock. This stays compositor-only:
+ * no JS timer, canvas redraw, or main-thread animation work. */
+.bobbit-sidebar-accessory-turn-front {
+	animation: bobbit-sidebar-accessory-turn-front 6s step-end infinite;
+}
+.bobbit-sidebar-accessory-turn-right {
+	opacity: 0;
+	animation: bobbit-sidebar-accessory-turn-right 6s step-end infinite;
+}
+@keyframes bobbit-sidebar-accessory-turn-front {
+	0%, 73%, 87%, 100% { opacity: 1; }
+	74%, 86% { opacity: 0; }
+}
+@keyframes bobbit-sidebar-accessory-turn-right {
+	0%, 73%, 87%, 100% { opacity: 0; }
+	74%, 86% { opacity: 1; }
+}
+
 /* ============================================================================
  * EMPTY STATE — gentle floating animation for placeholder icons
  * ============================================================================ */

--- a/src/ui/bobbit-render.ts
+++ b/src/ui/bobbit-render.ts
@@ -761,6 +761,7 @@ export function renderSidebarBobbitCanvas(opts: SidebarBobbitOptions): TemplateR
 	else p = CANONICAL_PALETTE;
 
 	const isBusy = status === "streaming" || status === "busy" || isCompacting;
+	const isCancelling = isAborting && (status === "streaming" || isBusy);
 	// Idle / not-currently-viewed sessions render with sleeping eyes (closed)
 	// to match the chat blob's sleeping pose. noDesaturate previews (role
 	// manager etc.) keep awake eyes so the bobbit looks alive in selection UI.
@@ -923,7 +924,9 @@ export function renderSidebarBobbitCanvas(opts: SidebarBobbitOptions): TemplateR
 			}
 
 			const rightPixels = spriteData.sidebarRightFacingPixels;
-			animateSidebarTurn = !!rightPixels?.length && isSelected && !isCompacting;
+			// Normal compaction squishes without a gaze cycle. Cancelling compaction
+			// still uses bobbit-eyes-squash-s, so its right-facing beat must swap too.
+			animateSidebarTurn = !!rightPixels?.length && isSelected && (!isCompacting || isCancelling);
 			const showRightOnly = !!rightPixels?.length && unread && !isSelected;
 			if (!showRightOnly) {
 				accLeft = sidebarOriginX + frontBounds.xShift * S;
@@ -943,7 +946,6 @@ export function renderSidebarBobbitCanvas(opts: SidebarBobbitOptions): TemplateR
 
 	// Animation styles (same logic as before)
 	const isIdle = status === "idle" && !isCompacting && !isSelected && !noDesaturate;
-	const isCancelling = isAborting && (status === "streaming" || isBusy);
 	const filters: string[] = [];
 	if (hueRotate && status !== "starting" && status !== "terminated") filters.push(`hue-rotate(${hueRotate}deg)`);
 	if (isCancelling) filters.push("saturate(0.3)");

--- a/src/ui/bobbit-render.ts
+++ b/src/ui/bobbit-render.ts
@@ -861,61 +861,83 @@ export function renderSidebarBobbitCanvas(opts: SidebarBobbitOptions): TemplateR
 		eyeUrl = cached;
 	}
 
-	// Accessory at HI× scale
+	// Accessory at HI× scale. Headset/ponytail provide a smaller right-facing
+	// sidebar frame. Selected rows swap between two cached bitmaps using a
+	// step-end CSS opacity animation; unread rows render only the right-facing
+	// bitmap. No JS timer or per-frame canvas work is involved.
 	let accUrl = "";
 	let accCssW = 0;
 	let accCssH = 0;
 	let accLeft = 0;
+	let rightAccUrl = "";
+	let rightAccCssW = 0;
+	let rightAccCssH = 0;
+	let rightAccLeft = 0;
+	let animateSidebarTurn = false;
 	const sidebarContainerWidth = 20;
 	let sidebarOriginX = centerInContainer ? (sidebarContainerWidth - cssW) / 2 : 0;
 	if (hasAccessory) {
 		const spriteData = SPRITE_ACCESSORIES[acc.id];
 		if (spriteData && spriteData.pixels.length > 0) {
-			let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
-			for (const [x, y] of spriteData.pixels) {
-				if (x < minX) minX = x;
-				if (y < minY) minY = y;
-				if (x > maxX) maxX = x;
-				if (y > maxY) maxY = y;
-			}
-			const xShift = Math.min(0, minX);
-			const yShift = Math.min(0, minY);
-			const srcW = maxX - xShift + 1;
-			const srcH = maxY - yShift + 1;
+			const boundsFor = (pixels: SpritePixel[]) => {
+				let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
+				for (const [x, y] of pixels) {
+					if (x < minX) minX = x;
+					if (y < minY) minY = y;
+					if (x > maxX) maxX = x;
+					if (y > maxY) maxY = y;
+				}
+				const xShift = Math.min(0, minX);
+				const yShift = Math.min(0, minY);
+				return { xShift, yShift, maxX, srcW: maxX - xShift + 1, srcH: maxY - yShift + 1 };
+			};
+			const rasterize = (pixels: SpritePixel[], cacheKey: string, bounds: ReturnType<typeof boundsFor>) => {
+				let cached = sidebarAccessoryUrlCache.get(cacheKey);
+				if (cached === undefined) {
+					const canvas = document.createElement("canvas");
+					canvas.width = bounds.srcW * HI;
+					canvas.height = bounds.srcH * HI;
+					const ctx = canvas.getContext("2d")!;
+					ctx.imageSmoothingEnabled = false;
+					for (const [x, y, color] of pixels) {
+						ctx.fillStyle = color;
+						ctx.fillRect((x - bounds.xShift) * HI, (y - bounds.yShift) * HI, HI, HI);
+					}
+					cached = canvas.toDataURL();
+					sidebarAccessoryUrlCache.set(cacheKey, cached);
+				}
+				return cached;
+			};
 
+			const frontBounds = boundsFor(spriteData.pixels);
 			// Preserve coordinate alignment between body + accessory. Static author
 			// avatars center the complete group; sidebar rows retain their historical
 			// left alignment except for accessories with left-of-body pixels.
-			if (centerInContainer || xShift < 0) {
-				const groupRight = Math.max(BODY_WIDTH, maxX + 1);
-				const groupWidth = (groupRight - xShift) * S;
+			if (centerInContainer || frontBounds.xShift < 0) {
+				const groupRight = Math.max(BODY_WIDTH, frontBounds.maxX + 1);
+				const groupWidth = (groupRight - frontBounds.xShift) * S;
 				const groupLeft = groupWidth <= sidebarContainerWidth
 					? (sidebarContainerWidth - groupWidth) / 2
 					: 0;
-				sidebarOriginX = groupLeft - xShift * S;
+				sidebarOriginX = groupLeft - frontBounds.xShift * S;
 			}
-			accLeft = sidebarOriginX + xShift * S;
 
-			// CSS geometry is derived from the (static) pixel bounds — cheap to
-			// recompute. Only the data-URL encode is cached, keyed by accessory
-			// id alone since each accessory's pixels are immutable.
-			accCssW = srcW * S;
-			accCssH = srcH * S;
-			let cached = sidebarAccessoryUrlCache.get(acc.id);
-			if (cached === undefined) {
-				const accCanvas = document.createElement("canvas");
-				accCanvas.width = srcW * HI;
-				accCanvas.height = srcH * HI;
-				const accCtx = accCanvas.getContext("2d")!;
-				accCtx.imageSmoothingEnabled = false;
-				for (const [x, y, color] of spriteData.pixels) {
-					accCtx.fillStyle = color;
-					accCtx.fillRect((x - xShift) * HI, (y - yShift) * HI, HI, HI);
-				}
-				cached = accCanvas.toDataURL();
-				sidebarAccessoryUrlCache.set(acc.id, cached);
+			const rightPixels = spriteData.sidebarRightFacingPixels;
+			animateSidebarTurn = !!rightPixels?.length && isSelected && !isCompacting;
+			const showRightOnly = !!rightPixels?.length && unread && !isSelected;
+			if (!showRightOnly) {
+				accLeft = sidebarOriginX + frontBounds.xShift * S;
+				accCssW = frontBounds.srcW * S;
+				accCssH = frontBounds.srcH * S;
+				accUrl = rasterize(spriteData.pixels, acc.id, frontBounds);
 			}
-			accUrl = cached;
+			if (rightPixels?.length && (showRightOnly || animateSidebarTurn)) {
+				const rightBounds = boundsFor(rightPixels);
+				rightAccLeft = sidebarOriginX + rightBounds.xShift * S;
+				rightAccCssW = rightBounds.srcW * S;
+				rightAccCssH = rightBounds.srcH * S;
+				rightAccUrl = rasterize(rightPixels, `${acc.id}|right`, rightBounds);
+			}
 		}
 	}
 
@@ -987,10 +1009,14 @@ export function renderSidebarBobbitCanvas(opts: SidebarBobbitOptions): TemplateR
 		? html`<img src="${eyeUrl}" width="${BODY_WIDTH * HI}" height="${BODY_HEIGHT * HI}" style="position:absolute;left:${sidebarOriginX}px;top:${eyeTop};width:${cssW}px;height:${cssH}px;will-change:transform;${eyeAnim}">`
 		: "";
 
-	// Accessory layer
+	// Accessory layers. The optional second bitmap is opacity-swapped in lockstep
+	// with bobbit-eyes-s; static unread rows use only that right-facing bitmap.
 	const accessoryLayer = accUrl
-		? html`<img src="${accUrl}" style="position:absolute;left:${accLeft}px;top:${accTop};width:${accCssW}px;height:${accCssH}px;will-change:transform;${accTransform}${accFilter}">`
+		? html`<img src="${accUrl}" class="bobbit-sidebar-accessory--front${animateSidebarTurn ? " bobbit-sidebar-accessory-turn-front" : ""}" style="position:absolute;left:${accLeft}px;top:${accTop};width:${accCssW}px;height:${accCssH}px;will-change:transform;${accTransform}${accFilter}">`
+		: "";
+	const rightAccessoryLayer = rightAccUrl
+		? html`<img src="${rightAccUrl}" class="bobbit-sidebar-accessory--right${animateSidebarTurn ? " bobbit-sidebar-accessory-turn-right" : ""}" style="position:absolute;left:${rightAccLeft}px;top:${accTop};width:${rightAccCssW}px;height:${rightAccCssH}px;will-change:transform${animateSidebarTurn ? ",opacity" : ""};${accTransform}${accFilter}">`
 		: "";
 
-	return html`<span style="display:inline-flex;align-items:center;justify-content:center;width:${containerWidth};height:${containerHeight};flex-shrink:0;position:relative;overflow:hidden;margin-top:1px;${filterStyle}${bobAnim}${cancelAnim}${idleAnim}">${bodyLayer}${blinkLayer}${eyeLayer}${accessoryLayer}</span>`;
+	return html`<span style="display:inline-flex;align-items:center;justify-content:center;width:${containerWidth};height:${containerHeight};flex-shrink:0;position:relative;overflow:hidden;margin-top:1px;${filterStyle}${bobAnim}${cancelAnim}${idleAnim}">${bodyLayer}${blinkLayer}${eyeLayer}${accessoryLayer}${rightAccessoryLayer}</span>`;
 }

--- a/src/ui/bobbit-sprite-data.ts
+++ b/src/ui/bobbit-sprite-data.ts
@@ -53,6 +53,9 @@ export interface AccessorySpriteData {
   addsHeight: boolean;
   /** Y-axis delta when rendering in blob context vs sidebar context */
   blobYAdjust: number;
+  /** Optional sidebar-only frame used while the eyes face right. Kept as a
+   *  pixel subset so swapping frames needs only a compositor opacity animation. */
+  sidebarRightFacingPixels?: SpritePixel[];
 }
 
 // ============================================================================
@@ -524,13 +527,7 @@ export const ACCESSORY_NURSE_CAP: AccessorySpriteData = {
  * only (NOT in the flask exception set) so it is counter-hue-rotated and stays
  * neutral across every session palette.
  */
-export const ACCESSORY_HEADSET: AccessorySpriteData = {
-  id: 'headset',
-  label: 'Headset',
-  yOffset: 2,
-  addsHeight: false,
-  blobYAdjust: 2,
-  pixels: [
+const headsetFrontPixels: SpritePixel[] = [
     // Row 0
     [2, 0, '#000'], [3, 0, '#000'], [4, 0, '#000'], [5, 0, '#000'], [6, 0, '#000'], [7, 0, '#000'],
     // Row 1
@@ -547,7 +544,18 @@ export const ACCESSORY_HEADSET: AccessorySpriteData = {
     [0, 6, '#000'], [1, 6, '#000'], [7, 6, '#1f2937'], [8, 6, '#000'], [9, 6, '#000'],
     // Row 7
     [4, 7, '#f97316'], [5, 7, '#1f2937'], [6, 7, '#1f2937'],
-  ],
+];
+
+export const ACCESSORY_HEADSET: AccessorySpriteData = {
+  id: 'headset',
+  label: 'Headset',
+  yOffset: 2,
+  addsHeight: false,
+  blobYAdjust: 2,
+  pixels: headsetFrontPixels,
+  // Sidebar eyes have a simpler right-facing beat than the chat choreography:
+  // retain the band and near cup, but let the body occlude the far/right cup.
+  sidebarRightFacingPixels: headsetFrontPixels.filter(([x, y]) => !(y >= 2 && y <= 6 && x >= 7)),
 };
 
 /**
@@ -576,13 +584,7 @@ export const ACCESSORY_HEADSET: AccessorySpriteData = {
  * (right) curtain rotates out of view. Mirrors the headset's technique and reuses
  * its exact phase stops.
  */
-export const ACCESSORY_PONYTAIL: AccessorySpriteData = {
-  id: 'ponytail',
-  label: 'Ponytail',
-  yOffset: 0,
-  addsHeight: false,
-  blobYAdjust: 0,
-  pixels: [
+const ponytailFrontPixels: SpritePixel[] = [
     // Row 0: crown top — all rim, continuing the body's own outline
     [3, 0, '#0e0d18'], [4, 0, '#0e0d18'], [5, 0, '#0e0d18'], [6, 0, '#0e0d18'], [7, 0, '#0e0d18'],
     // Row 1: crown closed; sheen streak on the left
@@ -601,7 +603,18 @@ export const ACCESSORY_PONYTAIL: AccessorySpriteData = {
     // Row 7: translucent jaw sweep
     [2, 7, 'rgba(24,23,38,0.30)'], [3, 7, 'rgba(24,23,38,0.30)'], [4, 7, 'rgba(24,23,38,0.30)'],
     [5, 7, 'rgba(24,23,38,0.30)'], [6, 7, 'rgba(24,23,38,0.30)'], [7, 7, 'rgba(24,23,38,0.30)'],
-  ],
+];
+
+export const ACCESSORY_PONYTAIL: AccessorySpriteData = {
+  id: 'ponytail',
+  label: 'Ponytail',
+  yOffset: 0,
+  addsHeight: false,
+  blobYAdjust: 0,
+  pixels: ponytailFrontPixels,
+  // The compact sidebar frame only needs occlusion: preserve the crown and
+  // near curtain while hiding the far curtain, right-side tail, and cheek flecks.
+  sidebarRightFacingPixels: ponytailFrontPixels.filter(([x, y]) => !(y >= 2 && y <= 6 && x >= 7)),
 };
 
 /** Registry of all accessories by ID */

--- a/tests/fixtures/sidebar-bobbit-datauri-cache.html
+++ b/tests/fixtures/sidebar-bobbit-datauri-cache.html
@@ -2,6 +2,7 @@
 <html>
 <head>
 <meta charset="utf-8">
+<link rel="stylesheet" href="../../src/app/app.css">
 <style>
   * { margin: 0; padding: 0; box-sizing: border-box; }
 </style>

--- a/tests2/browser/fixtures/sidebar-bobbit-datauri-cache.spec.ts
+++ b/tests2/browser/fixtures/sidebar-bobbit-datauri-cache.spec.ts
@@ -66,6 +66,7 @@ async function installSpyAndLoad(page: import("@playwright/test").Page): Promise
 	});
 	await page.goto(fileUrl(FIXTURE));
 	await page.waitForFunction(() => (window as any).__ready === true);
+	await page.waitForFunction(() => Array.from(document.styleSheets).some(sheet => sheet.href?.endsWith("/src/app/app.css")));
 }
 
 test.describe("Sidebar bobbit data-URL memoization", () => {
@@ -240,6 +241,78 @@ test.describe("Sidebar bobbit data-URL memoization", () => {
 		// render is a pure cache hit. Pre-memoization this would be 4 * N = 32.
 		expect(result.calls).toBe(4);
 		expect(result.calls).toBeLessThan(4 * N);
+	});
+
+	test("headset and ponytail swap cached right-facing frames without JS redraw work", async ({ page }) => {
+		await installSpyAndLoad(page);
+
+		const result = await page.evaluate(async () => {
+			const api = (window as any).__sidebarBobbit;
+			const host = document.getElementById("host")!;
+			const capture = () => ({
+				front: host.querySelector<HTMLImageElement>(".bobbit-sidebar-accessory--front"),
+				right: host.querySelector<HTMLImageElement>(".bobbit-sidebar-accessory--right"),
+				calls: (window as any).__dataUrlCalls as number,
+			});
+
+			(window as any).__dataUrlCalls = 0;
+			api.renderInto(host, { status: "busy", isSelected: true, accessory: api.ACCESSORY_DEFS.headset });
+			const selectedHeadset = capture();
+			const sampleTurnAt = async (time: number) => {
+				for (const element of [selectedHeadset.front, selectedHeadset.right]) {
+					for (const animation of element?.getAnimations() ?? []) {
+						animation.pause();
+						animation.currentTime = time;
+					}
+				}
+				await new Promise<void>(resolve => requestAnimationFrame(() => resolve()));
+				return {
+					front: getComputedStyle(selectedHeadset.front!).opacity,
+					right: getComputedStyle(selectedHeadset.right!).opacity,
+				};
+			};
+			const rightPhase = await sampleTurnAt(4_500);
+			const frontPhase = await sampleTurnAt(5_400);
+			const selected = {
+				frontClass: selectedHeadset.front?.className ?? "",
+				rightClass: selectedHeadset.right?.className ?? "",
+				frontSrc: selectedHeadset.front?.src ?? "",
+				rightSrc: selectedHeadset.right?.src ?? "",
+				rightPhase,
+				frontPhase,
+				calls: selectedHeadset.calls,
+			};
+
+			(window as any).__dataUrlCalls = 0;
+			api.renderInto(host, { status: "idle", unread: true, accessory: api.ACCESSORY_DEFS.ponytail });
+			const unreadPonytail = capture();
+			const unread = {
+				frontPresent: !!unreadPonytail.front,
+				rightPresent: !!unreadPonytail.right,
+				rightClass: unreadPonytail.right?.className ?? "",
+				calls: unreadPonytail.calls,
+			};
+
+			(window as any).__dataUrlCalls = 0;
+			api.renderInto(host, { status: "idle", unread: true, accessory: api.ACCESSORY_DEFS.ponytail });
+			const repeatedUnreadCalls = (window as any).__dataUrlCalls as number;
+			return { selected, unread, repeatedUnreadCalls };
+		});
+
+		expect(result.selected.frontClass).toContain("bobbit-sidebar-accessory-turn-front");
+		expect(result.selected.rightClass).toContain("bobbit-sidebar-accessory-turn-right");
+		expect(result.selected.frontSrc).not.toEqual(result.selected.rightSrc);
+		expect(result.selected.rightPhase).toEqual({ front: "0", right: "1" });
+		expect(result.selected.frontPhase).toEqual({ front: "1", right: "0" });
+		// Body + selected-eye + front accessory + right accessory: one-time only.
+		expect(result.selected.calls).toBe(4);
+		expect(result.unread.frontPresent).toBe(false);
+		expect(result.unread.rightPresent).toBe(true);
+		expect(result.unread.rightClass).not.toContain("bobbit-sidebar-accessory-turn-right");
+		// Body + blink + right accessory; the unused front bitmap is never encoded.
+		expect(result.unread.calls).toBe(3);
+		// Re-rendering performs no canvas encodes or frame-generation work.
+		expect(result.repeatedUnreadCalls).toBe(0);
 	});
 
 	test("single-layer sprite: only one encode across many renders", async ({ page }) => {

--- a/tests2/browser/fixtures/sidebar-bobbit-datauri-cache.spec.ts
+++ b/tests2/browser/fixtures/sidebar-bobbit-datauri-cache.spec.ts
@@ -258,8 +258,8 @@ test.describe("Sidebar bobbit data-URL memoization", () => {
 			(window as any).__dataUrlCalls = 0;
 			api.renderInto(host, { status: "busy", isSelected: true, accessory: api.ACCESSORY_DEFS.headset });
 			const selectedHeadset = capture();
-			const sampleTurnAt = async (time: number) => {
-				for (const element of [selectedHeadset.front, selectedHeadset.right]) {
+			const sampleTurnAt = async (layers: ReturnType<typeof capture>, time: number) => {
+				for (const element of [layers.front, layers.right]) {
 					for (const animation of element?.getAnimations() ?? []) {
 						animation.pause();
 						animation.currentTime = time;
@@ -267,12 +267,12 @@ test.describe("Sidebar bobbit data-URL memoization", () => {
 				}
 				await new Promise<void>(resolve => requestAnimationFrame(() => resolve()));
 				return {
-					front: getComputedStyle(selectedHeadset.front!).opacity,
-					right: getComputedStyle(selectedHeadset.right!).opacity,
+					front: getComputedStyle(layers.front!).opacity,
+					right: getComputedStyle(layers.right!).opacity,
 				};
 			};
-			const rightPhase = await sampleTurnAt(4_500);
-			const frontPhase = await sampleTurnAt(5_400);
+			const rightPhase = await sampleTurnAt(selectedHeadset, 4_500);
+			const frontPhase = await sampleTurnAt(selectedHeadset, 5_400);
 			const selected = {
 				frontClass: selectedHeadset.front?.className ?? "",
 				rightClass: selectedHeadset.right?.className ?? "",
@@ -281,6 +281,20 @@ test.describe("Sidebar bobbit data-URL memoization", () => {
 				rightPhase,
 				frontPhase,
 				calls: selectedHeadset.calls,
+			};
+
+			api.renderInto(host, {
+				status: "busy",
+				isCompacting: true,
+				isSelected: true,
+				isAborting: true,
+				accessory: api.ACCESSORY_DEFS.headset,
+			});
+			const cancellingCompaction = capture();
+			const cancelling = {
+				frontClass: cancellingCompaction.front?.className ?? "",
+				rightClass: cancellingCompaction.right?.className ?? "",
+				rightPhase: await sampleTurnAt(cancellingCompaction, 4_500),
 			};
 
 			(window as any).__dataUrlCalls = 0;
@@ -296,7 +310,7 @@ test.describe("Sidebar bobbit data-URL memoization", () => {
 			(window as any).__dataUrlCalls = 0;
 			api.renderInto(host, { status: "idle", unread: true, accessory: api.ACCESSORY_DEFS.ponytail });
 			const repeatedUnreadCalls = (window as any).__dataUrlCalls as number;
-			return { selected, unread, repeatedUnreadCalls };
+			return { selected, cancelling, unread, repeatedUnreadCalls };
 		});
 
 		expect(result.selected.frontClass).toContain("bobbit-sidebar-accessory-turn-front");
@@ -306,6 +320,9 @@ test.describe("Sidebar bobbit data-URL memoization", () => {
 		expect(result.selected.frontPhase).toEqual({ front: "1", right: "0" });
 		// Body + selected-eye + front accessory + right accessory: one-time only.
 		expect(result.selected.calls).toBe(4);
+		expect(result.cancelling.frontClass).toContain("bobbit-sidebar-accessory-turn-front");
+		expect(result.cancelling.rightClass).toContain("bobbit-sidebar-accessory-turn-right");
+		expect(result.cancelling.rightPhase).toEqual({ front: "0", right: "1" });
 		expect(result.unread.frontPresent).toBe(false);
 		expect(result.unread.rightPresent).toBe(true);
 		expect(result.unread.rightClass).not.toContain("bobbit-sidebar-accessory-turn-right");

--- a/tests2/core/headset-accessory.test.ts
+++ b/tests2/core/headset-accessory.test.ts
@@ -58,6 +58,15 @@ describe("headset accessory", () => {
 		assert.ok(has(5, 7, "#1f2937") && has(6, 7, "#1f2937"), "boom arm from the right cup");
 	});
 
+	it("provides a minimal right-facing sidebar frame", () => {
+		const right = ACCESSORY_HEADSET.sidebarRightFacingPixels ?? [];
+		const rightHas = (x: number, y: number) => right.some(([px, py]) => px === x && py === y);
+		assert.ok(right.length > 0 && right.length < ACCESSORY_HEADSET.pixels.length, "right frame is a pixel subset");
+		assert.ok(rightHas(1, 4), "near/left cup remains visible");
+		assert.ok(!rightHas(8, 4) && !rightHas(9, 4), "far/right cup is occluded");
+		assert.ok(rightHas(7, 1) && rightHas(8, 1), "top band remains intact");
+	});
+
 	it("uses only neutral greys + the foam pop (stays neutral across hues)", () => {
 		const allowed = new Set(["#000", "#1f2937", "#374151", "#4b5563", "#6b7280", "#f97316"]);
 		for (const [, , c] of ACCESSORY_HEADSET.pixels) {
@@ -88,14 +97,21 @@ describe("headset accessory", () => {
 		assert.ok(chatDivs.length >= 2, "headset div in both bobbit-render templates");
 		// Sidebar canvas seat special-case (+0.5 sprite px).
 		assert.match(render, /isHeadset/, "sidebar accTransform seat special-case");
-		// Sidebar canvas must preserve negative accessory x pixels by rasterizing
-		// from minX and shifting the shared body/accessory origin together.
+		// Sidebar canvas must preserve negative accessory x pixels and cache both
+		// immutable frames; CSS swaps opacity without any JS animation timer.
 		assert.match(render, /let minX = Infinity/, "sidebar accessory bounds track minX");
 		assert.match(render, /const xShift = Math\.min\(0, minX\)/, "sidebar accessory keeps negative x extent");
-		assert.match(render, /const srcW = maxX - xShift \+ 1/, "sidebar accessory canvas includes negative x pixels");
-		assert.match(render, /fillRect\(\(x - xShift\) \* HI/, "sidebar accessory rasterization offsets by minX");
+		assert.match(render, /srcW: maxX - xShift \+ 1/, "sidebar accessory canvas includes negative x pixels");
+		assert.match(render, /fillRect\(\(x - bounds\.xShift\) \* HI/, "sidebar rasterization offsets by minX");
+		assert.match(render, /sidebarRightFacingPixels/, "sidebar consumes the right-facing frame");
+		assert.match(render, /`\$\{acc\.id\}\|right`/, "right-facing bitmap has a stable cache key");
 		assert.match(render, /left:\$\{sidebarOriginX\}px/, "sidebar body layers share adjusted x origin");
 		assert.match(render, /left:\$\{accLeft\}px/, "sidebar accessory layer uses minX-aware left edge");
+		const sidebarCss = read("src/app/app.css");
+		assert.match(sidebarCss, /bobbit-sidebar-accessory-turn-front 6s step-end infinite/, "front frame uses compositor step animation");
+		assert.match(sidebarCss, /bobbit-sidebar-accessory-turn-right 6s step-end infinite/, "right frame uses compositor step animation");
+		assert.match(sidebarCss, /74%, 86% \{ opacity: 1; \}/, "right frame aligns with the sidebar right-gaze beat");
+		assert.doesNotMatch(render, /setInterval|requestAnimationFrame/, "sidebar frame swap adds no polling loop");
 		assert.match(read("src/ui/components/StreamingMessageContainer.ts"), /bobbit-blob__headset/);
 
 		// Role-manager inline display rules (per-blob gating, no html-class leak).

--- a/tests2/core/headset-accessory.test.ts
+++ b/tests2/core/headset-accessory.test.ts
@@ -104,6 +104,7 @@ describe("headset accessory", () => {
 		assert.match(render, /srcW: maxX - xShift \+ 1/, "sidebar accessory canvas includes negative x pixels");
 		assert.match(render, /fillRect\(\(x - bounds\.xShift\) \* HI/, "sidebar rasterization offsets by minX");
 		assert.match(render, /sidebarRightFacingPixels/, "sidebar consumes the right-facing frame");
+		assert.match(render, /isSelected && \(!isCompacting \|\| isCancelling\)/, "cancelling compaction keeps the eye/accessory turn synchronized");
 		assert.match(render, /`\$\{acc\.id\}\|right`/, "right-facing bitmap has a stable cache key");
 		assert.match(render, /left:\$\{sidebarOriginX\}px/, "sidebar body layers share adjusted x origin");
 		assert.match(render, /left:\$\{accLeft\}px/, "sidebar accessory layer uses minX-aware left edge");

--- a/tests2/core/ponytail-accessory.test.ts
+++ b/tests2/core/ponytail-accessory.test.ts
@@ -121,6 +121,17 @@ describe("ponytail accessory", () => {
 		for (const [, , c] of px) assert.ok(allowed.has(c), `unexpected ponytail colour ${c}`);
 	});
 
+	it("provides a minimal right-facing sidebar frame", () => {
+		const right = ACCESSORY_PONYTAIL.sidebarRightFacingPixels ?? [];
+		const rightHas = (x: number, y: number) => right.some(([px, py]) => px === x && py === y);
+		assert.ok(right.length > 0 && right.length < px.length, "right frame is a pixel subset");
+		assert.ok(rightHas(1, 3) && rightHas(1, 4), "near/left curtain remains visible");
+		assert.ok(!rightHas(7, 3) && !rightHas(8, 4), "far/right curtain is occluded");
+		assert.ok(!right.some(([x, y]) => x >= 9 && y >= 2), "right-side tail is occluded");
+		assert.ok(rightHas(7, 1) && rightHas(8, 1), "crown remains intact");
+		assert.ok(rightHas(7, 7), "bottom jaw sweep remains visible");
+	});
+
 	it("is allowed as a staff accessory", () => {
 		assert.equal(normalizeStaffAccessory("ponytail"), "ponytail");
 	});
@@ -168,6 +179,8 @@ describe("ponytail accessory", () => {
 		const render = read("src/ui/bobbit-render.ts");
 		const divs = render.match(/bobbit-blob__ponytail/g) ?? [];
 		assert.ok(divs.length >= 2, "ponytail div in both bobbit-render templates");
+		assert.match(render, /sidebarRightFacingPixels/, "sidebar consumes the occluded frame");
+		assert.match(render, /showRightOnly = !!rightPixels\?\.length && unread && !isSelected/, "unread right gaze renders only the occluded frame");
 		assert.match(read("src/ui/components/StreamingMessageContainer.ts"), /bobbit-blob__ponytail/);
 
 		const rm = read("src/app/role-manager.css");

--- a/tests2/tests-map.json
+++ b/tests2/tests-map.json
@@ -1868,7 +1868,7 @@
     },
     {
       "path": "tests2/core/headset-accessory.test.ts",
-      "reason": "Pins the 'headset' accessory end-to-end wiring (sprite data, app.css overlay + downward seat, blob DOM templates, sidebar canvas seat special-case, role-manager inline rules, staff allowlist) so a refactor can't drop one context.",
+      "reason": "Pins the 'headset' accessory end-to-end wiring (sprite data, app.css overlay + downward seat, blob DOM templates, sidebar canvas seat and cached compositor-only right-facing frame, role-manager inline rules, staff allowlist) so a refactor can't drop one context.",
       "execution": {
         "runner": "vitest",
         "tier": "unit",
@@ -1877,7 +1877,7 @@
     },
     {
       "path": "tests2/core/ponytail-accessory.test.ts",
-      "reason": "Pins the 'ponytail' accessory end-to-end wiring (sprite data, app.css overlay + occlusion keyframes, blob DOM templates, role-manager inline rules, staff allowlist) plus the two properties easy to 'tidy' into bugs: the parting/forehead/mouth are drawn by omission (never baked body colour, which would break hue rotation) and the right-facing turn moves the tail to negative x rather than hiding it.",
+      "reason": "Pins the 'ponytail' accessory end-to-end wiring (sprite data, app.css overlay + chat occlusion keyframes, cached compositor-only sidebar right-facing frame, blob DOM templates, role-manager inline rules, staff allowlist) plus the omission and turn-direction invariants that are easy to break.",
       "execution": {
         "runner": "vitest",
         "tier": "unit",


### PR DESCRIPTION
## Summary
- add right-facing sidebar frames for the support headset and ponytail
- swap cached bitmaps on the existing compositor-only eye animation clock
- render only the occluded frame for unread right-gazing rows
- document and test frame synchronization, caching, and the no-redraw behavior

## Validation
- npm run check
- npx vitest run --config vitest.config.ts tests2/core/headset-accessory.test.ts tests2/core/ponytail-accessory.test.ts
- npm run test:browser -- --workers=1 tests2/browser/fixtures/sidebar-bobbit-datauri-cache.spec.ts

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)