### PR TITLE
Hide recovered context overflow errors

### DIFF
--- a/src/app/compaction-types.ts
+++ b/src/app/compaction-types.ts
@@ -18,6 +18,15 @@
 /** "manual" → /compact slash; "auto" → threshold-driven; "overflow" → context-limit error. */
 export type CompactionTrigger = "manual" | "auto" | "overflow";
 
+/** Provider-neutral recognition for context-limit failures that auto-compaction
+ * can recover from. Keep this shared by live-event suppression and transcript
+ * rendering: some runtimes emit the error before `auto_compaction_start`, while
+ * others emit a failed retry after it. */
+export function isContextOverflowError(message: unknown): boolean {
+	if (typeof message !== "string" || message.length === 0) return false;
+	return /prompt is too long|tokens?\s*>\s*\d|(?:input|request|prompt)[^\n]{0,100}(?:exceeds?|exceeded)[^\n]{0,100}context window|context (?:window|length)[^\n]{0,100}(?:exceeds?|exceeded)/i.test(message);
+}
+
 /** Three lifecycle states the renderer branches on. */
 export type CompactionState = "in-progress" | "complete" | "error";
 

--- a/src/app/message-reducer.ts
+++ b/src/app/message-reducer.ts
@@ -16,6 +16,7 @@
  */
 
 import type { MessageAuthor } from "../shared/message-author.js";
+import { isContextOverflowError } from "./compaction-types.js";
 
 export type MessageOrigin = "server" | "optimistic" | "synthetic" | "permission";
 
@@ -69,6 +70,7 @@ export type Action =
 	| { type: "permission-reconciled"; current: any | null; reason?: string }
 	| { type: "blocked-tool-call-placeholder"; message: any; seq?: number }
 	| { type: "compaction-placeholder"; message: any }
+	| { type: "suppress-latest-context-overflow-error" }
 	| { type: "compaction-result"; message: any; success: boolean; toolResult?: any }
 	| { type: "system-notification"; message: any }
 	| { type: "mutation-pending"; message: any }
