### PR TITLE
Fix prompt dispatch after Pi settlement

### DIFF
--- a/docs/auto-retry.md
+++ b/docs/auto-retry.md
@@ -68,9 +68,9 @@ If a bounded retry budget is exhausted, the server clears the stale countdown wi
 
 ## Pi internal retry events
 
-Current Pi runtimes, including the selected `0.84.1` line, can emit `agent_end` with `willRetry: true` before its own retry loop has produced the final turn outcome. Bobbit treats that event as non-final: the session stays streaming, one-time tool grants remain active, queued prompts are not drained, and `waitForIdle()` keeps waiting. Only a later `agent_end` where `willRetry !== true` completes the Bobbit turn lifecycle.
+Current Pi runtimes, including the selected `0.84.1` line, can emit `agent_end` with `willRetry: true` before its own retry loop has produced the final turn outcome. Bobbit treats that event as non-final: the session stays streaming, one-time tool grants remain active, queued prompts are not drained, and `waitForIdle()` keeps waiting. A later `agent_end` where `willRetry !== true` completes terminal turn bookkeeping, but next-turn dispatch remains fenced until Pi emits `agent_settled` after clearing its active-run guard.
 
-This keeps Pi's internal retry attempts from looking like separate user-visible turns or opening a queue window before the retry settles. The contract is pinned by `tests2/core/pi-rpc-agent-end-retry.test.ts`.
+This keeps Pi's internal retry attempts from looking like separate user-visible turns and prevents a final terminal event from opening a prompt window during Pi's post-run processing. The retry contract is pinned by `tests2/core/pi-rpc-agent-end-retry.test.ts`; the settlement fence is pinned by `tests2/core/reliable-compaction-release.test.ts`.
 
 ## Dispatch-time prompt failures
 
@@ -78,7 +78,7 @@ A prompt can fail before the agent starts a turn and before any assistant `messa
 
 - `recoverPromptDispatch()` re-enqueues the failed prompt row at the front of the queue as the durable copy.
 - The session is restored to `idle`, enough error state is synthesized for retry bookkeeping, and `auto_retry_pending` is emitted through the same scheduler used by `message_end` errors.
-- The auto timer still calls `retryLastPrompt(..., { auto: true })`; that method consumes the recovered queue row before dispatching, so a later `agent_end` drain cannot replay the same prompt a second time.
+- The auto timer still calls `retryLastPrompt(..., { auto: true })`; that method consumes the recovered queue row before dispatching, so a later settlement-driven queue drain cannot replay the same prompt a second time.
 - If stale `turnHadToolCalls` state exists from a previous turn, dispatch-time recovery clears it because this failed prompt never reached `agent_start` and therefore cannot have run tools.
 
 A fresh user prompt supersedes a recovered dispatch-failure row. The new prompt cancels the pending retry, emits `auto_retry_cancelled`, drops the recovered stale row, and dispatches the user's new intent so old work cannot replay after the follow-up succeeds.

--- a/docs/compaction.md
+++ b/docs/compaction.md
@@ -50,7 +50,9 @@ Input affinity depends on the compaction type:
 
 - during **manual** compaction, prompts and steers target the next turn;
 - during **threshold** or **overflow** compaction, steers target the continuing turn while prompts target the next turn; and
-- when Pi reports `willRetry: true`, only continuation steers may re-enter the interrupted turn. Next-turn work waits for its final `agent_end`.
+- when Pi reports `willRetry: true`, only continuation steers may re-enter the interrupted turn. Next-turn work waits for `agent_settled` after the final `agent_end`.
+
+Pi's final `agent_end` is not a fresh-prompt admission boundary. Pi may still perform threshold compaction and queued-continuation processing while its active-run guard remains set; it clears that guard immediately before `agent_settled`. Bobbit therefore completes user-visible terminal bookkeeping at `agent_end` but fences queue draining and idle-time prompt admission until `agent_settled`. A definite no-start RPC rejection also rolls back both the live and persisted optimistic streaming state.
 
 Every occurrence remains in the visible delivery outbox while fenced. See [Reliable prompt and steer delivery](prompt-queue.md) for identity, settlement, and recovery.
 
@@ -62,7 +64,8 @@ Every occurrence remains in the visible delivery outbox while fenced. See [Relia
 | --- | --- |
 | Manual success | Clear the fence once. If the session is safely idle, drain next-turn work normally. |
 | Threshold/overflow continues, or `willRetry: true` | Clear once and release queued continuation steers in FIFO order. Keep next-turn work parked. |
-| Final non-retry turn boundary | Retarget any remaining continuation rows once with `continuation-ended`, then drain next-turn work. |
+| Final non-retry `agent_end` | Retarget any remaining continuation rows once with `continuation-ended`; keep next-turn work parked while Pi performs post-run work. |
+| `agent_settled` | Clear the active-run admission fence and drain next-turn work. |
 | Automatic compaction failure | Clear the compaction epoch but do not inject continuation work into a possibly failed/interrupted turn. The final safe turn boundary owns later release. |
 | Stop near compaction end | Record the compaction finish, defer release to Stop/replacement ownership, reconcile the in-flight attempt, and retarget undispatched continuation work. |
 

--- a/docs/compaction.md
+++ b/docs/compaction.md
@@ -52,7 +52,12 @@ Input affinity depends on the compaction type:
 - during **threshold** or **overflow** compaction, steers target the continuing turn while prompts target the next turn; and
 - when Pi reports `willRetry: true`, only continuation steers may re-enter the interrupted turn. Next-turn work waits for `agent_settled` after the final `agent_end`.
 
-Pi's final `agent_end` is not a fresh-prompt admission boundary. Pi may still perform threshold compaction and queued-continuation processing while its active-run guard remains set; it clears that guard immediately before `agent_settled`. Bobbit therefore completes user-visible terminal bookkeeping at `agent_end` but fences queue draining and idle-time prompt admission until `agent_settled`. A definite no-start RPC rejection also rolls back both the live and persisted optimistic streaming state.
+Pi's final `agent_end` is not a fresh-prompt admission boundary. In Pi `0.84.1`, it is emitted before the run's `finally` path clears `_isAgentRunActive`; threshold compaction and queued-continuation processing may still follow. Pi clears that guard immediately before `agent_settled`. Bobbit therefore uses the two events for different purposes:
+
+- final `agent_end` completes user-visible terminal bookkeeping, retargets undispatched continuation work, persists idle state, and resolves turn waiters;
+- `agent_settled` proves that Pi can start a fresh prompt, clears Bobbit's active-run admission fence, and owns the next-turn queue drain.
+
+A definite no-start signal, including Pi's canonical compaction-active rejection, reverses optimistic dispatch state: the exact occurrence returns to its durable queue state, `streamingStartedAt` is cleared, persisted `wasStreaming` becomes false, and the server broadcasts `idle`. This status rollback runs only while the session is still `streaming`. If Stop, replacement, or a newer lifecycle transition already owns another status, the late rejection may reconcile its exact attempt but cannot overwrite that owner or settle its waiters.
 
 Every occurrence remains in the visible delivery outbox while fenced. See [Reliable prompt and steer delivery](prompt-queue.md) for identity, settlement, and recovery.
 
@@ -70,6 +75,27 @@ Every occurrence remains in the visible delivery outbox while fenced. See [Relia
 | Stop near compaction end | Record the compaction finish, defer release to Stop/replacement ownership, reconcile the in-flight attempt, and retarget undispatched continuation work. |
 
 No lock spans an RPC acknowledgement. Queue and ledger persistence happens before handoff, and stale lifecycle generations cannot drain after a replacement.
+
+### Stop across the settlement boundary
+
+Stop owns the release boundary so terminal or compaction callbacks cannot race a queued prompt onto a bridge that is about to be stopped.
+
+- **Graceful Stop** waits for the old Pi run's `agent_settled`, not merely `agent_end`. While the shared replacement fence is active, Bobbit captures `message_end`, `compaction_end`, final `agent_end`, and `agent_settled`; it then replays that sequence through normal lifecycle bookkeeping with queue draining deferred. The Stop coordinator performs one drain only after replay is complete.
+- **Hard Stop** is used when the grace period expires. Because the killed process cannot emit `agent_settled`, Bobbit synthesizes settlement. If compaction was active—even if its `compaction_start` followed an already handled `agent_end`—Bobbit first finalizes that epoch as an aborted `compaction_end`. It then runs idempotent synthetic terminal bookkeeping, replaces and rehydrates the bridge, reconciles exact transcript evidence, and lets the coordinator release remaining FIFO work once against the canonical replacement.
+
+Finalizing interrupted compaction matters for liveness: leaving `isCompacting` set would strand every durable prompt after replacement. Idempotent terminal and compaction finishers prevent the synthetic path from counting the turn, resolving waiters, or releasing the same occurrence twice.
+
+### Deferred error-recovery occurrence
+
+A new prompt can implicitly recover an ordinary errored turn after its final `agent_end`. If Pi has not emitted `agent_settled`, Bobbit reports the admission as queued and stores the exact model-facing recovery payload instead of attempting the RPC early:
+
+```text
+[SYSTEM: previous turn failed with: <first 200 characters of the error>. Your previous turn was interrupted. Pick up where you left off — re-check state first and avoid redoing completed work.]
+
+<model-facing prompt text>
+```
+
+For a stable-ID prompt, Bobbit updates the already admitted durable row rather than creating a second occurrence. The row keeps its `intentId`, lane, sequence, creation time, and delivery state while the recovery payload, images, attachments, author/source, streaming behavior, cold-start flag, and title-generation flag are preserved for dispatch. Legacy admission creates one equivalent deferred row. `agent_settled` dispatches that row once, ahead of later FIFO work, and prompt-author settlement correlates the Pi echo against the same recovery payload.
 
 ### Recoverable `length` overflow
 
@@ -255,7 +281,8 @@ Reducer invariants are pinned in `tests2/core/message-reducer.test.ts` and `mess
 
 Deterministic CI coverage uses named runtime barriers rather than timing sleeps:
 
-- `tests2/core/reliable-compaction-release.test.ts` pins admission fencing and the single release owner across manual, threshold, overflow, failure, and Stop outcomes.
+- `tests2/core/reliable-compaction-release.test.ts` pins admission fencing, deferred error-recovery payload identity, guarded rejection rollback, and the single release owner across manual, threshold, overflow, failure, and Stop outcomes.
+- `tests2/core/session-manager-force-abort-grace.test.ts` pins graceful settlement replay plus hard-Stop settlement synthesis and interrupted-compaction finalization.
 - `tests2/core/pi-installed-contract.test.ts` pins Pi event order, `willRetry`, direct-prompt rejection during compaction, recoverable-length tail removal, and the one-retry cap.
 - `tests2/core/assistant-stream-session-broadcast.test.ts` pins invalidation-before-release ordering and one invalidation for the first recoverable tail.
 - `tests2/integration/reliable-intent-recovery.test.ts` exercises held compaction boundaries and visible outbox continuity through failure and recovery.

--- a/docs/pi-runtime-compatibility.md
+++ b/docs/pi-runtime-compatibility.md
@@ -44,6 +44,8 @@ Pi emits `compaction_start` before compaction and `compaction_end` after releasi
 
 `compaction_end.willRetry` describes the interrupted agent turn, not another compaction operation. Bobbit completes the compaction boundary and preserves continuation affinity while waiting for the final non-retry `agent_end`.
 
