### PR TITLE
Fix force abort when state RPC hangs

### DIFF
--- a/src/server/agent/session-manager.ts
+++ b/src/server/agent/session-manager.ts
@@ -14136,6 +14136,17 @@ export class SessionManager {
 		// and returns gracefully without force-kill.
 		void (async () => { await session.rpcClient.abort(); })().catch(() => {});
 
+		// Ask for the transcript path opportunistically while the grace timer is
+		// already running. A wedged bridge commonly blocks every RPC, not only
+		// abort(). Never await this snapshot after the grace boundary: doing so
+		// would leave the session visibly "aborting" and postpone stop() until the
+		// bridge command timeout. The durable store remains the fallback when this
+		// best-effort request does not settle in time.
+		let stateBeforeKill: any;
+		void (async () => {
+			try { stateBeforeKill = await session.rpcClient.getState(); } catch { /* use durable path */ }
+		})();
+
 		const settled = await settledPromise;
 
 		if (settled) {
@@ -14155,16 +14166,15 @@ export class SessionManager {
 		// Graceful abort didn't work — force kill and restart the agent
 		console.log(`[session-manager] Force-aborting session ${id} — killing agent process`);
 
-		// Get the agent session file before killing so we can restore.
-		// Path is in the agent's coordinate system — no translation needed.
+		// Prefer an agent-reported transcript path when the best-effort snapshot
+		// completed during the grace period. Otherwise retain the durable path and
+		// kill immediately; recovery must never wait on the bridge being replaced.
+		// Paths remain in the agent's coordinate system — no translation needed.
 		const persistedBeforeAbort = this.resolveStoreForSession(id).get(id);
 		let agentSessionFile = persistedBeforeAbort?.agentSessionFile;
-		try {
-			const stateResp = await session.rpcClient.getState();
-			if (stateResp.success && stateResp.data?.sessionFile) {
-				agentSessionFile = stateResp.data.sessionFile;
-			}
-		} catch { /* retain the durable transcript path */ }
+		if (stateBeforeKill?.success && stateBeforeKill.data?.sessionFile) {
+			agentSessionFile = stateBeforeKill.data.sessionFile;
+		}
 
 		// Kill the process. Force-abort reuses this SessionInfo for the replacement,
 		// so cancel old-bridge activity transactions before stop can resolve a stale

--- a/tests2/core/session-manager-force-abort-grace.test.ts
+++ b/tests2/core/session-manager-force-abort-grace.test.ts
@@ -91,6 +91,69 @@ describe("SessionManager.forceAbort grace race (S8)", () => {
 		assert.ok(elapsed >= GRACE - 20, `did not force-kill before the grace period (${elapsed}ms)`);
 	});
 
+	it("does not remain aborting while a wedged bridge blocks the pre-kill state snapshot", async () => {
+		// Observed live-session shape: Escape sends the same abort command as Stop
+		// while Pi is streaming a partial edit call. Abort emits no agent_end, and
+		// other RPCs on the same bridge also stop answering. forceAbort correctly
+		// races abort() against its grace timer,
+		// but then asks that same bridge for getState() before calling stop(). A
+		// blocked state snapshot therefore leaves the visible status at "aborting"
+		// instead of force-killing at the grace boundary.
+		registerRpcBridgeFactory(() => { throw new Error("no respawn in test"); });
+
+		const manager: any = new SessionManager();
+		manager._testStore = { update: vi.fn(() => {}), get: vi.fn(() => undefined) };
+		managers.push(manager);
+
+		let releaseState!: () => void;
+		const stateGate = new Promise<void>((resolve) => { releaseState = resolve; });
+		const stop = vi.fn(async () => {});
+		const session: any = {
+			id: "s-wedged-state-snapshot",
+			title: "Wedged during tool call",
+			titleGenerated: true,
+			cwd: tmpRoot,
+			status: "streaming",
+			statusVersion: 1,
+			streamingStartedAt: Date.now(),
+			createdAt: Date.now(),
+			lastActivity: Date.now(),
+			clients: new Set([{ readyState: 1, send: () => {} }]),
+			promptQueue: new PromptQueue(),
+			eventBuffer: new EventBuffer(),
+			inFlightSteerTexts: [],
+			unsubscribe: () => {},
+			rpcClient: {
+				abort: () => new Promise<void>(() => {}),
+				onEvent: () => () => {},
+				getState: async () => {
+					await stateGate;
+					return { success: false };
+				},
+				stop,
+			},
+		};
+		manager.sessions.set(session.id, session);
+
+		const GRACE = 30;
+		const aborting = manager.forceAbort(session.id, GRACE).catch(() => {});
+		await new Promise((resolve) => setTimeout(resolve, GRACE + 50));
+		const stopStartedAtGraceBoundary = stop.mock.calls.length > 0;
+		const statusAfterGrace = session.status;
+
+		// Release the intentionally wedged RPC so cleanup always completes before
+		// the assertion fails; the test must not leak a replacement coordinator.
+		releaseState();
+		await aborting;
+
+		assert.equal(
+			stopStartedAtGraceBoundary,
+			true,
+			`force-kill did not start after ${GRACE}ms; session remained ${statusAfterGrace}`,
+		);
+		assert.notEqual(statusAfterGrace, "aborting", "the grace boundary must end the visible aborting state");
+	});
+
 	/**
 	 * Force-abort respawn must derive its tool allowlist from the session/persisted
 	 * allowedTools, NOT recompute it from the role alone. A restricted child/delegate


### PR DESCRIPTION
## Summary
- request the pre-kill agent state opportunistically during the abort grace period
- fall back to the persisted transcript path when the state RPC remains wedged
- add a regression test for Escape leaving a session stuck in `aborting`

## Testing
- `npm run check`
- `npm run test:unit`
- `npm run test:browser` — 740 passed, 8 skipped
- `npm run test:e2e` — one unrelated tail-chat scroll test failed; isolated retry passed
- independent delegate review — pass, no findings

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)