@@ -500,9 +502,43 @@ export function reduce(state: ReducerState, action: Action): ReducerState {
 
 		case "snapshot": {
 			const tick = state.nextTick;
-			const enriched = deduplicateSnapshotUserDeliveryIntents(
+			let enriched = deduplicateSnapshotUserDeliveryIntents(
 				action.messages.map(enrichUserMessage),
 			);
+			// A post-compaction snapshot can retain the provider's context-limit
+			// boundary row. Preserve the suppression established by the live
+			// auto_compaction_start instead of replacing it with an untagged copy.
+			// Match reverse occurrence ordinals per exact provider message: the
+			// compacted snapshot may omit older history, while a later identical
+			// error must not inherit suppression from this recovered occurrence.
+			const suppressedOrdinals = new Map<string, Set<number>>();
+			const stateOrdinals = new Map<string, number>();
+			for (let i = state.messages.length - 1; i >= 0; i--) {
+				const message = state.messages[i] as any;
+				if (message.role !== "assistant" || message.stopReason !== "error" || !isContextOverflowError(message.errorMessage)) continue;
+				const key = message.errorMessage as string;
+				const ordinal = stateOrdinals.get(key) ?? 0;
+				stateOrdinals.set(key, ordinal + 1);
+				if (message._suppressedByOverflowRecovery === true) {
+					const ordinals = suppressedOrdinals.get(key) ?? new Set<number>();
+					ordinals.add(ordinal);
+					suppressedOrdinals.set(key, ordinals);
+				}
+			}
+			if (suppressedOrdinals.size > 0) {
+				const snapshotOrdinals = new Map<string, number>();
+				for (let i = enriched.length - 1; i >= 0; i--) {
+					const message = enriched[i] as any;
+					if (message.role !== "assistant" || message.stopReason !== "error" || !isContextOverflowError(message.errorMessage)) continue;
+					const key = message.errorMessage as string;
+					const ordinal = snapshotOrdinals.get(key) ?? 0;
+					snapshotOrdinals.set(key, ordinal + 1);
+					if (suppressedOrdinals.get(key)?.has(ordinal)) {
+						enriched = enriched.slice();
+						enriched[i] = { ...message, _suppressedByOverflowRecovery: true };
+					}
+				}
+			}
 			// Two-way compaction dedup:
 			//   (a) State has a rich synthetic (`__compaction_summary` toolCall) —
 			//       drop the server's plain-text marker from this snapshot. Rich
@@ -1050,6 +1086,24 @@ export function reduce(state: ReducerState, action: Action): ReducerState {
 				nextTick: tick + 1,
 				highestSeq: state.highestSeq,
 			};
+		}
+
+		case "suppress-latest-context-overflow-error": {
+			// Providers may emit the recoverable error before auto_compaction_start,
+			// so the later compaction event must retroactively hide that live row.
+			let target = -1;
+			for (let i = state.messages.length - 1; i >= 0; i--) {
+				const message = state.messages[i] as any;
+				if (message.role !== "assistant") continue;
+				if (message.stopReason === "error" && isContextOverflowError(message.errorMessage)) {
+					target = i;
+				}
+				break;
+			}
+			if (target < 0 || (state.messages[target] as any)._suppressedByOverflowRecovery === true) return state;
+			const messages = state.messages.slice();
+			messages[target] = { ...messages[target], _suppressedByOverflowRecovery: true };
+			return { ...state, messages };
 		}
 
 		case "compaction-placeholder": {

--- a/src/app/remote-agent.ts
+++ b/src/app/remote-agent.ts
@@ -66,6 +66,7 @@ import { computeStreamingMessageId } from "./streaming-message-id.js";
 import {
 	buildCompactionSummaryMessages,
 	buildInProgressCompactionPayload,
+	isContextOverflowError,
 	parseOverflowTokenCount,
 	type CompactionSummaryPayload,
 	type CompactionTrigger,
@@ -3668,8 +3669,7 @@ export class RemoteAgent {
 							this._overflowRecoveryDeadline !== null
 							&& Date.now() <= this._overflowRecoveryDeadline
 							&& msg.stopReason === "error"
-							&& typeof msg.errorMessage === "string"
-							&& /prompt is too long|tokens?\s*>\s*\d/i.test(msg.errorMessage)
+							&& isContextOverflowError(msg.errorMessage)
 						) {
 							msg = { ...msg, _suppressedByOverflowRecovery: true };
 							suppressedOverflowRetry = true;
@@ -3882,6 +3882,7 @@ export class RemoteAgent {
 				// surfacing as a standalone red banner.
 				if (this._triggerFromEvent(event) === "overflow") {
 					this._overflowRecoveryDeadline = Date.now() + 60_000;
+					this.apply({ type: "suppress-latest-context-overflow-error" });
 				}
 				// Add a rich in-progress synthetic so compaction is visible in chat history
 				this._addCompactingPlaceholder(this._triggerFromEvent(event));

--- a/tests/e2e/mock-agent-core.mjs
+++ b/tests/e2e/mock-agent-core.mjs
@@ -1135,6 +1135,18 @@ export class MockAgentCore {
 				};
 				this.emit({ type: "message_end", message: truncated });
 				await this._crossBarrier("overflow:length-tail", { reason });
+				const preCompactionError = this._reliableScenario.compaction?.overflow?.preCompactionError;
+				if (typeof preCompactionError === "string" && preCompactionError.length > 0) {
+					this.emit({
+						type: "message_end",
+						message: {
+							role: "assistant",
+							content: [],
+							stopReason: "error",
+							errorMessage: preCompactionError,
+						},
+					});
+				}
 			}
 			const completed = await this._handleAutoCompaction(3, reason);
 			if (!completed || !this.currentAbortController || this.currentAbortController.signal.aborted) {
@@ -1473,9 +1485,13 @@ export class MockAgentCore {
 		const startType = isManual ? "compaction_start" : "auto_compaction_start";
 		const endType = isManual ? "compaction_end" : "auto_compaction_end";
 		const scenario = this._reliableScenario.compaction?.[reason] || {};
+		const retainedErrorMessage = typeof scenario.preCompactionError === "string"
+			? scenario.preCompactionError
+			: null;
 		this.ensureSessionFile();
 		const ts = new Date().toISOString();
-		const firstKeptEntryId = "kept-0";
+		const firstKeptEntryId = retainedErrorMessage ? "retained-overflow-error" : "kept-0";
+		const keptEntryId = "kept-0";
 		const tokensBefore = 50_000;
 		const entries = [];
 		for (let i = 0; i < preCount; i++) {
@@ -1502,24 +1518,43 @@ export class MockAgentCore {
 			firstKeptEntryId,
 			tokensBefore,
 		});
+		// Codex can retain the overflow error at the active-branch boundary even
+		// after compaction succeeds. This reproduces the snapshot that used to
+		// replace the live row and lose its client-only suppression marker.
+		const retainedErrorMsg = retainedErrorMessage
+			? { role: "assistant", content: [], stopReason: "error", errorMessage: retainedErrorMessage }
+			: null;
+		if (retainedErrorMsg) {
+			entries.push({
+				type: "message",
+				id: firstKeptEntryId,
+				parentId: null,
+				timestamp: ts,
+				ts,
+				message: retainedErrorMsg,
+			});
+		}
 		// Kept active-branch tail. Text deliberately avoids the "Context
 		// compacted" prefix so it is NOT mistaken for a legacy text-marker by
 		// the client reducer's compaction dedup.
 		const keptMsg = { role: "assistant", content: [{ type: "text", text: "Resuming work after the summary." }] };
 		entries.push({
 			type: "message",
-			id: firstKeptEntryId,
-			parentId: null,
+			id: keptEntryId,
+			parentId: retainedErrorMsg ? firstKeptEntryId : null,
 			timestamp: ts,
 			ts,
 			message: keptMsg,
 		});
 		// Persist the full transcript (with ids) and pin it so get_state keeps it.
 		this._postCompactionEntries = entries;
-		this._lastTranscriptEntryId = firstKeptEntryId;
+		this._lastTranscriptEntryId = keptEntryId;
 		this._persistTranscript();
 		// getMessages() returns only the active branch post-compaction.
-		this.conversationMessages = [{ id: firstKeptEntryId, ...keptMsg }];
+		this.conversationMessages = [
+			...(retainedErrorMsg ? [{ id: firstKeptEntryId, ...retainedErrorMsg }] : []),
+			{ id: keptEntryId, ...keptMsg },
+		];
 
 		// Lifecycle: start → deterministic hold → end. Legacy tests retain the
 		// short tick when no named barrier is armed.

--- a/tests2/browser/journeys/reliable-agent-turns.fixture.ts
+++ b/tests2/browser/journeys/reliable-agent-turns.fixture.ts
@@ -157,6 +157,7 @@ export class ReliableTurnRuntime {
 		reason: CompactionHold["reason"];
 		outcome?: CompactionHold["outcome"];
 		willRetry?: boolean;
+		preCompactionError?: string;
 	}): CompactionHold {
 		if (this.nextCompaction) throw new Error("A compaction barrier is already armed");
 		const hold: CompactionHold = {
@@ -171,6 +172,7 @@ export class ReliableTurnRuntime {
 				[options.reason]: {
 					outcome: hold.outcome,
 					willRetry: options.willRetry,
+					preCompactionError: options.preCompactionError,
 				},
 			},
 		});

--- a/tests2/browser/journeys/reliable-agent-turns.journey.spec.ts
+++ b/tests2/browser/journeys/reliable-agent-turns.journey.spec.ts
@@ -205,12 +205,19 @@ test.describe("Journey: Reliable Agent Turns", () => {
 		});
 	}
 
-	test("overflow compaction releases continuation steers during willRetry but holds next-turn prompts until agent_settled", async ({ page, gateway }) => {
+	test("overflow compaction hides the superseded provider error and releases each delivery lane once", async ({ page, gateway }) => {
 		const scenario = await createScenario(page, gateway);
 		try {
-			const overflow = scenario.runtime.holdNextCompaction({ reason: "overflow", willRetry: true });
+			const providerError = "Codex error: Your input exceeds the context window of this model. Please adjust your input and try again.";
+			const overflow = scenario.runtime.holdNextCompaction({
+				reason: "overflow",
+				willRetry: true,
+				preCompactionError: providerError,
+			});
 			await submit(page, "RELIABLE_COMPACTION:overflow RAT_OVERFLOW");
 			await overflow.compaction.entered;
+			await expect(page.getByTestId("compaction-summary-card").first()).toBeVisible({ timeout: 15_000 });
+			await expect(page.getByText(providerError, { exact: true })).toHaveCount(0);
 
 			const promptText = "RAT_OVERFLOW_NEXT_TURN";
 			const steerText = "RAT_OVERFLOW_CONTINUATION";
@@ -224,6 +231,9 @@ test.describe("Journey: Reliable Agent Turns", () => {
 
 			overflow.compaction.release();
 			await overflow.retry!.entered;
+			await expect(page.getByTestId("compaction-summary-card").first())
+				.toHaveAttribute("data-state", "complete", { timeout: 15_000 });
+			await expect(page.getByText(providerError, { exact: true })).toHaveCount(0);
 			await expectOneCarrier(page, steerId, "transcript");
 			await expectOneCarrier(page, promptId, "outbox");
 			await expectIntentState(page, promptId, "queued", /Queued for next turn/);

--- a/tests2/core/compaction-types.test.ts
+++ b/tests2/core/compaction-types.test.ts
@@ -24,6 +24,7 @@ import {
 	COMPACTION_ACTIVE_TOOLCALL_ID,
 	buildCompactionSummaryMessages,
 	buildInProgressCompactionPayload,
+	isContextOverflowError,
 	parseOverflowTokenCount,
 } from "../../src/app/compaction-types.ts";
 import { readOrphanedBeforeCompaction } from "../../src/server/agent/transcript-reader.ts";
@@ -40,6 +41,13 @@ const RICH_USAGE = {
 };
 
 describe("compaction-types", () => {
+	it("recognizes provider-specific context overflow errors without matching unrelated failures", () => {
+		assert.strictEqual(isContextOverflowError("prompt is too long: 202592 tokens > 200000 maximum"), true);
+		assert.strictEqual(isContextOverflowError("Codex error: Your input exceeds the context window of this model. Please adjust your input and try again."), true);
+		assert.strictEqual(isContextOverflowError("rate limited while opening a context window"), false);
+		assert.strictEqual(isContextOverflowError(undefined), false);
+	});
+
 	it("parseOverflowTokenCount: canonical Anthropic 400 string", () => {
 		assert.strictEqual(
 			parseOverflowTokenCount("prompt is too long: 202592 tokens > 200000 maximum"),

--- a/tests2/core/message-reducer.test.ts
+++ b/tests2/core/message-reducer.test.ts
@@ -813,6 +813,67 @@ describe("message-reducer", () => {
 		assert.strictEqual(payload.tokensBefore, PARSED);
 	});
 
+	it("(12e-recovery) overflow start suppresses a preceding Codex context error only", () => {
+		const providerError = "Codex error: Your input exceeds the context window of this model. Please adjust your input and try again.";
+		const overflow = {
+			id: "overflow-error",
+			role: "assistant",
+			content: [],
+			stopReason: "error",
+			errorMessage: providerError,
+		};
+		const recovered = applyAll([
+			liveMessageEnd(1, overflow),
+			{ type: "suppress-latest-context-overflow-error" },
+		]);
+		assert.strictEqual(
+			(recovered.messages.find((message) => message.id === "overflow-error") as any)?._suppressedByOverflowRecovery,
+			true,
+		);
+		const refreshed = reduce(recovered, {
+			type: "snapshot",
+			messages: [
+				{ ...overflow, id: "retained-overflow-error" },
+				assistantMsg("kept-assistant", "Resuming work after the summary."),
+			],
+		});
+		assert.strictEqual(
+			(refreshed.messages.find((message) => message.id === "retained-overflow-error") as any)?._suppressedByOverflowRecovery,
+			true,
+			"post-compaction snapshots must not resurrect the hidden provider error",
+		);
+		const repeatedLive = reduce(recovered, liveMessageEnd(2, { ...overflow, id: "later-identical-error" }));
+		const repeatedSnapshot = reduce(repeatedLive, {
+			type: "snapshot",
+			messages: [
+				{ ...overflow, id: "retained-overflow-error" },
+				{ ...overflow, id: "later-identical-error" },
+			],
+		});
+		assert.strictEqual(
+			(repeatedSnapshot.messages.find((message) => message.id === "retained-overflow-error") as any)?._suppressedByOverflowRecovery,
+			true,
+		);
+		assert.strictEqual(
+			(repeatedSnapshot.messages.find((message) => message.id === "later-identical-error") as any)?._suppressedByOverflowRecovery,
+			undefined,
+			"a later identical error must remain visible until its own compaction starts",
+		);
+
+		const unrelated = {
+			id: "rate-limit-error",
+			role: "assistant",
+			content: [],
+			stopReason: "error",
+			errorMessage: "rate limited while opening a context window",
+		};
+		const untouched = applyAll([
+			liveMessageEnd(1, unrelated),
+			{ type: "suppress-latest-context-overflow-error" },
+		]);
+		assert.strictEqual((untouched.messages[0] as any)._suppressedByOverflowRecovery, undefined);
+	});
+
 	it("(12c-replacement) sidecar synthetic in snapshot is rendered as rich card", () => {
 		// With the compaction sidecar (docs/design/persist-compaction-history.md
 		// §A), the server splices the rich synthetic into snapshots directly.


### PR DESCRIPTION
## Summary

- recognize provider-specific context-window overflow failures through a shared provider-neutral helper
- suppress the superseded error when overflow recovery starts and preserve that suppression through post-compaction snapshots
- reproduce the retained Codex boundary error in the deterministic mock runtime and cover it in unit and browser tests

## Testing

- `npm run check`
- `npm run test:unit -- tests2/core/compaction-types.test.ts tests2/core/message-reducer.test.ts`
- `npm run test:v2:browser -- --grep "overflow compaction hides" tests2/browser/journeys/reliable-agent-turns.journey.spec.ts`

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)