+Pi `0.84.1` emits that final `agent_end` before clearing its active-run guard. The event completes Bobbit's terminal turn bookkeeping, but it does not admit a fresh prompt. Pi may still compact or process queued continuation work before `_emitAgentSettled()` clears the guard and emits `agent_settled`; Bobbit drains next-turn work only at that later boundary. Graceful Stop waits for and replays settlement, while hard Stop synthesizes it after killing the old process and marks interrupted compaction aborted. See [Context compaction](compaction.md#reliable-turn-fence-and-release).
+
 For a recoverable assistant `stopReason: "length"`, Pi removes the first truncated tail, performs overflow compaction, and retries the input at most once. Bobbit assigns `assistantStreamId` values and emits `assistant_stream_invalidated` before retry output so the browser and snapshots mirror Pi's rewritten branch. Only the retry's final non-retrying terminal is canonical. See [Context compaction](compaction.md#recoverable-length-overflow).
 
 ### Steer acknowledgement boundary

--- a/docs/prompt-queue.md
+++ b/docs/prompt-queue.md
@@ -72,9 +72,9 @@ A steer targets `continuation` only while a turn is streaming, including thresho
 Release rules are lane-aware:
 
 - live continuation steers dispatch serially while the current turn can accept them;
-- next-turn work waits for the final non-retry `agent_end` and drains by lane sequence;
+- final non-retry `agent_end` retargets undispatched continuation rows once with `continuation-ended`, but next-turn work remains parked;
 - `agent_end(willRetry: true)` is not a turn boundary;
-- final turn completion retargets undispatched continuation rows once with `continuation-ended`;
+- `agent_settled` proves Pi's active run has ended and drains next-turn work by lane sequence;
 - Stop retargets queued continuation rows with `continuation-aborted`; and
 - a proven-no-start in-flight occurrence may be restored once, retaining its ID and relative priority.
 
@@ -102,11 +102,11 @@ Stop never silently deletes accepted work.
 - If administrative abort recovery cannot preserve or prove an attempt, Bobbit retains a non-retryable `cancelled` row with `abort-recovery-failed`; it does not claim the model did not see it.
 - Explicit Dismiss writes a cancellation tombstone before removing a queued or uncertain carrier. A stale second tab cannot delete a newer Retry because IndexedDB mutations use revision checks.
 
-The `aborting` session status is broadcast immediately while graceful Stop or force replacement owns the lifecycle. Queue and compaction callbacks do not drain around that owner.
+The `aborting` session status is broadcast immediately while graceful Stop or force replacement owns the lifecycle. Queue and compaction callbacks do not drain around that owner. Graceful Stop waits through `agent_settled` and replays the captured terminal sequence before its coordinator drains once. A hard Stop synthesizes the missing settlement, finalizes any interrupted compaction as aborted, rehydrates a replacement, and releases only after exact transcript reconciliation. See [Stop across the settlement boundary](compaction.md#stop-across-the-settlement-boundary).
 
 ### Definite rejection versus ambiguity
 
-A `{ success: false }` Pi response is a definite pre-receipt rejection. Bobbit restores the exact row at the queue front as retryable `failed`. **Retry** keeps the same `intentId` and creates a new attempt only when dispatch resumes.
+A `{ success: false }` Pi response is a definite pre-receipt rejection. Bobbit restores the exact row at the queue front as retryable `failed`. **Retry** keeps the same `intentId` and creates a new attempt only when dispatch resumes. Bobbit also reverses its optimistic live and persisted streaming state, but only while that attempt still owns `streaming`; a late rejection cannot overwrite `aborting`, replacement, or a newer lifecycle owner.
 
 A thrown call or transport loss is ambiguous: Pi may have received it even though Bobbit missed the acknowledgement. Bobbit keeps the ledger row as `uncertain`, disables Retry, and waits for exact transcript evidence or explicit Dismiss. This fail-closed rule prefers visible uncertainty over duplicate model input.
 
@@ -123,7 +123,9 @@ Reload, reconnect, and a second tab combine the IndexedDB local spool with the s
 
 ### Errored turns
 
-A genuine model/provider error parks accepted work while Bobbit applies its bounded auto-retry and manual-retry policies. A new prompt can implicitly unstick ordinary errors below the consecutive-error cap; at the cap the visible queue remains parked until explicit Retry. See [Auto-Retry](auto-retry.md) and [Session wedged after errored turn](debugging.md#session-wedged-after-errored-turn).
+A genuine model/provider error parks accepted work while Bobbit applies its bounded auto-retry and manual-retry policies. A new prompt can implicitly unstick ordinary errors below the consecutive-error cap; at the cap the visible queue remains parked until explicit Retry.
+
+If that prompt arrives after final `agent_end` but before `agent_settled`, Bobbit does not call Pi. It keeps one durable occurrence in place and replaces only its model-facing payload and dispatch metadata with the error-recovery envelope. Stable identity and FIFO fields remain unchanged; images, attachments, source/author, and dispatch flags travel with the deferred payload. Settlement dispatches that exact row once before later FIFO work. See [Deferred error-recovery occurrence](compaction.md#deferred-error-recovery-occurrence), [Auto-Retry](auto-retry.md), and [Session wedged after errored turn](debugging.md#session-wedged-after-errored-turn).
 
 ## `bash_bg wait` interaction
 

--- a/src/server/agent/session-manager.ts
+++ b/src/server/agent/session-manager.ts
@@ -6284,8 +6284,9 @@ export class SessionManager {
 					}
 				}
 				const prefixedDispatch = buildErrorRecoveryPrefix(errorSnippet, dispatchText);
+				const settlementFenced = session._piAgentRunSettled === false;
 				await this.dispatchDirectPrompt(session, prefixedDispatch, opts?.images, opts?.attachments, !!opts?.isSteered, !!opts?.coldStart, source, author, accepted.id, accepted.id, opts?.streamingBehavior, false, false, opts?.suppressTitleGen);
-				return { status: "dispatched" };
+				return { status: settlementFenced ? "queued" : "dispatched" };
 			}
 			if (session.status === "idle") {
 				this.drainQueue(session);
@@ -6488,8 +6489,9 @@ export class SessionManager {
 			// cleared).
 			// Inject the recovery prefix into the model-facing dispatch text.
 			const prefixedDispatch = buildErrorRecoveryPrefix(errSnippet, dispatchText);
+			const settlementFenced = session._piAgentRunSettled === false;
 			await this.dispatchDirectPrompt(session, prefixedDispatch, opts?.images, opts?.attachments, !!opts?.isSteered, !!opts?.coldStart, source, author, undefined, undefined, opts?.streamingBehavior, undefined, false, opts?.suppressTitleGen);
-			return { status: "dispatched" };
+			return { status: settlementFenced ? "queued" : "dispatched" };
 		}
 
 		// If agent is idle and queue is empty, dispatch directly. Mark streaming
@@ -7473,7 +7475,23 @@ export class SessionManager {
 			const existing = durableQueueRowId
 				? session.promptQueue.toArray().find((row) => row.id === durableQueueRowId)
 				: undefined;
-			if (!existing) {
+			if (existing) {
+				// Admission created this occurrence before the error-recovery envelope was
+				// known. Preserve its identity/lane/state while durably replacing only the
+				// model-facing payload and dispatch metadata that settlement must replay.
+				Object.assign(existing, {
+					text,
+					images,
+					attachments,
+					isSteered: isSteered ?? false,
+					source,
+					verifierOwned,
+					author,
+					streamingBehavior,
+					coldStart,
+					suppressTitleGen,
+				});
+			} else {
 				const deferred = {
 					id: durableQueueRowId ?? randomUUID(),
 					text,
@@ -8094,14 +8112,14 @@ export class SessionManager {
 				}
 				return;
 			}
-			if (session.turnTerminalHandled) return;
-			session.turnTerminalHandled = true;
-			// A synthetic hard-kill terminal has no later Pi settlement event. Graceful
-			// replacement replay still waits for the old bridge's real agent_settled;
-			// coordinator ownership alone must not bypass Pi's active-run guard.
+			// A synthetic hard-kill terminal has no later Pi settlement event. Synthesize
+			// settlement even when the real final agent_end already performed this turn's
+			// bookkeeping; graceful replacement replay still waits for agent_settled.
 			if (opts?.replacementOwnedTerminal && opts.abortAttemptOutcome !== undefined) {
 				session._piAgentRunSettled = true;
 			}
+			if (session.turnTerminalHandled) return;
+			session.turnTerminalHandled = true;
 
 			// Revoke one-time granted tools after the turn completes
 			if (session.oneTimeGrantedTools && session.oneTimeGrantedTools.length > 0) {

--- a/src/server/agent/session-manager.ts
+++ b/src/server/agent/session-manager.ts
@@ -7385,7 +7385,7 @@ export class SessionManager {
 			session.turnHadToolCalls = false;
 			session.recoverDrainAttempts = 0;
 			if (providerAuthFailure) this.surfaceProviderAuthFailure(session, reason, source);
-			else broadcastStatus(session, "idle");
+			else this.rollbackRejectedPromptDispatch(session);
 			this.broadcastQueue(session);
 			this.surfaceManualRetryRequired(session);
 			return;

--- a/src/server/agent/session-manager.ts
+++ b/src/server/agent/session-manager.ts
@@ -1081,13 +1081,6 @@ export interface SessionInfo {
 	/** A compaction end observed while Stop owns the turn; released by replacement. */
 	_reliableCompactionReleaseDeferred?: boolean;
 	/**
-	 * Pi keeps its run active after the final agent_end while post-run work such
-	 * as threshold compaction completes. Only agent_settled proves that a fresh
-	 * prompt RPC can start. Undefined preserves compatibility with old/replayed
-	 * lifecycles that never emitted agent_start/agent_settled.
-	 */
-	_piAgentRunSettled?: boolean;
-	/**
 	 * Latest in-flight `message_update` payload. Set on every `message_update`
 	 * event with a non-empty `event.message`; cleared on `message_end`,
 	 * `agent_end`, and `process_exit`. Used to splice the in-flight row into
@@ -6284,9 +6277,8 @@ export class SessionManager {
 					}
 				}
 				const prefixedDispatch = buildErrorRecoveryPrefix(errorSnippet, dispatchText);
-				const settlementFenced = session._piAgentRunSettled === false;
 				await this.dispatchDirectPrompt(session, prefixedDispatch, opts?.images, opts?.attachments, !!opts?.isSteered, !!opts?.coldStart, source, author, accepted.id, accepted.id, opts?.streamingBehavior, false, false, opts?.suppressTitleGen);
-				return { status: settlementFenced ? "queued" : "dispatched" };
+				return { status: "dispatched" };
 			}
 			if (session.status === "idle") {
 				this.drainQueue(session);
@@ -6489,15 +6481,14 @@ export class SessionManager {
 			// cleared).
 			// Inject the recovery prefix into the model-facing dispatch text.
 			const prefixedDispatch = buildErrorRecoveryPrefix(errSnippet, dispatchText);
-			const settlementFenced = session._piAgentRunSettled === false;
 			await this.dispatchDirectPrompt(session, prefixedDispatch, opts?.images, opts?.attachments, !!opts?.isSteered, !!opts?.coldStart, source, author, undefined, undefined, opts?.streamingBehavior, undefined, false, opts?.suppressTitleGen);
-			return { status: settlementFenced ? "queued" : "dispatched" };
+			return { status: "dispatched" };
 		}
 
 		// If agent is idle and queue is empty, dispatch directly. Mark streaming
 		// before awaiting rpcClient.prompt(): Pi 0.77 OpenAI/Codex preflight can be
 		// slow, and clients/API polling must see the turn as in-flight immediately.
-		if (session.status === "idle" && session._piAgentRunSettled !== false && session.promptQueue.isEmpty) {
+		if (session.status === "idle" && session.promptQueue.isEmpty) {
 			if (!opts?.suppressTitleGen) this.tryGenerateTitleFromPrompt(sessionId, text);
 			await this.dispatchDirectPrompt(session, dispatchText, opts?.images, opts?.attachments, !!opts?.isSteered, !!opts?.coldStart, source, author, undefined, undefined, opts?.streamingBehavior, undefined, false, opts?.suppressTitleGen);
 			return { status: "dispatched" };
@@ -7200,21 +7191,6 @@ export class SessionManager {
 		broadcastStatus(session, "streaming", { streamingStartedAt: session.streamingStartedAt });
 	}
 
-	/** Roll back an optimistic prompt dispatch after Pi proves that no run opened. */
-	private rollbackRejectedPromptDispatch(session: SessionInfo): void {
-		// Stop/replacement or a later lifecycle transition owns every non-streaming
-		// state. A late rejection may clean up its exact queue/sidecar attempt, but it
-		// must not settle abort waiters or overwrite a newer status owner.
-		if (session.status !== "streaming") return;
-		session.streamingStartedAt = undefined;
-		this.resolveStoreForSession(session.id).update(session.id, {
-			wasStreaming: false,
-			streamingStartedAt: undefined,
-		});
-		broadcastStatus(session, "idle");
-		this.resolveIdleWaiters(session.id);
-	}
-
 	private async applyDirectProviderEnv(bridgeOptions: RpcBridgeOptions, sandboxed: boolean | undefined, provider?: string): Promise<void> {
 		if (sandboxed) return;
 		bridgeOptions.env = mergeHostAgentProviderEnv(bridgeOptions.env, this.preferencesStore, {
@@ -7398,7 +7374,7 @@ export class SessionManager {
 			this.broadcastQueue(session);
 			return;
 		}
-		this.rollbackRejectedPromptDispatch(session);
+		broadcastStatus(session, "idle");
 		this.broadcastQueue(session);
 		if (this.maybeAutoRetryPromptDeliveryFailure(session, safeReason, source)) {
 			// Bounded retry exhaustion switches regular prompts to manual recovery.
@@ -7468,52 +7444,6 @@ export class SessionManager {
 		// replacement coordinator. All unrelated dispatch remains fenced until the
 		// coordinator releases.
 		if (session.isCompacting || session.status === "aborting" || (replacementKind !== undefined && replacementKind !== "poison-redrive")) return;
-		if (session._piAgentRunSettled === false && replacementKind !== "poison-redrive") {
-			// An accepted stable occurrence already owns its durable queue row. Legacy
-			// and automatic-retry callers have no such row, so create one before
-			// returning; agent_settled will drain the same occurrence exactly once.
-			const existing = durableQueueRowId
-				? session.promptQueue.toArray().find((row) => row.id === durableQueueRowId)
-				: undefined;
-			if (existing) {
-				// Admission created this occurrence before the error-recovery envelope was
-				// known. Preserve its identity/lane/state while durably replacing only the
-				// model-facing payload and dispatch metadata that settlement must replay.
-				Object.assign(existing, {
-					text,
-					images,
-					attachments,
-					isSteered: isSteered ?? false,
-					source,
-					verifierOwned,
-					author,
-					streamingBehavior,
-					coldStart,
-					suppressTitleGen,
-				});
-			} else {
-				const deferred = {
-					id: durableQueueRowId ?? randomUUID(),
-					text,
-					images,
-					attachments,
-					isSteered: isSteered ?? false,
-					createdAt: this.clock.now(),
-					source,
-					verifierOwned,
-					author,
-					streamingBehavior,
-					coldStart,
-					suppressTitleGen,
-				};
-				session.promptQueue.restoreAtFront(deferred);
-			}
-			session.lastPromptText = text;
-			session.lastPromptImages = images;
-			session.lastPromptSource = source;
-			this.broadcastQueue(session);
-			return;
-		}
 		const reliableRow = durableQueueRowId
 			? (session.promptQueue.toArray() as ReliableQueuedMessage[]).find((row) => row.id === durableQueueRowId && row.kind !== undefined)
 			: undefined;
@@ -7582,9 +7512,9 @@ export class SessionManager {
 						dispatchEpoch: prepared.dispatchEpoch,
 					}, { front: true });
 					this.broadcastQueue(session);
-					// Pi rejected before opening a turn; undo every optimistic status plane
-					// so the matching compaction finisher can own the sole redrain.
-					this.rollbackRejectedPromptDispatch(session);
+					// Pi rejected before opening a turn; undo the optimistic idle dispatch
+					// status so the matching compaction finisher can own the sole redrain.
+					broadcastStatus(session, "idle");
 					console.warn(`[session-manager] intent dispatch restored session=${session.id} intent=${reliableRow.id} attempt=${prepared.attemptId} outcome=compaction-active`);
 					return;
 				}
@@ -7599,7 +7529,6 @@ export class SessionManager {
 						attemptId: prepared.attemptId,
 						dispatchEpoch: prepared.dispatchEpoch,
 					}, { front: true });
-					this.rollbackRejectedPromptDispatch(session);
 				} else if (index !== -1) {
 					attempt.state = "uncertain";
 					attempt.retryable = false;
@@ -7687,10 +7616,6 @@ export class SessionManager {
 		if (this.getModelSelectionRecoveryAdmission(session.id).condition) return;
 		if (!this._sessionWriterIsCurrent(session)) return;
 		if (session.isCompacting || session.status === "aborting" || (this._sessionReplacementCoordinators?.has(session.id) ?? false)) return;
-		// agent_end is not Pi's prompt-admission boundary: automatic compaction and
-		// queued continuation handling still run before agent_settled clears the
-		// runtime's active-run guard.
-		if (session._piAgentRunSettled === false) return;
 		if (session.promptQueue.isEmpty) return;
 
 		const reliableNext = (session.promptQueue.toArray() as ReliableQueuedMessage[])
@@ -8055,9 +7980,6 @@ export class SessionManager {
 		}
 
 		if (event.type === "agent_start") {
-			// Pi's run remains active through agent_end post-processing. A later
-			// agent_settled is the sole fresh-prompt admission boundary.
-			session._piAgentRunSettled = false;
 			// The session has begun its turn — clear the boot re-prompt marker so
 			// the set doesn't leak across the process lifetime (restoreSession is
 			// also re-invoked on in-place respawn).
@@ -8111,12 +8033,6 @@ export class SessionManager {
 					session.lastAssistantTerminalIdentity = undefined;
 				}
 				return;
-			}
-			// A synthetic hard-kill terminal has no later Pi settlement event. Synthesize
-			// settlement even when the real final agent_end already performed this turn's
-			// bookkeeping; graceful replacement replay still waits for agent_settled.
-			if (opts?.replacementOwnedTerminal && opts.abortAttemptOutcome !== undefined) {
-				session._piAgentRunSettled = true;
 			}
 			if (session.turnTerminalHandled) return;
 			session.turnTerminalHandled = true;
@@ -8213,10 +8129,8 @@ export class SessionManager {
 				session.recoverDrainAttempts = 0;
 				// A graceful Stop or canonical coordinated prompt performs terminal
 				// bookkeeping while replacement ownership is still held. The coordinator
-				// performs the sole drain after prompt acknowledgement settles. For a
-				// normal Pi turn, agent_end precedes post-run compaction; drainQueue is
-				// fenced until agent_settled clears Pi's active-run guard.
-				if (!deferQueueDrain && session._piAgentRunSettled !== false) this.drainQueue(session);
+				// performs the sole drain after prompt acknowledgement settles.
+				if (!deferQueueDrain) this.drainQueue(session);
 				else if (coordinator && writerIsCurrent && !opts?.replacementOwnedTerminal) {
 					coordinator.drainOnRelease = true;
 				}
@@ -8237,18 +8151,6 @@ export class SessionManager {
 				this._finishSessionSetup(session).catch((err) => {
 					console.error(`[session-manager] Deferred setup error for session ${session.id}:`, err);
 				});
-			}
-		} else if (event.type === "agent_settled") {
-			// Pi sets its internal active-run flag false immediately before this event,
-			// after all retry/compaction/queued-continuation post-processing. New-turn
-			// work must enter Pi here, never synchronously from agent_end.
-			session._piAgentRunSettled = true;
-			if (session.status === "idle"
-				&& !session.lastTurnErrored
-				&& !session.isCompacting
-				&& !deferQueueDrain) {
-				session.recoverDrainAttempts = 0;
-				this.drainQueue(session);
 			}
 		} else if (event.type === "auto_compaction_start" || event.type === "compaction_start") {
 			session.isCompacting = true;
@@ -8397,7 +8299,6 @@ export class SessionManager {
 				reason,
 			});
 		} else if (event.type === "process_exit") {
-			session._piAgentRunSettled = true;
 			session.streamingStartedAt = undefined;
 			this.resolveStoreForSession(session.id).update(session.id, {
 				wasStreaming: false,
@@ -15951,19 +15852,12 @@ export class SessionManager {
 			// The canonical listener is lifecycle-fenced while Stop owns the shared
 			// coordinator. Preserve its terminal sequence and replay bookkeeping once
 			// after graceful settlement; this listener never broadcasts the events.
-			if (event.type === "message_end"
-				|| event.type === "compaction_end"
-				|| event.type === "auto_compaction_end") {
-				deferredTerminalEvents.push(event);
-			}
-			// agent_end is only user-visible terminal output. Pi still owns finishRun,
-			// automatic compaction, and queued continuation work until agent_settled.
-			// Ending the grace race at agent_end recreates the busy prompt race when
-			// coordinator release drains against that still-active run.
+			if (event.type === "message_end") deferredTerminalEvents.push(event);
+			// A retryable agent_end (willRetry:true) means Pi is about to retry the
+			// attempt, not that the run stopped — treating it as settled would end
+			// the grace race early and skip force-kill while the agent is still
+			// live. Only a final (willRetry:false) agent_end settles the abort.
 			if (event.type === "agent_end" && event.willRetry !== true) {
-				deferredTerminalEvents.push(event);
-			}
-			if (event.type === "agent_settled") {
 				deferredTerminalEvents.push(event);
 				this.clock.clearTimeout(settleTimer);
 				unsubSettle();
@@ -16033,25 +15927,6 @@ export class SessionManager {
 		// before the hard kill even though the old live listener never observed it.
 		// The staged switch listener consumes only proven echoes; anything still
 		// unresolved is re-enqueued after replay (or on replacement failure).
-
-		// A hard kill during compaction cannot emit its end event. Finalize that
-		// active epoch as aborted before terminal bookkeeping so isCompacting cannot
-		// permanently fence the durable queue on coordinator release.
-		if (session.isCompacting) {
-			const syntheticCompactionEnd = {
-				type: "compaction_end",
-				reason: session._reliableCompactionReason ?? "threshold",
-				compactionId: session._reliableCompactionId,
-				aborted: true,
-				success: false,
-				error: "compaction interrupted by Stop",
-			};
-			this.handleAgentLifecycle(session, syntheticCompactionEnd, {
-				replacementOwnedTerminal: true,
-				deferQueueDrain: true,
-			});
-			emitSessionEvent(session, syntheticCompactionEnd);
-		}
 
 		// Hard kill cannot emit Pi's terminal lifecycle event. Run the exact same
 		// canonical terminal bookkeeping once before deriving the replacement

--- a/src/server/agent/session-manager.ts
+++ b/src/server/agent/session-manager.ts
@@ -1081,6 +1081,13 @@ export interface SessionInfo {
 	/** A compaction end observed while Stop owns the turn; released by replacement. */
 	_reliableCompactionReleaseDeferred?: boolean;
 	/**
+	 * Pi keeps its run active after the final agent_end while post-run work such
+	 * as threshold compaction completes. Only agent_settled proves that a fresh
+	 * prompt RPC can start. Undefined preserves compatibility with old/replayed
+	 * lifecycles that never emitted agent_start/agent_settled.
+	 */
+	_piAgentRunSettled?: boolean;
+	/**
 	 * Latest in-flight `message_update` payload. Set on every `message_update`
 	 * event with a non-empty `event.message`; cleared on `message_end`,
 	 * `agent_end`, and `process_exit`. Used to splice the in-flight row into
@@ -6277,8 +6284,9 @@ export class SessionManager {
 					}
 				}
 				const prefixedDispatch = buildErrorRecoveryPrefix(errorSnippet, dispatchText);
+				const settlementFenced = session._piAgentRunSettled === false;
 				await this.dispatchDirectPrompt(session, prefixedDispatch, opts?.images, opts?.attachments, !!opts?.isSteered, !!opts?.coldStart, source, author, accepted.id, accepted.id, opts?.streamingBehavior, false, false, opts?.suppressTitleGen);
-				return { status: "dispatched" };
+				return { status: settlementFenced ? "queued" : "dispatched" };
 			}
 			if (session.status === "idle") {
 				this.drainQueue(session);
@@ -6481,14 +6489,15 @@ export class SessionManager {
 			// cleared).
 			// Inject the recovery prefix into the model-facing dispatch text.
 			const prefixedDispatch = buildErrorRecoveryPrefix(errSnippet, dispatchText);
+			const settlementFenced = session._piAgentRunSettled === false;
 			await this.dispatchDirectPrompt(session, prefixedDispatch, opts?.images, opts?.attachments, !!opts?.isSteered, !!opts?.coldStart, source, author, undefined, undefined, opts?.streamingBehavior, undefined, false, opts?.suppressTitleGen);
-			return { status: "dispatched" };
+			return { status: settlementFenced ? "queued" : "dispatched" };
 		}
 
 		// If agent is idle and queue is empty, dispatch directly. Mark streaming
 		// before awaiting rpcClient.prompt(): Pi 0.77 OpenAI/Codex preflight can be
 		// slow, and clients/API polling must see the turn as in-flight immediately.
-		if (session.status === "idle" && session.promptQueue.isEmpty) {
+		if (session.status === "idle" && session._piAgentRunSettled !== false && session.promptQueue.isEmpty) {
 			if (!opts?.suppressTitleGen) this.tryGenerateTitleFromPrompt(sessionId, text);
 			await this.dispatchDirectPrompt(session, dispatchText, opts?.images, opts?.attachments, !!opts?.isSteered, !!opts?.coldStart, source, author, undefined, undefined, opts?.streamingBehavior, undefined, false, opts?.suppressTitleGen);
 			return { status: "dispatched" };
@@ -7191,6 +7200,21 @@ export class SessionManager {
 		broadcastStatus(session, "streaming", { streamingStartedAt: session.streamingStartedAt });
 	}
 
+	/** Roll back an optimistic prompt dispatch after Pi proves that no run opened. */
+	private rollbackRejectedPromptDispatch(session: SessionInfo): void {
+		// Stop/replacement or a later lifecycle transition owns every non-streaming
+		// state. A late rejection may clean up its exact queue/sidecar attempt, but it
+		// must not settle abort waiters or overwrite a newer status owner.
+		if (session.status !== "streaming") return;
+		session.streamingStartedAt = undefined;
+		this.resolveStoreForSession(session.id).update(session.id, {
+			wasStreaming: false,
+			streamingStartedAt: undefined,
+		});
+		broadcastStatus(session, "idle");
+		this.resolveIdleWaiters(session.id);
+	}
+
 	private async applyDirectProviderEnv(bridgeOptions: RpcBridgeOptions, sandboxed: boolean | undefined, provider?: string): Promise<void> {
 		if (sandboxed) return;
 		bridgeOptions.env = mergeHostAgentProviderEnv(bridgeOptions.env, this.preferencesStore, {
@@ -7374,7 +7398,7 @@ export class SessionManager {
 			this.broadcastQueue(session);
 			return;
 		}
-		broadcastStatus(session, "idle");
+		this.rollbackRejectedPromptDispatch(session);
 		this.broadcastQueue(session);
 		if (this.maybeAutoRetryPromptDeliveryFailure(session, safeReason, source)) {
 			// Bounded retry exhaustion switches regular prompts to manual recovery.
@@ -7444,6 +7468,52 @@ export class SessionManager {
 		// replacement coordinator. All unrelated dispatch remains fenced until the
 		// coordinator releases.
 		if (session.isCompacting || session.status === "aborting" || (replacementKind !== undefined && replacementKind !== "poison-redrive")) return;
+		if (session._piAgentRunSettled === false && replacementKind !== "poison-redrive") {
+			// An accepted stable occurrence already owns its durable queue row. Legacy
+			// and automatic-retry callers have no such row, so create one before
+			// returning; agent_settled will drain the same occurrence exactly once.
+			const existing = durableQueueRowId
+				? session.promptQueue.toArray().find((row) => row.id === durableQueueRowId)
+				: undefined;
+			if (existing) {
+				// Admission created this occurrence before the error-recovery envelope was
+				// known. Preserve its identity/lane/state while durably replacing only the
+				// model-facing payload and dispatch metadata that settlement must replay.
+				Object.assign(existing, {
+					text,
+					images,
+					attachments,
+					isSteered: isSteered ?? false,
+					source,
+					verifierOwned,
+					author,
+					streamingBehavior,
+					coldStart,
+					suppressTitleGen,
+				});
+			} else {
+				const deferred = {
+					id: durableQueueRowId ?? randomUUID(),
+					text,
+					images,
+					attachments,
+					isSteered: isSteered ?? false,
+					createdAt: this.clock.now(),
+					source,
+					verifierOwned,
+					author,
+					streamingBehavior,
+					coldStart,
+					suppressTitleGen,
+				};
+				session.promptQueue.restoreAtFront(deferred);
+			}
+			session.lastPromptText = text;
+			session.lastPromptImages = images;
+			session.lastPromptSource = source;
+			this.broadcastQueue(session);
+			return;
+		}
 		const reliableRow = durableQueueRowId
 			? (session.promptQueue.toArray() as ReliableQueuedMessage[]).find((row) => row.id === durableQueueRowId && row.kind !== undefined)
 			: undefined;
@@ -7512,9 +7582,9 @@ export class SessionManager {
 						dispatchEpoch: prepared.dispatchEpoch,
 					}, { front: true });
 					this.broadcastQueue(session);
-					// Pi rejected before opening a turn; undo the optimistic idle dispatch
-					// status so the matching compaction finisher can own the sole redrain.
-					broadcastStatus(session, "idle");
+					// Pi rejected before opening a turn; undo every optimistic status plane
+					// so the matching compaction finisher can own the sole redrain.
+					this.rollbackRejectedPromptDispatch(session);
 					console.warn(`[session-manager] intent dispatch restored session=${session.id} intent=${reliableRow.id} attempt=${prepared.attemptId} outcome=compaction-active`);
 					return;
 				}
@@ -7529,6 +7599,7 @@ export class SessionManager {
 						attemptId: prepared.attemptId,
 						dispatchEpoch: prepared.dispatchEpoch,
 					}, { front: true });
+					this.rollbackRejectedPromptDispatch(session);
 				} else if (index !== -1) {
 					attempt.state = "uncertain";
 					attempt.retryable = false;
@@ -7616,6 +7687,10 @@ export class SessionManager {
 		if (this.getModelSelectionRecoveryAdmission(session.id).condition) return;
 		if (!this._sessionWriterIsCurrent(session)) return;
 		if (session.isCompacting || session.status === "aborting" || (this._sessionReplacementCoordinators?.has(session.id) ?? false)) return;
+		// agent_end is not Pi's prompt-admission boundary: automatic compaction and
+		// queued continuation handling still run before agent_settled clears the
+		// runtime's active-run guard.
+		if (session._piAgentRunSettled === false) return;
 		if (session.promptQueue.isEmpty) return;
 
 		const reliableNext = (session.promptQueue.toArray() as ReliableQueuedMessage[])
@@ -7980,6 +8055,9 @@ export class SessionManager {
 		}
 
 		if (event.type === "agent_start") {
+			// Pi's run remains active through agent_end post-processing. A later
+			// agent_settled is the sole fresh-prompt admission boundary.
+			session._piAgentRunSettled = false;
 			// The session has begun its turn — clear the boot re-prompt marker so
 			// the set doesn't leak across the process lifetime (restoreSession is
 			// also re-invoked on in-place respawn).
@@ -8033,6 +8111,12 @@ export class SessionManager {
 					session.lastAssistantTerminalIdentity = undefined;
 				}
 				return;
+			}
+			// A synthetic hard-kill terminal has no later Pi settlement event. Synthesize
+			// settlement even when the real final agent_end already performed this turn's
+			// bookkeeping; graceful replacement replay still waits for agent_settled.
+			if (opts?.replacementOwnedTerminal && opts.abortAttemptOutcome !== undefined) {
+				session._piAgentRunSettled = true;
 			}
 			if (session.turnTerminalHandled) return;
 			session.turnTerminalHandled = true;
@@ -8129,8 +8213,10 @@ export class SessionManager {
 				session.recoverDrainAttempts = 0;
 				// A graceful Stop or canonical coordinated prompt performs terminal
 				// bookkeeping while replacement ownership is still held. The coordinator
-				// performs the sole drain after prompt acknowledgement settles.
-				if (!deferQueueDrain) this.drainQueue(session);
+				// performs the sole drain after prompt acknowledgement settles. For a
+				// normal Pi turn, agent_end precedes post-run compaction; drainQueue is
+				// fenced until agent_settled clears Pi's active-run guard.
+				if (!deferQueueDrain && session._piAgentRunSettled !== false) this.drainQueue(session);
 				else if (coordinator && writerIsCurrent && !opts?.replacementOwnedTerminal) {
 					coordinator.drainOnRelease = true;
 				}
@@ -8151,6 +8237,18 @@ export class SessionManager {
 				this._finishSessionSetup(session).catch((err) => {
 					console.error(`[session-manager] Deferred setup error for session ${session.id}:`, err);
 				});
+			}
+		} else if (event.type === "agent_settled") {
+			// Pi sets its internal active-run flag false immediately before this event,
+			// after all retry/compaction/queued-continuation post-processing. New-turn
+			// work must enter Pi here, never synchronously from agent_end.
+			session._piAgentRunSettled = true;
+			if (session.status === "idle"
+				&& !session.lastTurnErrored
+				&& !session.isCompacting
+				&& !deferQueueDrain) {
+				session.recoverDrainAttempts = 0;
+				this.drainQueue(session);
 			}
 		} else if (event.type === "auto_compaction_start" || event.type === "compaction_start") {
 			session.isCompacting = true;
@@ -8299,6 +8397,7 @@ export class SessionManager {
 				reason,
 			});
 		} else if (event.type === "process_exit") {
+			session._piAgentRunSettled = true;
 			session.streamingStartedAt = undefined;
 			this.resolveStoreForSession(session.id).update(session.id, {
 				wasStreaming: false,
@@ -15852,12 +15951,19 @@ export class SessionManager {
 			// The canonical listener is lifecycle-fenced while Stop owns the shared
 			// coordinator. Preserve its terminal sequence and replay bookkeeping once
 			// after graceful settlement; this listener never broadcasts the events.
-			if (event.type === "message_end") deferredTerminalEvents.push(event);
-			// A retryable agent_end (willRetry:true) means Pi is about to retry the
-			// attempt, not that the run stopped — treating it as settled would end
-			// the grace race early and skip force-kill while the agent is still
-			// live. Only a final (willRetry:false) agent_end settles the abort.
+			if (event.type === "message_end"
+				|| event.type === "compaction_end"
+				|| event.type === "auto_compaction_end") {
+				deferredTerminalEvents.push(event);
+			}
+			// agent_end is only user-visible terminal output. Pi still owns finishRun,
+			// automatic compaction, and queued continuation work until agent_settled.
+			// Ending the grace race at agent_end recreates the busy prompt race when
+			// coordinator release drains against that still-active run.
 			if (event.type === "agent_end" && event.willRetry !== true) {
+				deferredTerminalEvents.push(event);
+			}
+			if (event.type === "agent_settled") {
 				deferredTerminalEvents.push(event);
 				this.clock.clearTimeout(settleTimer);
 				unsubSettle();
@@ -15927,6 +16033,25 @@ export class SessionManager {
 		// before the hard kill even though the old live listener never observed it.
 		// The staged switch listener consumes only proven echoes; anything still
 		// unresolved is re-enqueued after replay (or on replacement failure).
+
+		// A hard kill during compaction cannot emit its end event. Finalize that
+		// active epoch as aborted before terminal bookkeeping so isCompacting cannot
+		// permanently fence the durable queue on coordinator release.
+		if (session.isCompacting) {
+			const syntheticCompactionEnd = {
+				type: "compaction_end",
+				reason: session._reliableCompactionReason ?? "threshold",
+				compactionId: session._reliableCompactionId,
+				aborted: true,
+				success: false,
+				error: "compaction interrupted by Stop",
+			};
+			this.handleAgentLifecycle(session, syntheticCompactionEnd, {
+				replacementOwnedTerminal: true,
+				deferQueueDrain: true,
+			});
+			emitSessionEvent(session, syntheticCompactionEnd);
+		}
 
 		// Hard kill cannot emit Pi's terminal lifecycle event. Run the exact same
 		// canonical terminal bookkeeping once before deriving the replacement

--- a/src/server/agent/session-manager.ts
+++ b/src/server/agent/session-manager.ts
@@ -1081,6 +1081,13 @@ export interface SessionInfo {
 	/** A compaction end observed while Stop owns the turn; released by replacement. */
 	_reliableCompactionReleaseDeferred?: boolean;
 	/**
+	 * Pi keeps its run active after the final agent_end while post-run work such
+	 * as threshold compaction completes. Only agent_settled proves that a fresh
+	 * prompt RPC can start. Undefined preserves compatibility with old/replayed
+	 * lifecycles that never emitted agent_start/agent_settled.
+	 */
+	_piAgentRunSettled?: boolean;
+	/**
 	 * Latest in-flight `message_update` payload. Set on every `message_update`
 	 * event with a non-empty `event.message`; cleared on `message_end`,
 	 * `agent_end`, and `process_exit`. Used to splice the in-flight row into
@@ -6488,7 +6495,7 @@ export class SessionManager {
 		// If agent is idle and queue is empty, dispatch directly. Mark streaming
 		// before awaiting rpcClient.prompt(): Pi 0.77 OpenAI/Codex preflight can be
 		// slow, and clients/API polling must see the turn as in-flight immediately.
-		if (session.status === "idle" && session.promptQueue.isEmpty) {
+		if (session.status === "idle" && session._piAgentRunSettled !== false && session.promptQueue.isEmpty) {
 			if (!opts?.suppressTitleGen) this.tryGenerateTitleFromPrompt(sessionId, text);
 			await this.dispatchDirectPrompt(session, dispatchText, opts?.images, opts?.attachments, !!opts?.isSteered, !!opts?.coldStart, source, author, undefined, undefined, opts?.streamingBehavior, undefined, false, opts?.suppressTitleGen);
 			return { status: "dispatched" };
@@ -7191,6 +7198,21 @@ export class SessionManager {
 		broadcastStatus(session, "streaming", { streamingStartedAt: session.streamingStartedAt });
 	}
 
+	/** Roll back an optimistic prompt dispatch after Pi proves that no run opened. */
+	private rollbackRejectedPromptDispatch(session: SessionInfo): void {
+		// Stop/replacement or a later lifecycle transition owns every non-streaming
+		// state. A late rejection may clean up its exact queue/sidecar attempt, but it
+		// must not settle abort waiters or overwrite a newer status owner.
+		if (session.status !== "streaming") return;
+		session.streamingStartedAt = undefined;
+		this.resolveStoreForSession(session.id).update(session.id, {
+			wasStreaming: false,
+			streamingStartedAt: undefined,
+		});
+		broadcastStatus(session, "idle");
+		this.resolveIdleWaiters(session.id);
+	}
+
 	private async applyDirectProviderEnv(bridgeOptions: RpcBridgeOptions, sandboxed: boolean | undefined, provider?: string): Promise<void> {
 		if (sandboxed) return;
 		bridgeOptions.env = mergeHostAgentProviderEnv(bridgeOptions.env, this.preferencesStore, {
@@ -7374,7 +7396,7 @@ export class SessionManager {
 			this.broadcastQueue(session);
 			return;
 		}
-		broadcastStatus(session, "idle");
+		this.rollbackRejectedPromptDispatch(session);
 		this.broadcastQueue(session);
 		if (this.maybeAutoRetryPromptDeliveryFailure(session, safeReason, source)) {
 			// Bounded retry exhaustion switches regular prompts to manual recovery.
@@ -7444,6 +7466,36 @@ export class SessionManager {
 		// replacement coordinator. All unrelated dispatch remains fenced until the
 		// coordinator releases.
 		if (session.isCompacting || session.status === "aborting" || (replacementKind !== undefined && replacementKind !== "poison-redrive")) return;
+		if (session._piAgentRunSettled === false && replacementKind !== "poison-redrive") {
+			// An accepted stable occurrence already owns its durable queue row. Legacy
+			// and automatic-retry callers have no such row, so create one before
+			// returning; agent_settled will drain the same occurrence exactly once.
+			const existing = durableQueueRowId
+				? session.promptQueue.toArray().find((row) => row.id === durableQueueRowId)
+				: undefined;
+			if (!existing) {
+				const deferred = {
+					id: durableQueueRowId ?? randomUUID(),
+					text,
+					images,
+					attachments,
+					isSteered: isSteered ?? false,
+					createdAt: this.clock.now(),
+					source,
+					verifierOwned,
+					author,
+					streamingBehavior,
+					coldStart,
+					suppressTitleGen,
+				};
+				session.promptQueue.restoreAtFront(deferred);
+			}
+			session.lastPromptText = text;
+			session.lastPromptImages = images;
+			session.lastPromptSource = source;
+			this.broadcastQueue(session);
+			return;
+		}
 		const reliableRow = durableQueueRowId
 			? (session.promptQueue.toArray() as ReliableQueuedMessage[]).find((row) => row.id === durableQueueRowId && row.kind !== undefined)
 			: undefined;
@@ -7512,9 +7564,9 @@ export class SessionManager {
 						dispatchEpoch: prepared.dispatchEpoch,
 					}, { front: true });
 					this.broadcastQueue(session);
-					// Pi rejected before opening a turn; undo the optimistic idle dispatch
-					// status so the matching compaction finisher can own the sole redrain.
-					broadcastStatus(session, "idle");
+					// Pi rejected before opening a turn; undo every optimistic status plane
+					// so the matching compaction finisher can own the sole redrain.
+					this.rollbackRejectedPromptDispatch(session);
 					console.warn(`[session-manager] intent dispatch restored session=${session.id} intent=${reliableRow.id} attempt=${prepared.attemptId} outcome=compaction-active`);
 					return;
 				}
@@ -7529,6 +7581,7 @@ export class SessionManager {
 						attemptId: prepared.attemptId,
 						dispatchEpoch: prepared.dispatchEpoch,
 					}, { front: true });
+					this.rollbackRejectedPromptDispatch(session);
 				} else if (index !== -1) {
 					attempt.state = "uncertain";
 					attempt.retryable = false;
@@ -7616,6 +7669,10 @@ export class SessionManager {
 		if (this.getModelSelectionRecoveryAdmission(session.id).condition) return;
 		if (!this._sessionWriterIsCurrent(session)) return;
 		if (session.isCompacting || session.status === "aborting" || (this._sessionReplacementCoordinators?.has(session.id) ?? false)) return;
+		// agent_end is not Pi's prompt-admission boundary: automatic compaction and
+		// queued continuation handling still run before agent_settled clears the
+		// runtime's active-run guard.
+		if (session._piAgentRunSettled === false) return;
 		if (session.promptQueue.isEmpty) return;
 
 		const reliableNext = (session.promptQueue.toArray() as ReliableQueuedMessage[])
@@ -7980,6 +8037,9 @@ export class SessionManager {
 		}
 
 		if (event.type === "agent_start") {
+			// Pi's run remains active through agent_end post-processing. A later
+			// agent_settled is the sole fresh-prompt admission boundary.
+			session._piAgentRunSettled = false;
 			// The session has begun its turn — clear the boot re-prompt marker so
 			// the set doesn't leak across the process lifetime (restoreSession is
 			// also re-invoked on in-place respawn).
@@ -8036,6 +8096,12 @@ export class SessionManager {
 			}
 			if (session.turnTerminalHandled) return;
 			session.turnTerminalHandled = true;
+			// A synthetic hard-kill terminal has no later Pi settlement event. Graceful
+			// replacement replay still waits for the old bridge's real agent_settled;
+			// coordinator ownership alone must not bypass Pi's active-run guard.
+			if (opts?.replacementOwnedTerminal && opts.abortAttemptOutcome !== undefined) {
+				session._piAgentRunSettled = true;
+			}
 
 			// Revoke one-time granted tools after the turn completes
 			if (session.oneTimeGrantedTools && session.oneTimeGrantedTools.length > 0) {
@@ -8129,8 +8195,10 @@ export class SessionManager {
 				session.recoverDrainAttempts = 0;
 				// A graceful Stop or canonical coordinated prompt performs terminal
 				// bookkeeping while replacement ownership is still held. The coordinator
-				// performs the sole drain after prompt acknowledgement settles.
-				if (!deferQueueDrain) this.drainQueue(session);
+				// performs the sole drain after prompt acknowledgement settles. For a
+				// normal Pi turn, agent_end precedes post-run compaction; drainQueue is
+				// fenced until agent_settled clears Pi's active-run guard.
+				if (!deferQueueDrain && session._piAgentRunSettled !== false) this.drainQueue(session);
 				else if (coordinator && writerIsCurrent && !opts?.replacementOwnedTerminal) {
 					coordinator.drainOnRelease = true;
 				}
@@ -8151,6 +8219,18 @@ export class SessionManager {
 				this._finishSessionSetup(session).catch((err) => {
 					console.error(`[session-manager] Deferred setup error for session ${session.id}:`, err);
 				});
+			}
+		} else if (event.type === "agent_settled") {
+			// Pi sets its internal active-run flag false immediately before this event,
+			// after all retry/compaction/queued-continuation post-processing. New-turn
+			// work must enter Pi here, never synchronously from agent_end.
+			session._piAgentRunSettled = true;
+			if (session.status === "idle"
+				&& !session.lastTurnErrored
+				&& !session.isCompacting
+				&& !deferQueueDrain) {
+				session.recoverDrainAttempts = 0;
+				this.drainQueue(session);
 			}
 		} else if (event.type === "auto_compaction_start" || event.type === "compaction_start") {
 			session.isCompacting = true;
@@ -8299,6 +8379,7 @@ export class SessionManager {
 				reason,
 			});
 		} else if (event.type === "process_exit") {
+			session._piAgentRunSettled = true;
 			session.streamingStartedAt = undefined;
 			this.resolveStoreForSession(session.id).update(session.id, {
 				wasStreaming: false,
@@ -15852,12 +15933,19 @@ export class SessionManager {
 			// The canonical listener is lifecycle-fenced while Stop owns the shared
 			// coordinator. Preserve its terminal sequence and replay bookkeeping once
 			// after graceful settlement; this listener never broadcasts the events.
-			if (event.type === "message_end") deferredTerminalEvents.push(event);
-			// A retryable agent_end (willRetry:true) means Pi is about to retry the
-			// attempt, not that the run stopped — treating it as settled would end
-			// the grace race early and skip force-kill while the agent is still
-			// live. Only a final (willRetry:false) agent_end settles the abort.
+			if (event.type === "message_end"
+				|| event.type === "compaction_end"
+				|| event.type === "auto_compaction_end") {
+				deferredTerminalEvents.push(event);
+			}
+			// agent_end is only user-visible terminal output. Pi still owns finishRun,
+			// automatic compaction, and queued continuation work until agent_settled.
+			// Ending the grace race at agent_end recreates the busy prompt race when
+			// coordinator release drains against that still-active run.
 			if (event.type === "agent_end" && event.willRetry !== true) {
+				deferredTerminalEvents.push(event);
+			}
+			if (event.type === "agent_settled") {
 				deferredTerminalEvents.push(event);
 				this.clock.clearTimeout(settleTimer);
 				unsubSettle();
@@ -15927,6 +16015,25 @@ export class SessionManager {
 		// before the hard kill even though the old live listener never observed it.
 		// The staged switch listener consumes only proven echoes; anything still
 		// unresolved is re-enqueued after replay (or on replacement failure).
+
+		// A hard kill during compaction cannot emit its end event. Finalize that
+		// active epoch as aborted before terminal bookkeeping so isCompacting cannot
+		// permanently fence the durable queue on coordinator release.
+		if (session.isCompacting) {
+			const syntheticCompactionEnd = {
+				type: "compaction_end",
+				reason: session._reliableCompactionReason ?? "threshold",
+				compactionId: session._reliableCompactionId,
+				aborted: true,
+				success: false,
+				error: "compaction interrupted by Stop",
+			};
+			this.handleAgentLifecycle(session, syntheticCompactionEnd, {
+				replacementOwnedTerminal: true,
+				deferQueueDrain: true,
+			});
+			emitSessionEvent(session, syntheticCompactionEnd);
+		}
 
 		// Hard kill cannot emit Pi's terminal lifecycle event. Run the exact same
 		// canonical terminal bookkeeping once before deriving the replacement

--- a/tests/e2e/mock-agent-core.mjs
+++ b/tests/e2e/mock-agent-core.mjs
@@ -297,12 +297,9 @@ export class MockAgentCore {
 		if (event?.type === "message_end" && event.message && typeof event.message === "object") {
 			this._appendTranscriptMessage(event.message);
 		}
-		// Pi 0.82 distinguishes a low-level agent_end from the fully durable,
-		// no-more-continuations settlement boundary. History cursor enrichment must
-		// observe the latter, after every terminal message has been persisted.
-		if (event?.type === "agent_end" && event.willRetry !== true) {
-			this._onEvent({ type: "agent_settled" });
-		}
+		// Pi emits agent_settled explicitly only after post-agent compaction and
+		// continuation handling completes. Terminal call sites below preserve that
+		// ordering instead of synthesizing settlement inside agent_end emission.
 	}
 
 	_nextTranscriptEntryId() {
@@ -1118,6 +1115,7 @@ export class MockAgentCore {
 			}
 			this.currentAbortController = null;
 			this.emit({ type: "agent_end" });
+			this.emit({ type: "agent_settled" });
 			this.emit({ type: "session_status", status: "idle" });
 			return;
 		}
@@ -1143,6 +1141,7 @@ export class MockAgentCore {
 				this._reliableOverflowRetryActive = false;
 				this.currentAbortController = null;
 				this.emit({ type: "agent_end", willRetry: false });
+				this.emit({ type: "agent_settled" });
 				this.emit({ type: "session_status", status: "idle" });
 				return;
 			}
@@ -1154,6 +1153,7 @@ export class MockAgentCore {
 			await this._crossBarrier(`${reason}:before-final-agent-end`, { reason });
 			this.currentAbortController = null;
 			this.emit({ type: "agent_end", willRetry: false });
+			this.emit({ type: "agent_settled" });
 			this._reliableOverflowRetryActive = false;
 			this.emit({ type: "session_status", status: "idle" });
 			return;
@@ -1177,6 +1177,7 @@ export class MockAgentCore {
 			}
 			this.currentAbortController = null;
 			this.emit({ type: "agent_end" });
+			this.emit({ type: "agent_settled" });
 			this.emit({ type: "session_status", status: "idle" });
 			return;
 		}
@@ -1228,6 +1229,7 @@ export class MockAgentCore {
 			this.emit({ type: "tool_execution_end", toolCallId: toolId, toolName: "bash_bg", isError: false });
 			this.currentAbortController = null;
 			this.emit({ type: "agent_end" });
+			this.emit({ type: "agent_settled" });
 			this.emit({ type: "session_status", status: "idle" });
 			return;
 		}
@@ -1260,6 +1262,7 @@ export class MockAgentCore {
 			this.emit({ type: "tool_execution_end", toolCallId: toolId, toolName: "bash_bg", isError: false });
 			this.currentAbortController = null;
 			this.emit({ type: "agent_end" });
+			this.emit({ type: "agent_settled" });
 			this.emit({ type: "session_status", status: "idle" });
 			return;
 		}
@@ -1281,6 +1284,7 @@ export class MockAgentCore {
 			}
 			this.currentAbortController = null;
 			this.emit({ type: "agent_end" });
+			this.emit({ type: "agent_settled" });
 			this.emit({ type: "session_status", status: "idle" });
 			return;
 		}
@@ -1441,6 +1445,7 @@ export class MockAgentCore {
 		await this._crossBarrier("turn:before-agent-end");
 		this.emit({ type: "agent_end" });
 		await this._crossBarrier("turn:after-agent-end");
+		this.emit({ type: "agent_settled" });
 		this.emit({ type: "session_status", status: "idle" });
 	}
 
@@ -2272,6 +2277,7 @@ export class MockAgentCore {
 			this.emit({ type: "message_end", message: toolResultMsg });
 			this.emit({ type: "tool_execution_end", toolId, toolName: deniedTool, isError: true });
 			this.emit({ type: "agent_end" });
+			this.emit({ type: "agent_settled" });
 			this.emit({ type: "session_status", status: "idle" });
 			return;
 		}
@@ -3435,6 +3441,7 @@ export class MockAgentCore {
 				}
 				this.emit({ type: "agent_end" });
 				await this._crossBarrier(`abort:${occurrence}:after-agent-end`, commandReceipt);
+				this.emit({ type: "agent_settled" });
 				this.emit({ type: "session_status", status: "idle" });
 				return { success: true };
 			}

--- a/tests2/browser/journeys/reliable-agent-turns.journey.spec.ts
+++ b/tests2/browser/journeys/reliable-agent-turns.journey.spec.ts
@@ -205,7 +205,7 @@ test.describe("Journey: Reliable Agent Turns", () => {
 		});
 	}
 
-	test("overflow compaction releases continuation steers during willRetry but holds next-turn prompts until final agent_end", async ({ page, gateway }) => {
+	test("overflow compaction releases continuation steers during willRetry but holds next-turn prompts until agent_settled", async ({ page, gateway }) => {
 		const scenario = await createScenario(page, gateway);
 		try {
 			const overflow = scenario.runtime.holdNextCompaction({ reason: "overflow", willRetry: true });

--- a/tests2/core/orphan-tool-result-recovery.test.ts
+++ b/tests2/core/orphan-tool-result-recovery.test.ts
@@ -179,6 +179,7 @@ function harness(options?: {
 					},
 				});
 				manager.handleAgentLifecycle(restored, { type: "agent_end", messages: [] });
+				manager.handleAgentLifecycle(restored, { type: "agent_settled" });
 				const call = promptCallCount++;
 				if (call === 0 && options.rejectRedriveWith) {
 					return options.throwRedriveRejection

--- a/tests2/core/orphan-tool-result-rehydration-boundaries.test.ts
+++ b/tests2/core/orphan-tool-result-rehydration-boundaries.test.ts
@@ -700,6 +700,7 @@ describe("executable SessionManager rehydration boundaries", () => {
 				message: { role: "assistant", content: [{ type: "text", text: "queued done" }], stopReason: "stop" },
 			});
 			listener?.({ type: "agent_end", messages: [] });
+			listener?.({ type: "agent_settled" });
 			return { success: true };
 		});
 		const ps = persisted("boot-continuation-dispatch-fence", file, { wasStreaming: true });
@@ -719,11 +720,14 @@ describe("executable SessionManager rehydration boundaries", () => {
 			message: { role: "assistant", content: [{ type: "text", text: "continued" }], stopReason: "stop" },
 		});
 		listener?.({ type: "agent_end", messages: [] });
-		const canonicalBeforeAck = manager.sessions.get(ps.id);
-		expect(canonicalBeforeAck?.status).toBe("idle");
-		expect(canonicalBeforeAck?.completedTurnCount).toBe(1);
-		expect(canonicalBeforeAck?.promptQueue.toArray().map((row: any) => row.text))
+		const canonicalBeforeSettlement = manager.sessions.get(ps.id);
+		expect(canonicalBeforeSettlement?.status).toBe("idle");
+		expect(canonicalBeforeSettlement?.completedTurnCount).toBe(1);
+		expect(canonicalBeforeSettlement?.promptQueue.toArray().map((row: any) => row.text))
 			.toEqual(["accepted while boot prompt is pending"]);
+		expect(bridge.prompt).not.toHaveBeenCalled();
+
+		listener?.({ type: "agent_settled" });
 		expect(bridge.prompt).not.toHaveBeenCalled();
 
 		bootAccepted.resolve();

--- a/tests2/core/pi-installed-contract.test.ts
+++ b/tests2/core/pi-installed-contract.test.ts
@@ -174,6 +174,49 @@ describe("installed Pi runtime contract for reliable agent turns", () => {
 		expect(normalizer.normalize(postTerminalDelta)).not.toHaveProperty("message");
 	});
 
+	it("clears the active-run guard before emitting agent_settled to installed-runtime observers", async () => {
+		const observations: Array<{ observer: "extension" | "session"; type: string; isStreaming: boolean }> = [];
+		const receiver: any = Object.create(AgentSession.prototype);
+		Object.assign(receiver, {
+			_isAgentRunActive: false,
+			_eventListeners: [
+				(event: any) => observations.push({
+					observer: "session",
+					type: event.type,
+					isStreaming: receiver.isStreaming,
+				}),
+			],
+			_extensionRunner: {
+				emit: vi.fn(async (event: any) => {
+					observations.push({
+						observer: "extension",
+						type: event.type,
+						isStreaming: receiver.isStreaming,
+					});
+				}),
+			},
+			_flushPendingBashMessages: vi.fn(),
+			_handlePostAgentRun: vi.fn(async () => false),
+			agent: {
+				prompt: vi.fn(async () => {
+					receiver._emit({ type: "agent_end", messages: [] });
+				}),
+				continue: vi.fn(),
+			},
+		});
+
+		await (AgentSession.prototype as any)._runAgentPrompt.call(receiver, [userMessage("settlement contract")]);
+
+		expect(observations, "PI_CONTRACT_AGENT_SETTLED_BEFORE_ACTIVE_RUN_RELEASE").toEqual([
+			{ observer: "session", type: "agent_end", isStreaming: true },
+			{ observer: "extension", type: "agent_settled", isStreaming: false },
+			{ observer: "session", type: "agent_settled", isStreaming: false },
+		]);
+		expect(receiver.agent.prompt).toHaveBeenCalledOnce();
+		expect(receiver._handlePostAgentRun).toHaveBeenCalledOnce();
+		expect(receiver.isIdle).toBe(true);
+	});
+
 	it("orders manual compaction events and releases its controller before compaction_end", async () => {
 		const observations: Array<{ event: any; controllerReleased: boolean }> = [];
 		const receiver: any = {

--- a/tests2/core/pi-rpc-agent-end-retry.test.ts
+++ b/tests2/core/pi-rpc-agent-end-retry.test.ts
@@ -111,10 +111,15 @@ describe("Pi RPC agent_end retry contract", () => {
 		manager.handleAgentLifecycle(session, { type: "agent_end", willRetry: false, messages: [] });
 		await flush();
 
-		// Only the final (willRetry:false) agent_end increments the counter — exactly once.
+		// Only the final (willRetry:false) agent_end increments the counter — exactly once,
+		// but Pi still owns post-run work until agent_settled.
 		assert.equal(session.completedTurnCount, 1);
 		assert.deepEqual(session.allowedTools, ["write"]);
 		assert.deepEqual(session.oneTimeGrantedTools, []);
+		expect(prompt).not.toHaveBeenCalled();
+
+		manager.handleAgentLifecycle(session, { type: "agent_settled" });
+		await flush();
 		expect(prompt).toHaveBeenCalledTimes(1);
 		expect(prompt.mock.calls[0][0]).toBe("queued until Pi settles");
 	});
@@ -331,12 +336,13 @@ describe("Pi RPC agent_end retry contract", () => {
 		// second compaction_end; the next agent_end is the terminal turn boundary.
 		emit({ type: "agent_start" });
 		emit({ type: "agent_end", messages: [], willRetry: false });
+		emit({ type: "agent_settled" });
 		await wait;
 		await flush();
 
 		expect(idleResolved).toBe(true);
 		expect(session.eventBuffer.getAll().filter((entry: any) => entry.event.type === "compaction_end")).toHaveLength(1);
-		// The terminal turn boundary briefly settles idle and then drains the
+		// The terminal turn boundary settles idle; agent_settled then drains the
 		// queued prompt, whose optimistic dispatch makes the session streaming.
 		expect(session.status).toBe("streaming");
 		expect(session.completedTurnCount).toBe(1);

--- a/tests2/core/reliable-compaction-release.test.ts
+++ b/tests2/core/reliable-compaction-release.test.ts
@@ -226,8 +226,13 @@ describe("post-terminal reliable drain settlement", () => {
 		{ label: "stable occurrence", intentId: "post-error-follow-up" },
 		{ label: "legacy occurrence", intentId: undefined },
 	])("fences a $label accepted after error agent_end until agent_settled", async ({ intentId }) => {
-		const prompt = vi.fn(async () => ({ success: true }));
-		const { manager, session } = useHarness({
+		const prompt = vi.fn(async (
+			_text: string,
+			_images?: unknown,
+			_options?: unknown,
+			_streamingBehavior?: unknown,
+		) => ({ success: true }));
+		const { manager, session, storeUpdates } = useHarness({
 			id: `post-error-settlement-${intentId ?? "legacy"}`,
 			status: "streaming",
 			prompt,
@@ -239,17 +244,69 @@ describe("post-terminal reliable drain settlement", () => {
 		});
 		manager.handleAgentLifecycle(session, { type: "agent_end", willRetry: false, messages: [] });
 
-		await manager.enqueuePrompt(session.id, "recover after error", intentId ? { intentId } : undefined);
+		const modelText = "expanded recovery payload";
+		const images = [{ type: "image", data: "cGl4ZWw=", mimeType: "image/png" }];
+		const attachments = [{ name: "recovery.txt", mimeType: "text/plain", size: 8 }];
+		const admission = await manager.enqueuePrompt(session.id, "recover after error", {
+			...(intentId ? { intentId } : {}),
+			modelText,
+			images,
+			attachments,
+			streamingBehavior: "followUp",
+			suppressTitleGen: true,
+		});
 		await flushMicrotasks();
+		expect(admission).toEqual({ status: "queued" });
 		expect(prompt, "POST_ERROR_PROMPT_DISPATCHED_BEFORE_PI_SETTLED").not.toHaveBeenCalled();
 		expect(session.promptQueue.toArray()).toHaveLength(1);
-		expect(session.promptQueue.peek()?.text).toContain("recover after error");
+		const deferred = session.promptQueue.peek()!;
+		expect(deferred.text).toContain("terminal model failure");
+		expect(deferred.text).toContain(modelText);
+		expect(deferred.text).not.toBe(modelText);
+		expect(deferred).toMatchObject({
+			images,
+			attachments,
+			streamingBehavior: "followUp",
+			suppressTitleGen: true,
+		});
 		expect(session.lastTurnErrored).toBe(false);
+
+		if (intentId) {
+			const persistedRows = storeUpdates
+				.map((update: any) => update.messageQueue?.find((row: any) => row.id === intentId))
+				.filter(Boolean);
+			expect(persistedRows[0]?.text).toBe(modelText);
+			expect(persistedRows.at(-1)?.text).toBe(deferred.text);
+			for (const field of ["id", "kind", "targetTurn", "sequence", "createdAt", "deliveryState"] as const) {
+				expect(persistedRows.at(-1)?.[field], `${field} changed while preserving the deferred payload`)
+					.toEqual(persistedRows[0]?.[field]);
+			}
+		}
+
+		const later = session.promptQueue.enqueue("later FIFO occurrence");
+		expect(session.promptQueue.toArray().map((row: any) => row.id)).toEqual([deferred.id, later.id]);
 
 		manager.handleAgentLifecycle(session, { type: "agent_settled" });
 		await flushMicrotasks();
 		expect(prompt).toHaveBeenCalledTimes(1);
-		expect(session.promptQueue.toArray()).toEqual([]);
+		expect(prompt.mock.calls[0]?.[0]).toBe(deferred.text);
+		expect(prompt.mock.calls[0]?.[1]).toEqual(images);
+		expect(prompt.mock.calls[0]?.[3]).toBe("followUp");
+		expect(session.promptQueue.toArray().map((row: any) => row.id)).toEqual([later.id]);
+
+		manager.handleAgentLifecycle(session, { type: "agent_start" });
+		const piPromptText = prompt.mock.calls[0]![0];
+		for (const type of ["message_start", "message_end"] as const) {
+			const event = manager.prepareVisibleAgentEvent(session, {
+				type,
+				message: { id: `pi-user-${intentId ?? "legacy"}`, role: "user", content: piPromptText, timestamp: 1_700_000_000_030 },
+			});
+			manager.handleAgentLifecycle(session, event);
+		}
+		const settled = readAuthorSidecar(session.id).find((row) =>
+			intentId ? row.intentId === intentId : promptAuthorBindingMatchesText(row, piPromptText));
+		expect(settled?.settlement?.outcome).toBe("echoed");
+		expect(promptAuthorBindingMatchesText(settled!, piPromptText)).toBe(true);
 	});
 
 	it("rolls every status plane back to idle after a definite no-start rejection", async () => {

--- a/tests2/core/reliable-compaction-release.test.ts
+++ b/tests2/core/reliable-compaction-release.test.ts
@@ -1,19 +1,38 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+	initAuthorSidecarDir,
+	promptAuthorBindingMatchesText,
+	readAuthorSidecar,
+} from "../../src/server/agent/author-sidecar.js";
+import {
+	barrier,
 	flushMicrotasks,
 	makeReliableIntentHarness,
 	type ReliableIntentHarness,
 } from "./helpers/reliable-intent-fixture.js";
 
 const harnesses: ReliableIntentHarness[] = [];
+let authorStateDir = "";
 const useHarness = (overrides: Record<string, any> = {}) => {
 	const harness = makeReliableIntentHarness(overrides);
 	harnesses.push(harness);
 	return harness;
 };
 
+beforeEach(() => {
+	authorStateDir = fs.mkdtempSync(path.join(os.tmpdir(), "reliable-compaction-release-"));
+	initAuthorSidecarDir(authorStateDir, {
+		secretsDir: path.join(authorStateDir, "private-secrets"),
+		hmacKey: Buffer.alloc(32, 0x52),
+	});
+});
+
 afterEach(() => {
 	while (harnesses.length > 0) harnesses.pop()!.cleanup();
+	fs.rmSync(authorStateDir, { recursive: true, force: true });
 	vi.restoreAllMocks();
 });
 
@@ -111,6 +130,154 @@ describe("reliable compaction admission fences", () => {
 			expect(session.promptQueue.toArray().map((row: any) => row.id)).toEqual(["P2"]);
 		},
 	);
+});
+
+describe("post-terminal reliable drain settlement", () => {
+	it("waits through post-agent compaction and dispatches next-turn work only after agent_settled", async () => {
+		const promptRpc = barrier<any>();
+		const prompt = vi.fn(() => promptRpc.hold());
+		const { manager, session, steer, storeUpdates } = useHarness({
+			id: "post-terminal-settled-drain",
+			status: "streaming",
+			prompt,
+		});
+
+		manager.handleAgentLifecycle(session, { type: "agent_start" });
+
+		// Prove that the preceding same-run steer is not a stale carrier: Pi echoes
+		// it and the exact attempt settles in the fsynced author sidecar.
+		await manager.deliverLiveSteer(session.id, "prior live steer", { intentId: "steer-before-terminal" });
+		await flushMicrotasks();
+		expect(steer).toHaveBeenCalledTimes(1);
+		const piSteerText = steer.mock.calls[0]![0];
+		for (const type of ["message_start", "message_end"] as const) {
+			const event = manager.prepareVisibleAgentEvent(session, {
+				type,
+				message: { id: "pi-user-steer-before-terminal", role: "user", content: piSteerText, timestamp: 1_700_000_000_010 },
+			});
+			manager.handleAgentLifecycle(session, event);
+		}
+		const settledSteer = readAuthorSidecar(session.id).find((row) => row.intentId === "steer-before-terminal");
+		expect(settledSteer?.settlement?.outcome).toBe("echoed");
+		expect(promptAuthorBindingMatchesText(settledSteer!, piSteerText)).toBe(true);
+		expect(session.inFlightSteerTexts).toEqual([]);
+
+		await manager.enqueuePrompt(session.id, "queued after current turn", { intentId: "prompt-after-turn" });
+		expect(session.promptQueue.toArray()).toMatchObject([{
+			id: "prompt-after-turn",
+			kind: "prompt",
+			targetTurn: "next-turn",
+			deliveryState: "queued",
+		}]);
+
+		manager.handleAgentLifecycle(session, {
+			type: "message_end",
+			message: { id: "assistant-final", role: "assistant", stopReason: "stop", content: "done" },
+		});
+		manager.handleAgentLifecycle(session, { type: "agent_end", willRetry: false, messages: [] });
+		await flushMicrotasks();
+
+		// agent_end is user-visible terminal bookkeeping, but Pi's run remains active.
+		expect(session.completedTurnCount).toBe(1);
+		expect(session.status).toBe("idle");
+		expect(prompt, "POST_TERMINAL_PROMPT_DISPATCHED_BEFORE_PI_SETTLED").not.toHaveBeenCalled();
+		expect(session.promptQueue.toArray().map((row: any) => row.id)).toEqual(["prompt-after-turn"]);
+		expect(session.inFlightSteerTexts).toEqual([]);
+		expect(storeUpdates.at(-1)).toMatchObject({ wasStreaming: false, streamingStartedAt: undefined });
+
+		manager.handleAgentLifecycle(session, {
+			type: "compaction_start",
+			reason: "threshold",
+			compactionId: "compact-post-terminal",
+		});
+		manager.handleAgentLifecycle(session, compactionEnd("threshold", {
+			compactionId: "compact-post-terminal",
+			willRetry: false,
+		}));
+		await flushMicrotasks();
+		expect(session.isCompacting).toBe(false);
+		expect(prompt, "POST_COMPACTION_PROMPT_DISPATCHED_BEFORE_PI_SETTLED").not.toHaveBeenCalled();
+
+		manager.handleAgentLifecycle(session, { type: "agent_settled" });
+		await promptRpc.entered;
+		expect(prompt).toHaveBeenCalledTimes(1);
+		expect(session.status).toBe("streaming");
+		expect(session.promptQueue.toArray()).toEqual([]);
+		expect(session.inFlightSteerTexts).toMatchObject([{ intentId: "prompt-after-turn", state: "dispatching" }]);
+
+		// The next real Pi turn correlates and settles the exact occurrence normally.
+		manager.handleAgentLifecycle(session, { type: "agent_start" });
+		const piPromptText = (prompt.mock.calls as any[][])[0]![0];
+		for (const type of ["message_start", "message_end"] as const) {
+			const event = manager.prepareVisibleAgentEvent(session, {
+				type,
+				message: { id: "pi-user-prompt-after-turn", role: "user", content: piPromptText, timestamp: 1_700_000_000_020 },
+			});
+			manager.handleAgentLifecycle(session, event);
+		}
+		promptRpc.release({ success: true });
+		await flushMicrotasks();
+		expect(session.inFlightSteerTexts).toEqual([]);
+		expect(readAuthorSidecar(session.id).find((row) => row.intentId === "prompt-after-turn")?.settlement?.outcome)
+			.toBe("echoed");
+	});
+
+	it.each([
+		{ label: "stable occurrence", intentId: "post-error-follow-up" },
+		{ label: "legacy occurrence", intentId: undefined },
+	])("fences a $label accepted after error agent_end until agent_settled", async ({ intentId }) => {
+		const prompt = vi.fn(async () => ({ success: true }));
+		const { manager, session } = useHarness({
+			id: `post-error-settlement-${intentId ?? "legacy"}`,
+			status: "streaming",
+			prompt,
+		});
+		manager.handleAgentLifecycle(session, { type: "agent_start" });
+		manager.handleAgentLifecycle(session, {
+			type: "message_end",
+			message: { id: "assistant-error", role: "assistant", stopReason: "error", errorMessage: "terminal model failure" },
+		});
+		manager.handleAgentLifecycle(session, { type: "agent_end", willRetry: false, messages: [] });
+
+		await manager.enqueuePrompt(session.id, "recover after error", intentId ? { intentId } : undefined);
+		await flushMicrotasks();
+		expect(prompt, "POST_ERROR_PROMPT_DISPATCHED_BEFORE_PI_SETTLED").not.toHaveBeenCalled();
+		expect(session.promptQueue.toArray()).toHaveLength(1);
+		expect(session.promptQueue.peek()?.text).toContain("recover after error");
+		expect(session.lastTurnErrored).toBe(false);
+
+		manager.handleAgentLifecycle(session, { type: "agent_settled" });
+		await flushMicrotasks();
+		expect(prompt).toHaveBeenCalledTimes(1);
+		expect(session.promptQueue.toArray()).toEqual([]);
+	});
+
+	it("rolls every status plane back to idle after a definite no-start rejection", async () => {
+		const prompt = vi.fn(async () => ({ success: false, error: "Agent is already processing." }));
+		const { manager, session, storeUpdates } = useHarness({
+			id: "definite-prompt-rejection-rollback",
+			status: "idle",
+			prompt,
+		});
+		vi.spyOn(console, "error").mockImplementation(() => {});
+
+		await manager.enqueuePrompt(session.id, "rejected occurrence", { intentId: "rejected-prompt" });
+		await flushMicrotasks();
+
+		expect(session.promptQueue.toArray()).toMatchObject([{
+			id: "rejected-prompt",
+			deliveryState: "failed",
+			retryable: true,
+			deliveryError: "bridge-rejected",
+		}]);
+		expect(session.inFlightSteerTexts).toEqual([]);
+		expect(readAuthorSidecar(session.id).find((row) => row.intentId === "rejected-prompt")?.settlement?.outcome)
+			.toBe("cancelled");
+		expect(session.status, "POST_TERMINAL_REJECTION_LEFT_FALSE_STREAMING_STATUS").toBe("idle");
+		expect(session.streamingStartedAt).toBeUndefined();
+		expect(storeUpdates.filter((update) => update.wasStreaming === false).at(-1))
+			.toMatchObject({ wasStreaming: false, streamingStartedAt: undefined });
+	});
 });
 
 describe("failed automatic compaction release", () => {

--- a/tests2/core/session-manager-direct-prompt-lifecycle.test.ts
+++ b/tests2/core/session-manager-direct-prompt-lifecycle.test.ts
@@ -774,7 +774,7 @@ describe("SessionManager direct idle prompt lifecycle", () => {
 		);
 	});
 
-	it("surfaces durable work when an explicit Retry dispatch is rejected", async () => {
+	it("surfaces durable work and rolls back optimistic streaming when an explicit Retry is rejected", async () => {
 		const manager = makeManager();
 		const prompt = vi.fn(async () => ({ success: false, error: "invalid request schema" }));
 		const { session, client } = putSession(manager, {
@@ -786,9 +786,25 @@ describe("SessionManager direct idle prompt lifecycle", () => {
 
 		await assert.rejects(() => manager.retryLastPrompt(session.id), /invalid request schema/);
 
+		const retryRowId = session.explicitRetryQueueRowId;
+		assert.ok(retryRowId, "explicit Retry retains its accepted durable row identity");
+		assert.equal(session.status, "idle");
+		assert.equal(session.streamingStartedAt, undefined, "definite rejection clears the optimistic timestamp");
+		assert.deepEqual(
+			manager._testStore.update.mock.calls
+				.map(([, update]: any[]) => update)
+				.filter((update: any) => Object.hasOwn(update, "wasStreaming")),
+			[
+				{ wasStreaming: true, streamingStartedAt: manager._testClock.now() },
+				{ wasStreaming: false, streamingStartedAt: undefined },
+			],
+			"persisted streaming state rolls back after the optimistic write",
+		);
 		assert.equal(session.pendingAutoRetryTimer, undefined, "a rejected explicit Retry has no automatic owner");
 		assert.equal(session.manualRetryRequired, true, "rejected Retry must leave its durable row visibly parked");
 		assert.equal(session.promptQueue.length, 1, "the explicit Retry row remains durable");
+		assert.equal(session.promptQueue.peek()?.id, retryRowId, "the exact Retry row remains first");
+		assert.equal(readAuthorSidecar(session.id).at(-1)?.settlement?.outcome, "cancelled", "the rejected attempt settles its sidecar");
 		assert.equal(
 			client.sent.some((msg: any) => msg.type === "event" && msg.data?.type === "manual_retry_required"),
 			true,
@@ -798,6 +814,61 @@ describe("SessionManager direct idle prompt lifecycle", () => {
 			manager._testStore.update.mock.calls.some(([, update]: any[]) => update.manualRetryRequired === true),
 			"the rejected explicit Retry must persist the parked-state marker",
 		);
+
+		manager._testClock.advance(0);
+		await flushAsyncWork();
+		assert.equal(prompt.mock.calls.length, 1, "manual recovery cannot redrain the rejected Retry");
+	});
+
+	it("does not let a late explicit Retry rejection overwrite Stop ownership", async () => {
+		const manager = makeManager();
+		const pending = deferred<any>();
+		const prompt = vi.fn(() => pending.promise);
+		const abort = vi.fn(async () => ({ success: true }));
+		const { session, client } = putSession(manager, {
+			lastTurnErrored: true,
+			lastTurnErrorMessage: "invalid request schema",
+			lastPromptText: "retry while Stop interleaves",
+			rpcClient: { prompt, abort },
+		});
+
+		const retryPromise = manager.retryLastPrompt(session.id);
+		assert.equal(prompt.mock.calls.length, 1);
+		assert.equal(session.status, "streaming");
+		const optimisticStartedAt = session.streamingStartedAt;
+		const retryRowId = session.explicitRetryQueueRowId;
+		assert.ok(retryRowId, "explicit Retry owns one durable row before the RPC settles");
+
+		await manager.abortSessionTurn(session.id);
+		assert.equal(abort.mock.calls.length, 1);
+		assert.equal(session.status, "aborting");
+
+		pending.resolve({ success: false, error: "invalid request schema" });
+		await assert.rejects(retryPromise, /invalid request schema/);
+
+		assert.equal(session.status, "aborting", "late rejection must not steal Stop's status ownership");
+		assert.equal(session.streamingStartedAt, optimisticStartedAt, "late rejection must not clear Stop-owned lifecycle state");
+		assert.deepEqual(
+			client.sent.filter((msg: any) => msg.type === "session_status").map((msg: any) => msg.status),
+			["streaming", "aborting"],
+			"the rejection cannot emit a later idle frame",
+		);
+		assert.equal(
+			manager._testStore.update.mock.calls
+				.map(([, update]: any[]) => update)
+				.filter((update: any) => Object.hasOwn(update, "wasStreaming") && update.wasStreaming === false)
+				.length,
+			0,
+			"the late rejection cannot persist idle over Stop ownership",
+		);
+		assert.equal(session.manualRetryRequired, true, "the failed Retry remains manual despite Stop ownership");
+		assert.equal(session.promptQueue.length, 1);
+		assert.equal(session.promptQueue.peek()?.id, retryRowId, "the same Retry row remains parked at the front");
+		assert.equal(readAuthorSidecar(session.id).at(-1)?.settlement?.outcome, "cancelled", "the rejected attempt still settles its sidecar");
+
+		manager._testClock.advance(0);
+		await flushAsyncWork();
+		assert.equal(prompt.mock.calls.length, 1, "the Stop-interleaved Retry cannot redrain automatically");
 	});
 
 	it("retryLastPrompt routes mid-work provider-auth prompt failures through recovery", async () => {

--- a/tests2/core/session-manager-direct-prompt-lifecycle.test.ts
+++ b/tests2/core/session-manager-direct-prompt-lifecycle.test.ts
@@ -1406,12 +1406,12 @@ describe("SessionManager direct idle prompt lifecycle", () => {
 		await Promise.resolve();
 		await Promise.resolve();
 
-		assert.equal(session.status, "idle");
+		assert.equal(session.status, "aborting", "late prompt rejection must not steal Stop's status ownership");
 		assert.equal(session.promptQueue.length, 1);
 		assert.equal(session.promptQueue.peek()?.text, "recover after abort-before-acceptance");
 		assert.deepEqual(
 			client.sent.filter((msg: any) => msg.type === "session_status").map((msg: any) => msg.status),
-			["streaming", "aborting", "idle"],
+			["streaming", "aborting"],
 		);
 	});
 

--- a/tests2/core/session-manager-force-abort-grace.test.ts
+++ b/tests2/core/session-manager-force-abort-grace.test.ts
@@ -265,6 +265,9 @@ describe("SessionManager.forceAbort grace race (S8)", () => {
 			status: "streaming",
 			statusVersion: 1,
 			streamingStartedAt: Date.now(),
+			isCompacting: true,
+			_reliableCompactionId: "graceful-stop-compaction",
+			_reliableCompactionReason: "threshold",
 			createdAt: Date.now(),
 			lastActivity: Date.now(),
 			clients: new Set(),
@@ -279,10 +282,20 @@ describe("SessionManager.forceAbort grace race (S8)", () => {
 			rpcClient: {
 				abort: async () => {
 					emit({
+						type: "compaction_end",
+						reason: "threshold",
+						compactionId: "graceful-stop-compaction",
+						aborted: true,
+						success: false,
+						error: "aborted",
+					});
+					emit({
 						type: "message_end",
 						message: { role: "assistant", content: [{ type: "text", text: "stopped" }], stopReason: "error", errorMessage: "aborted" },
 					});
 					emit({ type: "agent_end", messages: [] });
+					assert.equal(drainQueue.mock.calls.length, 0, "agent_end cannot release queued work before Pi settles");
+					emit({ type: "agent_settled" });
 				},
 				onEvent: (listener: (event: any) => void) => {
 					listeners.add(listener);
@@ -304,6 +317,7 @@ describe("SessionManager.forceAbort grace race (S8)", () => {
 		assert.equal(session.lastTurnErrored, false, "user Stop clears the synthetic abort error");
 		assert.equal(session.lastTurnErrorMessage, undefined);
 		assert.equal(session.streamingStartedAt, undefined);
+		assert.equal(session.isCompacting, false, "graceful Stop replays compaction_end before release");
 		assert.equal(session.status, "idle");
 		assert.equal(resolveIdleWaiters.mock.calls.length, 1, "idle waiters settle exactly once");
 		assert.equal(drainQueue.mock.calls.length, 1, "only coordinator release drains");
@@ -342,6 +356,9 @@ describe("SessionManager.forceAbort grace race (S8)", () => {
 			status: "streaming",
 			statusVersion: 1,
 			streamingStartedAt: Date.now(),
+			isCompacting: true,
+			_reliableCompactionId: "hard-stop-compaction",
+			_reliableCompactionReason: "threshold",
 			createdAt: Date.now(),
 			lastActivity: Date.now(),
 			clients: new Set(),
@@ -379,6 +396,7 @@ describe("SessionManager.forceAbort grace race (S8)", () => {
 		assert.equal(session.lastTurnErrorMessage, undefined);
 		assert.equal(session.consecutiveErrorTurns, 0);
 		assert.equal(session.streamingStartedAt, undefined);
+		assert.equal(session.isCompacting, false, "hard Stop synthesizes an aborted compaction end");
 		assert.equal(resolveIdleWaiters.mock.calls.length, 1);
 		assert.ok(update.mock.calls.some(([, patch]: any[]) =>
 			patch.wasStreaming === false && patch.streamingStartedAt === undefined

--- a/tests2/core/session-manager-force-abort-grace.test.ts
+++ b/tests2/core/session-manager-force-abort-grace.test.ts
@@ -327,6 +327,118 @@ describe("SessionManager.forceAbort grace race (S8)", () => {
 		), "durable restart bookkeeping records an idle session");
 	});
 
+	it("releases one exact FIFO occurrence after hard Stop kills post-terminal compaction", async () => {
+		const replacementPrompt = vi.fn(async (_text: string) => ({ success: true }));
+		const replacement = {
+			running: true,
+			start: vi.fn(async () => {}),
+			stop: vi.fn(async () => {}),
+			onEvent: vi.fn(() => () => {}),
+			prompt: replacementPrompt,
+		};
+		registerRpcBridgeFactory(() => replacement as any);
+
+		const manager: any = new SessionManager();
+		const persisted: any = {
+			id: "s-post-terminal-hard-stop",
+			modelProvider: "anthropic",
+			modelId: "fixture-model",
+			effectiveThinkingLevel: "medium",
+			wasStreaming: true,
+		};
+		manager._testStore = {
+			get: vi.fn(() => persisted),
+			update: vi.fn((_id: string, patch: any) => Object.assign(persisted, patch)),
+		};
+		manager.lifecycleHub = { dispatch: vi.fn(async () => {}) };
+		manager.resolveIdleWaiters = vi.fn();
+		manager.readCompactionTranscriptEntries = vi.fn(async () => undefined);
+		manager.finalizeCompactionSidecar = vi.fn(async () => undefined);
+		manager.requireCurrentCatalogSpawnModel = vi.fn(async (model: string) => model);
+		manager.resolveCurrentCatalogPreferredThinkingLevel = vi.fn(async () => "medium");
+		manager.ensureMcpManagerForContext = vi.fn(async () => {});
+		manager.buildToolActivationArgs = vi.fn(() => ({ args: [], env: {}, runtimeExtensions: [] }));
+		manager.applyDirectProviderEnv = vi.fn(async () => {});
+		manager.finalizeSpawnOptions = vi.fn(async () => {});
+		manager.tryAutoSelectModel = vi.fn(async () => {});
+		manager.tryApplyDefaultThinkingLevel = vi.fn(async () => {});
+		managers.push(manager);
+
+		const oldPrompt = vi.fn(async () => ({ success: true }));
+		const oldStop = vi.fn(async () => {});
+		const session: any = {
+			id: persisted.id,
+			title: "Post-terminal hard Stop",
+			titleGenerated: true,
+			cwd: tmpRoot,
+			status: "idle",
+			statusVersion: 1,
+			createdAt: Date.now(),
+			lastActivity: Date.now(),
+			clients: new Set(),
+			promptQueue: new PromptQueue(),
+			eventBuffer: new EventBuffer(),
+			inFlightSteerTexts: [],
+			completedTurnCount: 0,
+			setupComplete: true,
+			unsubscribe: vi.fn(),
+			rpcClient: {
+				abort: () => new Promise<void>(() => {}),
+				onEvent: () => () => {},
+				getState: async () => ({ success: false }),
+				stop: oldStop,
+				prompt: oldPrompt,
+			},
+		};
+		manager.sessions.set(session.id, session);
+
+		manager.handleAgentLifecycle(session, { type: "agent_start" });
+		await manager.enqueuePrompt(session.id, "first durable replacement turn", {
+			intentId: "intent-hard-stop-first",
+		});
+		await manager.enqueuePrompt(session.id, "second durable replacement turn", {
+			intentId: "intent-hard-stop-second",
+		});
+		const [first, second] = session.promptQueue.toArray();
+		manager.handleAgentLifecycle(session, {
+			type: "message_end",
+			message: { id: "assistant-before-compaction", role: "assistant", stopReason: "stop", content: "done" },
+		});
+		manager.handleAgentLifecycle(session, { type: "agent_end", willRetry: false, messages: [] });
+		manager.handleAgentLifecycle(session, {
+			type: "compaction_start",
+			reason: "threshold",
+			compactionId: "post-terminal-hard-stop-compaction",
+		});
+
+		assert.equal(session._piAgentRunSettled, false);
+		assert.equal(session.turnTerminalHandled, true);
+		assert.equal(session.completedTurnCount, 1);
+		assert.equal(manager.lifecycleHub.dispatch.mock.calls.length, 1);
+		assert.equal(manager.resolveIdleWaiters.mock.calls.length, 1);
+		assert.deepEqual(session.promptQueue.toArray().map((row: any) => row.id), [first.id, second.id]);
+
+		await manager.forceAbort(session.id, 10);
+		await vi.waitFor(() => assert.equal(replacementPrompt.mock.calls.length, 1));
+
+		assert.equal(oldStop.mock.calls.length, 1, "the unsettled old bridge is hard-killed");
+		assert.equal(oldPrompt.mock.calls.length, 0, "the old bridge never receives replacement work");
+		assert.equal(session._piAgentRunSettled, true, "hard kill synthesizes the missing settlement boundary");
+		assert.equal(session.isCompacting, false, "hard kill finalizes post-terminal compaction as aborted");
+		assert.equal(session._reliableFinishedCompactionIds.has("post-terminal-hard-stop-compaction"), true);
+		assert.equal(session.completedTurnCount, 1, "duplicate synthetic terminal cannot repeat turn bookkeeping");
+		assert.equal(manager.lifecycleHub.dispatch.mock.calls.length, 1);
+		assert.equal(manager.resolveIdleWaiters.mock.calls.length, 1);
+		assert.equal(replacementPrompt.mock.calls[0]?.[0], first.text);
+		assert.deepEqual(session.promptQueue.toArray().map((row: any) => row.id), [second.id]);
+		assert.equal(session.inFlightSteerTexts.length, 1);
+		assert.equal(session.inFlightSteerTexts[0]?.intentId, first.id);
+		assert.equal(session.inFlightSteerTexts[0]?.state, "dispatching");
+		assert.equal(session.inFlightSteerTexts[0]?.sequence, first.sequence);
+		assert.equal(manager._sessionReplacementCoordinators.has(session.id), false, "only coordinator release drains");
+		assert.equal(session.lifecycleGeneration, 1, "replacement generation remains canonical");
+	});
+
 	it("performs hard-abort terminal bookkeeping before replacement grant derivation", async () => {
 		registerRpcBridgeFactory(() => { throw new Error("stop after activation capture"); });
 		const manager: any = new SessionManager();

--- a/tests2/core/session-restore-last-activity.test.ts
+++ b/tests2/core/session-restore-last-activity.test.ts
@@ -77,6 +77,7 @@ class RestoreBridge {
 			{ type: "tool_execution_end", toolName: "read" },
 			{ type: "message_end", message: { id: `new-${this.id}`, role: "assistant", content: [] } },
 			{ type: "agent_end" },
+			{ type: "agent_settled" },
 		];
 		for (const event of events) this.emit(event);
 		if (this.promptError) throw this.promptError;
@@ -972,6 +973,7 @@ describe("authoritative session activity attribution", () => {
 		// origin quarantine because no new prompt has been dispatched.
 		for (const bridge of bridges.values()) {
 			for (const event of [...LIFECYCLE_EVENTS, ...REPLAY_VISIBLE_EVENTS]) bridge.emit(event);
+			bridge.emit({ type: "agent_settled" });
 		}
 		await store.flushAsync();
 
@@ -986,7 +988,8 @@ describe("authoritative session activity attribution", () => {
 		expect(transitions.filter(({ patch }) => "lastReadAt" in patch)).toEqual([]);
 
 		const target = rows[1];
-		await manager.enqueuePrompt(target.id, "genuine post-restore prompt");
+		await expect(manager.enqueuePrompt(target.id, "genuine post-restore prompt"))
+			.resolves.toEqual({ status: "dispatched" });
 		await store.flushAsync();
 		const after = store.get(target.id)!;
 		expect(after.lastActivity).toBeGreaterThan(after.lastReadAt!);

--- a/tests2/integration/reliable-intent-recovery.test.ts
+++ b/tests2/integration/reliable-intent-recovery.test.ts
@@ -45,6 +45,50 @@ async function closeConnection(conn: WsConnection): Promise<void> {
 test.setTimeout(30_000);
 
 test.describe("Reliable intent recovery protocol", () => {
+	test("holds next-turn intent after agent_end until Pi emits agent_settled", async ({ gateway }) => {
+		const sessionId = await createSession();
+		const conn = await connectWs(sessionId);
+		const core = reliableMockCore(gateway, sessionId);
+		const intent = "intent-post-agent-end-settled-0001";
+		const text = "DELIVER_ONLY_AFTER_AGENT_SETTLED";
+		try {
+			core.armBarrier("turn:before-agent-end");
+			core.armBarrier("turn:after-agent-end");
+			core.armBarrier("prompt:2:received");
+			const cursor = conn.messageCount();
+			conn.send({ type: "prompt", text: "FIRST_TURN_BEFORE_SETTLEMENT" });
+			await core.waitForBarrier("turn:before-agent-end");
+
+			conn.send({ type: "prompt", text, intentId: intent });
+			const queued = await conn.waitForFrom(cursor, (frame) => frameHasIntentIds(frame, [intent]));
+			expect(intentRows(queued)).toEqual([
+				expect.objectContaining({ id: intent, deliveryState: "queued", targetTurn: "next-turn" }),
+			]);
+			expect(commandTexts(core).filter((command) => command === text)).toHaveLength(0);
+			expect((gateway.sessionManager.getSession(sessionId) as any)?._piAgentRunSettled,
+				"agent_start must install the Pi settlement fence").toBe(false);
+
+			core.releaseBarrier("turn:before-agent-end");
+			await core.waitForBarrier("turn:after-agent-end");
+			expect(commandTexts(core).filter((command) => command === text),
+				"agent_end must not call prompt while Pi still owns finishRun").toHaveLength(0);
+
+			core.releaseBarrier("turn:after-agent-end");
+			await core.waitForBarrier("prompt:2:received");
+			expect(commandTexts(core).filter((command) => command === text)).toHaveLength(1);
+			core.releaseBarrier("prompt:2:received");
+			await conn.waitForFrom(cursor, (frame) => frame.type === "event"
+				&& frame.data?.type === "message_end"
+				&& deliveryIntentId(frame) === intent);
+			await conn.waitForFrom(cursor, statusPredicate("idle"));
+			expect(userMessageEnds(conn.messages.slice(cursor), text).map(deliveryIntentId)).toEqual([intent]);
+		} finally {
+			core.releaseAllBarriers();
+			await closeConnection(conn);
+			await deleteSession(sessionId);
+		}
+	});
+
 	test("mock runtime exposes threshold failure and overflow retry barriers without sleeps", async ({ gateway }) => {
 		const sessionId = await createSession();
 		const conn = await connectWs(sessionId);

--- a/tests2/tests-map.json
+++ b/tests2/tests-map.json
@@ -3129,7 +3129,7 @@
     },
     {
       "path": "tests2/core/pi-installed-contract.test.ts",
-      "reason": "Installed-runtime contract coverage for the aligned Pi trio version, delta-only streaming with terminal authority, compaction event order and retry metadata, manual-compaction prompt rejection, recoverable-length overflow retry, queue release, and steer acknowledgement before user echo.",
+      "reason": "Installed-runtime contract coverage for the aligned Pi trio version, active-run release before agent_settled observers, delta-only streaming with terminal authority, compaction event order and retry metadata, manual-compaction prompt rejection, recoverable-length overflow retry, queue release, and steer acknowledgement before user echo.",
       "execution": {
         "runner": "vitest",
         "tier": "unit",

--- a/tests2/tests-map.json
+++ b/tests2/tests-map.json
@@ -3156,7 +3156,7 @@
     },
     {
       "path": "tests2/core/reliable-compaction-release.test.ts",
-      "reason": "Core reliable-turn compaction coverage for admission fencing, single release across manual, threshold, overflow, failure, and abort outcomes, continuation-versus-next-turn ordering, and Stop interleavings, using the shared deterministic reliable-intent fixture.",
+      "reason": "Core reliable-turn compaction coverage for admission fencing, agent_end-to-agent_settled next-turn release, definite-rejection status rollback, single release across manual, threshold, overflow, failure, and abort outcomes, continuation-versus-next-turn ordering, and Stop interleavings, using the shared deterministic reliable-intent fixture.",
       "execution": {
         "runner": "vitest",
         "tier": "unit",
@@ -3165,7 +3165,7 @@
     },
     {
       "path": "tests2/integration/reliable-intent-recovery.test.ts",
-      "reason": "In-process gateway and mock-Pi integration coverage for barrier-driven compaction, durable ID-keyed admission, ordered identical steers, delayed acknowledgement and echo, reconnect, restart, abort, failure, and exactly-once transcript recovery, with helper-owned deterministic runtime barriers.",
+      "reason": "In-process gateway and mock-Pi integration coverage for agent_end-to-agent_settled admission fencing, barrier-driven compaction, durable ID-keyed admission, ordered identical steers, delayed acknowledgement and echo, reconnect, restart, abort, failure, and exactly-once transcript recovery, with helper-owned deterministic runtime barriers.",
       "execution": {
         "runner": "vitest",
         "tier": "unit",
@@ -3174,7 +3174,7 @@
     },
     {
       "path": "tests2/browser/journeys/reliable-agent-turns.journey.spec.ts",
-      "reason": "Browser journey covering the reliable-turn visible-carrier invariant across idle and busy prompts, rapid identical steers, delayed acknowledgement and echo, manual, threshold, and overflow compaction, Stop races, reload, reconnect, second-tab convergence, and actionable delivery failure through its dedicated runtime fixture.",
+      "reason": "Browser journey covering the reliable-turn visible-carrier invariant across idle and busy prompts, agent_end-to-agent_settled release, rapid identical steers, delayed acknowledgement and echo, manual, threshold, and overflow compaction, Stop races, reload, reconnect, second-tab convergence, and actionable delivery failure through its dedicated runtime fixture.",
       "execution": {
         "runner": "playwright",
         "tier": "browser",


### PR DESCRIPTION
## Summary
- fence next-turn prompt dispatch until Pi 0.84.1 emits `agent_settled`
- preserve durable identity, FIFO ordering, exact deferred recovery payloads, and ownership-safe rejection rollback
- handle graceful and hard Stop settlement, including interrupted compaction
- update mock/runtime fixtures, installed Pi contracts, focused regressions, and lifecycle documentation

## Validation
- full workflow build and type-check passed
- full unit, browser, and E2E suites passed after fixture alignment
- spec/regression, integrated implementation, and security reviews passed
- installed Pi trio verified at 0.84.1

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)