### PR TITLE
Raise CI type-check heap limit

### DIFF
--- a/.github/workflows/build-unit-gate.yml
+++ b/.github/workflows/build-unit-gate.yml
@@ -48,6 +48,8 @@ jobs:
 
       - name: Type-check
         run: npm run check
+        env:
+          NODE_OPTIONS: --max-old-space-size=4096
 
       - name: Unit gate
         run: npm run test:unit

--- a/tests2/core/build-unit-gate-ci.test.ts
+++ b/tests2/core/build-unit-gate-ci.test.ts
@@ -100,6 +100,11 @@ describe("native CI qualification workflows", () => {
 
 		assert.ok(buildIndex >= 0, "workflow must build before qualification");
 		assert.ok(typeCheckIndex > buildIndex, "workflow must type-check after building");
+		assert.deepEqual(
+			steps[typeCheckIndex]?.env,
+			{ NODE_OPTIONS: "--max-old-space-size=4096" },
+			"type-checking must have enough heap for the complete tests2 program on native CI",
+		);
 		assert.equal(unitGates.length, 1, "workflow must run the unit suite once");
 		assert.equal(steps[typeCheckIndex + 1]?.name, "Unit gate", "unit gate must start immediately after type-checking");
 		assert.equal(unitGates[0]?.run, "npm run test:unit", "branch checks use the normal Vitest retry policy");


### PR DESCRIPTION
## Summary
- raise the Node heap limit to 4 GiB for the native CI type-check step
- pin the heap setting in the workflow contract test
- keep the larger heap scoped to type-checking without skipping or retrying checks

The macOS runner was intermittently exhausting Node's default ~2 GiB heap while checking the complete tests2 TypeScript program, so unit tests never started.

## Testing
- `npm run build`
- `NODE_OPTIONS=--max-old-space-size=4096 npm run check`
- `npm run test:unit` (1,107 files passed; 10,421 tests passed)
- focused `tests2/core/build-unit-gate-ci.test.ts` (6 tests passed)

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)
