### PR TITLE
Fix Windows verification file identity

### DIFF
--- a/src/server/agent/verification-content-digest.ts
+++ b/src/server/agent/verification-content-digest.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import { constants, type Stats } from "node:fs";
+import { constants, type BigIntStats, type Stats } from "node:fs";
 import { lstat, open, readlink, realpath } from "node:fs/promises";
 import path from "node:path";
 import { Writable } from "node:stream";
@@ -92,13 +92,12 @@ function isWithin(root: string, candidate: string): boolean {
 	return relative === "" || (!relative.startsWith(`..${path.sep}`) && relative !== ".." && !path.isAbsolute(relative));
 }
 
-function sameIdentity(left: Stats, right: Stats): boolean {
-	return Number.isSafeInteger(left.dev)
-		&& Number.isSafeInteger(left.ino)
-		&& Number.isSafeInteger(right.dev)
-		&& Number.isSafeInteger(right.ino)
-		&& left.dev === right.dev
-		&& left.ino === right.ino;
+/** Identity comparisons must use full-width stat values; Windows file IDs can exceed 2^53. */
+export function sameVerificationFileIdentity(
+	left: Pick<BigIntStats, "dev" | "ino">,
+	right: Pick<BigIntStats, "dev" | "ino">,
+): boolean {
+	return left.dev === right.dev && left.ino === right.ino;
 }
 
 /** Reject every symlink or non-directory component below the canonical root. */
@@ -157,17 +156,17 @@ async function hashRegularFile(root: string, absolutePath: string): Promise<{ di
 		| (typeof constants.O_NONBLOCK === "number" ? constants.O_NONBLOCK : 0);
 	const handle = await open(absolutePath, flags);
 	try {
-		const openedStats = await handle.stat();
+		const openedStats = await handle.stat({ bigint: true });
 		if (!openedStats.isFile() || openedStats.isSymbolicLink()) throw digestFailure();
 
 		// Repeat validation after open, then tie the pathname to the descriptor.
 		await validateDirectoryAncestors(root, absolutePath);
-		const pathnameStats = await lstat(absolutePath);
-		if (!pathnameStats.isFile() || pathnameStats.isSymbolicLink() || !sameIdentity(openedStats, pathnameStats)) throw digestFailure();
+		const pathnameStats = await lstat(absolutePath, { bigint: true });
+		if (!pathnameStats.isFile() || pathnameStats.isSymbolicLink() || !sameVerificationFileIdentity(openedStats, pathnameStats)) throw digestFailure();
 
 		return {
 			digest: await hashOpenedFile(handle),
-			executable: (openedStats.mode & 0o111) !== 0,
+			executable: (openedStats.mode & 0o111n) !== 0n,
 		};
 	} finally {
 		await handle.close();

--- a/tests2/core/verification-content-digest.test.ts
+++ b/tests2/core/verification-content-digest.test.ts
@@ -6,6 +6,7 @@ import path from "node:path";
 import { afterEach, describe, it } from "vitest";
 import {
 	computeVerificationContentDigest,
+	sameVerificationFileIdentity,
 	VerificationContentDigestError,
 } from "../../src/server/agent/verification-content-digest.ts";
 
@@ -39,6 +40,26 @@ const TRACKED = [".gitignore", ".gitattributes", "text.txt", "source.txt"];
 const failedDigest = (error: unknown) => error instanceof VerificationContentDigestError && error.code === "VERIFICATION_CONTENT_DIGEST_FAILED";
 
 describe("computeVerificationContentDigest", () => {
+	it("compares full-width filesystem identities without Number precision loss", () => {
+		const wide = 2n ** 53n;
+		assert.equal(
+			sameVerificationFileIdentity({ dev: wide + 10n, ino: wide + 1n }, { dev: wide + 10n, ino: wide + 1n }),
+			true,
+			"equal identities above Number.MAX_SAFE_INTEGER must remain valid",
+		);
+		assert.equal(Number(wide), Number(wide + 1n), "the regression values must alias when coerced to Number");
+		assert.equal(
+			sameVerificationFileIdentity({ dev: wide + 10n, ino: wide }, { dev: wide + 10n, ino: wide + 1n }),
+			false,
+			"distinct wide file IDs must still detect pathname replacement",
+		);
+		assert.equal(
+			sameVerificationFileIdentity({ dev: wide, ino: wide + 20n }, { dev: wide + 1n, ino: wide + 20n }),
+			false,
+			"distinct wide device IDs must still detect pathname replacement",
+		);
+	});
+
 	it("witnesses raw source bytes, additions, modes, and excludes ignored files", async () => {
 		const root = await fixture();
 		const initial = await computeVerificationContentDigest(root, inventory(TRACKED));


### PR DESCRIPTION
## Summary
- compare verification file identity with full-width bigint device and inode values
- preserve existing anti-replacement checks on Windows/NTFS
- add regression coverage for IDs beyond JavaScript integer precision

## Verification
- `npx vitest run --config vitest.config.ts --project v2-core --silent=passed-only tests2/core/verification-content-digest.test.ts`
- `npm run check`

This fixes `PINNED_CHECKOUT_ACQUIRE_FAILED` before gate reviewers can start on Windows.

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)