### PR TITLE
Promote session to goal

### DIFF
--- a/docs/design/prototypes/goal-proposal-worktree-mode.html
+++ b/docs/design/prototypes/goal-proposal-worktree-mode.html
@@ -1,0 +1,799 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Goal proposal — worktree mode prototype</title>
+  <!--
+    PURPOSE
+    High-fidelity interaction spec for extending the existing Worktree row in
+    src/app/proposal-panels.ts::renderGoalForm. This is a prototype only.
+
+    CONSISTENCY RATIONALE
+    - Keeps the control in the existing Worktree row and preserves the row's
+      64px desktop label column; no new form section or card is introduced.
+    - Reuses the segmented-button grammar already used by
+      goal-form-divergence-policy: rounded border, border-separated options,
+      primary selected fill, background/secondary unselected states.
+    - Reuses current form type sizes: 12px labels, 11px supporting copy, 10px
+      monospace path text, 36px controls, 8px gaps, and Bobbit theme tokens.
+    - Uses visible inline disabled text instead of a tooltip because a disabled
+      control cannot receive keyboard focus.
+
+    IMPLEMENTATION CONTRACT
+    1. Add the selector inside the current linked-project Worktree row, replacing
+       its read-only value span. Keep Directory behaviour unchanged for proposals
+       without a linked project unless promotion eligibility supports that case.
+    2. Model the selector as a native radio group (name="goal-worktree-mode") so
+       Arrow keys switch modes and only one value can be submitted. Values:
+       "new" and "current-session". Persist the latter only when explicitly set;
+       absent remains "new" for draft compatibility.
+    3. Eligibility comes from the proposal-owning session. The browser must never
+       submit branch/path as authority; displayed coordinates are read-only.
+    4. When Current session is unavailable, disable only that radio and render
+       its concise server reason in #current-session-reason. Never rely only on
+       title/tooltip. If a restored draft selected it and eligibility changed,
+       retain the draft value, disable Create Goal, and let New worktree recover.
+    5. Set aria-describedby on the group to the selected description, coordinates,
+       and disabled/error message. Keep the submit error in role="alert" and busy
+       feedback in aria-live="polite".
+    6. When Current session is selected, keep the existing Sandbox and
+       Auto-start team controls visible but disabled. Their values are inherited:
+       promotion preserves the source sandbox, and the source is the lead already.
+       This avoids implying either resource will be reprovisioned.
+    7. Suggested test ids:
+       goal-form-worktree-mode, goal-form-worktree-new,
+       goal-form-worktree-current-session, goal-form-worktree-summary,
+       goal-form-worktree-branch, goal-form-worktree-path,
+       goal-form-worktree-current-unavailable.
+  -->
+  <style>
+    :root {
+      /* Semantic fallback only; the Bobbit theme bridge overrides it. */
+      --positive: oklch(0.55 0.15 145);
+      --negative: oklch(0.55 0.18 25);
+      --warning: oklch(0.62 0.15 75);
+    }
+
+    * { box-sizing: border-box; }
+    html, body { min-height: 100%; }
+    body {
+      margin: 0;
+      background: var(--background);
+      color: var(--foreground);
+      font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      font-size: 14px;
+    }
+    button, input, select, textarea { font: inherit; }
+    button, label, select { -webkit-tap-highlight-color: transparent; }
+
+    .prototype-shell {
+      min-height: 100vh;
+      display: grid;
+      grid-template-rows: auto 1fr;
+    }
+    .demo-bar {
+      display: flex;
+      align-items: center;
+      flex-wrap: wrap;
+      gap: 10px 18px;
+      padding: 10px 16px;
+      border-bottom: 1px solid var(--border);
+      background: var(--card);
+      color: var(--card-foreground);
+    }
+    .demo-title {
+      margin-right: auto;
+      font-size: 12px;
+      font-weight: 650;
+    }
+    .demo-control {
+      display: inline-flex;
+      align-items: center;
+      gap: 7px;
+      color: var(--muted-foreground);
+      font-size: 11px;
+    }
+    .demo-control select {
+      height: 30px;
+      max-width: 220px;
+      padding: 0 28px 0 9px;
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      color: var(--foreground);
+      background: var(--background);
+    }
+    .demo-control input { accent-color: var(--primary); }
+    .reset-button {
+      height: 30px;
+      padding: 0 10px;
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      color: var(--foreground);
+      background: var(--background);
+      cursor: pointer;
+    }
+    .reset-button:hover { background: var(--secondary); }
+    .reset-button:focus-visible,
+    .demo-control select:focus-visible {
+      outline: 2px solid var(--ring);
+      outline-offset: 2px;
+    }
+
+    .stage {
+      display: grid;
+      place-items: start center;
+      padding: 28px 16px 56px;
+      background: color-mix(in oklch, var(--muted) 30%, var(--background));
+    }
+    .panel {
+      width: min(100%, 760px);
+      height: min(760px, calc(100vh - 116px));
+      min-height: 620px;
+      display: flex;
+      flex-direction: column;
+      overflow: hidden;
+      border: 1px solid var(--border);
+      border-radius: 9px;
+      background: var(--card);
+      color: var(--card-foreground);
+      box-shadow: 0 18px 45px color-mix(in oklch, var(--foreground) 9%, transparent);
+    }
+
+    .panel-head {
+      min-height: 46px;
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      padding: 0 20px;
+      border-bottom: 1px solid var(--border);
+    }
+    .goal-icon {
+      width: 18px;
+      height: 18px;
+      color: var(--primary);
+      flex: none;
+    }
+    .panel-title {
+      min-width: 0;
+      font-size: 13px;
+      font-weight: 650;
+    }
+    .panel-subtitle {
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      color: var(--muted-foreground);
+      font-size: 11px;
+    }
+    .tabs {
+      flex: none;
+      display: flex;
+      align-items: center;
+      gap: 4px;
+      min-height: 39px;
+      padding: 8px 20px 0;
+      border-bottom: 1px solid var(--border);
+    }
+    .tab {
+      position: relative;
+      height: 31px;
+      padding: 0 12px;
+      border: 0;
+      border-bottom: 2px solid transparent;
+      color: var(--muted-foreground);
+      background: transparent;
+      font-size: 12px;
+      font-weight: 550;
+    }
+    .tab[aria-selected="true"] {
+      border-bottom-color: var(--primary);
+      color: var(--foreground);
+    }
+    .tab:not([aria-selected="true"]):hover { color: var(--foreground); }
+    .tab:focus-visible {
+      outline: 2px solid var(--ring);
+      outline-offset: -3px;
+      border-radius: 4px;
+    }
+    .revision {
+      margin-left: auto;
+      margin-bottom: 6px;
+      padding: 2px 8px;
+      border: 1px solid var(--border);
+      border-radius: 999px;
+      color: var(--muted-foreground);
+      font-size: 11px;
+    }
+
+    .form-body {
+      flex: 1;
+      min-height: 0;
+      overflow-y: auto;
+      display: flex;
+      flex-direction: column;
+      gap: 10px;
+      padding: 16px 20px 12px;
+    }
+    .top-row {
+      display: grid;
+      grid-template-columns: minmax(0, 1fr) 235px;
+      gap: 10px;
+    }
+    .form-row {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      min-width: 0;
+    }
+    .form-label {
+      width: 64px;
+      flex: 0 0 64px;
+      color: var(--muted-foreground);
+      font-size: 12px;
+      font-weight: 550;
+    }
+    .input,
+    .select {
+      width: 100%;
+      height: 36px;
+      min-width: 0;
+      padding: 0 9px;
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      background: var(--background);
+      color: var(--foreground);
+      font-size: 14px;
+    }
+    .input:focus-visible,
+    .select:focus-visible,
+    .spec-box:focus-visible {
+      outline: 2px solid var(--ring);
+      outline-offset: 1px;
+    }
+
+    .worktree-row { align-items: flex-start; }
+    .worktree-row > .form-label { padding-top: 9px; }
+    .worktree-control {
+      flex: 1;
+      min-width: 0;
+      display: flex;
+      flex-direction: column;
+      gap: 7px;
+    }
+    .mode-and-project {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      min-width: 0;
+    }
+    .mode-group {
+      position: relative;
+      display: inline-flex;
+      flex: none;
+      height: 36px;
+      overflow: hidden;
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      background: var(--background);
+    }
+    .mode-option {
+      position: relative;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      min-width: 126px;
+      height: 34px;
+      padding: 0 12px;
+      color: var(--muted-foreground);
+      background: var(--background);
+      font-size: 12px;
+      font-weight: 550;
+      cursor: pointer;
+      user-select: none;
+      transition: background-color 120ms ease, color 120ms ease;
+    }
+    .mode-option + .mode-option { border-left: 1px solid var(--border); }
+    .mode-option:hover { color: var(--foreground); background: var(--secondary); }
+    .mode-option:has(input:checked) {
+      color: var(--primary-foreground);
+      background: var(--primary);
+    }
+    .mode-option:has(input:focus-visible) {
+      z-index: 1;
+      outline: 2px solid var(--ring);
+      outline-offset: -3px;
+      border-radius: 4px;
+    }
+    .mode-option:has(input:disabled) {
+      color: var(--muted-foreground);
+      background: var(--muted);
+      cursor: not-allowed;
+    }
+    .mode-option input {
+      position: absolute;
+      width: 1px;
+      height: 1px;
+      margin: 0;
+      clip-path: inset(50%);
+      white-space: nowrap;
+    }
+    .project-name {
+      min-width: 0;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      color: var(--muted-foreground);
+      font-size: 11px;
+    }
+    .project-name strong { color: var(--foreground); font-weight: 550; }
+
+    .mode-summary {
+      min-width: 0;
+      padding: 8px 10px;
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      background: color-mix(in oklch, var(--secondary) 45%, transparent);
+    }
+    .mode-description {
+      margin: 0 0 6px;
+      color: var(--foreground);
+      font-size: 11px;
+      line-height: 1.4;
+    }
+    .coordinates {
+      display: grid;
+      grid-template-columns: 45px minmax(0, 1fr);
+      gap: 3px 8px;
+      margin: 0;
+      font-size: 10px;
+      line-height: 1.45;
+    }
+    .coordinates dt { color: var(--muted-foreground); }
+    .coordinates dd {
+      min-width: 0;
+      margin: 0;
+      color: var(--foreground);
+      font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+      overflow-wrap: anywhere;
+    }
+    .unavailable {
+      display: none;
+      align-items: flex-start;
+      gap: 5px;
+      margin: 0;
+      color: var(--muted-foreground);
+      font-size: 11px;
+      line-height: 1.35;
+    }
+    .unavailable.is-visible { display: flex; }
+    .unavailable svg {
+      width: 13px;
+      height: 13px;
+      margin-top: 1px;
+      flex: none;
+      color: var(--warning);
+    }
+    .loading-dot {
+      width: 11px;
+      height: 11px;
+      margin: 2px 1px 0;
+      flex: none;
+      border: 1.5px solid var(--border);
+      border-top-color: var(--primary);
+      border-radius: 50%;
+      animation: spin 650ms linear infinite;
+    }
+
+    .toggles {
+      display: flex;
+      flex-wrap: wrap;
+      align-items: center;
+      gap: 8px 18px;
+      padding-top: 1px;
+    }
+    .switch-label {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      color: var(--muted-foreground);
+      font-size: 12px;
+      font-weight: 550;
+      cursor: pointer;
+    }
+    .switch-label:has(.switch:disabled) { cursor: not-allowed; }
+    .switch {
+      appearance: none;
+      position: relative;
+      width: 32px;
+      height: 18px;
+      margin: 0;
+      border-radius: 999px;
+      background: var(--muted);
+      cursor: pointer;
+      transition: background-color 160ms ease;
+    }
+    .switch::after {
+      content: "";
+      position: absolute;
+      top: 2px;
+      left: 2px;
+      width: 14px;
+      height: 14px;
+      border-radius: 50%;
+      background: var(--muted-foreground);
+      transition: transform 160ms ease, background-color 160ms ease;
+    }
+    .switch:checked { background: var(--primary); }
+    .switch:checked::after {
+      transform: translateX(14px);
+      background: var(--primary-foreground);
+    }
+    .switch:focus-visible { outline: 2px solid var(--ring); outline-offset: 2px; }
+    .switch:disabled { cursor: not-allowed; }
+    .info-mark { cursor: help; font-size: 9px; }
+
+    .spec-head {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      margin-top: 2px;
+    }
+    .spec-label { color: var(--muted-foreground); font-size: 12px; font-weight: 550; }
+    .mini-actions { display: flex; gap: 5px; }
+    .mini-button {
+      height: 24px;
+      padding: 0 8px;
+      border: 1px solid var(--border);
+      border-radius: 5px;
+      background: transparent;
+      color: var(--muted-foreground);
+      font-size: 10px;
+      cursor: pointer;
+    }
+    .mini-button:hover { color: var(--foreground); background: var(--secondary); }
+    .spec-box {
+      flex: 1;
+      min-height: 186px;
+      padding: 12px;
+      overflow-y: auto;
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      background: color-mix(in oklch, var(--secondary) 30%, transparent);
+      color: var(--foreground);
+      font-size: 13px;
+      line-height: 1.5;
+    }
+    .spec-box h2 { margin: 0 0 8px; font-size: 15px; }
+    .spec-box p { margin: 0 0 8px; }
+    .spec-box ul { margin: 0; padding-left: 20px; }
+
+    .footer {
+      flex: none;
+      min-height: 62px;
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      padding: 12px 20px;
+      border-top: 1px solid var(--border);
+    }
+    .feedback {
+      flex: 1;
+      min-width: 0;
+      margin: 0;
+      font-size: 11px;
+      line-height: 1.35;
+    }
+    .feedback.error { color: var(--negative); }
+    .feedback.success { color: var(--positive); }
+    .footer-actions { display: flex; align-items: center; gap: 8px; margin-left: auto; }
+    .button {
+      height: 34px;
+      padding: 0 13px;
+      border: 1px solid transparent;
+      border-radius: 6px;
+      font-size: 12px;
+      font-weight: 600;
+      cursor: pointer;
+    }
+    .button.ghost { color: var(--foreground); background: transparent; }
+    .button.ghost:hover { background: var(--secondary); }
+    .button.primary {
+      min-width: 111px;
+      color: var(--primary-foreground);
+      background: var(--primary);
+      border-color: var(--primary);
+    }
+    .button.primary:hover:not(:disabled) {
+      background: color-mix(in oklch, var(--primary) 88%, var(--foreground));
+    }
+    .button:focus-visible { outline: 2px solid var(--ring); outline-offset: 2px; }
+    .button:disabled { cursor: not-allowed; color: var(--muted-foreground); background: var(--muted); border-color: var(--border); }
+    .button-busy { display: inline-flex; align-items: center; justify-content: center; gap: 7px; }
+    .spinner {
+      width: 12px;
+      height: 12px;
+      border: 1.5px solid color-mix(in oklch, var(--primary-foreground) 45%, transparent);
+      border-top-color: var(--primary-foreground);
+      border-radius: 50%;
+      animation: spin 650ms linear infinite;
+    }
+    @keyframes spin { to { transform: rotate(360deg); } }
+    @media (prefers-reduced-motion: reduce) {
+      *, *::before, *::after { scroll-behavior: auto !important; transition-duration: 0.01ms !important; animation-duration: 0.01ms !important; animation-iteration-count: 1 !important; }
+    }
+
+    @media (max-width: 620px) {
+      .demo-bar { align-items: flex-start; }
+      .demo-title { width: 100%; }
+      .stage { padding: 0; }
+      .panel {
+        width: 100%;
+        height: calc(100vh - 104px);
+        min-height: 620px;
+        border-inline: 0;
+        border-radius: 0;
+      }
+      .panel-head, .form-body, .footer { padding-inline: 14px; }
+      .tabs { padding-inline: 14px; overflow-x: auto; }
+      .top-row { grid-template-columns: 1fr; }
+      .top-row .form-label, .form-label { width: 68px; flex-basis: 68px; }
+      .mode-and-project { align-items: flex-start; flex-direction: column; }
+      .mode-group { width: 100%; }
+      .mode-option { flex: 1; min-width: 0; }
+      .footer { align-items: flex-start; flex-wrap: wrap; }
+      .feedback { flex-basis: 100%; }
+      .footer-actions { width: 100%; justify-content: flex-end; }
+    }
+  </style>
+</head>
+<body>
+  <div class="prototype-shell">
+    <header class="demo-bar" aria-label="Prototype state controls">
+      <div class="demo-title">Prototype states</div>
+      <label class="demo-control">
+        Session eligibility
+        <select id="scenario">
+          <option value="eligible">Eligible regular session</option>
+          <option value="goal">Already belongs to a goal</option>
+          <option value="missing">Missing dedicated worktree</option>
+          <option value="archived">Session is archived</option>
+          <option value="checking">Checking eligibility</option>
+        </select>
+      </label>
+      <label class="demo-control"><input id="fail-next" type="checkbox" /> Fail next creation</label>
+      <button class="reset-button" id="reset" type="button">Reset</button>
+    </header>
+
+    <main class="stage">
+      <section class="panel" aria-labelledby="proposal-title">
+        <header class="panel-head">
+          <svg class="goal-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" aria-hidden="true"><circle cx="12" cy="12" r="8"/><circle cx="12" cy="12" r="3"/><path d="M15 9l5-5m0 0v4m0-4h-4"/></svg>
+          <div>
+            <div class="panel-title" id="proposal-title">Goal Proposal</div>
+            <div class="panel-subtitle">Promote Session to Goal</div>
+          </div>
+        </header>
+
+        <nav class="tabs" role="tablist" aria-label="Goal proposal sections">
+          <button class="tab" type="button" role="tab" aria-selected="true">Goal</button>
+          <button class="tab" type="button" role="tab" aria-selected="false">Workflow</button>
+          <button class="tab" type="button" role="tab" aria-selected="false">Roles</button>
+          <button class="tab" type="button" role="tab" aria-selected="false">Metadata</button>
+          <span class="revision">rev 2</span>
+        </nav>
+
+        <div class="form-body" role="tabpanel" aria-label="Goal">
+          <div class="top-row">
+            <div class="form-row">
+              <label class="form-label" for="title">Title</label>
+              <input class="input" id="title" value="Promote Session to Goal" />
+            </div>
+            <div class="form-row">
+              <label class="form-label" for="workflow" style="width:auto;flex-basis:auto">Workflow</label>
+              <select class="select" id="workflow"><option>Software delivery</option></select>
+            </div>
+          </div>
+
+          <div class="form-row worktree-row">
+            <span class="form-label" id="worktree-label">Worktree</span>
+            <div class="worktree-control">
+              <div class="mode-and-project">
+                <div class="mode-group" role="radiogroup" aria-labelledby="worktree-label" aria-describedby="mode-description coordinate-list current-session-reason" data-testid="goal-form-worktree-mode">
+                  <label class="mode-option">
+                    <input id="mode-new" type="radio" name="goal-worktree-mode" value="new" checked data-testid="goal-form-worktree-new" />
+                    <span>New worktree</span>
+                  </label>
+                  <label class="mode-option" id="current-option">
+                    <input id="mode-current" type="radio" name="goal-worktree-mode" value="current-session" data-testid="goal-form-worktree-current-session" />
+                    <span>Current session</span>
+                  </label>
+                </div>
+                <span class="project-name">Project <strong>Bobbit</strong></span>
+              </div>
+
+              <div class="mode-summary" id="mode-summary" data-testid="goal-form-worktree-summary">
+                <p class="mode-description" id="mode-description">Bobbit will create a dedicated branch and worktree for the goal.</p>
+                <dl class="coordinates" id="coordinate-list">
+                  <dt>Branch</dt><dd id="branch-value" data-testid="goal-form-worktree-branch">goal/promote-session-to-goal-a1b2</dd>
+                  <dt>Path</dt><dd id="path-value" data-testid="goal-form-worktree-path">C:\Users\jsubr\w\bobbit-wt\goal-promote-session-to-goal-a1b2</dd>
+                </dl>
+              </div>
+
+              <p class="unavailable" id="current-session-reason" data-testid="goal-form-worktree-current-unavailable" aria-live="polite">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="12" cy="12" r="9"/><path d="M12 8v5m0 3h.01"/></svg>
+                <span id="reason-copy"></span>
+              </p>
+            </div>
+          </div>
+
+          <div class="toggles">
+            <label class="switch-label" id="sandbox-label"><input class="switch" id="sandbox-switch" type="checkbox" checked /> Sandbox <span class="info-mark" title="Runs each team agent in an isolated Docker container">ⓘ</span></label>
+            <label class="switch-label" id="auto-start-label"><input class="switch" id="auto-start-switch" type="checkbox" checked /> Auto-start team <span class="info-mark" title="Automatically start the team lead when the worktree is ready">ⓘ</span></label>
+            <label class="switch-label"><input class="switch" type="checkbox" /> Browser QA <span class="info-mark" title="Run the browser QA verification step">ⓘ</span></label>
+          </div>
+
+          <div class="spec-head">
+            <span class="spec-label">Spec</span>
+            <div class="mini-actions">
+              <button class="mini-button" type="button">Copy</button>
+              <button class="mini-button" type="button">Edit</button>
+            </div>
+          </div>
+          <div class="spec-box" tabindex="0">
+            <h2>Objective</h2>
+            <p>Promote the proposal-owning session into the accepted goal without copying or moving its checkout.</p>
+            <ul>
+              <li>Keep the same session, transcript, branch, and worktree.</li>
+              <li>Attach the normal goal workflow, gates, and team capabilities.</li>
+              <li>Preserve staged, unstaged, and untracked work exactly.</li>
+            </ul>
+          </div>
+        </div>
+
+        <footer class="footer">
+          <p class="feedback" id="feedback" role="status" aria-live="polite"></p>
+          <div class="footer-actions">
+            <button class="button ghost" type="button">Dismiss</button>
+            <button class="button primary" id="create" type="button"><span>Create Goal</span></button>
+          </div>
+        </footer>
+      </section>
+    </main>
+  </div>
+
+  <script>
+    (() => {
+      const NEW_COORDS = {
+        branch: "goal/promote-session-to-goal-a1b2",
+        path: "C:\\Users\\jsubr\\w\\bobbit-wt\\goal-promote-session-to-goal-a1b2",
+      };
+      const CURRENT_COORDS = {
+        branch: "goal/cf3419f7/ux-designer-ff6b",
+        path: "C:\\Users\\jsubr\\w\\bobbit-wt\\goal-cf3419f7-ux-designer-ff6b",
+      };
+      const reasons = {
+        goal: "Current session unavailable — this session already belongs to a goal.",
+        missing: "Current session unavailable — this session does not have a dedicated branch and worktree.",
+        archived: "Current session unavailable — archived sessions cannot be promoted.",
+        checking: "Checking whether this session can be reused…",
+      };
+
+      const scenario = document.querySelector("#scenario");
+      const modeNew = document.querySelector("#mode-new");
+      const modeCurrent = document.querySelector("#mode-current");
+      const currentOption = document.querySelector("#current-option");
+      const reason = document.querySelector("#current-session-reason");
+      const reasonCopy = document.querySelector("#reason-copy");
+      const description = document.querySelector("#mode-description");
+      const branch = document.querySelector("#branch-value");
+      const path = document.querySelector("#path-value");
+      const feedback = document.querySelector("#feedback");
+      const create = document.querySelector("#create");
+      const sandboxSwitch = document.querySelector("#sandbox-switch");
+      const sandboxLabel = document.querySelector("#sandbox-label");
+      const autoStartSwitch = document.querySelector("#auto-start-switch");
+      const autoStartLabel = document.querySelector("#auto-start-label");
+      const failNext = document.querySelector("#fail-next");
+      const reset = document.querySelector("#reset");
+      let busy = false;
+
+      function selectedMode() {
+        return modeCurrent.checked ? "current" : "new";
+      }
+
+      function renderMode() {
+        const current = selectedMode() === "current";
+        const coords = current ? CURRENT_COORDS : NEW_COORDS;
+        description.textContent = current
+          ? "This session becomes the goal lead in place. Its checkout, transcript, and sandbox stay unchanged."
+          : "Bobbit will create a dedicated branch and worktree for the goal.";
+        branch.textContent = coords.branch;
+        path.textContent = coords.path;
+        sandboxSwitch.disabled = current || busy;
+        sandboxLabel.title = current ? "Inherited from the current session; promotion does not recreate its sandbox." : "";
+        autoStartSwitch.disabled = current || busy;
+        autoStartLabel.title = current ? "The current session becomes the goal lead immediately." : "";
+      }
+
+      function renderScenario() {
+        const value = scenario.value;
+        const eligible = value === "eligible";
+        modeCurrent.disabled = !eligible;
+        currentOption.setAttribute("aria-disabled", eligible ? "false" : "true");
+        reason.classList.toggle("is-visible", !eligible);
+        reasonCopy.textContent = reasons[value] || "";
+        const oldSpinner = reason.querySelector(".loading-dot");
+        if (oldSpinner) oldSpinner.remove();
+        const icon = reason.querySelector("svg");
+        if (value === "checking") {
+          icon.style.display = "none";
+          const spinner = document.createElement("span");
+          spinner.className = "loading-dot";
+          spinner.setAttribute("aria-hidden", "true");
+          reason.prepend(spinner);
+        } else {
+          icon.style.display = "block";
+        }
+        if (!eligible && modeCurrent.checked) modeNew.checked = true;
+        feedback.textContent = "";
+        feedback.className = "feedback";
+        renderMode();
+      }
+
+      function setBusy(next) {
+        busy = next;
+        create.disabled = next;
+        scenario.disabled = next;
+        modeNew.disabled = next;
+        modeCurrent.disabled = next || scenario.value !== "eligible";
+        sandboxSwitch.disabled = next || selectedMode() === "current";
+        autoStartSwitch.disabled = next || selectedMode() === "current";
+        create.setAttribute("aria-busy", String(next));
+        create.innerHTML = next
+          ? '<span class="button-busy"><span class="spinner" aria-hidden="true"></span>Creating…</span>'
+          : "<span>Create Goal</span>";
+      }
+
+      modeNew.addEventListener("change", renderMode);
+      modeCurrent.addEventListener("change", renderMode);
+      scenario.addEventListener("change", renderScenario);
+
+      create.addEventListener("click", () => {
+        if (busy) return;
+        feedback.textContent = selectedMode() === "current"
+          ? "Promoting this session without changing its checkout…"
+          : "Creating a new goal worktree…";
+        feedback.className = "feedback";
+        setBusy(true);
+        window.setTimeout(() => {
+          setBusy(false);
+          if (failNext.checked) {
+            failNext.checked = false;
+            feedback.textContent = "Couldn’t promote this session. Nothing was changed. Try again.";
+            feedback.className = "feedback error";
+            feedback.setAttribute("role", "alert");
+          } else {
+            feedback.textContent = selectedMode() === "current"
+              ? "Goal created. This session is now the goal lead."
+              : "Goal created. Worktree setup has started.";
+            feedback.className = "feedback success";
+            feedback.setAttribute("role", "status");
+          }
+        }, 1050);
+      });
+
+      reset.addEventListener("click", () => {
+        scenario.value = "eligible";
+        failNext.checked = false;
+        modeNew.checked = true;
+        feedback.textContent = "";
+        feedback.className = "feedback";
+        renderScenario();
+      });
+
+      renderScenario();
+    })();
+  </script>
+</body>
+</html>

--- a/docs/design/session-goal-promotion.md
+++ b/docs/design/session-goal-promotion.md
@@ -1,5 +1,7 @@
 # Promote Session to Goal — implementation design
 
+Status: implemented. For the durable operator/developer contract, see [Goals, Workflows, Tasks & Gates — Promote the current session in place](../goals-workflows-tasks.md#promote-the-current-session-in-place) and [REST API — Current-session goal promotion](../rest-api.md#current-session-goal-promotion). The comparative design and implementation inventory below preserve the rationale for the selected architecture.
+
 ## Scope and invariants
 
 A goal proposal may choose one of two worktree modes:
@@ -60,15 +62,9 @@ When mode is absent or `new-worktree`, the panel continues to call the existing 
 A new pure `evaluateSessionGoalPromotion(...)` in `src/server/agent/session-goal-promotion.ts` returns:
 
 ```ts
-type SessionGoalPromotionEligibility = {
-  eligible: boolean;
-  code: string;
-  reason?: string;
-  branch?: string;
-  worktreePath?: string;
-  repoWorktreeCount?: number;
-  sandboxed?: boolean;
-};
+type SessionGoalPromotionEligibility =
+  | { eligible: true; coordinates: SessionGoalPromotionCoordinates }
+  | { eligible: false; code: SessionGoalPromotionReasonCode; reason: string };
 ```
 
 Both the GET projection and the final locked accept recheck call this same helper. Eligibility requires all of the following:
@@ -81,7 +77,7 @@ Both the GET projection and the final locked accept recheck call this same helpe
 6. For sandboxed sessions, the existing project container/realm and owned sandbox worktree coordinate are reachable. Eligibility never creates either one.
 7. No existing live goal provenance, team reservation, or conflicting lead/session attachment claims this owner, except the exact idempotent promotion relation returned on retry.
 
-Reasons are stable, concise UI text (for example, `Current session is unavailable while the session is working`, `Current session does not own a dedicated worktree`, or `Current session targets a different project`). The UI is advisory; acceptance always performs the locked recheck.
+Reasons are stable, concise UI text (for example, `Current session must be idle.`, `Current session has no dedicated worktree and branch.`, or `Current session belongs to a different project.`). The UI is advisory; acceptance always performs the locked recheck.
 
 ## Selected control flow
 
@@ -104,7 +100,7 @@ Until the verified candidate becomes canonical after successful old-bridge stop,
 1. dispose only the staged replacement;
 2. call `TeamManager.releaseAdoptedLead(goalId, ownerId)` only if the reservation still has that exact empty lead relation;
 3. call `GateStore.removeGoalGates(goalId)` only for the attempt-created goal;
-4. call `GoalManager.deleteGoal(goalId)` only if `worktreeOwnerSessionId` still equals `ownerId` and the source was not committed;
+4. call the narrow `GoalManager.deleteAdoptedGoalAttempt(goalId, ownerId)` only if provenance still matches, the goal remains unarchived and `todo`, and the source was not committed;
 5. flush affected stores.
 
 Compensation never calls Git, sandbox removal, worktree cleanup, session archive, or transcript cleanup. It does not remove a team entry that gained agents or changed lead, and does not remove an unrelated/reconciled goal. Fault injection must cover failure after goal creation, gate initialization, lead reservation, candidate start, transcript switch, tuple verification, durable session update, and old-bridge stop.
@@ -127,7 +123,7 @@ This pass runs inside the existing `restore-teams` boot phase. Then `SessionMana
 
 ### Archive, teardown, purge, and cleanup
 
-- Direct archive/termination/purge of a live promoted source conflicts while its non-archived goal or team reservation references it.
+- Direct archive/termination/purge of a live promoted source conflicts while its non-archived adopted goal exists.
 - Direct `team/teardown` of a live promoted goal conflicts because keeping the session alive would require out-of-scope demotion.
 - Goal archive is the allowed ordered path: publish goal archival intent, remove worker agents, remove the promoted reservation/subscriptions, then archive the source session through its existing lifecycle owner. The goal is never treated as having provisioned the source checkout.
 - Sandbox cleanup remains session-owned. Promotion does not set `borrowsWorktree`, change the owner ID, call `SandboxManager.createWorktree`, or transfer the project container.
@@ -146,7 +142,7 @@ The key distinction tested at every cleanup seam is:
 - **New worktree** — selected by default for absent/old proposals; shows the existing predicted goal path/component summary.
 - **Current session** — shows the server-projected exact branch, worktree path, and component count. It is disabled with the server reason when ineligible.
 
-The proposal owner comes from `state.activeProposals.goal.sessionId` (or the historical override owner), never `activeSessionId()` after a tab switch. `GoalProposalFormSnapshot`, its identity key, and `GoalFormConfig` carry the parsed mode/projection so edit, rehydrate, reload, snapshot restore, and continued-draft flows redraw consistently. Selecting a radio persists through `setGoalProposalWorktreeMode`; the returned stamped `proposal_update` remains the UI source of truth.
+The proposal owner comes from `state.activeProposals.goal.sessionId` (or the historical override owner), never `activeSessionId()` after a tab switch. `GoalProposalFormSnapshot`, its identity key, and `GoalFormConfig` carry the parsed mode/projection so edit, rehydrate, reload, snapshot restore, and continued-draft flows redraw consistently. Selecting a radio persists through `persistGoalWorktreeMode`; the returned stamped `proposal_update` remains the UI source of truth.
 
 If a restored `current-session` selection becomes ineligible, it stays visibly selected, shows the reason, and disables Create until the user selects New worktree. In current-session mode the sandbox display is read-only from the source and the Auto-start control is disabled with copy explaining that the current session becomes lead immediately.
 
@@ -154,23 +150,23 @@ Acceptance branches only at the API call: new mode uses existing `createGoal`; c
 
 ## Implementation map and test seams
 
-### Expected changed and new files
+### Planned change inventory (historical)
 
 | File | Existing/new symbol | Exact responsibility |
 |---|---|---|
 | `src/server/proposals/proposal-types.ts` | `GOAL_FRONTMATTER_KEYS`, `validateGoalInlineFields` | Preserve/validate optional `worktreeMode`; skip absent mode so old serialized bytes do not change. |
-| `src/server/agent/session-goal-promotion.ts` **(new)** | `GoalWorktreeMode`, `evaluateSessionGoalPromotion`, `findExistingSessionPromotion` | Pure eligibility/reason projection and exact provenance lookup shared by GET and final recheck. No paths from a request are inputs. |
+| `src/server/agent/session-goal-promotion.ts` **(new)** | `SessionGoalWorktreeMode`, `evaluateSessionGoalPromotion`, `lookupSessionGoalPromotion` | Pure eligibility/reason projection and exact provenance lookup shared by GET and final recheck. No paths from a request are inputs. |
 | `src/server/server.ts` | `handleApiRoute()` editable-proposal route block and goal archive/team teardown blocks | Add owner-scoped GET/PUT/accept operations, per-owner single flight, normal goal+gate composition, conditional compensation, and promoted lifecycle conflicts/order. Keep general `POST /api/goals` unchanged. |
 | `src/server/agent/goal-store.ts` | `PersistedGoal`, canonical validation (`STRING_FIELDS`) | Persist/validate optional `worktreeOwnerSessionId`; absence remains the legacy shape. |
-| `src/server/agent/goal-manager.ts` | `GoalManager.createGoal`, `GoalManager.archiveGoal`, internal `AdoptedGoalWorkspace` | Add internal adoption branch that copies exact canonical coordinates and starts ready without provisioning/setup/hook; guard archive cleanup by live source ownership; expose conditional attempt deletion through existing `deleteGoal`. |
+| `src/server/agent/goal-manager.ts` | `GoalManager.createGoal`, `GoalManager.archiveGoal`, `deleteAdoptedGoalAttempt`, internal `AdoptedGoalWorkspace` | Add internal adoption branch that copies exact canonical coordinates and starts ready without provisioning/setup/hook; guard archive cleanup by live source ownership; expose narrow conditional attempt deletion. |
 | `src/server/agent/team-manager.ts` | `TeamManager.adoptExistingLead` **(new)**, `releaseAdoptedLead` **(new)**, `restoreTeams`, `startTeam`, `teardownTeam` | Persist one existing-lead reservation, maintain `sessionToGoal`, make repeat/conflict behavior explicit, reconcile before orphan cleanup, prevent second lead and direct teardown. |
 | `src/server/agent/session-manager.ts` | `SessionManager.promoteToGoalLead` **(new)**, `_coordinateSessionReplacement`, generalized `_assignRoleStaged`, `terminateSession`, `storeArchive`, `purgeOneSession`, `buildArchivedWorktreeScanContext` | Stage/verify/rollback prospective goal-lead context on the same runtime identity and realm; block source destruction while live references remain; keep all component paths protected. |
 | `src/app/state.ts` | `GatewaySession`, `Goal` | Carry the existing authoritative eligibility inputs and new goal provenance projection needed by UI/reload diagnostics. No independent durable client state. |
-| `src/app/api.ts` | `getGoalProposalWorktreeMode` **(new)**, `setGoalProposalWorktreeMode` **(new)**, `acceptGoalProposalInCurrentSession` **(new)**, existing `createGoal` | Add owner-scoped calls; reject/omit coordinate authority client-side; leave existing new-worktree request construction byte-compatible. |
+| `src/app/api.ts` | `fetchGoalWorktreeMode` **(new)**, `updateGoalWorktreeMode` **(new)**, `acceptGoalProposalInCurrentSession` **(new)**, existing `createGoal` | Add owner-scoped calls; reject/omit coordinate authority client-side; leave existing new-worktree request construction byte-compatible. |
 | `src/app/proposal-panels.ts` | `GoalFormConfig`, `renderGoalForm`, `GoalProposalFormSnapshot`, `goalProposalFormIdentityKey`, `syncProposalFormState`, goal accept handler | Render/persist the radio choice and exact projection, bind to proposal owner, block invalid restored mode, and choose only the acceptance API path. |
 | `tests2/core/session-goal-promotion-proposal.test.ts` **(new)** | Cases below | Proposal default/bytes, enum, edit/snapshot/reopen persistence, and owner-scoped route authority. |
 | `tests2/core/session-goal-promotion-eligibility.test.ts` **(new)** | Cases below | Pure single/multi-repo/sandbox eligibility matrix and stable reasons. |
-| `tests2/core/session-goal-promotion-managers.test.ts` **(new)** | Cases below | Adopted goal creation, reservation/idempotency, staged continuity/rollback, restore, and cleanup ownership guards. |
+| `tests2/core/session-goal-promotion-session-runtime.test.ts` **(new)** | Cases below | Staged same-session continuity/rollback, sandbox identity, restart preservation, and cleanup ownership guards. |
 | `tests2/integration/session-goal-promotion.test.ts` **(new)** | Cases below | Real API/Git/runtime retry, dirty checkout, multi-repo, sandbox preservation, restart, and cleanup behavior. |
 | `tests2/browser/journeys/session-goal-promotion.journey.spec.ts` **(new)** | `Journey: Current-session goal promotion` | Registered visible selection/acceptance/continuity/reload/archive journey plus disabled and new-worktree controls. |
 | `tests2/tests-map.json` | browser/unit registration rows | Register every new v2 test, including the browser file as `smoke-journey`. |
@@ -200,7 +196,7 @@ Every reused contract below has an existing exact `tests2` anchor. These tests r
 | Sandbox worktree lifecycle ownership | `tests2/core/borrowed-sandbox-worktree-ownership.test.ts` — `describe("borrowed sandbox worktree ownership")`, tests `"round-trips borrowed ownership across persistence and never verifies or removes the source worktree"`, `"keeps owned sandbox cleanup as the control and removes its registered worktree coordinate exactly once"`, and `"persists flattened ownership and rejects owner termination before mutation until its nested-cwd borrower is archived"`. |
 | Inventory and sweeper reference safety | `tests2/core/worktree-inventory.test.ts` — `describe("worktree inventory classifier")`, tests `"protects an exact live worktree but not a branch-only match"`, `"protects durable multi-repo team-agent component worktrees"`, and `"revalidates session and pool claims arriving during a deferred cleanup scan"`; `tests2/core/worktree-sweeper-multi.test.ts` — `describe("worktree-sweeper — bounded asynchronous sweep")`, tests `"preserves a worktree claimed after the initial diagnostic snapshot"` and `"preserves every ownership, pool, container, detached, archive, and branch-drift guard"`. |
 
-## Exact new tests
+## Planned verification inventory (historical)
 
 ### `tests2/core/session-goal-promotion-proposal.test.ts`
 
@@ -223,7 +219,7 @@ Every reused contract below has an existing exact `tests2` anchor. These tests r
 - `it.each(...)` named `"rejects unsafe coordinates: $label"` covering missing/stale live-vs-durable `cwd`, `worktreePath`, `branch`, `repoPath`, incomplete/duplicate multi-repo entries, unavailable sandbox owner/container, and project mismatch
 - `it("returns stable concise reason codes and never reads a caller-supplied coordinate")`
 
-### `tests2/core/session-goal-promotion-managers.test.ts`
+### Manager and runtime coverage
 
 `describe("GoalManager adopted workspace")`
 

--- a/docs/design/session-goal-promotion.md
+++ b/docs/design/session-goal-promotion.md
@@ -1,0 +1,301 @@
+# Promote Session to Goal — implementation design
+
+## Scope and invariants
+
+A goal proposal may choose one of two worktree modes:
+
+- `new-worktree` is the default. It keeps the existing `POST /api/goals` path and serialization unchanged.
+- `current-session` promotes the proposal-owning regular session in place. It adopts that session's exact checkout and makes the same Bobbit session the goal's lead.
+
+Promotion changes graph metadata and the agent's canonical goal/team context only. It does not copy, move, rename, reset, checkout, commit, provision, run setup, or create/transfer a sandbox worktree. The source session remains the checkout and sandbox lifecycle owner. `PersistedGoal.worktreeOwnerSessionId` records provenance and links retries/recovery; it does **not** transfer ownership from the session to the goal.
+
+The accepted scope is limited to the proposal owner in the same registered project. Arbitrary session IDs, branches, worktree paths, repository coordinates, cross-project adoption, busy-session promotion, demotion, and a second team lead are out of scope.
+
+```ts
+type GoalWorktreeMode = "new-worktree" | "current-session";
+
+interface PersistedGoal {
+  /** Adoption provenance/idempotency link; the referenced session still owns the checkout. */
+  worktreeOwnerSessionId?: string;
+}
+```
+
+`worktreeMode` is a human proposal-review choice, not a `propose_goal` tool argument. When it is absent, parsing resolves it as `new-worktree`, but serialization leaves it absent. Therefore existing drafts and ordinary acceptance request bodies remain byte-for-byte unchanged.
+
+## Comparative design
+
+### A/B comparison
+
+| Approach | Control/data flow | New state owner and persisted state | Expected files/APIs | Failure and restart recovery | Test seams | Why rejected/selected |
+|---|---|---|---|---|---|---|
+| **A — compose existing managers** | Proposal-owner route derives the source from its path and draft; locked recheck → normal `GoalManager.createGoal` with an internal adopted-workspace input → normal gate initialization → `TeamManager.adoptExistingLead` reservation → `SessionManager.promoteToGoalLead` staged replacement → commit or attempt-owned compensation. | No new durable transaction owner. One optional proposal enum and one optional goal provenance field. Existing session attachment fields and existing `PersistedTeamEntry.teamLeadSessionId` remain canonical. A per-owner in-memory single-flight lock is only concurrency control. | Extend owner-scoped proposal routes in `src/server/server.ts`; add pure eligibility/composition helpers in `src/server/agent/session-goal-promotion.ts`; narrow manager methods in `goal-manager.ts`, `team-manager.ts`, and `session-manager.ts`; existing proposal, goal, session, team, gate, UI, and cleanup stores remain owners of their current data. | Candidate runtime is verified before the old bridge stops. Pre-commit failure removes only the matching adopted team reservation, gates, and goal, and leaves the old session/runtime intact. A crash is recognized by `worktreeOwnerSessionId` during pre-session boot reconciliation: complete the exact attachment or compensate the incomplete attempt. Repeats return the one existing goal/lead. | Existing proposal-file, goal creation, staged replacement, sandbox-realm, team-restore, and shared-worktree tests listed below; new focused proposal/eligibility/manager/integration/browser tests cover the new branches. | **Selected.** It adds the minimum state and composes already-tested creation, persistence, staged replacement, restore, and reference guards. No requirement needs a second transaction journal or hidden-goal lifecycle. |
+| **B — dedicated promotion transaction service** | An `InPlacePromotionService` would create a pending transaction, hide a provisional goal, journal each phase (goal, gates, lead, runtime, commit), then publish it. Every read path would need to interpret pending visibility. | New durable promotion transaction/journal store, phase state machine, hidden/pending goal status, recovery owner, retention/cleanup policy, and transaction-to-goal/session indexes. | New service and store modules; journal schema/migration; pending-aware goal/session/team APIs and broadcasts; boot journal replay; administration/diagnostic cleanup; UI pending/failure states in addition to every file required by A. | Explicit phase replay is possible, but every crash boundary needs journal durability, visibility, rollback, stale-transaction, and journal-corruption handling. The service would still call the same manager seams to replace the runtime and reserve the lead. | A full fault matrix for every persisted phase, corrupt/missing journal entries, pending visibility, journal cleanup, and restart replay, in addition to A's tests. | **Rejected.** It introduces several state owners and recovery semantics without satisfying an unmet requirement. The optional goal provenance relation plus conditional compensation already supplies idempotency and crash recognition. Reconsider only if implementation proves the existing stores cannot conditionally compensate or reconcile. |
+
+Also rejected:
+
+- adding caller-supplied `promoteSessionId`, branch, or paths to general `POST /api/goals`;
+- creating a no-worktree goal and later mutating it from arbitrary client coordinates;
+- copying/spawning a second lead and moving transcript state;
+- inferring adoption from equal paths, branch shape, or a `team-lead` role;
+- provisioning or transferring a sandbox worktree during promotion.
+
+## Proposal contract and owner-scoped API
+
+`src/server/proposals/proposal-types.ts` adds `worktreeMode` to `GOAL_FRONTMATTER_KEYS` and validates only the two enum values in `validateGoalInlineFields`. The serializer's existing skip-undefined behavior is retained. No default is written into old or untouched drafts.
+
+The existing session proposal namespace gains three goal-only operations:
+
+| Method and route | Contract |
+|---|---|
+| `GET /api/sessions/:ownerId/proposal/goal/worktree-mode` | Parse the owner's draft and return `{ mode, eligibility }`. `mode` defaults in the response only. `eligibility` is recomputed from the owner session and authoritative project/session records; the active browser tab is irrelevant. |
+| `PUT /api/sessions/:ownerId/proposal/goal/worktree-mode` | Accept only `{ mode: "new-worktree" | "current-session" }`. Re-read the owner's goal draft, replace only `worktreeMode`, write through `writeProposalFile`, and emit the normal stamped `proposal_update`. It accepts no coordinates or source-session field. |
+| `POST /api/sessions/:ownerId/proposal/goal/accept` | Used only when the persisted mode is `current-session`. It may carry the same human-editable goal definition fields used by the panel, but rejects source/session/worktree/branch/repository/sandbox authority fields. It derives the source, project, mode, and adoption coordinates from `ownerId`, the draft, and canonical server records. |
+
+When mode is absent or `new-worktree`, the panel continues to call the existing `createGoal()` client helper and `POST /api/goals`; it does not call the new accept route. This keeps ordinary goal creation unchanged.
+
+`writeProposalFile`, `parseProposalFile`, `latestRev`, snapshot restoration, WebSocket rehydrate, proposal-directory archive retention, and `copyProposalDirIfPresent` continue to carry the enum without a second draft store. An archived owner remains ineligible; a continued session owns its byte-identical copied draft and is evaluated as the new proposal owner.
+
+## Eligibility
+
+A new pure `evaluateSessionGoalPromotion(...)` in `src/server/agent/session-goal-promotion.ts` returns:
+
+```ts
+type SessionGoalPromotionEligibility = {
+  eligible: boolean;
+  code: string;
+  reason?: string;
+  branch?: string;
+  worktreePath?: string;
+  repoWorktreeCount?: number;
+  sandboxed?: boolean;
+};
+```
+
+Both the GET projection and the final locked accept recheck call this same helper. Eligibility requires all of the following:
+
+1. The route owner is an existing, non-archived, live `idle` regular interactive session with a durable transcript.
+2. It has no `assistantType`/legacy assistant marker, `goalId`, `teamGoalId`, `teamLeadSessionId`, `staffId`, `delegateOf`, `parentSessionId`, or `childKind`; it is not `readOnly`, `nonInteractive`, compacting, streaming, starting, aborting, terminated, or already claimed by another promotion.
+3. The proposal's stamped target project equals the source session's registered project.
+4. The session owns rather than borrows the checkout: `borrowsWorktree !== true`, and the exact durable `cwd`, `worktreePath`, `branch`, and `repoPath` exist and agree with the live projection.
+5. For multi-repo projects, `repoWorktrees` contains every configured Git repository exactly once and every component coordinate is present. A partial set is unsafe.
+6. For sandboxed sessions, the existing project container/realm and owned sandbox worktree coordinate are reachable. Eligibility never creates either one.
+7. No existing live goal provenance, team reservation, or conflicting lead/session attachment claims this owner, except the exact idempotent promotion relation returned on retry.
+
+Reasons are stable, concise UI text (for example, `Current session is unavailable while the session is working`, `Current session does not own a dedicated worktree`, or `Current session targets a different project`). The UI is advisory; acceptance always performs the locked recheck.
+
+## Selected control flow
+
+1. `POST .../accept` enters a single-flight lock keyed by proposal owner ID.
+2. It looks up a non-archived goal with `worktreeOwnerSessionId === ownerId`. If the relation is complete, return that goal. If it is incomplete, reconcile it; never create another goal.
+3. Re-read the goal draft, source session, source project, workflow, form definition, and eligibility. Reject any submitted authority fields.
+4. Call normal `GoalManager.createGoal` with an **internal-only** `adoptedWorkspace` input built from the canonical source record. The adopted branch copies exact `cwd`, `worktreePath`, `branch`, `repoPath`, `repoWorktrees`, and `sandboxed`, stamps `worktreeOwnerSessionId`, and writes `setupStatus: "ready"`. It bypasses only `resolveWorktreeSupport`, pool claim/fill, worktree creation/rename, setup commands, and `goalProvisioned`; normal ID, nesting, metadata, workflow snapshot, goal-store validation, and timestamps remain unchanged.
+5. Initialize gates with the existing `GateStore.initGatesForGoal`, then flush the goal and gate stores at the same external creation boundary used by ordinary goal creation.
+6. `TeamManager.adoptExistingLead(goalId, ownerId)` installs the empty existing `PersistedTeamEntry` (`agents: []`) and `sessionToGoal` mapping before awaited runtime work. Exact repeats return the reservation; a different goal/lead claim conflicts. `startTeam` sees this reservation and cannot spawn a second lead.
+7. Resolve the canonical `team-lead` role from the new goal, then call `SessionManager.promoteToGoalLead`. It uses `_coordinateSessionReplacement` and a generalized `_assignRoleStaged` target projection. Every prompt/tool/extension/env/model decision reads the **prospective** `goalId`, `teamGoalId`, role, project, sandbox, and coordinates, not the old session fields.
+8. The candidate uses the same Bobbit ID, transcript/JSONL, `cwd`, worktree/repository coordinates, sandbox realm, clients, event frame, queued intents/background-process owner, model tuple, and title. It adds goal/team-lead prompt context, `BOBBIT_GOAL_ID`, goal and team extensions/tools, and the canonical role/accessory. It sends no duplicate kickoff prompt.
+9. Start, switch the existing transcript, and validate the exact model/thinking tuple and sandbox realm. Write all attachment fields (`goalId`, `teamGoalId`, role/accessory and unchanged coordinates) in one **tentative** store update immediately before stopping the old bridge, matching the existing staged-replacement ordering. If old stop rejects, restore the exact prior presence/value of every field and retain the old listener/runtime.
+10. Once old stop succeeds, synchronously install the already-verified candidate on the existing `SessionInfo`; this canonical bridge installation is the commit point. There is no fallible/awaited operation between successful old stop and the swap. The Bobbit session ID and clients do not change.
+11. Subscribe team-lead events, transition a `todo` goal to `in-progress`, clear the proposal, and return the goal. Failures after canonical installation are repaired idempotently and do not roll back a working graph; a retry returns the committed relation.
+
+### Commit and compensation boundary
+
+Until the verified candidate becomes canonical after successful old-bridge stop, the attachment is uncommitted. The original session stays canonical and usable for every failure through a rejected old stop. A caught pre-commit failure conditionally performs, in order:
+
+1. dispose only the staged replacement;
+2. call `TeamManager.releaseAdoptedLead(goalId, ownerId)` only if the reservation still has that exact empty lead relation;
+3. call `GateStore.removeGoalGates(goalId)` only for the attempt-created goal;
+4. call `GoalManager.deleteGoal(goalId)` only if `worktreeOwnerSessionId` still equals `ownerId` and the source was not committed;
+5. flush affected stores.
+
+Compensation never calls Git, sandbox removal, worktree cleanup, session archive, or transcript cleanup. It does not remove a team entry that gained agents or changed lead, and does not remove an unrelated/reconciled goal. Fault injection must cover failure after goal creation, gate initialization, lead reservation, candidate start, transcript switch, tuple verification, durable session update, and old-bridge stop.
+
+The relation is committed only after the tentative attachment remains durable, old-bridge stop succeeds, and the verified candidate is synchronously installed as canonical. A process crash after the tentative update but before canonical installation is recognized from the provenance/reservation/session tuple at boot and is completed or compensated before session restore. Failures after canonical installation are recovered idempotently rather than compensated.
+
+## Restart and lifecycle
+
+### Boot restoration
+
+`TeamManager.restoreTeams` gains a first pass for goals carrying `worktreeOwnerSessionId`, before orphan-team cleanup. For each relation it uses the owning project stores to:
+
+- verify same-project source identity and exact adopted coordinates;
+- ensure exactly one `PersistedTeamEntry` reserves that source as lead;
+- repair the source's durable `goalId`, `teamGoalId`, role/accessory fields when the relation is unambiguous;
+- initialize any missing workflow gates caused by a crash before the normal creation flush;
+- remove only an uncommitted attempt-owned goal/gates/reservation when repair cannot safely complete.
+
+This pass runs inside the existing `restore-teams` boot phase. Then `SessionManager.restoreSessions` reconstructs the runtime from canonical goal/team metadata, and `resubscribeTeamEvents` restores subscriptions. It never invokes `startTeam`, creates a session, provisions a checkout, or creates a sandbox realm. Conflicting/multiple provenance claims fail closed and remain diagnostic rather than guessing.
+
+### Archive, teardown, purge, and cleanup
+
+- Direct archive/termination/purge of a live promoted source conflicts while its non-archived goal or team reservation references it.
+- Direct `team/teardown` of a live promoted goal conflicts because keeping the session alive would require out-of-scope demotion.
+- Goal archive is the allowed ordered path: publish goal archival intent, remove worker agents, remove the promoted reservation/subscriptions, then archive the source session through its existing lifecycle owner. The goal is never treated as having provisioned the source checkout.
+- Sandbox cleanup remains session-owned. Promotion does not set `borrowsWorktree`, change the owner ID, call `SandboxManager.createWorktree`, or transfer the project container.
+- `SessionManager.purgeOneSession`, `GoalManager.archiveGoal`, archived-worktree inventory, and the boot sweeper protect every component path while either endpoint or the team relation is live. Final cleanup is allowed once only after all three references are gone.
+- A promoted host worktree is preserved through ordinary session archive retention; sandbox/container cleanup follows the source session's existing lifecycle. No cleanup path infers authority from `worktreeOwnerSessionId` alone.
+
+The key distinction tested at every cleanup seam is:
+
+- **source ownership:** the session created and still owns the checkout/sandbox lifecycle;
+- **goal provenance:** `worktreeOwnerSessionId` says which session was adopted and enables idempotency/recovery, but does not authorize the goal to delete that checkout.
+
+## UI
+
+`renderGoalForm` in `src/app/proposal-panels.ts` changes the existing **Worktree** row into an accessible native radio group:
+
+- **New worktree** — selected by default for absent/old proposals; shows the existing predicted goal path/component summary.
+- **Current session** — shows the server-projected exact branch, worktree path, and component count. It is disabled with the server reason when ineligible.
+
+The proposal owner comes from `state.activeProposals.goal.sessionId` (or the historical override owner), never `activeSessionId()` after a tab switch. `GoalProposalFormSnapshot`, its identity key, and `GoalFormConfig` carry the parsed mode/projection so edit, rehydrate, reload, snapshot restore, and continued-draft flows redraw consistently. Selecting a radio persists through `setGoalProposalWorktreeMode`; the returned stamped `proposal_update` remains the UI source of truth.
+
+If a restored `current-session` selection becomes ineligible, it stays visibly selected, shows the reason, and disables Create until the user selects New worktree. In current-session mode the sandbox display is read-only from the source and the Auto-start control is disabled with copy explaining that the current session becomes lead immediately.
+
+Acceptance branches only at the API call: new mode uses existing `createGoal`; current mode uses `acceptGoalProposalInCurrentSession`. A successful promotion navigates to the goal while the current session/transcript remains the same lead.
+
+## Implementation map and test seams
+
+### Expected changed and new files
+
+| File | Existing/new symbol | Exact responsibility |
+|---|---|---|
+| `src/server/proposals/proposal-types.ts` | `GOAL_FRONTMATTER_KEYS`, `validateGoalInlineFields` | Preserve/validate optional `worktreeMode`; skip absent mode so old serialized bytes do not change. |
+| `src/server/agent/session-goal-promotion.ts` **(new)** | `GoalWorktreeMode`, `evaluateSessionGoalPromotion`, `findExistingSessionPromotion` | Pure eligibility/reason projection and exact provenance lookup shared by GET and final recheck. No paths from a request are inputs. |
+| `src/server/server.ts` | `handleApiRoute()` editable-proposal route block and goal archive/team teardown blocks | Add owner-scoped GET/PUT/accept operations, per-owner single flight, normal goal+gate composition, conditional compensation, and promoted lifecycle conflicts/order. Keep general `POST /api/goals` unchanged. |
+| `src/server/agent/goal-store.ts` | `PersistedGoal`, canonical validation (`STRING_FIELDS`) | Persist/validate optional `worktreeOwnerSessionId`; absence remains the legacy shape. |
+| `src/server/agent/goal-manager.ts` | `GoalManager.createGoal`, `GoalManager.archiveGoal`, internal `AdoptedGoalWorkspace` | Add internal adoption branch that copies exact canonical coordinates and starts ready without provisioning/setup/hook; guard archive cleanup by live source ownership; expose conditional attempt deletion through existing `deleteGoal`. |
+| `src/server/agent/team-manager.ts` | `TeamManager.adoptExistingLead` **(new)**, `releaseAdoptedLead` **(new)**, `restoreTeams`, `startTeam`, `teardownTeam` | Persist one existing-lead reservation, maintain `sessionToGoal`, make repeat/conflict behavior explicit, reconcile before orphan cleanup, prevent second lead and direct teardown. |
+| `src/server/agent/session-manager.ts` | `SessionManager.promoteToGoalLead` **(new)**, `_coordinateSessionReplacement`, generalized `_assignRoleStaged`, `terminateSession`, `storeArchive`, `purgeOneSession`, `buildArchivedWorktreeScanContext` | Stage/verify/rollback prospective goal-lead context on the same runtime identity and realm; block source destruction while live references remain; keep all component paths protected. |
+| `src/app/state.ts` | `GatewaySession`, `Goal` | Carry the existing authoritative eligibility inputs and new goal provenance projection needed by UI/reload diagnostics. No independent durable client state. |
+| `src/app/api.ts` | `getGoalProposalWorktreeMode` **(new)**, `setGoalProposalWorktreeMode` **(new)**, `acceptGoalProposalInCurrentSession` **(new)**, existing `createGoal` | Add owner-scoped calls; reject/omit coordinate authority client-side; leave existing new-worktree request construction byte-compatible. |
+| `src/app/proposal-panels.ts` | `GoalFormConfig`, `renderGoalForm`, `GoalProposalFormSnapshot`, `goalProposalFormIdentityKey`, `syncProposalFormState`, goal accept handler | Render/persist the radio choice and exact projection, bind to proposal owner, block invalid restored mode, and choose only the acceptance API path. |
+| `tests2/core/session-goal-promotion-proposal.test.ts` **(new)** | Cases below | Proposal default/bytes, enum, edit/snapshot/reopen persistence, and owner-scoped route authority. |
+| `tests2/core/session-goal-promotion-eligibility.test.ts` **(new)** | Cases below | Pure single/multi-repo/sandbox eligibility matrix and stable reasons. |
+| `tests2/core/session-goal-promotion-managers.test.ts` **(new)** | Cases below | Adopted goal creation, reservation/idempotency, staged continuity/rollback, restore, and cleanup ownership guards. |
+| `tests2/integration/session-goal-promotion.test.ts` **(new)** | Cases below | Real API/Git/runtime retry, dirty checkout, multi-repo, sandbox preservation, restart, and cleanup behavior. |
+| `tests2/browser/journeys/session-goal-promotion.journey.spec.ts` **(new)** | `Journey: Current-session goal promotion` | Registered visible selection/acceptance/continuity/reload/archive journey plus disabled and new-worktree controls. |
+| `tests2/tests-map.json` | browser/unit registration rows | Register every new v2 test, including the browser file as `smoke-journey`. |
+
+No change is expected in `src/server/agent/team-store.ts`: `PersistedTeamEntry.teamLeadSessionId` already persists an empty lead reservation. No new session ownership field is expected in `session-store.ts`: `goalId`, `teamGoalId`, role, coordinates, sandbox flags, and transcript identity already have the required durable owners.
+
+### Existing composition anchors
+
+Every reused contract below has an existing exact `tests2` anchor. These tests remain unchanged; the new tests cover only promotion-specific branches.
+
+| Reused symbol/contract | Existing exact tests2 anchor |
+|---|---|
+| `GOAL_FRONTMATTER_KEYS` / goal plugin parse-write compatibility | `tests2/core/proposal-files.test.ts` — `describe("goal proposal round-trip")`, tests `"writes, reads, parses with frontmatter"` and `"round-trips the Sub-goals tab fields (subgoalsAllowed, maxNestingDepth, divergencePolicy, maxConcurrentChildren)"`; `tests2/core/proposal-rehydrate.test.ts` — `describe("goal proposal rehydrate — spec round-trip")`, test `"is idempotent on a body that already ends with a single newline (write→parse→write byte-stable)"`. |
+| `writeProposalFile` / `editProposalFile` / snapshot restore | `tests2/core/proposal-files.test.ts` — `describe("editProposalFile semantics")`, test `"malformed edit rolls back on YAML_PARSE_ERROR; on-disk file unchanged"`; `describe("snapshot history")`, test `"restoreSnapshot round-trip: rev1 fields A, rev2 fields B, restore rev1 -> rev3 with fields A"`; `tests2/integration/proposal-edit-api.test.ts` — `test.describe("editable proposals — REST API")`, test `"seed → edit → GET reflects new content"`. |
+| Archived/reopened proposal byte preservation via `copyProposalDirIfPresent` | `tests2/core/continue-archived-clone.test.ts` — `describe("copyProposalDirIfPresent")`, tests `"clones the live file plus every history snapshot byte-identical"` and `"is idempotent — running twice does not throw and leaves the clone intact"`; `tests2/integration/continue-archived-assistant.test.ts` — `test.describe("Continue-Archived (assistant) — Path B")`, test `"goal-assistant: clones live file + history snapshots byte-identical"`. |
+| `GoalManager.createGoal` workflow snapshot/default framework | `tests2/core/goal-manager-default-workflow.test.ts` — `describe("GoalManager workflow defaulting")`, tests `"falls back to the first workflow in store order when no id is supplied"` and `"throws 'Workflow not found' when an explicit unknown id is supplied to a non-empty store"`. |
+| Existing setup single-flight/ready transition, which adoption bypasses rather than changes | `tests2/core/parallel-goal-setup-repro.test.ts` — `describe("parallel goal setup reproductions")`, tests `"GOAL_SETUP_SINGLE_FLIGHT_EARLY_START_REGRESSION: a duplicate auto-start must await the authoritative setup"` and `"GOAL_SETUP_STALE_ERROR_ATOMIC_CLEAR_REGRESSION: ready must remove the active setupError in the same transition"`. |
+| Existing multi-repo goal provisioning control | `tests2/integration/multi-repo-goal.test.ts` — test `"multi-repo goal creates per-repo worktrees"`. The new adoption test asserts this provisioning does **not** run for current-session mode. |
+| `_coordinateSessionReplacement` + `_assignRoleStaged` transcript/bridge continuity | `tests2/core/orphan-tool-result-rehydration-boundaries.test.ts` — `describe("executable SessionManager rehydration boundaries")`, tests `"repairs assignRole history and replaces the old bridge cursor projection"`, `"durably queues prompts during assignRole staging and dispatches them only after commit"`, and `"preserves prompt acceptance order before and after replacement installation"`. |
+| Staged rollback and candidate-before-old-stop safety | Same file/describe — tests `"rolls staged prompts back durably and dispatches them on the original bridge after assignment failure"`, `"cancels an active staged role on Stop and restores the untouched canonical bridge"`, and the parameterized test `"does not install an assignRole replacement when the $realm history switch fails"`. |
+| Replacement serialization/idempotent lifecycle | Same file/describe — tests `"serializes concurrent assignRole replacements and leaves only the final bridge live"` and `"serializes assignRole then restart across the old-stop await and commits only the restart bridge"`. |
+| Sandbox realm reuse/fail-closed replacement | Same file/describe — tests `"assignRole wires a real sandbox replacement before rehydrating container history"` and `"assignRole leaves the original sandbox bridge usable when realm wiring is unavailable"`; `tests2/integration/sandbox-restore.test.ts` — `test.describe("sandbox session restore")`, test `"restores sandboxed session with projectId and goalId"`. |
+| Existing `PersistedTeamEntry` restoration and reverse indexes | `tests2/core/team-manager.test.ts` — `describe("TeamManager")` → `describe("persistence")`, test `"should persist team state and restore on new TeamManager instance"`; `tests2/core/team-manager-async-recovery.test.ts` — `describe("TeamManager awaited async recovery")`, test `"supports an explicit boot boundary: team restore completes before session restore and event resubscription"`. |
+| `startTeam` duplicate-lead guard | `tests2/core/team-manager.test.ts` — `describe("TeamManager")` → `describe("startTeam")`, test `"should throw if team is already active for the goal"`; `tests2/core/paused-team-start-repro.test.ts` — `describe("TeamManager paused team start")`, test `"PAUSED_TEAM_START_AUTO_RESUME resumes once through the lifecycle before creating one lead"` (including its repeated explicit-start assertion). |
+| Session/team durable attachment fields | `tests2/core/session-store.test.ts` — `describe("SessionStore")` → `describe("update()")`, tests `"updates role and teamGoalId"` and `"updates goalId and taskId"`; `describe("persistence")`, test `"persists sessions to disk and reloads"`. |
+| Live session reference guard in goal/session cleanup | `tests2/core/shared-worktree-guard-repro.test.ts` — `describe("shared worktree guard reproductions")`, tests `"purging an archived session must not remove a worktree referenced by a live session cwd"`, `"purging an archived multi-repo session must keep shared repoWorktrees and may clean unshared ones"`, and `"goal archive must not remove a multi-repo worktree referenced by a live session resolver"`. |
+| Sandbox worktree lifecycle ownership | `tests2/core/borrowed-sandbox-worktree-ownership.test.ts` — `describe("borrowed sandbox worktree ownership")`, tests `"round-trips borrowed ownership across persistence and never verifies or removes the source worktree"`, `"keeps owned sandbox cleanup as the control and removes its registered worktree coordinate exactly once"`, and `"persists flattened ownership and rejects owner termination before mutation until its nested-cwd borrower is archived"`. |
+| Inventory and sweeper reference safety | `tests2/core/worktree-inventory.test.ts` — `describe("worktree inventory classifier")`, tests `"protects an exact live worktree but not a branch-only match"`, `"protects durable multi-repo team-agent component worktrees"`, and `"revalidates session and pool claims arriving during a deferred cleanup scan"`; `tests2/core/worktree-sweeper-multi.test.ts` — `describe("worktree-sweeper — bounded asynchronous sweep")`, tests `"preserves a worktree claimed after the initial diagnostic snapshot"` and `"preserves every ownership, pool, container, detached, archive, and branch-drift guard"`. |
+
+## Exact new tests
+
+### `tests2/core/session-goal-promotion-proposal.test.ts`
+
+`describe("session-goal promotion proposal mode")`
+
+- `it("keeps an absent worktreeMode byte-identical and resolves it as new-worktree")`
+- `it("round-trips current-session through write, edit, reload, snapshot restore, and archive-copy")`
+- `it("rejects every worktreeMode other than new-worktree and current-session")`
+- `it("updates only the proposal owner's mode and emits the stamped proposal_update")`
+- `it("accepts no session, branch, worktree, repo, or sandbox authority in the selector body")`
+
+### `tests2/core/session-goal-promotion-eligibility.test.ts`
+
+`describe("evaluateSessionGoalPromotion")`
+
+- `it("accepts an idle regular owner with one complete dedicated worktree")`
+- `it("accepts complete multi-repo coordinates and reports the exact component count")`
+- `it("accepts an owned reachable sandbox realm without creating it")`
+- `it.each(...)` named `"rejects forbidden relation or lifecycle state: $label"` covering assistant/legacy assistant, goal, team lead/member, staff, delegate, first-class child, archived, read-only, noninteractive, borrowed, streaming, compacting, starting, aborting, terminated, and already claimed states
+- `it.each(...)` named `"rejects unsafe coordinates: $label"` covering missing/stale live-vs-durable `cwd`, `worktreePath`, `branch`, `repoPath`, incomplete/duplicate multi-repo entries, unavailable sandbox owner/container, and project mismatch
+- `it("returns stable concise reason codes and never reads a caller-supplied coordinate")`
+
+### `tests2/core/session-goal-promotion-managers.test.ts`
+
+`describe("GoalManager adopted workspace")`
+
+- `it("copies exact single-repo coordinates, provenance, and sandbox flag and starts ready")`
+- `it("copies exact multi-repo coordinates without calling support, pool, git, setup, or goalProvisioned")`
+- `it("leaves ordinary createGoal output and setup behavior unchanged when adoption is absent")`
+
+`describe("TeamManager adopted existing lead")`
+
+- `it("persists one empty reservation and maps the existing session as lead")`
+- `it("returns the exact reservation on repeat and rejects a different goal or lead")`
+- `it("blocks startTeam from spawning a second lead")`
+- `it("releases only an unchanged attempt-owned empty reservation")`
+- `it("reconciles provenance before orphan cleanup and restores exactly one reverse index")`
+
+`describe("SessionManager promoteToGoalLead")`
+
+- `it("keeps the Bobbit id, transcript, title, clients, event frame, queue, background owner, model tuple, cwd, and coordinates while loading goal/team tools")`
+- `it("uses the prospective team-lead role and goal metadata at every candidate setup edge")`
+- `it("reuses the exact sandbox container and never creates or transfers a sandbox worktree")`
+- `it("restores every prior field and the old usable bridge for failures through a rejected old stop")`
+- `it("treats canonical bridge installation as commit and repairs later failures idempotently")`
+- `it("serializes concurrent retries and commits only one promoted bridge")`
+- `it("restores the promoted association and tools from durable state after restart")`
+
+`describe("promoted source lifecycle guards")`
+
+- `it("blocks direct source archive, purge, and direct team teardown while the goal is live")`
+- `it("archives goal first, then reservation and source, without treating provenance as checkout ownership")`
+- `it("protects single and multi-repo paths while session, goal, or team still references them")`
+- `it("allows final cleanup exactly once after every live reference is gone")`
+
+### `tests2/integration/session-goal-promotion.test.ts`
+
+`test.describe("current-session goal promotion API")`
+
+- `test("promotes the proposal owner with the same id, transcript, branch, worktree, dirty index, unstaged and untracked files")`
+- `test("creates normal workflow gates and enables goal, gate, task, and team tools on the original session")`
+- `test("concurrent accepts and retries produce one goal, one lead, and no new worktree or session")`
+- `test("faults after goal, gates, reservation, candidate start, switch, verification, tentative durable update, and rejected old stop compensate only attempt-owned state")`
+- `test("a failure after canonical bridge installation keeps the committed relation and retry returns it")`
+- `test("restart restores one provenance relation, lead reservation, original transcript, and runtime context")`
+- `test("adopts exact multi-repo coordinates without changing git worktree list or component status")`
+- `test("sandbox promotion retains the same container and worktree owner and makes zero create/remove calls")`
+- `test("cleanup refuses every live endpoint and removes the adopted checkout only after ordered goal archive")`
+- `test("absent and explicit new-worktree proposals retain the existing goal creation behavior")`
+
+The first integration case snapshots before/after: session ID, transcript path and content hash, `git rev-parse HEAD`, branch, `git worktree list --porcelain`, staged diff, unstaged diff, untracked file list/content, worktree/repository coordinates, and session count. Every value except goal/team/runtime metadata must remain equal.
+
+### Registered browser journey
+
+Add `tests2/browser/journeys/session-goal-promotion.journey.spec.ts` to `tests2/tests-map.json` as `smoke-journey`.
+
+`test.describe("Journey: Current-session goal promotion")`
+
+1. `test("selects Current session, promotes the original lead, survives reload, and archives safely")`
+   - create an eligible regular session and record its URL/session ID, transcript sentinel, branch, and worktree path;
+   - open its goal proposal and assert **New worktree** is initially selected;
+   - select **Current session** and assert the exact authoritative branch/path/component count are shown;
+   - reload before acceptance and assert Current session remains selected;
+   - accept and assert the goal shows the original session ID as lead, the transcript sentinel remains visible, and no second lead/session appears;
+   - exercise visible workflow gate, task, and team controls from the promoted session;
+   - reload the gateway/page and assert the same session remains the sole lead with the same transcript;
+   - assert worktree cleanup is blocked while the live goal/session references it, archive through the goal UI, then assert ordered cleanup completes without a dangling goal/team row.
+2. `test("shows the authoritative reason when Current session is unavailable")`
+   - open a proposal owned by an ineligible regular-session fixture (missing/borrowed worktree);
+   - assert Current session is disabled, its concise server reason is visible, no editable coordinate is rendered, and New worktree remains actionable.
+3. `test("keeps New worktree goal creation unchanged")`
+   - leave the default selected, accept, and assert a distinct goal branch/worktree and distinct team-lead session are created while the proposal owner is not attached as lead.
+
+These are real-app journeys, not fixture-only rendering tests: they cover navigation, selection, acceptance, same-session continuity, reload/restart restoration, archive, and cleanup.
+
+## Acceptance proof
+
+A successful `current-session` acceptance has exactly one goal, one existing-lead reservation, and the original session. The goal and session expose identical pre-promotion branch/worktree/repository coordinates; Git status/content, HEAD, transcript, Bobbit ID, sandbox/container, and lifecycle ownership are unchanged. The refreshed runtime has canonical goal/team context and tools. Restart reconstructs the same graph. Cleanup cannot remove the checkout while the live source, goal, or team relation references it. An absent or `new-worktree` mode never enters this flow.

--- a/docs/goals-workflows-tasks.md
+++ b/docs/goals-workflows-tasks.md
@@ -93,6 +93,57 @@ Durable regression coverage is kept near the affected contracts:
 
 > **Legacy note — per-goal setup command removed.** An earlier design (PR #816) added bespoke per-goal `worktreeSetupCommand` / `worktreeSetupTimeoutMs` fields on `PersistedGoal`, plus matching REST, `propose_goal`, and goal-dialog affordances. That surface is **superseded by goal metadata and the `goalProvisioned` hook** and has been removed: the goal-store load path **drops** those legacy fields, the REST / `propose_goal` / UI inputs no longer exist, and posting them has no effect. Only the **component / project** `worktree_setup_command` (and its `worktree_setup_timeout_ms`) remains supported. To run goal-specific setup, declare metadata that an extension's `goalProvisioned` provider acts on — that hook fires at **every** worktree provisioning in the subtree (including pool claims), so filesystem treatments land on every agent and sub-goal worktree symmetrically, which the single per-goal command could not guarantee.
 
+### Promote the current session in place
+
+A goal proposal can either provision a new goal workspace or adopt the proposal-owning session's existing workspace. The second mode is useful when planning turns into implementation after work has already started: the user keeps the same conversation, checkout, dirty files, and sandbox instead of moving that state into a newly spawned Team Lead.
+
+The proposal's **Worktree** row exposes two modes:
+
+- **New worktree** is the default and retains the ordinary `POST /api/goals` path. An absent mode and an explicitly selected New worktree serialize identically, so existing proposal files and callers remain compatible.
+- **Current session** promotes the proposal owner in place. The panel shows the server-derived branch, worktree path, sandbox state, and multi-repository worktree count. Sandbox and auto-start controls become read-only because the existing realm is retained and that session becomes the lead immediately.
+
+The choice is stored as the optional `worktreeMode: current-session` field in the goal proposal's frontmatter. Proposal edits, revision snapshots, reload rehydration, and archived-draft continuation therefore use the existing proposal-file lifecycle rather than a second preference store. Selecting New worktree removes the field. If an archived draft still selects Current session, the selection remains visible but its archived owner is ineligible; a copied continue-archived draft is evaluated against the new proposal owner.
+
+#### Eligibility and authority
+
+Eligibility is recomputed from live and durable server state both when the panel reads the proposal and immediately before acceptance. The panel's result is advisory; a session that becomes busy or otherwise unsafe before submit is rejected by the final check.
+
+The proposal owner must be:
+
+- a live, non-archived, idle regular interactive session in the proposal's registered project;
+- free of goal, team, staff, assistant, delegate, child, task, read-only, non-interactive, or borrowed-worktree relationships (the ordinary baseline role is allowed);
+- backed by an available durable transcript;
+- the owner of a dedicated branch and worktree whose live and persisted `cwd`, `worktreePath`, `repoPath`, and `branch` agree;
+- complete for every configured Git component in a multi-repository project; and
+- still attached to the same reachable sandbox container when sandboxed.
+
+Promotion also fails when another session, goal, team, or staff record claims an overlapping workspace, or when multiple live goals claim the same promotion provenance. The eligibility response uses stable reason codes such as `SESSION_NOT_IDLE`, `SESSION_HAS_RELATION`, `WORKTREE_UNAVAILABLE`, `MULTI_REPO_MISMATCH`, `SANDBOX_UNAVAILABLE`, and `WORKSPACE_CLAIMED`; see the [owner-scoped REST contract](rest-api.md#current-session-goal-promotion) for the complete response shape.
+
+The source is always the owner named by the proposal route and must remain in the same project. The accept body cannot choose a session, project, checkout, branch, repository, container, or sandbox mode. This prevents a valid proposal from being turned into authority over another checkout by editing a request or draft. Current-session promotion creates a top-level goal; a `parentGoalId` is rejected because adopting a regular session as a nested child would introduce a second lifecycle owner.
+
+#### Acceptance and continuity
+
+Acceptance composes the normal goal framework with an adopted workspace:
+
+1. Create the goal with its normal workflow snapshot, metadata, inline roles, policy, and gate records.
+2. Copy the canonical session coordinates onto the goal, stamp `worktreeOwnerSessionId` as provenance, and mark setup `ready` without provisioning, pool claims, setup commands, or a `goalProvisioned` hook.
+3. Reserve the existing session as the team's only lead. An adopted goal cannot fall through to ordinary `startTeam()` and spawn a second lead.
+4. Replace the agent bridge in place with canonical `team-lead` prompt, goal/team tools, and `BOBBIT_GOAL_ID`, then resume the same transcript. No duplicate kickoff prompt is sent.
+
+The Bobbit session ID, transcript file, title, connected clients, queued work, model/thinking tuple, `cwd`, branch, single- or multi-repository worktrees, sandbox container, and checkout contents stay attached to the same session. Promotion performs no Git checkout, reset, commit, copy, move, rename, or worktree creation, so staged, unstaged, and untracked work is unchanged. `worktreeOwnerSessionId` is an idempotency and recovery link only: the source session remains the checkout and sandbox lifecycle owner.
+
+#### Failure, restart, and cleanup
+
+Acceptance is single-flight per proposal owner. While the reservation is held, competing role or destructive session mutations return `409 SESSION_GOAL_PROMOTION_IN_PROGRESS`. A retry locates an existing live goal only through `worktreeOwnerSessionId`; matching paths or branch names are never enough.
+
+Before the replacement runtime becomes canonical, compensation may remove only the attempt-created empty lead reservation, gates, and adopted goal. It does not touch the source runtime, transcript, sandbox, or checkout. Once runtime replacement commits, later finalization failures retain the exact goal/session/team graph; retry finalizes and returns that same goal instead of creating another.
+
+On gateway restart, adopted-goal reconciliation runs before ordinary orphan-team recovery. It verifies same-project identity and exact coordinates, repairs an unambiguous missing lead reservation, attachment fields, or workflow gates, and then restores the original session runtime and team subscriptions. It never calls ordinary team start, creates a session, provisions a worktree, or transfers a sandbox. Ambiguous records fail closed. If the promoted transcript, worktree, or recorded sandbox realm cannot be restored safely, Bobbit preserves the source as dormant rather than archiving it, repairing the adopted checkout, replacing its container, or silently downgrading it to the host.
+
+A live promoted session cannot be archived or purged directly (`409 PROMOTED_SESSION_LIFECYCLE_CONFLICT`), and its team cannot be torn down independently. Archive the goal instead. The ordered goal path first publishes the goal's archived state, then removes workers and team subscriptions and archives the source session. Archive retention preserves the session-owned worktree; final session purge may remove it only after no live session, goal, team, staff, pool, or container reference remains. Multi-repository component worktrees follow the same ownership rule, and adopted branches are not treated as goal-created remote branches.
+
+For the implementation rationale and recovery boundaries, see [Promote Session to Goal — implementation design](design/session-goal-promotion.md).
+
 ### Headquarters no-worktree goals
 
 Headquarters can host explicit data-only goals without a git worktree. A goal created with `projectId: "headquarters"`, `worktree: false`, and a valid workflow snapshot can reach `setupStatus: "ready"` with no `branch`, `worktreePath`, or `repoPath`.

--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -480,12 +480,89 @@ In-flight `propose_*` payloads are mirrored to `.bobbit/state/proposal-drafts/<s
 | Method | Path | Description |
 |---|---|---|
 | `GET` | `/api/sessions/:id/proposal/:type` | Read the raw proposal file body. `200` with `text/markdown` (goal) or `application/yaml` (others). `404 {ok:false, code:"FILE_NOT_FOUND", message}` if no draft. |
+| `GET` | `/api/sessions/:id/proposal/goal/worktree-mode` | Read the goal draft's durable worktree mode and freshly recomputed eligibility for promoting its owner. An absent mode projects as `new-worktree`; coordinates are display-only server state. See [Current-session goal promotion](#current-session-goal-promotion). |
+| `PUT` | `/api/sessions/:id/proposal/goal/worktree-mode` | Persist exactly `{ mode: "new-worktree" | "current-session" }`, create a proposal revision, and broadcast the normal stamped `proposal_update`. New worktree removes the optional field to preserve legacy serialization. |
+| `POST` | `/api/sessions/:id/proposal/goal/accept` | Accept a draft whose persisted mode is `current-session`, create the normal goal/gates, and promote the proposal-owning session as its existing lead. Source and workspace authority are derived only from the route owner and canonical server state. |
 | `GET` | `/api/sessions/:id/proposal/:type/snapshot?rev=N` | Read a historical revision without mutating the live draft. Parses `<type>.history/<rev>.<ext>` through the per-type plugin and returns `200 {ok:true, rev, fields}`. Does not broadcast `proposal_update` and does not update `state.activeProposals`. `400 {ok:false, code:"INVALID_BODY"}` for invalid rev; `404 {ok:false, code:"SNAPSHOT_NOT_FOUND", message}` if the snapshot file is missing; `400` with `ParseError` shape if the snapshot fails to parse. Used by read-only historical proposal tabs. |
 | `POST` | `/api/sessions/:id/proposal/:type/seed` | Called by `propose_*` tool `execute()`. Body `{ args: <propose-args object> }`. Serialises args via the per-type plugin, atomically writes the file, parses, attempts to open/focus `proposal:<type>` in the side-panel workspace, then broadcasts `proposal_update {source:"seed", rev}`. `200 {ok:true, rev}` on success; `400` with structured error on parse/validate failure. For `type=goal`, the named `workflow` and `options` are validated against the project's workflows **before** writing. When project workflows are resolvable and non-empty, omitted, empty, or whitespace-only `workflow` is rejected with `400 {ok:false, code:"MISSING_WORKFLOW", message, availableWorkflows: [{ id, name }]}` so agents can retry with a valid workflow. Unknown values are rejected with `400 {ok:false, code:"UNKNOWN_WORKFLOW", availableWorkflows}` or `400 {ok:false, code:"UNKNOWN_OPTIONAL_STEP", validOptionalSteps}`. A rejected goal workflow seed writes no draft, creates no rev, emits no `__proposal_rev_v1__` success marker, and broadcasts no `proposal_update`; the real `propose_goal` tool call must persist/broadcast an errored tool result (`isError: true`) so the UI can render/open the failed attempt from the transcript tool-call input plus the validation result. Workflow validation is skipped only when there are genuinely no resolvable workflows. See [goals-workflows-tasks.md — Validating a proposed workflow at proposal time](goals-workflows-tasks.md#validating-a-proposed-workflow-at-proposal-time). |
 | `POST` | `/api/sessions/:id/proposal/:type/edit` | Surgical content edit. Body `{ old_text: string, new_text: string }`. Exact-string replacement, first-and-only-occurrence rule, empty `new_text` deletes. On success: writes atomically, broadcasts `proposal_update {source:"edit", rev}`, returns `200 {ok:true, newContent, rev}`. Does not open or focus side-panel tabs; already-open proposal tabs refresh from the content slot. On failure: file unchanged, returns 4xx with structured error. |
 | `POST` | `/api/sessions/:id/proposal/:type/restore` | Mutating rollback endpoint for explicit API restore flows. Body `{ rev: number }` (positive integer). Copies `<type>.history/<rev>.<ext>` back to the live draft AND writes a NEW snapshot at `currentRev+1` so the rollback appears in the timeline. Attempts to open/focus `proposal:<type>` in the side-panel workspace, then broadcasts `proposal_update {source:"restore", rev: newRev}`. `200 {ok:true, newRev, fields}` on success; `400 {ok:false, code:"INVALID_BODY"}` if `rev` is not a positive integer; `404 {ok:false, code:"SNAPSHOT_NOT_FOUND", message}` if the requested snapshot file is missing; `400` with `ParseError` shape if the snapshot fails to parse. Historical chat-card tabs use `GET /snapshot` instead so browsing old revisions is non-mutating. |
 | `DELETE` | `/api/sessions/:id/proposal/:type` | Delete the draft. Broadcasts `proposal_cleared`. `204` on success (idempotent — `204` even if the file was absent). Called by accept handlers after a successful save. The per-session `<type>.history/` directory is cleaned with the rest of the per-session draft dir on the 7-day purge (deferred from archive so the [archived-proposal-reopen flows](archived-proposal-reopen.md) can read drafts after the source session is archived). |
 | `GET` | `/api/sessions/:id/proposals` | List every parsed proposal draft for the session in one call. Returns `200 { proposals: Array<{ proposalType, fields, rev }> }`; `proposals` is empty when the per-session directory is absent or empty. Mirrors the WS `proposal_update {source:"rehydrate"}` broadcast as a one-shot REST call — used by fast-path session switch-backs (no fresh WS auth, so the broadcast doesn't run) and by the archived-session footer to decide whether to surface a "Resubmit `<type>` proposal" button (see [docs/archived-proposal-reopen.md](archived-proposal-reopen.md)). This is content hydration only and does not open or focus side-panel tabs. `400` on invalid sessionId; `500` on unexpected enumeration failure. |
+
+#### Current-session goal promotion
+
+The goal proposal panel uses these owner-scoped routes only for the **Current session** mode. New worktree proposals continue through `POST /api/goals` unchanged. The separation is deliberate: the server can bind promotion authority to the proposal owner instead of accepting an arbitrary source session or checkout in general goal creation.
+
+##### Worktree mode projection
+
+`GET /api/sessions/:ownerId/proposal/goal/worktree-mode` parses the owner's current goal draft and returns:
+
+```json
+{
+  "mode": "current-session",
+  "eligibility": {
+    "eligible": true,
+    "coordinates": {
+      "sessionId": "session-id",
+      "projectId": "project-id",
+      "cwd": "/existing/worktree/packages/app",
+      "worktreePath": "/existing/worktree",
+      "repoPath": "/repository",
+      "branch": "session/existing",
+      "repoWorktrees": { "api": "/existing/worktree/api" },
+      "sandboxed": false,
+      "componentCount": 1
+    }
+  }
+}
+```
+
+`repoWorktrees` and `containerId` are omitted when not applicable. An ineligible response replaces `coordinates` with `{ "eligible": false, "code": "...", "reason": "..." }`. The stable codes are:
+
+| Code | Meaning |
+|---|---|
+| `SESSION_NOT_LIVE` | The owner has no matching live and durable non-archived session. |
+| `SESSION_NOT_IDLE` | The owner is busy, compacting, restoring prior streaming work, dormant, lifecycle-fenced, or has pending prompt/steer work. |
+| `SESSION_HAS_RELATION` | Goal, team, non-baseline role, assistant, staff, delegate, child, or task metadata already owns the session. |
+| `SESSION_UNSAFE` | The session is read-only, non-interactive, terminal-child state, or borrows another worktree. |
+| `PROJECT_UNAVAILABLE` | The draft has no usable registered target project, or its target does not resolve. |
+| `PROJECT_MISMATCH` | Live or durable session state belongs to a different project. |
+| `TRANSCRIPT_UNAVAILABLE` | The canonical transcript is missing or unreachable in its host/container realm. |
+| `WORKTREE_UNAVAILABLE` | A dedicated branch/worktree is missing, unreachable, not current, or aliases the repository checkout. |
+| `WORKSPACE_MISMATCH` | Live and durable workspace or sandbox metadata disagree. |
+| `MULTI_REPO_MISMATCH` | Configured Git components and canonical component worktrees are incomplete, duplicated, aliased, or divergent. |
+| `SANDBOX_UNAVAILABLE` | The exact recorded sandbox container is absent or not ready. |
+| `PROMOTION_CONFLICT` | Multiple live adopted goals claim this owner, or retry provenance belongs to another project. |
+| `WORKSPACE_CLAIMED` | Another live session, goal, team agent, or staff record claims an overlapping workspace. |
+
+The first failing reason is concise enough for direct UI display. Eligibility is recomputed on every read; the route never trusts coordinates cached by the browser.
+
+`PUT /api/sessions/:ownerId/proposal/goal/worktree-mode` accepts no keys besides `mode`. `current-session` writes the optional frontmatter field; `new-worktree` removes it. Both responses use the GET shape after the edit. The route can preserve a restored Current session selection even when it is now ineligible; the UI disables acceptance until the user chooses New worktree or eligibility becomes valid.
+
+##### Accept in place
+
+`POST /api/sessions/:ownerId/proposal/goal/accept` requires a non-empty `title`. It accepts only human-editable goal definition fields:
+
+```text
+title, spec, workflowId, workflow, inlineRoles, enabledOptionalSteps,
+subgoalsAllowed, maxNestingDepth, divergencePolicy, maxConcurrentChildren,
+parentGoalId, metadata
+```
+
+The body must not contain `sessionId`, `ownerSessionId`, `promoteSessionId`, `projectId`, `cwd`, `worktree`, `worktreePath`, `branch`, `repoPath`, `repoWorktrees`, `sandboxed`, `containerId`, or `autoStartTeam`. Supplying one returns `400 PROMOTION_AUTHORITY_REJECTED`; other unknown keys return `400 INVALID_BODY`. The route derives the source session from `ownerId`, the project and selected mode from the draft, and every workspace/sandbox coordinate from matching live and durable records. A non-empty `parentGoalId` returns `422 PROMOTION_PARENT_UNSUPPORTED` because this flow creates a top-level goal.
+
+Immediately before mutation, the server rechecks that the draft still selects `current-session` and that the owner is eligible. A mode change returns `409 WORKTREE_MODE_MISMATCH`; an eligibility failure returns `409` with the corresponding code above. Successful acceptance returns the goal with `201`. The goal has `setupStatus: "ready"`, the exact source coordinates, and `worktreeOwnerSessionId: ownerId`; its team has that same session as `teamLeadSessionId` with no second lead.
+
+Acceptance is single-flight per owner. Exact retries find the one existing live goal by `worktreeOwnerSessionId` and return it with `201`, even after successful acceptance cleared the draft. Multiple matching goals return `409 PROMOTION_CONFLICT`. While an attempt owns the session reservation, competing role or destructive session mutations return retryable `409 SESSION_GOAL_PROMOTION_IN_PROGRESS`.
+
+Pre-commit failure compensates only an unchanged empty lead reservation plus the attempt-created gates and goal. Post-commit finalization failure keeps the attached session and goal for an exact retry. These boundaries preserve the original transcript, runtime, sandbox, and checkout in either case.
+
+##### Lifecycle conflicts
+
+While the adopted goal is live, direct source archive or purge returns `409 PROMOTED_SESSION_LIFECYCLE_CONFLICT`, and independent team teardown returns `409 PROMOTED_LEAD_TEARDOWN_CONFLICT`. Goal archive is the required ordered path. An archive racing unfinished acceptance returns `409 PROMOTION_IN_PROGRESS` before any goal state, verification, or cascade mutation.
+
+After successful goal archive, the goal is durably marked archived before its team reservation is removed and the source session is archived. Archive does not delete the session-owned worktree. A later session purge may clean it only after the normal reference guards find no live owner or borrower. See [Promote the current session in place](goals-workflows-tasks.md#promote-the-current-session-in-place) for restart recovery, sandbox preservation, and multi-repository cleanup semantics.
 
 #### Error response shape
 

--- a/scripts/affected/impact-rules.mjs
+++ b/scripts/affected/impact-rules.mjs
@@ -960,10 +960,10 @@ export const UNRESOLVED_REPOSITORY_READ_AUDIT = Object.freeze([
 	},
 	{
 		consumer: "tests2/integration/session-goal-promotion.test.ts",
-		allowReason: "isolated integration session worktree files created to prove staged and untracked content survives promotion",
+		allowReason: "isolated integration session worktree files created to prove staged and untracked content survives promotion and restart",
 		reads: frozen([
-			{ expression: "staged", count: 1 },
-			{ expression: "untracked", count: 1 },
+			{ expression: "staged", count: 2 },
+			{ expression: "untracked", count: 2 },
 		]),
 	},
 	{

--- a/scripts/affected/impact-rules.mjs
+++ b/scripts/affected/impact-rules.mjs
@@ -959,6 +959,14 @@ export const UNRESOLVED_REPOSITORY_READ_AUDIT = Object.freeze([
 		]),
 	},
 	{
+		consumer: "tests2/integration/session-goal-promotion.test.ts",
+		allowReason: "isolated integration session worktree files created to prove staged and untracked content survives promotion",
+		reads: frozen([
+			{ expression: "staged", count: 1 },
+			{ expression: "untracked", count: 1 },
+		]),
+	},
+	{
 		consumer: "tests2/integration/server-prebundle-runtime.test.ts",
 		allowReason: "isolated integration gateway, project, or harness-owned output",
 		reads: frozen([
@@ -1396,6 +1404,14 @@ export const UNRESOLVED_REPOSITORY_READ_AUDIT = Object.freeze([
 		reads: frozen([
 			{ expression: "promptPath!", count: 1 },
 			{ expression: "promptPath", count: 1 },
+		]),
+	},
+	{
+		consumer: "tests2/core/session-goal-promotion-proposal.test.ts",
+		allowReason: "test-owned proposal drafts copied between isolated temporary session directories",
+		reads: frozen([
+			{ expression: "proposalFilePath(stateDir, continuedId, \"goal\")", count: 1 },
+			{ expression: "proposalFilePath(stateDir, sourceId, \"goal\")", count: 1 },
 		]),
 	},
 	{

--- a/src/app/api.ts
+++ b/src/app/api.ts
@@ -2,6 +2,7 @@ import {
 	state,
 	renderApp,
 	setProjectsIfChanged,
+	invalidateGoalWorktreeModeProjection,
 	type GatewaySession,
 	type Goal,
 	type GoalWorktreeMode,
@@ -323,17 +324,67 @@ export function updateLocalSessionTitle(sessionId: string, title: string): void 
 	}
 }
 
+function watchesGoalPromotionProjection(sessionId: string): boolean {
+	return Object.prototype.hasOwnProperty.call(state.goalWorktreeModeBySession, sessionId)
+		|| Object.prototype.hasOwnProperty.call(state.goalWorktreeModeRevisionBySession, sessionId)
+		|| state.activeProposals.goal?.sessionId === sessionId;
+}
+
 export function updateLocalSessionStatus(sessionId: string, status: string): void {
 	const idx = state.gatewaySessions.findIndex((s) => s.id === sessionId);
 	if (idx >= 0) {
+		const previous = state.gatewaySessions[idx];
+		// A real owner status transition changes promotion eligibility. Drop only
+		// the display projection; the durable proposal mode stays untouched and the
+		// next render starts a fresh owner-scoped GET. Heartbeats with the same
+		// status deliberately do not create a refetch loop.
+		if (previous.status !== status && watchesGoalPromotionProjection(sessionId)) {
+			invalidateGoalWorktreeModeProjection(sessionId);
+		}
 		// NOTE: do NOT touch lastActivity here. The server is the sole writer of
 		// lastActivity (bumped on real activity in src/server/agent/session-setup.ts
 		// and friends, surfaced via /api/sessions polling every ~5s). Clobbering
 		// lastActivity to Date.now() on every session_status frame caused spurious
 		// "now ●" unread indicators in the sidebar on benign heartbeats and
 		// busy→idle transitions. See tests/spurious-idle-unread.spec.ts.
-		state.gatewaySessions[idx] = { ...state.gatewaySessions[idx], status };
+		state.gatewaySessions[idx] = { ...previous, status };
 		renderApp();
+	}
+}
+
+/** Public session fields that can change the server's promotion policy or its
+ * displayed canonical coordinates. Volatile activity/title/tag fields are
+ * intentionally excluded so polling does not refetch eligibility needlessly. */
+const GOAL_PROMOTION_SESSION_SNAPSHOT_KEYS = [
+	"status", "isCompacting", "isAborting", "restoreStartupWasStreaming", "dormant", "lifecycleFenced",
+	"goalId", "teamGoalId", "teamLeadSessionId", "role", "assistantType", "goalAssistant", "roleAssistant", "toolAssistant",
+	"delegateOf", "parentSessionId", "childKind", "childTerminal", "readOnly", "nonInteractive", "borrowsWorktree",
+	"borrowedWorktreeOwnerSessionId", "staffId", "taskId", "archived", "projectId", "cwd", "worktreePath", "repoPath",
+	"branch", "repoWorktrees", "sandboxed", "containerId",
+] as const;
+
+function goalPromotionSessionSnapshotFingerprint(session: GatewaySession | undefined): string {
+	if (!session) return "missing";
+	const record = session as GatewaySession & Record<string, unknown>;
+	return JSON.stringify(GOAL_PROMOTION_SESSION_SNAPSHOT_KEYS.map((key) => record[key]));
+}
+
+function invalidateChangedGoalPromotionSessionSnapshots(
+	previousSessions: readonly GatewaySession[],
+	nextSessions: readonly GatewaySession[],
+): void {
+	const previousById = new Map(previousSessions.map((session) => [session.id, session]));
+	const nextById = new Map(nextSessions.map((session) => [session.id, session]));
+	const watchedIds = new Set([
+		...Object.keys(state.goalWorktreeModeBySession),
+		...Object.keys(state.goalWorktreeModeRevisionBySession),
+		...(state.activeProposals.goal?.sessionId ? [state.activeProposals.goal.sessionId] : []),
+	]);
+	for (const sessionId of watchedIds) {
+		if (goalPromotionSessionSnapshotFingerprint(previousById.get(sessionId))
+			!== goalPromotionSessionSnapshotFingerprint(nextById.get(sessionId))) {
+			invalidateGoalWorktreeModeProjection(sessionId);
+		}
 	}
 }
 
@@ -791,6 +842,10 @@ export async function refreshSessions(): Promise<void> {
 				_prevSessionStatus.set(s.id, s.status);
 			}
 
+			// Session list snapshots can change eligibility without a live status
+			// frame (role/lifecycle/workspace updates, removal, restart recovery).
+			// Invalidate before replacement so the comparison uses the prior record.
+			invalidateChangedGoalPromotionSessionSnapshots(state.gatewaySessions, newSessions);
 			state.gatewaySessions = newSessions;
 
 			// Merge archived delegates of live sessions into state.archivedSessions

--- a/src/app/api.ts
+++ b/src/app/api.ts
@@ -2154,7 +2154,16 @@ export async function createGoal(title: string, cwd: string, opts?: { spec?: str
 		});
 		if (!res.ok) throw await errorFromResponse(res, `Failed to create goal: ${res.status}`);
 		const goal = await res.json() as Goal;
-		return await finishGoalCreate(goal);
+		await refreshSessions();
+		const goalsById = new Map(state.goals.map(g => [g.id, g]));
+		let cursor: Goal | undefined = goalsById.get(goal.id) ?? goal;
+		const seenGoalIds = new Set<string>();
+		while (cursor && !seenGoalIds.has(cursor.id)) {
+			seenGoalIds.add(cursor.id);
+			expandSidebarTreeNode({ kind: "goal", goalId: cursor.id }, { explicit: false });
+			cursor = cursor.parentGoalId ? goalsById.get(cursor.parentGoalId) : undefined;
+		}
+		return goal;
 	} catch (err) {
 		const { message, code, stack } = errorDetails(err);
 		showConnectionError("Failed to create goal", message, { code, stack });

--- a/src/app/api.ts
+++ b/src/app/api.ts
@@ -4,6 +4,8 @@ import {
 	setProjectsIfChanged,
 	type GatewaySession,
 	type Goal,
+	type GoalWorktreeMode,
+	type GoalWorktreeModeProjection,
 	type Project,
 	type RemotePrStatus,
 	type RemoteStateError,
@@ -2008,6 +2010,117 @@ export async function fetchGoalGitStatus(
 // GOAL API
 // ============================================================================
 
+export interface CurrentSessionGoalAcceptOptions {
+	spec?: string;
+	workflowId?: string;
+	enabledOptionalSteps?: string[];
+	workflow?: unknown;
+	inlineRoles?: Record<string, unknown>;
+	subgoalsAllowed?: boolean;
+	maxNestingDepth?: number;
+	divergencePolicy?: "strict" | "balanced" | "autonomous";
+	maxConcurrentChildren?: number;
+	parentGoalId?: string;
+	metadata?: Record<string, unknown>;
+}
+
+async function finishGoalCreate(goal: Goal): Promise<Goal> {
+	await refreshSessions();
+	const goalsById = new Map(state.goals.map(g => [g.id, g]));
+	let cursor: Goal | undefined = goalsById.get(goal.id) ?? goal;
+	const seenGoalIds = new Set<string>();
+	while (cursor && !seenGoalIds.has(cursor.id)) {
+		seenGoalIds.add(cursor.id);
+		expandSidebarTreeNode({ kind: "goal", goalId: cursor.id }, { explicit: false });
+		cursor = cursor.parentGoalId ? goalsById.get(cursor.parentGoalId) : undefined;
+	}
+	return goal;
+}
+
+/** Read the durable mode plus freshly recomputed promotion eligibility for the
+ * proposal-owning session. Coordinate fields are display-only. */
+export async function fetchGoalWorktreeMode(sessionId: string): Promise<GoalWorktreeModeProjection> {
+	const res = await gatewayFetch(`/api/sessions/${encodeURIComponent(sessionId)}/proposal/goal/worktree-mode`);
+	if (!res.ok) throw await errorFromResponse(res, `Failed to load worktree mode: ${res.status}`);
+	const body = await res.json() as any;
+	const eligibility = body?.eligibility && typeof body.eligibility === "object" ? body.eligibility : body;
+	const coordinates = eligibility?.coordinates && typeof eligibility.coordinates === "object"
+		? eligibility.coordinates
+		: body?.coordinates && typeof body.coordinates === "object" ? body.coordinates
+			: eligibility?.workspace && typeof eligibility.workspace === "object" ? eligibility.workspace
+				: body?.workspace && typeof body.workspace === "object" ? body.workspace : eligibility;
+	const rawMode = body?.mode ?? eligibility?.mode;
+	const componentCount = Number.isFinite(coordinates?.componentCount)
+		? Number(coordinates.componentCount)
+		: Array.isArray(coordinates?.components) ? coordinates.components.length
+			: coordinates?.repoWorktrees && typeof coordinates.repoWorktrees === "object" ? Object.keys(coordinates.repoWorktrees).length : undefined;
+	return {
+		mode: rawMode === "current-session" ? "current-session" : "new-worktree",
+		eligible: eligibility?.eligible === true,
+		...(typeof eligibility?.reason === "string" && eligibility.reason ? { reason: eligibility.reason } : {}),
+		...(typeof coordinates?.branch === "string" && coordinates.branch ? { branch: coordinates.branch } : {}),
+		...(typeof coordinates?.worktreePath === "string" && coordinates.worktreePath ? { worktreePath: coordinates.worktreePath } : {}),
+		...(componentCount !== undefined ? { componentCount } : {}),
+		...(typeof coordinates?.sandboxed === "boolean" ? { sandboxed: coordinates.sandboxed } : {}),
+	};
+}
+
+/** Persist only the human-owned mode. The server derives all promotion
+ * authority from the proposal owner and broadcasts the rewritten draft. */
+export async function updateGoalWorktreeMode(sessionId: string, mode: GoalWorktreeMode): Promise<GoalWorktreeModeProjection> {
+	const res = await gatewayFetch(`/api/sessions/${encodeURIComponent(sessionId)}/proposal/goal/worktree-mode`, {
+		method: "PUT",
+		body: JSON.stringify({ mode }),
+	});
+	if (!res.ok) throw await errorFromResponse(res, `Failed to update worktree mode: ${res.status}`);
+	const body = await res.json().catch(() => ({})) as any;
+	const eligibility = body?.eligibility && typeof body.eligibility === "object" ? body.eligibility : body;
+	const coordinates = eligibility?.coordinates && typeof eligibility.coordinates === "object" ? eligibility.coordinates : eligibility;
+	return {
+		mode: body?.mode === "current-session" ? "current-session" : mode,
+		eligible: eligibility?.eligible === true,
+		...(typeof eligibility?.reason === "string" && eligibility.reason ? { reason: eligibility.reason } : {}),
+		...(typeof coordinates?.branch === "string" && coordinates.branch ? { branch: coordinates.branch } : {}),
+		...(typeof coordinates?.worktreePath === "string" && coordinates.worktreePath ? { worktreePath: coordinates.worktreePath } : {}),
+		...(Number.isFinite(coordinates?.componentCount) ? { componentCount: Number(coordinates.componentCount) } : {}),
+		...(typeof coordinates?.sandboxed === "boolean" ? { sandboxed: coordinates.sandboxed } : {}),
+	};
+}
+
+/** Accept a current-session proposal without sending any session, project,
+ * branch, worktree, repository, sandbox, or cwd authority. */
+export async function acceptGoalProposalInCurrentSession(
+	sessionId: string,
+	title: string,
+	opts: CurrentSessionGoalAcceptOptions = {},
+): Promise<Goal | null> {
+	try {
+		const body: Record<string, unknown> = { title, spec: opts.spec ?? "" };
+		if (opts.workflowId) body.workflowId = opts.workflowId;
+		if (opts.enabledOptionalSteps?.length) body.enabledOptionalSteps = opts.enabledOptionalSteps;
+		if (opts.workflow !== undefined) body.workflow = opts.workflow;
+		if (opts.inlineRoles && Object.keys(opts.inlineRoles).length > 0) body.inlineRoles = opts.inlineRoles;
+		if (opts.subgoalsAllowed !== undefined) body.subgoalsAllowed = opts.subgoalsAllowed;
+		if (opts.maxNestingDepth !== undefined) body.maxNestingDepth = opts.maxNestingDepth;
+		if (opts.divergencePolicy !== undefined) body.divergencePolicy = opts.divergencePolicy;
+		if (opts.maxConcurrentChildren !== undefined) body.maxConcurrentChildren = opts.maxConcurrentChildren;
+		if (opts.parentGoalId) body.parentGoalId = opts.parentGoalId;
+		if (opts.metadata && Object.keys(opts.metadata).length > 0) body.metadata = opts.metadata;
+		const res = await gatewayFetch(`/api/sessions/${encodeURIComponent(sessionId)}/proposal/goal/accept`, {
+			method: "POST",
+			body: JSON.stringify(body),
+		});
+		if (!res.ok) throw await errorFromResponse(res, `Failed to promote session: ${res.status}`);
+		const responseBody = await res.json() as Goal | { goal: Goal };
+		const goal = "goal" in responseBody ? responseBody.goal : responseBody;
+		return await finishGoalCreate(goal);
+	} catch (err) {
+		const { message, code, stack } = errorDetails(err);
+		showConnectionError("Failed to promote session", message, { code, stack });
+		return null;
+	}
+}
+
 export async function createGoal(title: string, cwd: string, opts?: { spec?: string; workflowId?: string; reattemptOf?: string; sandboxed?: boolean; projectId?: string; enabledOptionalSteps?: string[]; autoStartTeam?: boolean; workflow?: unknown; inlineRoles?: Record<string, unknown>; subgoalsAllowed?: boolean; maxNestingDepth?: number; divergencePolicy?: "strict" | "balanced" | "autonomous"; maxConcurrentChildren?: number; parentGoalId?: string; metadata?: Record<string, unknown> }): Promise<Goal | null> {
 	const { spec = "", workflowId, reattemptOf, sandboxed, projectId, enabledOptionalSteps, autoStartTeam, workflow, inlineRoles, subgoalsAllowed, maxNestingDepth, divergencePolicy, maxConcurrentChildren, parentGoalId, metadata } = opts ?? {};
 	try {
@@ -2041,16 +2154,7 @@ export async function createGoal(title: string, cwd: string, opts?: { spec?: str
 		});
 		if (!res.ok) throw await errorFromResponse(res, `Failed to create goal: ${res.status}`);
 		const goal = await res.json() as Goal;
-		await refreshSessions();
-		const goalsById = new Map(state.goals.map(g => [g.id, g]));
-		let cursor: Goal | undefined = goalsById.get(goal.id) ?? goal;
-		const seenGoalIds = new Set<string>();
-		while (cursor && !seenGoalIds.has(cursor.id)) {
-			seenGoalIds.add(cursor.id);
-			expandSidebarTreeNode({ kind: "goal", goalId: cursor.id }, { explicit: false });
-			cursor = cursor.parentGoalId ? goalsById.get(cursor.parentGoalId) : undefined;
-		}
-		return goal;
+		return await finishGoalCreate(goal);
 	} catch (err) {
 		const { message, code, stack } = errorDetails(err);
 		showConnectionError("Failed to create goal", message, { code, stack });

--- a/src/app/proposal-panels.ts
+++ b/src/app/proposal-panels.ts
@@ -14,9 +14,12 @@ import { Button } from "@mariozechner/mini-lit/dist/Button.js";
 import { Input } from "@mariozechner/mini-lit/dist/Input.js";
 import { Check, Copy, Eye, FolderOpen, Goal as GoalIcon, Minus, Pencil, Plus, UserCheck, Users, Wrench } from "lucide";
 
-import { state, renderApp, setProjects, activeSessionId, isProposalStreaming } from "./state.js";
+import { state, renderApp, setProjects, activeSessionId, isProposalStreaming, type GoalWorktreeMode, type GoalWorktreeModeProjection } from "./state.js";
 import {
 	createGoal,
+	acceptGoalProposalInCurrentSession,
+	fetchGoalWorktreeMode,
+	updateGoalWorktreeMode,
 	createRole,
 	gatewayFetch,
 	refreshSessions,
@@ -652,6 +655,78 @@ const projectOuterScrollRef = createRef<HTMLDivElement>();
 // SHARED GOAL FORM
 // ============================================================================
 
+const _goalWorktreeModeFetching = new Set<string>();
+
+/** Proposal ownership is fixed by the slot (or historical tab source), never by
+ * whichever chat tab happens to be active. */
+function goalProposalOwnerSessionId(): string | undefined {
+	if (_proposalOverride?.type === "goal" && _proposalOverrideSessionId) return _proposalOverrideSessionId;
+	return state.activeProposals.goal?.sessionId;
+}
+
+function parsedGoalWorktreeMode(fields: Record<string, unknown> | undefined): GoalWorktreeMode {
+	return fields?.worktreeMode === "current-session" ? "current-session" : "new-worktree";
+}
+
+function goalProposalWorktreeMode(): GoalWorktreeMode {
+	return parsedGoalWorktreeMode(activeGoalProposalFormSnapshot() as Record<string, unknown> | undefined);
+}
+
+function ensureGoalWorktreeModeProjection(ownerSessionId: string | undefined): void {
+	if (!ownerSessionId || state.goalWorktreeModeBySession[ownerSessionId] || _goalWorktreeModeFetching.has(ownerSessionId)) return;
+	_goalWorktreeModeFetching.add(ownerSessionId);
+	state.goalWorktreeModeBySession[ownerSessionId] = {
+		mode: goalProposalWorktreeMode(),
+		eligible: false,
+		loading: true,
+	};
+	void fetchGoalWorktreeMode(ownerSessionId).then((projection) => {
+		state.goalWorktreeModeBySession[ownerSessionId] = projection;
+	}).catch(() => {
+		state.goalWorktreeModeBySession[ownerSessionId] = {
+			mode: goalProposalWorktreeMode(),
+			eligible: false,
+			reason: "Current session unavailable — eligibility could not be verified.",
+		};
+	}).finally(() => {
+		_goalWorktreeModeFetching.delete(ownerSessionId);
+		renderApp();
+	});
+}
+
+async function persistGoalWorktreeMode(ownerSessionId: string, mode: GoalWorktreeMode): Promise<void> {
+	const liveFields = state.activeProposals.goal?.sessionId === ownerSessionId
+		? state.activeProposals.goal.fields
+		: undefined;
+	const historicalFields = _proposalOverride?.type === "goal" && _proposalOverrideSessionId === ownerSessionId
+		? _proposalOverride.fields
+		: undefined;
+	const targetFields = historicalFields ?? liveFields;
+	if (!targetFields) return;
+	const hadMode = Object.prototype.hasOwnProperty.call(targetFields, "worktreeMode");
+	const previousMode = targetFields.worktreeMode;
+	if (mode === "new-worktree") delete targetFields.worktreeMode;
+	else targetFields.worktreeMode = mode;
+	const previousProjection = state.goalWorktreeModeBySession[ownerSessionId];
+	if (previousProjection) state.goalWorktreeModeBySession[ownerSessionId] = { ...previousProjection, mode };
+	_proposalInitializedFrom = null;
+	renderApp();
+	try {
+		await updateGoalWorktreeMode(ownerSessionId, mode);
+		// PUT rewrites the draft; GET gives the latest authoritative eligibility.
+		state.goalWorktreeModeBySession[ownerSessionId] = await fetchGoalWorktreeMode(ownerSessionId);
+	} catch (err) {
+		if (hadMode) targetFields.worktreeMode = previousMode;
+		else delete targetFields.worktreeMode;
+		state.goalWorktreeModeBySession[ownerSessionId] = previousProjection;
+		const { message, code, stack } = errorDetails(err);
+		showConnectionError("Failed to update worktree mode", message, { code, stack });
+	} finally {
+		_proposalInitializedFrom = null;
+		renderApp();
+	}
+}
+
 interface GoalFormConfig {
 	// Field values
 	title: string;
@@ -662,6 +737,11 @@ interface GoalFormConfig {
 	specEditMode: boolean;
 	enabledOptionalSteps: string[];
 	linkedProjectId?: string;
+	/** Durable selection from the proposal draft (absent defaults to new-worktree). */
+	worktreeMode?: GoalWorktreeMode;
+	/** Recomputed, display-only eligibility for the proposal owner. */
+	worktreeModeProjection?: GoalWorktreeModeProjection;
+	onWorktreeModeChange?: (mode: GoalWorktreeMode) => void;
 
 	/** Cross-project "Proposing into <Target>" banner (design §7). Rendered at the
 	 *  very top of the form when the goal targets a project other than the
@@ -1151,6 +1231,12 @@ function renderGoalForm(config: GoalFormConfig) {
 	if (wf && config.linkedProjectId) ensureQaConfigLoaded(config.linkedProjectId);
 	if (config.linkedProjectId) ensureProjectComponentsLoaded(config.linkedProjectId);
 	const componentSummary = config.linkedProjectId ? _projectComponentsCache.get(config.linkedProjectId) : undefined;
+	const worktreeMode = config.worktreeMode ?? "new-worktree";
+	const promotion = config.worktreeModeProjection;
+	const currentMode = worktreeMode === "current-session";
+	const currentUnavailable = currentMode && (!promotion || promotion.loading || !promotion.eligible);
+	const selectedBranch = currentMode ? (promotion?.branch || "Unavailable") : "Generated for this goal";
+	const selectedWorktreePath = currentMode ? (promotion?.worktreePath || "Unavailable") : worktreePath;
 	const optionalSteps: Array<{name: string; label: string; description?: string; type?: string}> = [];
 	if (wf) {
 		for (const gate of wf.gates) {
@@ -1173,7 +1259,7 @@ function renderGoalForm(config: GoalFormConfig) {
 	const lblCls = "text-xs text-muted-foreground font-medium shrink-0";
 
 	const createBusy = !!config.saving;
-	const createDisabled = (config.createDisabled ?? !config.title.trim()) || createBusy || !!config.streaming || noWorkflows || workflowProblem;
+	const createDisabled = (config.createDisabled ?? !config.title.trim()) || createBusy || !!config.streaming || noWorkflows || workflowProblem || currentUnavailable;
 
 	queueMicrotask(() => {
 		reconcileFollowTail(goalSpecPreviewRef.value);
@@ -1251,22 +1337,61 @@ function renderGoalForm(config: GoalFormConfig) {
 				` : ""}
 			</div>
 			${linkedProject ? html`
-				<div class="flex items-center gap-2 text-[11px] text-muted-foreground min-w-0">
-					<span class="${lblCls} w-20 md:w-16">Worktree</span>
-					<span class="truncate flex-1 min-w-0" title=${linkedProject.rootPath + ' → ' + worktreePath}>
-						<span class="font-medium text-foreground/80">${linkedProject.name}</span>
-						<code class="text-[10px] font-mono opacity-80 ml-1">${worktreePath}</code>
-					</span>
-				</div>
-				${componentSummary?.multiRepo ? html`
-					<div class="flex items-center gap-2 text-[11px] text-muted-foreground min-w-0" data-testid="multi-repo-indicator">
-						<span class="${lblCls} w-20 md:w-16"></span>
-						<span class="truncate flex-1 min-w-0 text-amber-600 dark:text-amber-400">
-							Will create ${componentSummary.componentCount} worktree${componentSummary.componentCount === 1 ? "" : "s"}
-							across ${componentSummary.repoCount} repo${componentSummary.repoCount === 1 ? "" : "s"}.
-						</span>
+				<div class="flex items-start gap-2 min-w-0">
+					<span class="${lblCls} w-20 md:w-16 mt-2" id="goal-worktree-label">Worktree</span>
+					<div class="flex-1 min-w-0 flex flex-col gap-1.5">
+						<div class="flex flex-wrap items-center gap-2 min-w-0">
+							<div
+								class="inline-flex rounded-md border border-border overflow-hidden bg-background"
+								role="radiogroup"
+								aria-labelledby="goal-worktree-label"
+								aria-describedby="goal-worktree-description goal-worktree-coordinates goal-worktree-reason"
+								data-testid="goal-form-worktree-mode"
+							>
+								<label class="relative inline-flex items-center justify-center min-w-[126px] h-9 px-3 text-xs font-medium cursor-pointer ${!currentMode ? "bg-primary text-primary-foreground" : "bg-background text-muted-foreground hover:bg-secondary hover:text-foreground"}">
+									<input class="absolute w-px h-px [clip-path:inset(50%)]" type="radio" name="goal-worktree-mode" value="new-worktree"
+										.checked=${!currentMode}
+										?disabled=${createBusy}
+										data-testid="goal-form-worktree-new"
+										@change=${() => config.onWorktreeModeChange?.("new-worktree")} />
+									<span>New worktree</span>
+								</label>
+								<label aria-disabled=${promotion?.eligible && !promotion.loading ? "false" : "true"}
+									class="relative inline-flex items-center justify-center min-w-[126px] h-9 px-3 border-l border-border text-xs font-medium ${currentMode ? "bg-primary text-primary-foreground" : promotion?.eligible && !promotion.loading ? "bg-background text-muted-foreground hover:bg-secondary hover:text-foreground cursor-pointer" : "bg-muted text-muted-foreground opacity-70 cursor-not-allowed"}">
+									<input class="absolute w-px h-px [clip-path:inset(50%)]" type="radio" name="goal-worktree-mode" value="current-session"
+										.checked=${currentMode}
+										?disabled=${createBusy || !promotion?.eligible || !!promotion?.loading}
+										data-testid="goal-form-worktree-current-session"
+										@change=${() => config.onWorktreeModeChange?.("current-session")} />
+									<span>Current session</span>
+								</label>
+							</div>
+							<span class="text-[11px] text-muted-foreground truncate"><strong class="font-medium text-foreground/80">${linkedProject.name}</strong></span>
+						</div>
+						<div class="rounded-md border border-border bg-muted/40 px-2.5 py-2 min-w-0" data-testid="goal-form-worktree-summary">
+							<p class="text-[11px] leading-snug text-foreground mb-1.5" id="goal-worktree-description">
+								${currentMode
+									? "This session becomes the goal lead in place. Its checkout, transcript, and sandbox stay unchanged."
+									: "Bobbit will create a dedicated branch and worktree for the goal."}
+							</p>
+							<dl class="grid grid-cols-[45px_minmax(0,1fr)] gap-x-2 gap-y-0.5 text-[10px] leading-snug" id="goal-worktree-coordinates">
+								<dt class="text-muted-foreground">Mode</dt><dd class="m-0 text-foreground">${currentMode ? "Current session" : "New worktree"}</dd>
+								<dt class="text-muted-foreground">Branch</dt><dd class="m-0 font-mono text-foreground break-all" data-testid="goal-form-worktree-branch">${selectedBranch}</dd>
+								<dt class="text-muted-foreground">Path</dt><dd class="m-0 font-mono text-foreground break-all" data-testid="goal-form-worktree-path">${selectedWorktreePath}</dd>
+								${currentMode && promotion?.componentCount ? html`<dt class="text-muted-foreground">Repos</dt><dd class="m-0 text-foreground">${promotion.componentCount} component worktree${promotion.componentCount === 1 ? "" : "s"}</dd>` : ""}
+							</dl>
+						</div>
+						<p id="goal-worktree-reason" class="text-[11px] leading-snug text-muted-foreground" aria-live="polite" data-testid="goal-form-worktree-current-unavailable">
+							${promotion?.loading ? "Checking whether this session can be reused…" : !promotion?.eligible ? (promotion?.reason || "Current session is unavailable for this proposal.") : ""}
+						</p>
+						${!currentMode && componentSummary?.multiRepo ? html`
+							<div class="text-[11px] text-muted-foreground text-amber-600 dark:text-amber-400" data-testid="multi-repo-indicator">
+								Will create ${componentSummary.componentCount} worktree${componentSummary.componentCount === 1 ? "" : "s"}
+								across ${componentSummary.repoCount} repo${componentSummary.repoCount === 1 ? "" : "s"}.
+							</div>
+						` : ""}
 					</div>
-				` : ""}
+				</div>
 			` : html`
 				<div class="flex items-start gap-2">
 					<label class="${lblCls} w-20 md:w-16 mt-2">Directory</label>
@@ -1285,22 +1410,23 @@ function renderGoalForm(config: GoalFormConfig) {
 				</div>
 			`}
 			<div class="flex flex-wrap items-center gap-x-4 gap-y-1.5 pt-0.5">
-				${sandboxConfigured ? html`
-					<label class="flex items-center gap-1.5 cursor-pointer ${!sandboxAvailable ? "opacity-40 pointer-events-none" : ""}">
-						<input type="checkbox" class="toggle-switch" .checked=${config.sandboxed}
-							?disabled=${!sandboxAvailable}
+				${sandboxConfigured || currentMode ? html`
+					<label class="flex items-center gap-1.5 ${currentMode || !sandboxAvailable ? "opacity-50 cursor-not-allowed" : "cursor-pointer"}">
+						<input type="checkbox" class="toggle-switch" .checked=${currentMode ? (promotion?.sandboxed ?? config.sandboxed) : config.sandboxed}
+							?disabled=${currentMode || !sandboxAvailable}
 							@change=${config.onSandboxChange} />
-						<span class="text-xs text-muted-foreground font-medium">Sandbox</span>
+						<span class="text-xs text-muted-foreground font-medium">Sandbox${currentMode ? " (inherited)" : ""}</span>
 						<span title=${!sandboxAvailable
 							? "Docker sandbox is configured but unavailable — check Docker status and image in Settings"
 							: "Runs each team agent in an isolated Docker container with restricted filesystem and network access"}
 							class="text-[9px] text-muted-foreground cursor-help">ⓘ</span>
 					</label>
 				` : ""}
-				<label class="flex items-center gap-1.5 cursor-pointer">
+				<label class="flex items-center gap-1.5 ${currentMode ? "opacity-50 cursor-not-allowed" : "cursor-pointer"}">
 					<input type="checkbox" class="toggle-switch" .checked=${config.autoStartTeam}
+						?disabled=${currentMode}
 						@change=${config.onAutoStartTeamChange} />
-					<span class="text-xs text-muted-foreground font-medium">Auto-start team</span>
+					<span class="text-xs text-muted-foreground font-medium">Auto-start team${currentMode ? " (already the lead)" : ""}</span>
 					<span title="Automatically start the team lead when the worktree is ready"
 						class="text-[9px] text-muted-foreground cursor-help">ⓘ</span>
 				</label>
@@ -1779,6 +1905,10 @@ function goalPreviewPanel() {
 	// re-attempt, and project-scoped goal creation stay behaviorally equivalent
 	// to the non-assistant proposal panel.
 	syncProposalFormState();
+	const worktreeOwnerSessionId = goalProposalOwnerSessionId();
+	ensureGoalWorktreeModeProjection(worktreeOwnerSessionId);
+	const worktreeMode = goalProposalWorktreeMode();
+	const worktreeModeProjection = worktreeOwnerSessionId ? state.goalWorktreeModeBySession[worktreeOwnerSessionId] : undefined;
 	ensureWorkflowsLoaded(state.previewProjectId || undefined);
 	ensureSandboxStatusLoaded();
 	ensureProposalRolesLoaded();
@@ -1825,7 +1955,7 @@ function goalPreviewPanel() {
 		// Snapshot form state up-front so a retry after createGoal() rejection
 		// reads the latest values (the user may have edited the workflow id /
 		// title between attempts).
-		const sessionId = activeSessionId();
+		const sessionId = worktreeOwnerSessionId;
 		const projectId = state.previewProjectId || undefined;
 		const inlineRolesField = Object.keys(_proposalInlineRoles).length > 0
 			? _proposalInlineRoles as Record<string, unknown>
@@ -1862,23 +1992,28 @@ function goalPreviewPanel() {
 		let goal;
 		try {
 			const submitCwd = isHeadquartersProject(projectId) && !state.previewCwdEdited ? "" : state.previewCwd.trim();
-			goal = await createGoal(trimmedTitle, submitCwd, {
+			const commonFields = {
 				spec: state.previewSpec,
 				workflowId,
 				workflow: inlineWorkflowField,
 				inlineRoles: inlineRolesField,
-				reattemptOf: reattemptGoalId || undefined,
-				sandboxed,
-				projectId,
 				enabledOptionalSteps,
-				autoStartTeam,
 				parentGoalId: parentGoalIdField,
 				subgoalsAllowed: subgoalSubmission.subgoalsAllowed,
 				maxNestingDepth: subgoalSubmission.maxNestingDepth,
 				divergencePolicy: divergencePolicyField,
 				maxConcurrentChildren: maxConcurrentChildrenField,
 				metadata: metadataRowsToObject(state.previewMetadataRows),
-			});
+			};
+			goal = worktreeMode === "current-session" && worktreeOwnerSessionId
+				? await acceptGoalProposalInCurrentSession(worktreeOwnerSessionId, trimmedTitle, commonFields)
+				: await createGoal(trimmedTitle, submitCwd, {
+					...commonFields,
+					reattemptOf: reattemptGoalId || undefined,
+					sandboxed,
+					projectId,
+					autoStartTeam,
+				});
 		} catch (err) {
 			const { message, code, stack } = errorDetails(err);
 			showConnectionError("Failed to create goal", message, { code, stack });
@@ -1972,6 +2107,9 @@ function goalPreviewPanel() {
 				enabledOptionalSteps: _assistantEnabledOptionalSteps,
 				crossProjectBanner: crossProjectBanner("goal", state.activeProposals.goal?.sessionId ?? activeSessionId()),
 				linkedProjectId: state.previewProjectId || undefined,
+				worktreeMode,
+				worktreeModeProjection,
+				onWorktreeModeChange: worktreeOwnerSessionId ? (mode) => { void persistGoalWorktreeMode(worktreeOwnerSessionId, mode); } : undefined,
 				workflowState: workflowStateFor(state.previewProjectId || undefined),
 				workflowErrorMessage,
 				workflowValidationFailed: !!workflowValidationError,
@@ -3950,6 +4088,7 @@ function projectLegacyToComponents(fields: Record<string, unknown>): Record<stri
 
 type GoalProposalFormSnapshot = {
 	title: string; spec: string; cwd?: string; workflow?: string; options?: string;
+	worktreeMode?: GoalWorktreeMode;
 	parentGoalId?: string; inlineWorkflow?: Workflow; inlineRoles?: Record<string, RoleData>;
 	subgoalsAllowed?: boolean; maxNestingDepth?: number;
 	divergencePolicy?: "strict" | "balanced" | "autonomous"; maxConcurrentChildren?: number;
@@ -3964,7 +4103,7 @@ function activeGoalProposalFormSnapshot(): GoalProposalFormSnapshot | undefined 
 }
 
 function goalProposalFormIdentityKey(proposal: GoalProposalFormSnapshot, workflowValidationKey: string): string {
-	return `${proposal.title}|${proposal.spec}|${proposal.cwd || ""}|${proposal.workflow || ""}|${proposal.options || ""}|${proposal.parentGoalId || ""}|${proposal.subgoalsAllowed ?? ""}|${proposal.maxNestingDepth ?? ""}|${proposal.divergencePolicy ?? ""}|${proposal.maxConcurrentChildren ?? ""}|${proposal.metadata ? JSON.stringify(proposal.metadata) : ""}|${workflowValidationKey}`;
+	return `${proposal.title}|${proposal.spec}|${proposal.cwd || ""}|${proposal.workflow || ""}|${proposal.options || ""}|${proposal.worktreeMode || ""}|${proposal.parentGoalId || ""}|${proposal.subgoalsAllowed ?? ""}|${proposal.maxNestingDepth ?? ""}|${proposal.divergencePolicy ?? ""}|${proposal.maxConcurrentChildren ?? ""}|${proposal.metadata ? JSON.stringify(proposal.metadata) : ""}|${workflowValidationKey}`;
 }
 
 function activeGoalProposalFormIdentityKey(): string | null {
@@ -4074,6 +4213,10 @@ function goalProposalPanel() {
 	}
 	useGoalProposalTabsContext(goalProposalTabsContextKey("proposal"));
 	syncProposalFormState();
+	const worktreeOwnerSessionId = goalProposalOwnerSessionId();
+	ensureGoalWorktreeModeProjection(worktreeOwnerSessionId);
+	const worktreeMode = goalProposalWorktreeMode();
+	const worktreeModeProjection = worktreeOwnerSessionId ? state.goalWorktreeModeBySession[worktreeOwnerSessionId] : undefined;
 	ensureWorkflowsLoaded(state.previewProjectId || undefined);
 	ensureSandboxStatusLoaded();
 	ensureProposalRolesLoaded();
@@ -4161,22 +4304,27 @@ function goalProposalPanel() {
 				const inlineRolesField = Object.keys(_proposalInlineRoles).length > 0
 					? _proposalInlineRoles as Record<string, unknown>
 					: undefined;
-				goal = await createGoal(trimmedTitle, _proposalCwd.trim(), {
+				const commonFields = {
 					spec: _proposalSpec,
 					workflowId: inlineWorkflowField ? undefined : workflowId,
 					workflow: inlineWorkflowField,
 					inlineRoles: inlineRolesField,
-					sandboxed,
-					projectId,
 					enabledOptionalSteps,
-					autoStartTeam,
 					parentGoalId: parentGoalIdField,
 					subgoalsAllowed: subgoalsAllowedField,
 					maxNestingDepth: maxNestingDepthField,
 					divergencePolicy: divergencePolicyField,
 					maxConcurrentChildren: maxConcurrentChildrenField,
 					metadata: metadataRowsToObject(_proposalMetadataRows),
-				});
+				};
+				goal = worktreeMode === "current-session" && worktreeOwnerSessionId
+					? await acceptGoalProposalInCurrentSession(worktreeOwnerSessionId, trimmedTitle, commonFields)
+					: await createGoal(trimmedTitle, _proposalCwd.trim(), {
+						...commonFields,
+						sandboxed,
+						projectId,
+						autoStartTeam,
+					});
 			} catch (err) {
 				const { message, code, stack } = errorDetails(err);
 				showConnectionError("Failed to create goal", message, { code, stack });
@@ -4184,7 +4332,7 @@ function goalProposalPanel() {
 			}
 			if (!goal) return;
 
-			const proposalSessionId = state.activeProposals.goal?.sessionId ?? activeSessionId();
+			const proposalSessionId = worktreeOwnerSessionId;
 
 			// --- Success: clear the proposal and navigate. ---
 			if (proposalSessionId) clearProposalAnnotations(proposalSessionId, "goal");
@@ -4203,7 +4351,9 @@ function goalProposalPanel() {
 			_proposalMetadataRows = [];
 			resetProposalTabsState();
 			await closeCurrentProposalPanel("goal", proposalSessionId);
-			if (proposalSessionId) void deleteProposalFile(proposalSessionId, "goal");
+			// Current-session acceptance owns its atomic draft clear on the server;
+			// the ordinary path keeps the existing client DELETE unchanged.
+			if (proposalSessionId && worktreeMode === "new-worktree") void deleteProposalFile(proposalSessionId, "goal");
 			setHashRoute("goal-dashboard", goal.id, true);
 		} finally {
 			_proposalSaving = false;
@@ -4270,6 +4420,9 @@ function goalProposalPanel() {
 		enabledOptionalSteps: _proposalEnabledOptionalSteps,
 		crossProjectBanner: crossProjectBanner("goal", state.activeProposals.goal?.sessionId ?? activeSessionId()),
 		linkedProjectId: state.previewProjectId || undefined,
+		worktreeMode,
+		worktreeModeProjection,
+		onWorktreeModeChange: worktreeOwnerSessionId ? (mode) => { void persistGoalWorktreeMode(worktreeOwnerSessionId, mode); } : undefined,
 		workflowState: workflowStateFor(state.previewProjectId || undefined),
 		workflowErrorMessage,
 		workflowValidationFailed: !!workflowValidationError,

--- a/src/app/proposal-panels.ts
+++ b/src/app/proposal-panels.ts
@@ -655,7 +655,8 @@ const projectOuterScrollRef = createRef<HTMLDivElement>();
 // SHARED GOAL FORM
 // ============================================================================
 
-const _goalWorktreeModeFetching = new Set<string>();
+const _goalWorktreeModeFetchIdBySession = new Map<string, number>();
+let _goalWorktreeModeNextFetchId = 0;
 
 /** Proposal ownership is fixed by the slot (or historical tab source), never by
  * whichever chat tab happens to be active. */
@@ -672,26 +673,70 @@ function goalProposalWorktreeMode(): GoalWorktreeMode {
 	return parsedGoalWorktreeMode(activeGoalProposalFormSnapshot() as Record<string, unknown> | undefined);
 }
 
-function ensureGoalWorktreeModeProjection(ownerSessionId: string | undefined): void {
-	if (!ownerSessionId || state.goalWorktreeModeBySession[ownerSessionId] || _goalWorktreeModeFetching.has(ownerSessionId)) return;
-	_goalWorktreeModeFetching.add(ownerSessionId);
+async function refreshGoalWorktreeModeProjection(
+	ownerSessionId: string,
+	options: { force?: boolean } = {},
+): Promise<GoalWorktreeModeProjection | undefined> {
+	if (!options.force && _goalWorktreeModeFetchIdBySession.has(ownerSessionId)) return undefined;
+	const fetchId = ++_goalWorktreeModeNextFetchId;
+	const invalidationRevision = state.goalWorktreeModeRevisionBySession[ownerSessionId] ?? 0;
+	_goalWorktreeModeFetchIdBySession.set(ownerSessionId, fetchId);
 	state.goalWorktreeModeBySession[ownerSessionId] = {
 		mode: goalProposalWorktreeMode(),
 		eligible: false,
 		loading: true,
 	};
-	void fetchGoalWorktreeMode(ownerSessionId).then((projection) => {
+	renderApp();
+	try {
+		const projection = await fetchGoalWorktreeMode(ownerSessionId);
+		// A newer forced read or a canonical session snapshot change supersedes
+		// this response. Never reinstall eligibility computed before that event.
+		if (_goalWorktreeModeFetchIdBySession.get(ownerSessionId) !== fetchId
+			|| (state.goalWorktreeModeRevisionBySession[ownerSessionId] ?? 0) !== invalidationRevision) {
+			return undefined;
+		}
 		state.goalWorktreeModeBySession[ownerSessionId] = projection;
-	}).catch(() => {
-		state.goalWorktreeModeBySession[ownerSessionId] = {
+		return projection;
+	} catch {
+		if (_goalWorktreeModeFetchIdBySession.get(ownerSessionId) !== fetchId
+			|| (state.goalWorktreeModeRevisionBySession[ownerSessionId] ?? 0) !== invalidationRevision) {
+			return undefined;
+		}
+		const unavailable: GoalWorktreeModeProjection = {
 			mode: goalProposalWorktreeMode(),
 			eligible: false,
 			reason: "Current session unavailable — eligibility could not be verified.",
 		};
-	}).finally(() => {
-		_goalWorktreeModeFetching.delete(ownerSessionId);
+		state.goalWorktreeModeBySession[ownerSessionId] = unavailable;
+		return unavailable;
+	} finally {
+		if (_goalWorktreeModeFetchIdBySession.get(ownerSessionId) === fetchId) {
+			_goalWorktreeModeFetchIdBySession.delete(ownerSessionId);
+		}
 		renderApp();
-	});
+	}
+}
+
+function ensureGoalWorktreeModeProjection(ownerSessionId: string | undefined): void {
+	if (!ownerSessionId || state.goalWorktreeModeBySession[ownerSessionId] || _goalWorktreeModeFetchIdBySession.has(ownerSessionId)) return;
+	void refreshGoalWorktreeModeProjection(ownerSessionId);
+}
+
+/** UI backstop immediately before current-session acceptance. The server still
+ * performs the authoritative locked recheck; this prevents dispatch when the
+ * latest owner-scoped projection already says the source became ineligible. */
+async function revalidateCurrentSessionGoalPromotion(ownerSessionId: string | undefined): Promise<boolean> {
+	if (!ownerSessionId) {
+		showConnectionError("Current session is unavailable", "The proposal owner could not be verified.");
+		return false;
+	}
+	const projection = await refreshGoalWorktreeModeProjection(ownerSessionId, { force: true });
+	if (projection?.eligible) return true;
+	showConnectionError(
+		"Current session is unavailable",
+		projection?.reason || "Eligibility changed while it was being checked. Try again.",
+	);
+	return false;
 }
 
 async function persistGoalWorktreeMode(ownerSessionId: string, mode: GoalWorktreeMode): Promise<void> {
@@ -713,8 +758,9 @@ async function persistGoalWorktreeMode(ownerSessionId: string, mode: GoalWorktre
 	renderApp();
 	try {
 		await updateGoalWorktreeMode(ownerSessionId, mode);
-		// PUT rewrites the draft; GET gives the latest authoritative eligibility.
-		state.goalWorktreeModeBySession[ownerSessionId] = await fetchGoalWorktreeMode(ownerSessionId);
+		// PUT rewrites the draft; a fenced GET gives the latest authoritative
+		// eligibility without allowing an older response to survive invalidation.
+		await refreshGoalWorktreeModeProjection(ownerSessionId, { force: true });
 	} catch (err) {
 		if (hadMode) targetFields.worktreeMode = previousMode;
 		else delete targetFields.worktreeMode;
@@ -1991,6 +2037,12 @@ function goalPreviewPanel() {
 		// (e.g. change workflow) and try again. See goal spec §1.
 		let goal;
 		try {
+			if (worktreeMode === "current-session"
+				&& !(await revalidateCurrentSessionGoalPromotion(worktreeOwnerSessionId))) {
+				_goalPreviewSaving = false;
+				renderApp();
+				return;
+			}
 			const submitCwd = isHeadquartersProject(projectId) && !state.previewCwdEdited ? "" : state.previewCwd.trim();
 			const commonFields = {
 				spec: state.previewSpec,
@@ -4264,6 +4316,8 @@ function goalProposalPanel() {
 		let goal;
 		try {
 			try {
+				if (worktreeMode === "current-session"
+					&& !(await revalidateCurrentSessionGoalPromotion(worktreeOwnerSessionId))) return;
 				// Parent goal is meaningful only while the system Subgoals feature is
 				// enabled. A stale/auto-filled parentGoalId from a team-lead proposal
 				// must not be submitted while the Sub-goals tab is hidden/off; accepting

--- a/src/app/state.ts
+++ b/src/app/state.ts
@@ -69,6 +69,22 @@ export interface Project {
   position?: number;
 }
 
+export type GoalWorktreeMode = "new-worktree" | "current-session";
+
+/** Server-authoritative eligibility and coordinates for promoting a proposal's
+ * owner session in place. This is a UI projection only; the proposal draft's
+ * `worktreeMode` field remains the durable selection. */
+export interface GoalWorktreeModeProjection {
+	mode: GoalWorktreeMode;
+	eligible: boolean;
+	reason?: string;
+	branch?: string;
+	worktreePath?: string;
+	componentCount?: number;
+	sandboxed?: boolean;
+	loading?: boolean;
+}
+
 export interface GatewaySession {
 	id: string;
 	title: string;
@@ -450,6 +466,9 @@ export const state = {
 			rev: number;
 		}
 	>>,
+	/** Recomputed promotion eligibility keyed by proposal owner session. Never
+	 * used as draft durability or as authority for submitted coordinates. */
+	goalWorktreeModeBySession: {} as Record<string, GoalWorktreeModeProjection | undefined>,
 	activeProjectId: null as string | null,
 	/** Per-session flag set when the user accepts a registered-mode project
 	 *  proposal. The proposal panel uses this to render a "Changes Saved" view

--- a/src/app/state.ts
+++ b/src/app/state.ts
@@ -469,6 +469,10 @@ export const state = {
 	/** Recomputed promotion eligibility keyed by proposal owner session. Never
 	 * used as draft durability or as authority for submitted coordinates. */
 	goalWorktreeModeBySession: {} as Record<string, GoalWorktreeModeProjection | undefined>,
+	/** Monotonic invalidation fence for eligibility requests. A session snapshot
+	 * change deletes the display projection and increments this value so an older
+	 * in-flight GET cannot reinstall stale eligibility. */
+	goalWorktreeModeRevisionBySession: {} as Record<string, number | undefined>,
 	activeProjectId: null as string | null,
 	/** Per-session flag set when the user accepts a registered-mode project
 	 *  proposal. The proposal panel uses this to render a "Changes Saved" view
@@ -916,6 +920,18 @@ export function resetArchivedExpandState(): void {
 
 	// Free memory — archived sessions will be re-fetched on next toggle-on
 	state.archivedSessions = [];
+}
+
+// ============================================================================
+// GOAL PROMOTION PROJECTION INVALIDATION
+// ============================================================================
+
+/** Mark an owner's display-only promotion projection stale. The durable mode
+ * remains in the proposal draft; the proposal panel refetches eligibility on
+ * its next render. */
+export function invalidateGoalWorktreeModeProjection(sessionId: string): void {
+	delete state.goalWorktreeModeBySession[sessionId];
+	state.goalWorktreeModeRevisionBySession[sessionId] = (state.goalWorktreeModeRevisionBySession[sessionId] ?? 0) + 1;
 }
 
 // ============================================================================

--- a/src/server/agent/goal-manager.ts
+++ b/src/server/agent/goal-manager.ts
@@ -39,6 +39,38 @@ export interface GoalProvisionedContext {
 }
 
 /**
+ * Canonical workspace coordinates supplied only by the owner-scoped session
+ * promotion path. GoalManager copies them verbatim and never provisions,
+ * renames, sets up, or assumes ownership of the checkout.
+ */
+export interface AdoptedGoalWorkspace {
+	ownerSessionId: string;
+	cwd: string;
+	worktreePath: string;
+	branch: string;
+	repoPath: string;
+	repoWorktrees?: Record<string, string>;
+	sandboxed?: boolean;
+}
+
+function assertAdoptedGoalWorkspace(value: AdoptedGoalWorkspace): void {
+	for (const field of ["ownerSessionId", "cwd", "worktreePath", "branch", "repoPath"] as const) {
+		if (typeof value[field] !== "string" || value[field].length === 0) {
+			throw new Error(`GoalManager.createGoal: adoptedWorkspace.${field} must be a non-empty string`);
+		}
+	}
+	if (value.repoWorktrees !== undefined) {
+		if (!value.repoWorktrees || Array.isArray(value.repoWorktrees)
+			|| Object.values(value.repoWorktrees).some(pathValue => typeof pathValue !== "string" || pathValue.length === 0)) {
+			throw new Error("GoalManager.createGoal: adoptedWorkspace.repoWorktrees must contain non-empty string paths");
+		}
+	}
+	if (value.sandboxed !== undefined && typeof value.sandboxed !== "boolean") {
+		throw new Error("GoalManager.createGoal: adoptedWorkspace.sandboxed must be boolean");
+	}
+}
+
+/**
  * Sanitize a goal title into a valid git branch name.
  * Lowercase, replace non-alphanumeric with hyphens, truncate, trim.
  *
@@ -336,10 +368,16 @@ export class GoalManager {
 	 * Create a goal instantly — persists to disk and returns immediately.
 	 * Does NOT create the worktree. Call setupWorktree() separately after responding.
 	 */
-	async createGoal(title: string, cwd: string, opts?: { spec?: string; workflowId?: string; workflowStore?: WorkflowStore; resolvedWorkflow?: Workflow; sandboxed?: boolean; enabledOptionalSteps?: string[]; projectId?: string; parentGoalId?: string; inlineRoles?: Record<string, import("./role-store.js").Role>; subgoalsAllowed?: boolean; maxNestingDepth?: number; divergencePolicy?: "strict" | "balanced" | "autonomous"; maxConcurrentChildren?: number; metadata?: Record<string, unknown>; worktree?: boolean }): Promise<PersistedGoal> {
-		const { spec = "", workflowId, workflowStore = this.workflowStore, resolvedWorkflow, sandboxed, enabledOptionalSteps, projectId, parentGoalId, inlineRoles, subgoalsAllowed, maxNestingDepth, divergencePolicy, maxConcurrentChildren, metadata } = opts ?? {};
+	async createGoal(title: string, cwd: string, opts?: { spec?: string; workflowId?: string; workflowStore?: WorkflowStore; resolvedWorkflow?: Workflow; sandboxed?: boolean; enabledOptionalSteps?: string[]; projectId?: string; parentGoalId?: string; inlineRoles?: Record<string, import("./role-store.js").Role>; subgoalsAllowed?: boolean; maxNestingDepth?: number; divergencePolicy?: "strict" | "balanced" | "autonomous"; maxConcurrentChildren?: number; metadata?: Record<string, unknown>; worktree?: boolean; adoptedWorkspace?: AdoptedGoalWorkspace }): Promise<PersistedGoal> {
+		const { spec = "", workflowId, workflowStore = this.workflowStore, resolvedWorkflow, sandboxed, enabledOptionalSteps, projectId, parentGoalId, inlineRoles, subgoalsAllowed, maxNestingDepth, divergencePolicy, maxConcurrentChildren, metadata, adoptedWorkspace } = opts ?? {};
 		const team = true;
 		const headquartersGoal = isHeadquartersProject(projectId);
+		if (adoptedWorkspace) {
+			assertAdoptedGoalWorkspace(adoptedWorkspace);
+			if (headquartersGoal) {
+				throw new Error("GoalManager.createGoal: headquarters sessions cannot adopt a worktree");
+			}
+		}
 		const worktree = !headquartersGoal && opts?.worktree !== false;
 		const now = Date.now();
 		const id = randomUUID();
@@ -348,10 +386,10 @@ export class GoalManager {
 		// maxConcurrentChildren are root-only (not inherited).
 		const nesting = deriveNestingFields(id, parentGoalId, (gid) => this.store.get(gid));
 
-		let worktreePath: string | undefined;
-		let branch: string | undefined;
-		let repoPath: string | undefined;
-		let goalCwd = cwd;
+		let worktreePath: string | undefined = adoptedWorkspace?.worktreePath;
+		let branch: string | undefined = adoptedWorkspace?.branch;
+		let repoPath: string | undefined = adoptedWorkspace?.repoPath;
+		let goalCwd = adoptedWorkspace?.cwd ?? cwd;
 		let setupStatus: "ready" | "preparing" = "ready";
 
 		// Detect git repo root — needed for team operations even without a worktree.
@@ -361,7 +399,7 @@ export class GoalManager {
 		// `<rootPath>-wt/<branch>/`) ONLY when at least one component is a git repo
 		// root; otherwise it falls back to the single-repo `isGitRepo(cwd)` probe,
 		// and to no-worktree when that also fails (never throws).
-		if (!headquartersGoal) {
+		if (!headquartersGoal && !adoptedWorkspace) {
 			const components = projectId && this.componentsResolver ? this.componentsResolver(projectId) : undefined;
 			const projectRoot = projectId && this.projectRootResolver ? this.projectRootResolver(projectId) : undefined;
 			const configuredBaseRef = projectId && this.baseRefResolver ? this.baseRefResolver(projectId) : undefined;
@@ -370,7 +408,7 @@ export class GoalManager {
 		}
 
 		// Compute worktree path and branch (but don't create yet)
-		if (worktree && repoPath) {
+		if (!adoptedWorkspace && worktree && repoPath) {
 			branch = `goal/${toBranchName(title)}-${id.slice(0, 8)}`;
 			worktreePath = path.join(path.resolve(repoPath, "..", `${path.basename(repoPath)}-wt`), branch.replace(/\//g, "-"));
 			// Apply subdirectory offset: if project rootPath (cwd) is a subdirectory of the
@@ -389,11 +427,17 @@ export class GoalManager {
 			createdAt: now,
 			updatedAt: now,
 			worktreePath,
+			...(adoptedWorkspace ? {
+				worktreeOwnerSessionId: adoptedWorkspace.ownerSessionId,
+				repoWorktrees: adoptedWorkspace.repoWorktrees
+					? structuredClone(adoptedWorkspace.repoWorktrees)
+					: undefined,
+			} : {}),
 			branch,
 			repoPath,
 			team,
 			setupStatus,
-			sandboxed,
+			sandboxed: adoptedWorkspace ? adoptedWorkspace.sandboxed : sandboxed,
 		};
 
 		// Stamp projectId so subgoals don't need a parentGoalId-chain walk.
@@ -1003,6 +1047,12 @@ export class GoalManager {
 		const goal = this.store.get(id);
 		if (!goal) return false;
 		const archived = this.store.archive(id);
+		if (archived && goal.worktreeOwnerSessionId) {
+			// A promoted lead may be terminated immediately after this method
+			// returns. Publish the archival first so restart recovery cannot mistake
+			// that ordered shutdown for a partial promotion.
+			await this.store.flush();
+		}
 		if (archived) {
 			try {
 				await cleanupGateDiagnosticsForGoal(id, this.diagnosticsStateDir);
@@ -1134,6 +1184,25 @@ export class GoalManager {
 	/** Narrow explicit deletion because GoalStore.update deliberately ignores undefined fields. */
 	async clearSchedulerRecovery(id: string): Promise<boolean> {
 		return this.store.clearSchedulerRecovery(id);
+	}
+
+	/**
+	 * Compensate a promotion attempt only when the goal still carries the exact
+	 * source-session provenance. This deliberately removes metadata only: the
+	 * adopted checkout, branch, sandbox, transcript, and source session remain
+	 * owned by their original lifecycle and are never cleaned here.
+	 */
+	async deleteAdoptedGoalAttempt(id: string, ownerSessionId: string): Promise<boolean> {
+		const goal = this.store.get(id);
+		if (!goal || goal.archived || goal.state !== "todo" || goal.worktreeOwnerSessionId !== ownerSessionId) return false;
+		try {
+			await cleanupGateDiagnosticsForGoal(id, this.diagnosticsStateDir);
+		} catch (err) {
+			console.warn(`[goal-manager] Failed to clean gate diagnostics for compensated adopted goal ${id}:`, err);
+		}
+		this.store.remove(id);
+		await this.store.flush();
+		return true;
 	}
 
 	async deleteGoal(id: string): Promise<boolean> {

--- a/src/server/agent/goal-store.ts
+++ b/src/server/agent/goal-store.ts
@@ -35,6 +35,11 @@ export interface PersistedGoal {
 	updatedAt: number;
 	/** Git worktree path (if goal has its own worktree) */
 	worktreePath?: string;
+	/**
+	 * Session that owned this checkout before it was adopted by the goal.
+	 * Provenance/idempotency only: the session remains the worktree lifecycle owner.
+	 */
+	worktreeOwnerSessionId?: string;
 	/** Git branch name for this goal's worktree */
 	branch?: string;
 	/** The original repo path (for worktree cleanup) */
@@ -238,7 +243,7 @@ const SETUP_STATUSES = new Set<SetupStatus>(["ready", "preparing", "retrying", "
 const MERGE_TARGETS = new Set(["master", "parent"]);
 const DIVERGENCE_POLICIES = new Set(["strict", "balanced", "autonomous"]);
 const STRING_FIELDS = [
-	"worktreePath", "branch", "repoPath", "projectId", "teamLeadSessionId", "setupError",
+	"worktreePath", "worktreeOwnerSessionId", "branch", "repoPath", "projectId", "teamLeadSessionId", "setupError",
 	"reattemptOf", "parentGoalId", "rootGoalId", "spawnedFromPlanId", "suggestedRole", "spawnedBySessionId",
 ] as const;
 const BOOLEAN_FIELDS = [
@@ -355,6 +360,7 @@ function validateGoal(
 		if (!Number.isFinite(value[field])) invalidGoal(label, `${field} must be finite`);
 	}
 	for (const field of STRING_FIELDS) if (value[field] !== undefined && typeof value[field] !== "string") invalidGoal(label, `${field} must be a string`);
+	if (value.worktreeOwnerSessionId === "") invalidGoal(label, "worktreeOwnerSessionId must be a non-empty string");
 	if (value.workflowId !== undefined && value.workflowId !== null && typeof value.workflowId !== "string") {
 		invalidGoal(label, "workflowId must be a string or null");
 	}

--- a/src/server/agent/session-goal-promotion.ts
+++ b/src/server/agent/session-goal-promotion.ts
@@ -1,0 +1,389 @@
+/**
+ * Pure policy for promoting a proposal-owning regular session into a goal lead.
+ *
+ * Callers must supply only records resolved from the proposal owner and the
+ * registered project. Request bodies are deliberately not part of this API, so
+ * a branch, path, session id, or sandbox supplied by a client can never become
+ * promotion authority.
+ */
+
+export const SESSION_GOAL_WORKTREE_MODES = ["new-worktree", "current-session"] as const;
+export type SessionGoalWorktreeMode = typeof SESSION_GOAL_WORKTREE_MODES[number];
+
+export function isSessionGoalWorktreeMode(value: unknown): value is SessionGoalWorktreeMode {
+	return value === "new-worktree" || value === "current-session";
+}
+
+/** Missing legacy proposal fields retain the existing goal-creation behavior. */
+export function resolveSessionGoalWorktreeMode(value: unknown): SessionGoalWorktreeMode {
+	return isSessionGoalWorktreeMode(value) ? value : "new-worktree";
+}
+
+export interface SessionGoalPromotionGoalRecord {
+	id: string;
+	projectId?: string;
+	archived?: boolean;
+	/** Provenance stamped only by the in-place promotion path. */
+	worktreeOwnerSessionId?: string;
+}
+
+export type SessionGoalPromotionLookup<G extends SessionGoalPromotionGoalRecord = SessionGoalPromotionGoalRecord> =
+	| { status: "none" }
+	| { status: "found"; goal: G }
+	| { status: "conflict"; goals: G[] };
+
+/**
+ * Locate an idempotent promotion retry by server-owned provenance. Equal paths
+ * or branches are intentionally insufficient. Multiple live matches fail
+ * closed instead of choosing an arbitrary goal.
+ */
+export function lookupSessionGoalPromotion<G extends SessionGoalPromotionGoalRecord>(
+	goals: readonly G[],
+	ownerSessionId: string,
+): SessionGoalPromotionLookup<G> {
+	const matches = goals.filter(goal => !goal.archived && goal.worktreeOwnerSessionId === ownerSessionId);
+	if (matches.length === 0) return { status: "none" };
+	if (matches.length === 1) return { status: "found", goal: matches[0] };
+	return { status: "conflict", goals: matches };
+}
+
+export interface SessionGoalPromotionLiveSession {
+	id: string;
+	projectId?: string;
+	cwd?: string;
+	worktreePath?: string;
+	repoPath?: string;
+	branch?: string;
+	repoWorktrees?: Readonly<Record<string, string>> | ReadonlyArray<{
+		repo: string;
+		worktreePath: string;
+	}>;
+	status: string;
+	isCompacting?: boolean;
+	restoreStartupWasStreaming?: boolean;
+	dormant?: boolean;
+	lifecycleFenced?: boolean;
+	goalId?: string;
+	teamGoalId?: string;
+	teamLeadSessionId?: string;
+	role?: string;
+	assistantType?: string;
+	delegateOf?: string;
+	parentSessionId?: string;
+	childKind?: string;
+	childTerminal?: boolean;
+	readOnly?: boolean;
+	nonInteractive?: boolean;
+	borrowsWorktree?: boolean;
+	borrowedWorktreeOwnerSessionId?: string;
+	staffId?: string;
+	taskId?: string;
+	sandboxed?: boolean;
+	containerId?: string;
+}
+
+export interface SessionGoalPromotionPersistedSession {
+	id: string;
+	projectId?: string;
+	cwd?: string;
+	worktreePath?: string;
+	repoPath?: string;
+	branch?: string;
+	repoWorktrees?: Readonly<Record<string, string>>;
+	agentSessionFile?: string;
+	archived?: boolean;
+	wasStreaming?: boolean;
+	goalId?: string;
+	teamGoalId?: string;
+	teamLeadSessionId?: string;
+	role?: string;
+	assistantType?: string;
+	goalAssistant?: boolean;
+	roleAssistant?: boolean;
+	toolAssistant?: boolean;
+	delegateOf?: string;
+	parentSessionId?: string;
+	childKind?: string;
+	childTerminal?: boolean;
+	readOnly?: boolean;
+	nonInteractive?: boolean;
+	borrowsWorktree?: boolean;
+	borrowedWorktreeOwnerSessionId?: string;
+	staffId?: string;
+	taskId?: string;
+	sandboxed?: boolean;
+}
+
+/** A live canonical record that already refers to some workspace path. */
+export interface SessionGoalPromotionWorkspaceClaim {
+	kind: "session" | "goal" | "team" | "staff";
+	id: string;
+	projectId?: string;
+	worktreePath?: string;
+	repoWorktrees?: Readonly<Record<string, string>>;
+	/** Set only for session claims; lets the source session claim its own checkout. */
+	sessionId?: string;
+	/** Set only for goal/team claims; exact retry provenance may claim the checkout. */
+	goalId?: string;
+}
+
+export interface EvaluateSessionGoalPromotionInput {
+	ownerSessionId: string;
+	/** Target project resolved from the proposal owner + draft, never a request coordinate. */
+	proposalProjectId?: string;
+	/** Registered canonical target project. */
+	project?: { id: string; rootPath: string };
+	liveSession?: SessionGoalPromotionLiveSession;
+	persistedSession?: SessionGoalPromotionPersistedSession;
+	/** Result of checking the canonical transcript in its host/container realm. */
+	transcriptAvailable: boolean;
+	/** Result of checking the canonical worktree + branch in its host/container realm. */
+	workspaceAvailable: boolean;
+	/** Additional manager-owned busy state (queued/replacing/background handoff). */
+	hasPendingWork?: boolean;
+	/** Distinct configured repositories that actually own Git worktrees. */
+	gitComponentRepos?: readonly string[];
+	/** Result of resolving and probing the existing project sandbox/container. */
+	sandboxReachable?: boolean;
+	workspaceClaims?: readonly SessionGoalPromotionWorkspaceClaim[];
+	goals?: readonly SessionGoalPromotionGoalRecord[];
+}
+
+export interface SessionGoalPromotionCoordinates {
+	sessionId: string;
+	projectId: string;
+	cwd: string;
+	worktreePath: string;
+	repoPath: string;
+	branch: string;
+	repoWorktrees?: Record<string, string>;
+	sandboxed: boolean;
+	containerId?: string;
+}
+
+export type SessionGoalPromotionReasonCode =
+	| "SESSION_NOT_LIVE"
+	| "SESSION_NOT_IDLE"
+	| "SESSION_HAS_RELATION"
+	| "SESSION_UNSAFE"
+	| "PROJECT_UNAVAILABLE"
+	| "PROJECT_MISMATCH"
+	| "TRANSCRIPT_UNAVAILABLE"
+	| "WORKTREE_UNAVAILABLE"
+	| "WORKSPACE_MISMATCH"
+	| "MULTI_REPO_MISMATCH"
+	| "SANDBOX_UNAVAILABLE"
+	| "PROMOTION_CONFLICT"
+	| "WORKSPACE_CLAIMED";
+
+export type SessionGoalPromotionEligibility =
+	| { eligible: true; coordinates: SessionGoalPromotionCoordinates }
+	| { eligible: false; code: SessionGoalPromotionReasonCode; reason: string };
+
+const REASONS: Record<SessionGoalPromotionReasonCode, string> = {
+	SESSION_NOT_LIVE: "Current session is not live.",
+	SESSION_NOT_IDLE: "Current session must be idle.",
+	SESSION_HAS_RELATION: "Current session already belongs to another Bobbit workflow.",
+	SESSION_UNSAFE: "Current session cannot be promoted safely.",
+	PROJECT_UNAVAILABLE: "The proposal project is unavailable.",
+	PROJECT_MISMATCH: "Current session belongs to a different project.",
+	TRANSCRIPT_UNAVAILABLE: "Current session has no available transcript.",
+	WORKTREE_UNAVAILABLE: "Current session has no dedicated worktree and branch.",
+	WORKSPACE_MISMATCH: "Current session workspace metadata is inconsistent.",
+	MULTI_REPO_MISMATCH: "Current session multi-repo worktrees are incomplete.",
+	SANDBOX_UNAVAILABLE: "Current session sandbox is unavailable.",
+	PROMOTION_CONFLICT: "Current session has conflicting goal promotion records.",
+	WORKSPACE_CLAIMED: "Current session worktree is already in use.",
+};
+
+function unavailable(code: SessionGoalPromotionReasonCode): SessionGoalPromotionEligibility {
+	return { eligible: false, code, reason: REASONS[code] };
+}
+
+function nonEmpty(value: unknown): value is string {
+	return typeof value === "string" && value.trim().length > 0;
+}
+
+function repoWorktreeMap(
+	value: SessionGoalPromotionLiveSession["repoWorktrees"] | SessionGoalPromotionPersistedSession["repoWorktrees"],
+): Record<string, string> | undefined {
+	if (!value) return undefined;
+	if (Array.isArray(value)) {
+		const result: Record<string, string> = {};
+		for (const entry of value) {
+			if (!entry || !nonEmpty(entry.repo) || !nonEmpty(entry.worktreePath) || result[entry.repo] !== undefined) return undefined;
+			result[entry.repo] = entry.worktreePath;
+		}
+		return result;
+	}
+	const result: Record<string, string> = {};
+	for (const [repo, worktreePath] of Object.entries(value)) {
+		if (!nonEmpty(repo) || !nonEmpty(worktreePath)) return undefined;
+		result[repo] = worktreePath;
+	}
+	return result;
+}
+
+function equalStringMaps(a: Readonly<Record<string, string>> | undefined, b: Readonly<Record<string, string>> | undefined): boolean {
+	const ak = Object.keys(a ?? {}).sort();
+	const bk = Object.keys(b ?? {}).sort();
+	return ak.length === bk.length
+		&& ak.every((key, index) => key === bk[index] && a![key] === b![key]);
+}
+
+function normalizePath(value: string): string {
+	let normalized = value.replace(/\\/g, "/").replace(/\/+$/, "");
+	if (/^[A-Za-z]:\//.test(normalized) || normalized.startsWith("//")) normalized = normalized.toLowerCase();
+	return normalized || "/";
+}
+
+function containsPath(parent: string, child: string): boolean {
+	const normalizedParent = normalizePath(parent);
+	const normalizedChild = normalizePath(child);
+	return normalizedChild === normalizedParent || normalizedChild.startsWith(`${normalizedParent}/`);
+}
+
+function relationPresent(session: SessionGoalPromotionLiveSession | SessionGoalPromotionPersistedSession): boolean {
+	return !!(
+		session.goalId
+		|| session.teamGoalId
+		|| session.teamLeadSessionId
+		|| session.role
+		|| session.assistantType
+		|| ("goalAssistant" in session && (session.goalAssistant || session.roleAssistant || session.toolAssistant))
+		|| session.delegateOf
+		|| session.parentSessionId
+		|| session.childKind
+		|| session.staffId
+		|| session.taskId
+	);
+}
+
+function unsafeMarkerPresent(session: SessionGoalPromotionLiveSession | SessionGoalPromotionPersistedSession): boolean {
+	return !!(
+		session.childTerminal
+		|| session.readOnly
+		|| session.nonInteractive
+		|| session.borrowsWorktree
+		|| session.borrowedWorktreeOwnerSessionId
+	);
+}
+
+function workspacePaths(worktreePath: string | undefined, repoWorktrees: Readonly<Record<string, string>> | undefined): string[] {
+	return [worktreePath, ...Object.values(repoWorktrees ?? {})]
+		.filter(nonEmpty)
+		.map(normalizePath);
+}
+
+function claimConflicts(
+	claim: SessionGoalPromotionWorkspaceClaim,
+	ownerSessionId: string,
+	retryGoalId: string | undefined,
+	promotionPaths: readonly string[],
+): boolean {
+	if (claim.kind === "session" && (claim.sessionId === ownerSessionId || claim.id === ownerSessionId)) return false;
+	if ((claim.kind === "goal" || claim.kind === "team") && retryGoalId && (claim.goalId === retryGoalId || claim.id === retryGoalId)) return false;
+	const claimPaths = workspacePaths(claim.worktreePath, claim.repoWorktrees);
+	return claimPaths.some(claimPath => promotionPaths.some(promotionPath =>
+		containsPath(claimPath, promotionPath) || containsPath(promotionPath, claimPath),
+	));
+}
+
+/**
+ * Recompute promotion eligibility from live + durable canonical state.
+ * The first failing reason is stable and intentionally concise for direct UI use.
+ */
+export function evaluateSessionGoalPromotion(
+	input: EvaluateSessionGoalPromotionInput,
+): SessionGoalPromotionEligibility {
+	const live = input.liveSession;
+	const persisted = input.persistedSession;
+	if (!live || !persisted || live.id !== input.ownerSessionId || persisted.id !== input.ownerSessionId || persisted.archived) {
+		return unavailable("SESSION_NOT_LIVE");
+	}
+	if (live.status !== "idle" || live.isCompacting || live.restoreStartupWasStreaming || persisted.wasStreaming || live.dormant || live.lifecycleFenced || input.hasPendingWork) {
+		return unavailable("SESSION_NOT_IDLE");
+	}
+	if (relationPresent(live) || relationPresent(persisted)) return unavailable("SESSION_HAS_RELATION");
+	if (unsafeMarkerPresent(live) || unsafeMarkerPresent(persisted)) return unavailable("SESSION_UNSAFE");
+
+	if (!input.project || !nonEmpty(input.proposalProjectId) || input.project.id !== input.proposalProjectId) {
+		return unavailable("PROJECT_UNAVAILABLE");
+	}
+	if (live.projectId !== input.project.id || persisted.projectId !== input.project.id) {
+		return unavailable("PROJECT_MISMATCH");
+	}
+	if (!input.transcriptAvailable || !nonEmpty(persisted.agentSessionFile)) {
+		return unavailable("TRANSCRIPT_UNAVAILABLE");
+	}
+
+	const coordinateKeys = ["cwd", "worktreePath", "repoPath", "branch"] as const;
+	if (coordinateKeys.some(key => !nonEmpty(live[key]) || !nonEmpty(persisted[key]))) {
+		return unavailable("WORKTREE_UNAVAILABLE");
+	}
+	if (coordinateKeys.some(key => live[key] !== persisted[key])) return unavailable("WORKSPACE_MISMATCH");
+	const cwd = live.cwd!;
+	const worktreePath = live.worktreePath!;
+	const repoPath = live.repoPath!;
+	const branch = live.branch!;
+	if (!input.workspaceAvailable || !containsPath(worktreePath, cwd) || normalizePath(worktreePath) === normalizePath(repoPath)) {
+		return unavailable("WORKTREE_UNAVAILABLE");
+	}
+
+	const liveRepoWorktrees = repoWorktreeMap(live.repoWorktrees);
+	const persistedRepoWorktrees = repoWorktreeMap(persisted.repoWorktrees);
+	if ((live.repoWorktrees && !liveRepoWorktrees) || (persisted.repoWorktrees && !persistedRepoWorktrees)) {
+		return unavailable("MULTI_REPO_MISMATCH");
+	}
+	if (!equalStringMaps(liveRepoWorktrees, persistedRepoWorktrees)) return unavailable("MULTI_REPO_MISMATCH");
+
+	const expectedRepos = input.gitComponentRepos ?? [];
+	const distinctRepos = new Set(expectedRepos);
+	if (distinctRepos.size !== expectedRepos.length) return unavailable("MULTI_REPO_MISMATCH");
+	if (expectedRepos.length > 1 || (expectedRepos.length === 1 && expectedRepos[0] !== ".")) {
+		const actualRepos = Object.keys(liveRepoWorktrees ?? {});
+		if (actualRepos.length !== distinctRepos.size || actualRepos.some(repo => !distinctRepos.has(repo))) {
+			return unavailable("MULTI_REPO_MISMATCH");
+		}
+		const componentPaths = Object.values(liveRepoWorktrees!);
+		if (new Set(componentPaths.map(normalizePath)).size !== componentPaths.length
+			|| componentPaths.some(componentPath => !containsPath(worktreePath, componentPath))) {
+			return unavailable("MULTI_REPO_MISMATCH");
+		}
+	} else if (Object.keys(liveRepoWorktrees ?? {}).length > 0) {
+		return unavailable("MULTI_REPO_MISMATCH");
+	}
+
+	if ((live.sandboxed === true) !== (persisted.sandboxed === true)) return unavailable("WORKSPACE_MISMATCH");
+	if (live.sandboxed && (!nonEmpty(live.containerId) || input.sandboxReachable !== true)) {
+		return unavailable("SANDBOX_UNAVAILABLE");
+	}
+
+	const promotionLookup = lookupSessionGoalPromotion(input.goals ?? [], input.ownerSessionId);
+	if (promotionLookup.status === "conflict") return unavailable("PROMOTION_CONFLICT");
+	if (promotionLookup.status === "found" && promotionLookup.goal.projectId !== input.project.id) {
+		return unavailable("PROMOTION_CONFLICT");
+	}
+	const retryGoalId = promotionLookup.status === "found" ? promotionLookup.goal.id : undefined;
+	const promotionPaths = workspacePaths(worktreePath, liveRepoWorktrees);
+	if ((input.workspaceClaims ?? []).some(claim =>
+		claimConflicts(claim, input.ownerSessionId, retryGoalId, promotionPaths),
+	)) {
+		return unavailable("WORKSPACE_CLAIMED");
+	}
+
+	return {
+		eligible: true,
+		coordinates: {
+			sessionId: input.ownerSessionId,
+			projectId: input.project.id,
+			cwd,
+			worktreePath,
+			repoPath,
+			branch,
+			repoWorktrees: liveRepoWorktrees && Object.keys(liveRepoWorktrees).length > 0 ? liveRepoWorktrees : undefined,
+			sandboxed: live.sandboxed === true,
+			containerId: live.sandboxed ? live.containerId : undefined,
+		},
+	};
+}

--- a/src/server/agent/session-manager.ts
+++ b/src/server/agent/session-manager.ts
@@ -3763,6 +3763,9 @@ export class SessionManager {
 						], { timeout: 5_000 });
 						worktreeOk = true;
 					} catch {
+						// A live adopted goal owns the promoted source's exact workspace.
+						// Container recovery may inspect it, but cannot repair or replace it.
+						this.assertPromotedSessionRecoveryAllowed(session.id, "repair or recreate its sandbox worktree");
 						// Try git worktree repair first
 						try {
 							await this.commandRunner.execFile("docker", [
@@ -3966,6 +3969,35 @@ export class SessionManager {
 	): void {
 		const reason = this.promotedSessionLifecycleGuard?.(sessionId, action);
 		if (reason) throw new PromotedSessionLifecycleConflictError(sessionId, reason);
+	}
+
+	/**
+	 * Recovery may inspect a promoted source, but it must not mutate its workspace
+	 * or archive its durable record while the adopted goal remains live. The goal
+	 * archive flow publishes goal archival first, so the canonical guard permits
+	 * its later ordered source teardown without a separate bypass.
+	 */
+	private assertPromotedSessionRecoveryAllowed(sessionId: string, operation: string): void {
+		try {
+			this.assertPromotedSessionLifecycleAllowed(sessionId, "archive");
+		} catch (error) {
+			if (error instanceof PromotedSessionLifecycleConflictError) {
+				console.warn(`[session-manager] Preserving promoted source ${sessionId}; recovery cannot ${operation} while its adopted goal is live`);
+			}
+			throw error;
+		}
+	}
+
+	/** Keep an unrecoverable promoted source dormant instead of archiving it. */
+	private preservePromotedSessionAfterRecoveryFailure(ps: PersistedSession, operation: string): boolean {
+		try {
+			this.assertPromotedSessionRecoveryAllowed(ps.id, operation);
+			return false;
+		} catch (error) {
+			if (!(error instanceof PromotedSessionLifecycleConflictError)) throw error;
+			if (!this.sessions.has(ps.id)) this.addPromotedRecoveryDormant(ps, error.message);
+			return true;
+		}
 	}
 
 	setExtensionChannelServices(services: ExtensionChannelServices | undefined): void {
@@ -10232,6 +10264,7 @@ export class SessionManager {
 		const delegateSurvivors: PersistedSession[] = [];
 		for (const ps of delegates) {
 			if (!ps.agentSessionFile) {
+				if (this.preservePromotedSessionAfterRecoveryFailure(ps, "archive its missing-transcript record")) continue;
 				try { this.getSessionStore(ps.projectId).archive(ps.id); } catch { /* project gone */ }
 				continue;
 			}
@@ -10247,6 +10280,7 @@ export class SessionManager {
 			});
 			if (reap.reap) {
 				console.log(`[session-manager] Reaping orphaned delegate child ${ps.id} on boot — ${reap.reason}`);
+				if (this.preservePromotedSessionAfterRecoveryFailure(ps, "archive its orphaned delegate record")) continue;
 				try { this.getSessionStore(ps.projectId).archive(ps.id); } catch { /* project gone */ }
 				continue;
 			}
@@ -10305,6 +10339,7 @@ export class SessionManager {
 				const reason = !dirExists ? "directory missing" : ".git metadata missing";
 				console.log(`[session-manager] Recovering worktree for "${ps.title}" (${ps.id}): ${reason}, branch: ${ps.branch}`);
 				try {
+					this.assertPromotedSessionRecoveryAllowed(ps.id, "repair or recreate its host worktree");
 					const { recoverWorktree } = await import("../skills/git.js");
 					const recovered = await recoverWorktree(ps.repoPath, ps.branch, ps.worktreePath, this.commandRunner, this.remoteGitPolicy);
 					if (recovered) {
@@ -10447,6 +10482,7 @@ export class SessionManager {
 			});
 			if (decision.reap) {
 				console.log(`[session-manager] Reaping ${ps.childKind} child ${ps.id} on boot — ${decision.reason}`);
+				if (this.preservePromotedSessionAfterRecoveryFailure(ps, "archive its orphaned child record")) return;
 				sessionStore.archive(ps.id);
 				return;
 			}
@@ -10475,6 +10511,7 @@ export class SessionManager {
 				} else {
 					console.log(`[session-manager] Archiving ${ps.id} — no agent session file (metadata preserved)`);
 				}
+				if (this.preservePromotedSessionAfterRecoveryFailure(ps, "archive its missing-transcript record")) return;
 				sessionStore.archive(ps.id);
 				return;
 			}
@@ -10507,6 +10544,7 @@ export class SessionManager {
 				return;
 			} else {
 				console.log(`[session-manager] Archiving ${ps.id} — agent session file not found: ${ps.agentSessionFile} (metadata preserved)`);
+				if (this.preservePromotedSessionAfterRecoveryFailure(ps, "archive its missing-transcript record")) return;
 				sessionStore.archive(ps.id);
 				return;
 			}
@@ -10544,7 +10582,11 @@ export class SessionManager {
 		} catch (err) {
 			const msg = err instanceof Error ? (err.stack || err.message) : String(err);
 			console.error(`[session-manager] Failed to restore "${ps.title}" (${ps.id}), will retry next restart:`, err);
-			this.addDormantSession(ps, msg);
+			if (err instanceof PromotedSessionLifecycleConflictError) {
+				this.addPromotedRecoveryDormant(ps, msg);
+			} else {
+				this.addDormantSession(ps, msg);
+			}
 		}
 	}
 
@@ -10597,6 +10639,25 @@ export class SessionManager {
 				inFlightSteerTexts: reconciled.inFlightSteerTexts,
 			},
 		};
+	}
+
+	private addPromotedRecoveryDormant(ps: PersistedSession, restoreError: string): void {
+		this.addDormantSession(ps, restoreError);
+		const dormant = this.sessions.get(ps.id);
+		if (!dormant) return;
+		// Preserve the canonical adopted workspace projection while recovery is
+		// quarantined. The durable record remains untouched and owns these values.
+		dormant.repoPath = ps.repoPath;
+		dormant.branch = ps.branch;
+		dormant.worktreePath = ps.worktreePath;
+		dormant.repoWorktrees = ps.repoWorktrees && ps.repoPath
+			? Object.entries(ps.repoWorktrees).map(([repo, worktreePath]) => ({
+				repo,
+				repoPath: repo === "." ? ps.repoPath! : path.join(ps.repoPath!, repo),
+				worktreePath,
+			}))
+			: undefined;
+		dormant.sandboxed = ps.sandboxed;
 	}
 
 	private addDormantSession(
@@ -10782,6 +10843,9 @@ export class SessionManager {
 				if ((ps as any)._preserveSandboxRealm) {
 					throw new Error(`Cannot respawn sandboxed session ${ps.id}: sandbox realm is unavailable`);
 				}
+				// An adopted source's sandbox realm is part of its canonical workspace.
+				// A transient restore outage must not silently transfer it to the host.
+				this.assertPromotedSessionRecoveryAllowed(ps.id, "downgrade its unavailable sandbox realm");
 				ps.sandboxed = false;
 				this.resolveStoreForSession(ps.id).update(ps.id, { sandboxed: false });
 				this.applyScopedGatewayCredentials(bridgeOptions, ps.id, ps.projectId, ps.goalId ?? ps.teamGoalId);
@@ -10804,6 +10868,7 @@ export class SessionManager {
 					console.log(`[session-manager] Sandbox worktree verified for ${ps.id}: ${ps.cwd}`);
 				} catch {
 					console.warn(`[session-manager] Sandbox worktree MISSING for ${ps.id}: ${ps.cwd} — attempting recovery`);
+					this.assertPromotedSessionRecoveryAllowed(ps.id, "repair or recreate its sandbox worktree");
 					let recovered = false;
 
 					// Try git worktree repair first — handles broken .git link files after hard container kill
@@ -10850,6 +10915,7 @@ export class SessionManager {
 							return;
 						}
 						console.warn(`[session-manager] Archiving session ${ps.id} — sandbox worktree unrecoverable`);
+						if (this.preservePromotedSessionAfterRecoveryFailure(ps, "archive its unrecoverable sandbox record")) return;
 						try { this.getSessionStore(ps.projectId).archive(ps.id); } catch { /* best-effort */ }
 						return; // Skip restoring this session
 					}
@@ -14589,6 +14655,9 @@ export class SessionManager {
 	 * case.
 	 */
 	private async archiveWithCascade(id: string, store?: SessionStore): Promise<boolean> {
+		// Defense in depth for internal recovery and maintenance callers. Ordered
+		// goal archival has already made the canonical guard return undefined here.
+		this.assertPromotedSessionRecoveryAllowed(id, "archive its session record");
 		await this.cascadeReapOwner(id);
 		// Extension Platform G1.4: notify lifecycle providers the session is
 		// shutting down. Best-effort and bounded by the hub's per-provider
@@ -14621,8 +14690,10 @@ export class SessionManager {
 		try { return await target.archiveAsync(id); } catch { return false; }
 	}
 
-	async terminateSession(id: string, opts?: { allowPromotedGoalLifecycle?: boolean }): Promise<boolean> {
-		if (!opts?.allowPromotedGoalLifecycle) this.assertPromotedSessionLifecycleAllowed(id, "archive");
+	async terminateSession(id: string, _opts?: { allowPromotedGoalLifecycle?: boolean }): Promise<boolean> {
+		// Legacy callers may still pass the old option, but canonical goal state —
+		// never a caller boolean — is the only authority for promoted teardown.
+		this.assertPromotedSessionLifecycleAllowed(id, "archive");
 		const persisted = this.getPersistedSession(id);
 		const live = this.sessions.get(id);
 		const lifecycleOwnerId = (live?.sandboxed || persisted?.sandboxed)
@@ -14878,8 +14949,9 @@ export class SessionManager {
 	 * Routes through the runtime archive seam (§6) so a dormant parent's live
 	 * children are cascade-reaped before it is archived.
 	 */
-	async storeArchive(id: string, opts?: { allowPromotedGoalLifecycle?: boolean }): Promise<boolean> {
-		if (!opts?.allowPromotedGoalLifecycle) this.assertPromotedSessionLifecycleAllowed(id, "archive");
+	async storeArchive(id: string, _opts?: { allowPromotedGoalLifecycle?: boolean }): Promise<boolean> {
+		// Preserve the legacy call shape without preserving its authority bypass.
+		this.assertPromotedSessionLifecycleAllowed(id, "archive");
 		const persisted = this.getPersistedSession(id);
 		const lifecycleOwnerId = persisted?.sandboxed
 			? (persisted.borrowsWorktree

--- a/src/server/agent/session-manager.ts
+++ b/src/server/agent/session-manager.ts
@@ -2999,6 +2999,32 @@ export class PromotedSessionLifecycleConflictError extends Error {
 	}
 }
 
+/** Retryable admission failure while a regular session is being promoted in place. */
+export class SessionGoalPromotionInProgressError extends Error {
+	readonly statusCode = 409;
+	readonly code = "SESSION_GOAL_PROMOTION_IN_PROGRESS";
+	readonly retryable = true;
+
+	constructor(sessionId: string) {
+		super(`Session ${sessionId} is reserved for current-session goal promotion; retry after promotion finishes`);
+		this.name = "SessionGoalPromotionInProgressError";
+	}
+}
+
+/**
+ * Opaque process-local authority for one current-session promotion attempt.
+ * SessionManager validates object identity; callers cannot manufacture authority
+ * by copying the visible fields.
+ */
+export interface SessionGoalPromotionReservation {
+	readonly sessionId: string;
+	readonly attemptId: string;
+}
+
+interface OwnedSessionGoalPromotionReservation extends SessionGoalPromotionReservation {
+	goalId?: string;
+}
+
 export interface SessionManagerOptions {
 	/** Override the path to pi-coding-agent cli.js */
 	agentCliPath?: string;
@@ -3244,6 +3270,12 @@ export class SessionManager {
 	 * `promptOwner` until the final replacement commits or rolls back.
 	 */
 	private _sessionReplacementCoordinators = new Map<string, SessionReplacementCoordinator>();
+	/**
+	 * Short-lived owner reservation spanning goal/gate/team mutation and the
+	 * coordinated runtime replacement. This is deliberately distinct from the
+	 * replacement coordinator: it closes admission before any graph mutation.
+	 */
+	private _sessionGoalPromotionReservations = new Map<string, OwnedSessionGoalPromotionReservation>();
 	/** Per-owner FIFO shared by sandbox history-reuse registration and termination. */
 	private _sandboxBorrowerLifecycleQueues = new Map<string, SandboxBorrowerLifecycleQueue>();
 	/**
@@ -10074,6 +10106,7 @@ export class SessionManager {
 	 * Re-attaches existing WS clients so the user can keep working.
 	 */
 	async restartAgent(sessionId: string, expectedOwner?: SessionBridgeOwner): Promise<void> {
+		this.assertSessionGoalPromotionMutationAllowed(sessionId);
 		this._assertModelSelectionReady(sessionId);
 		const session = this.sessions.get(sessionId);
 		if (!session) throw new Error("Session not found");
@@ -13974,6 +14007,90 @@ export class SessionManager {
 	}
 
 	/**
+	 * Reserve a regular session before any current-session goal graph mutation.
+	 * An exact retained attempt may reclaim its same process-local reservation for
+	 * post-commit finalization or pre-commit repair; every competing mutation fails.
+	 */
+	reserveSessionGoalPromotion(id: string, goalId?: string): SessionGoalPromotionReservation {
+		const existing = this._sessionGoalPromotionReservations.get(id);
+		if (existing) {
+			if (goalId && existing.goalId === goalId) return existing;
+			throw new SessionGoalPromotionInProgressError(id);
+		}
+		const session = this.sessions.get(id);
+		if (!session) throw new Error(`Session ${id} not found`);
+		if (this._sessionReplacementCoordinators.has(id)) {
+			throw new SessionGoalPromotionInProgressError(id);
+		}
+		const persisted = this.resolveStoreForSession(id).get(id);
+		if (!persisted) throw new Error(`Session ${id} has no persisted record`);
+		const alreadyPromoted = !!goalId
+			&& session.goalId === goalId
+			&& session.teamGoalId === goalId
+			&& session.role === "team-lead"
+			&& persisted.goalId === goalId
+			&& persisted.teamGoalId === goalId
+			&& persisted.role === "team-lead";
+		if (goalId) {
+			const goal = this.resolveGoal(goalId);
+			if (!goal || goal.worktreeOwnerSessionId !== id || !this.goalWorkspaceCoordinatesMatchSession(goal, persisted)) {
+				throw new Error(`Session ${id} cannot resume promotion for unrelated goal ${goalId}`);
+			}
+		}
+		const baselineRole = (role: string | undefined) => role === undefined || role === "general";
+		if (!alreadyPromoted && (!baselineRole(session.role) || !baselineRole(persisted.role) || session.role !== persisted.role)) {
+			throw new Error(`Session ${id} no longer has its canonical baseline role`);
+		}
+		const reservation: OwnedSessionGoalPromotionReservation = {
+			sessionId: id,
+			attemptId: randomUUID(),
+			...(goalId ? { goalId } : {}),
+		};
+		this._sessionGoalPromotionReservations.set(id, reservation);
+		return reservation;
+	}
+
+	/** Bind the attempt to the exact adopted goal before lead/runtime attachment. */
+	bindSessionGoalPromotion(reservation: SessionGoalPromotionReservation, goalId: string): void {
+		const owned = this.requireSessionGoalPromotionReservation(reservation.sessionId, reservation);
+		if (owned.goalId && owned.goalId !== goalId) {
+			throw new Error(`Session ${reservation.sessionId} promotion is already bound to goal ${owned.goalId}`);
+		}
+		owned.goalId = goalId;
+	}
+
+	/** Release only the exact attempt authority currently owned by SessionManager. */
+	releaseSessionGoalPromotion(reservation: SessionGoalPromotionReservation): boolean {
+		if (this._sessionGoalPromotionReservations.get(reservation.sessionId) !== reservation) return false;
+		this._sessionGoalPromotionReservations.delete(reservation.sessionId);
+		return true;
+	}
+
+	/** Public read seam for goal-level destructive admission before any mutation. */
+	isSessionGoalPromotionReserved(id: string): boolean {
+		return this._sessionGoalPromotionReservations.has(id);
+	}
+
+	/** Public admission seam for server routes that directly mutate relation fields. */
+	assertSessionGoalPromotionMutationAllowed(id: string): void {
+		if (this.isSessionGoalPromotionReserved(id)) {
+			throw new SessionGoalPromotionInProgressError(id);
+		}
+	}
+
+	private requireSessionGoalPromotionReservation(
+		id: string,
+		reservation: SessionGoalPromotionReservation,
+		goalId?: string,
+	): OwnedSessionGoalPromotionReservation {
+		const owned = this._sessionGoalPromotionReservations.get(id);
+		if (owned !== reservation || reservation.sessionId !== id || (goalId !== undefined && owned.goalId !== goalId)) {
+			throw new Error(`Session ${id} promotion reservation is missing or does not match goal ${goalId ?? "<unbound>"}`);
+		}
+		return owned;
+	}
+
+	/**
 	 * Assign a role to an existing session. Requests for the same session are
 	 * serialized. The first request marks the canonical session as `starting`, so
 	 * prompts accepted while any replacement is staged are durably queued instead
@@ -13982,6 +14099,7 @@ export class SessionManager {
 	 * or against the original bridge after a clean rollback.
 	 */
 	async assignRole(id: string, role: { name: string; promptTemplate: string; accessory: string }): Promise<boolean> {
+		this.assertSessionGoalPromotionMutationAllowed(id);
 		const coordinator = this._sessionReplacementCoordinators.get(id);
 		const session = this.sessions.get(id);
 		// In-place restore/respawn deliberately removes SessionInfo while its
@@ -14002,7 +14120,12 @@ export class SessionManager {
 	 * goal's lead without changing its identity, transcript, checkout, or sandbox.
 	 * Exact repeats are a no-op; conflicting attachments are rejected.
 	 */
-	async promoteToGoalLead(id: string, goalId: string): Promise<SessionInfo> {
+	async promoteToGoalLead(
+		id: string,
+		goalId: string,
+		reservation: SessionGoalPromotionReservation,
+	): Promise<SessionInfo> {
+		this.requireSessionGoalPromotionReservation(id, reservation, goalId);
 		const coordinator = this._sessionReplacementCoordinators.get(id);
 		const session = this.sessions.get(id);
 		if (!session && !coordinator) throw new Error(`Session ${id} not found`);
@@ -14041,8 +14164,16 @@ export class SessionManager {
 			}
 			return session;
 		}
-		if (session && (session.goalId || session.teamGoalId || session.role || session.assistantType || session.staffId || session.delegateOf || session.parentSessionId)) {
-			throw new Error(`Session ${id} already has goal, role, staff, assistant, delegate, or child metadata`);
+		if (session && (
+			session.goalId
+			|| session.teamGoalId
+			|| (session.role && session.role !== "general")
+			|| session.assistantType
+			|| session.staffId
+			|| session.delegateOf
+			|| session.parentSessionId
+		)) {
+			throw new Error(`Session ${id} already has goal, assigned role, staff, assistant, delegate, or child metadata`);
 		}
 		const expectedSandboxContainerId = session?.sandboxed ? session.containerId?.trim() : undefined;
 		if (session?.sandboxed && !expectedSandboxContainerId) {
@@ -14124,7 +14255,15 @@ export class SessionManager {
 			if (session.goalId === projection.goalId && session.teamGoalId === projection.teamGoalId && session.role === projection.role) {
 				return true;
 			}
-			if (session.goalId || session.teamGoalId || session.role || session.assistantType || session.staffId || session.delegateOf || session.parentSessionId) {
+			if (
+				session.goalId
+				|| session.teamGoalId
+				|| (session.role && session.role !== "general")
+				|| session.assistantType
+				|| session.staffId
+				|| session.delegateOf
+				|| session.parentSessionId
+			) {
 				throw new Error(`Session ${id} gained conflicting metadata before promotion staging`);
 			}
 		}
@@ -14826,6 +14965,7 @@ export class SessionManager {
 	}
 
 	async terminateSession(id: string, _opts?: { allowPromotedGoalLifecycle?: boolean }): Promise<boolean> {
+		this.assertSessionGoalPromotionMutationAllowed(id);
 		// Legacy callers may still pass the old option, but canonical goal state —
 		// never a caller boolean — is the only authority for promoted teardown.
 		this.assertPromotedSessionLifecycleAllowed(id, "archive");
@@ -15085,6 +15225,7 @@ export class SessionManager {
 	 * children are cascade-reaped before it is archived.
 	 */
 	async storeArchive(id: string, _opts?: { allowPromotedGoalLifecycle?: boolean }): Promise<boolean> {
+		this.assertSessionGoalPromotionMutationAllowed(id);
 		// Preserve the legacy call shape without preserving its authority bypass.
 		this.assertPromotedSessionLifecycleAllowed(id, "archive");
 		const persisted = this.getPersistedSession(id);
@@ -16634,6 +16775,7 @@ export class SessionManager {
 	}
 
 	async forceAbort(id: string, gracePeriodMs = 3000): Promise<void> {
+		this.assertSessionGoalPromotionMutationAllowed(id);
 		const coordinator = this._sessionReplacementCoordinators.get(id);
 		const session = this.sessions.get(id);
 		if (!session && !coordinator) return;

--- a/src/server/agent/session-manager.ts
+++ b/src/server/agent/session-manager.ts
@@ -414,16 +414,20 @@ interface ArchivedWorktreeGuardRef {
 	cwd?: string;
 	branch?: string;
 	repoWorktrees?: Record<string, string>;
+	archived?: boolean;
+	worktreeOwnerSessionId?: string;
 }
 
-/** Non-sandboxed polyrepo team leads borrow, but never own, the goal worktree set. */
-function hasGoalOwnedTeamLeadWorktrees(ps: Pick<PersistedSession, "role" | "goalId" | "teamGoalId" | "sandboxed" | "repoWorktrees">): boolean {
+/** Structural precondition shared by ordinary borrowed leads and adopted workspace owners. */
+function isNonSandboxedPolyrepoTeamLead(ps: Pick<PersistedSession, "role" | "goalId" | "teamGoalId" | "sandboxed" | "repoWorktrees">): boolean {
 	return ps.role === "team-lead"
 		&& !!(ps.teamGoalId ?? ps.goalId)
 		&& !ps.sandboxed
 		&& !!ps.repoWorktrees
 		&& Object.keys(ps.repoWorktrees).length > 0;
 }
+
+type StrictSandboxWiringOptions = SandboxWiringOptions & { expectedExistingContainerId?: string };
 
 interface ArchivedWorktreeScanContext {
 	candidateContexts: ProjectContext[];
@@ -3064,9 +3068,11 @@ type SessionRoleReplacementProjection = {
 	accessory: string;
 	/** Promotion retains the source session's verified tuple instead of adopting role defaults. */
 	preserveModelTuple: true;
+	/** Exact existing sandbox realm captured from the source before staging. */
+	expectedSandboxContainerId?: string;
 };
 
-type PromotionAttachmentField = "goalId" | "teamGoalId" | "role" | "accessory";
+type PromotionAttachmentField = "goalId" | "teamGoalId" | "role" | "accessory" | "containerId";
 type PromotionAttachmentSnapshot = Record<PromotionAttachmentField, { present: boolean; value: unknown }>;
 
 type SessionReplacementCoordinator = {
@@ -3751,6 +3757,14 @@ export class SessionManager {
 
 		for (const session of sessionsToRecover) {
 			try {
+				const persisted = this.getSessionStore(session.projectId).get(session.id);
+				if (persisted && this.isCanonicalAdoptedWorkspaceOwner(persisted)) {
+					const expected = persisted.containerId?.trim();
+					if (!expected || session.containerId !== expected || newContainerId !== expected) {
+						this.assertPromotedSessionRecoveryAllowed(session.id, "transfer to a recovered sandbox container");
+						throw new Error(`Cannot recover promoted session ${session.id}: sandbox container identity changed`);
+					}
+				}
 				// Verify/repair/recreate worktree if needed. Headquarters never owns
 				// sandbox worktrees, even for legacy sessions with /workspace-wt cwd.
 				if (projectId !== HEADQUARTERS_PROJECT_ID && !session.borrowsWorktree && session.cwd?.startsWith("/workspace-wt/")) {
@@ -4275,6 +4289,55 @@ export class SessionManager {
 		return this._testGoalManager?.getGoalStore().get(goalId);
 	}
 
+	/** Resolve adoption authority from the session's canonical project store, including archived goals. */
+	private resolveSessionGoal(ps: Pick<PersistedSession, "projectId" | "goalId" | "teamGoalId">): PersistedGoal | undefined {
+		const goalId = ps.teamGoalId ?? ps.goalId;
+		if (!goalId) return undefined;
+		if (this.projectContextManager && ps.projectId) {
+			return this.projectContextManager.getOrCreate(ps.projectId)?.goalStore.get(goalId);
+		}
+		return this.resolveGoal(goalId);
+	}
+
+	private goalWorkspaceCoordinatesMatchSession(goal: PersistedGoal, ps: PersistedSession): boolean {
+		if (goal.projectId !== ps.projectId || goal.branch !== ps.branch) return false;
+		if (normalizeWorktreeHostPath(goal.repoPath) !== normalizeWorktreeHostPath(ps.repoPath)) return false;
+		if (normalizeWorktreeHostPath(goal.worktreePath) !== normalizeWorktreeHostPath(ps.worktreePath)) return false;
+		const goalComponents = goal.repoWorktrees ?? {};
+		const sessionComponents = ps.repoWorktrees ?? {};
+		const goalRepos = Object.keys(goalComponents).sort();
+		const sessionRepos = Object.keys(sessionComponents).sort();
+		return goalRepos.length === sessionRepos.length
+			&& goalRepos.every((repo, index) => repo === sessionRepos[index]
+				&& normalizeWorktreeHostPath(goalComponents[repo]) === normalizeWorktreeHostPath(sessionComponents[repo]));
+	}
+
+	private goalExactlyAdoptsSession(goal: PersistedGoal, ps: PersistedSession): boolean {
+		if (!ps.goalId || ps.teamGoalId !== ps.goalId) return false;
+		return goal.id === ps.goalId
+			&& goal.worktreeOwnerSessionId === ps.id
+			&& this.goalWorkspaceCoordinatesMatchSession(goal, ps);
+	}
+
+	private isCanonicalAdoptedWorkspaceOwner(ps: PersistedSession): boolean {
+		const goal = this.resolveSessionGoal(ps);
+		return !!goal && this.goalExactlyAdoptsSession(goal, ps);
+	}
+
+	/** Ordinary polyrepo leads borrow goal worktrees; exact adopted sources remain their lifecycle owner. */
+	private hasGoalOwnedTeamLeadWorktrees(ps: PersistedSession): boolean {
+		return isNonSandboxedPolyrepoTeamLead(ps) && !this.isCanonicalAdoptedWorkspaceOwner(ps);
+	}
+
+	private adoptedWorkspaceHasLiveReference(ps: PersistedSession): boolean {
+		if (!this.isCanonicalAdoptedWorkspaceOwner(ps)) return false;
+		const records = this.getAllPersistedSessionsForWorktreeGuard();
+		const paths = ps.repoWorktrees && Object.keys(ps.repoWorktrees).length > 0
+			? Object.values(ps.repoWorktrees)
+			: [ps.worktreePath];
+		return paths.some(candidate => isWorktreePathReferencedByLiveSession(candidate, records, { ignoreSessionId: ps.id }));
+	}
+
 	/** Whether Docker sandbox mode is enabled in project config. */
 	get isSandboxEnabled(): boolean {
 		return (this.projectConfigStore?.get("sandbox") || "none") === "docker";
@@ -4553,7 +4616,7 @@ export class SessionManager {
 	private async applySandboxWiring(
 		bridgeOptions: RpcBridgeOptions,
 		sessionId: string,
-		opts?: SandboxWiringOptions,
+		opts?: StrictSandboxWiringOptions,
 	): Promise<boolean> {
 		// Resolve project ID before reading sandbox config. The selected project's
 		// config is authoritative; the server/HQ store is only a legacy fallback for
@@ -4578,16 +4641,31 @@ export class SessionManager {
 		if (!this.sandboxManager) {
 			throw new Error("Sandbox mode requires SandboxManager — not initialized");
 		}
-		// Lazy per-project init — idempotent. Handles restore paths and any call site
-		// that reached wiring without going through the explicit session-setup /
-		// goals / staff entry points.
-		await this.sandboxManager.ensureForProject(projectId);
+		const expectedExistingContainerId = opts?.expectedExistingContainerId?.trim();
+		if (opts?.expectedExistingContainerId !== undefined && !expectedExistingContainerId) {
+			throw new Error(`Cannot reuse sandbox for session ${sessionId}: expected container identity is missing`);
+		}
+		// Ordinary creation/restore lazily initializes as before. Promotion and
+		// promoted-source restore pass an exact identity and must only inspect the
+		// already-ready sandbox: never bootstrap, transfer, or repair its realm.
+		if (!expectedExistingContainerId) await this.sandboxManager.ensureForProject(projectId);
 		const sandbox = this.sandboxManager.get(projectId);
 		if (!sandbox) {
 			throw new Error(`No sandbox initialized for project ${projectId}`);
 		}
-
+		const assertExpectedContainer = () => {
+			if (!expectedExistingContainerId) return;
+			const status = sandbox.getStatus();
+			if (status.status !== "ready" || status.containerId !== expectedExistingContainerId) {
+				throw new Error(`Cannot reuse sandbox for session ${sessionId}: expected ready container ${expectedExistingContainerId}`);
+			}
+		};
+		assertExpectedContainer();
 		const containerId = await sandbox.getContainerId();
+		if (expectedExistingContainerId && containerId !== expectedExistingContainerId) {
+			throw new Error(`Cannot reuse sandbox for session ${sessionId}: container identity changed`);
+		}
+		assertExpectedContainer();
 
 		// Read gateway URL and generate scoped token for the container.
 		const gwUrl = this.readGatewayUrlForAgent();
@@ -4606,6 +4684,9 @@ export class SessionManager {
 			bridgeOptions.gatewayToken = adminToken;
 		}
 
+		// Re-check after credential wiring as well: a health transition during an
+		// await must reject before a candidate bridge can start.
+		assertExpectedContainer();
 		bridgeOptions.sandboxed = true;
 		bridgeOptions.containerId = containerId;
 		const projectRootPath = projectContext?.project.rootPath;
@@ -4715,6 +4796,7 @@ export class SessionManager {
 				scope: projectId,
 			});
 		});
+		assertExpectedContainer();
 
 		return true;
 	}
@@ -10658,6 +10740,7 @@ export class SessionManager {
 			}))
 			: undefined;
 		dormant.sandboxed = ps.sandboxed;
+		dormant.containerId = ps.containerId;
 	}
 
 	private addDormantSession(
@@ -10827,18 +10910,33 @@ export class SessionManager {
 		// ── Restore Docker sandbox wiring ──
 		let restoredSandboxed = ps.sandboxed === true && !(ps.projectId && isSandboxExemptProject(ps.projectId));
 		if (ps.sandboxed === true) {
-			// Keep applySandboxWiring as the single restore decision point. It uses
-			// the selected project's config internally, returns false for non-docker
-			// projects, and preserves Headquarters/system no-sandbox exemptions.
-			// On restore, the worktree already exists inside the container —
-			// pass the container-internal cwd directly (no branch = no worktree creation).
+			// Keep applySandboxWiring as the single restore decision point. Ordinary
+			// sessions retain lazy bootstrap. A canonical adopted source instead uses
+			// its durable promotion identity and fails closed if that exact container
+			// is no longer ready.
 			if (ps.cwd?.startsWith("/workspace")) {
 				bridgeOptions.cwd = ps.cwd;
 			}
-			restoredSandboxed = await this.applySandboxWiring(bridgeOptions, ps.id, {
-				projectId: ps.projectId,
-				goalId: ps.goalId ?? ps.teamGoalId,
-			});
+			const adoptedSource = this.isCanonicalAdoptedWorkspaceOwner(ps);
+			const expectedExistingContainerId = adoptedSource
+				? ps.containerId?.trim()
+				: undefined;
+			if (adoptedSource && !expectedExistingContainerId) {
+				this.assertPromotedSessionRecoveryAllowed(ps.id, "restore without its durable sandbox container identity");
+				throw new Error(`Cannot restore promoted session ${ps.id}: durable sandbox container identity is missing`);
+			}
+			try {
+				restoredSandboxed = await this.applySandboxWiring(bridgeOptions, ps.id, {
+					projectId: ps.projectId,
+					goalId: ps.goalId ?? ps.teamGoalId,
+					expectedExistingContainerId,
+				});
+			} catch (error) {
+				if (adoptedSource) {
+					this.assertPromotedSessionRecoveryAllowed(ps.id, "transfer to a replacement sandbox container");
+				}
+				throw error;
+			}
 			if (!restoredSandboxed) {
 				if ((ps as any)._preserveSandboxRealm) {
 					throw new Error(`Cannot respawn sandboxed session ${ps.id}: sandbox realm is unavailable`);
@@ -11327,20 +11425,9 @@ export class SessionManager {
 			}
 		}
 
-		// For sandbox sessions, resolve the container ID so git-status and other
-		// host-side operations can run commands inside the container via docker exec.
-		// The containerId is not persisted — it's resolved from SandboxManager which
-		// reconnects to the existing container by label on startup.
-		if (ps.sandboxed && this.sandboxManager && ps.projectId) {
-			try {
-				const sandbox = this.sandboxManager.get(ps.projectId);
-				if (sandbox) {
-					session.containerId = await sandbox.getContainerId();
-				}
-			} catch (err) {
-				console.warn(`[session-manager] Could not resolve container for sandbox session ${ps.id}: ${err}`);
-			}
-		}
+		// applySandboxWiring already established the bridge's exact realm. Reuse
+		// that verified identity rather than performing another fallible lookup.
+		if (ps.sandboxed && bridgeOptions.containerId) session.containerId = bridgeOptions.containerId;
 
 		// Install the replacement before enabling lifecycle side effects. A replayed
 		// agent_end must never dequeue durable intent against a provisional bridge.
@@ -13927,11 +14014,39 @@ export class SessionManager {
 		if (session?.projectId && goal.projectId && session.projectId !== goal.projectId) {
 			throw new Error(`Cannot promote session ${id} across projects`);
 		}
+		const sourcePersisted = this.resolveStoreForSession(id).get(id);
+		if (
+			goal.worktreeOwnerSessionId !== id
+			|| !sourcePersisted
+			|| !this.goalWorkspaceCoordinatesMatchSession(goal, sourcePersisted)
+		) {
+			throw new Error(`Cannot promote session ${id}: adopted workspace provenance or coordinates do not match`);
+		}
 		if (session?.goalId === goalId && session.teamGoalId === goalId && session.role === "team-lead") {
+			if (session.sandboxed) {
+				const persisted = this.resolveStoreForSession(id).get(id);
+				const expected = persisted?.containerId?.trim();
+				if (!expected || session.containerId !== expected) {
+					throw new Error(`Cannot reuse promoted session ${id}: sandbox container identity changed`);
+				}
+				const options: RpcBridgeOptions = { cwd: session.cwd };
+				const applied = await this.applySandboxWiring(options, id, {
+					projectId: session.projectId,
+					goalId,
+					expectedExistingContainerId: expected,
+				});
+				if (!applied || options.containerId !== expected) {
+					throw new Error(`Cannot reuse promoted session ${id}: sandbox realm is unavailable`);
+				}
+			}
 			return session;
 		}
 		if (session && (session.goalId || session.teamGoalId || session.role || session.assistantType || session.staffId || session.delegateOf || session.parentSessionId)) {
 			throw new Error(`Session ${id} already has goal, role, staff, assistant, delegate, or child metadata`);
+		}
+		const expectedSandboxContainerId = session?.sandboxed ? session.containerId?.trim() : undefined;
+		if (session?.sandboxed && !expectedSandboxContainerId) {
+			throw new Error(`Cannot promote sandboxed session ${id}: existing container identity is missing`);
 		}
 		const role = this.resolveSessionRole("team-lead", undefined, session?.projectId);
 		if (!role) throw new Error('Cannot promote session: role "team-lead" is unavailable');
@@ -13941,6 +14056,7 @@ export class SessionManager {
 			role: "team-lead",
 			accessory: role.accessory ?? "crown",
 			preserveModelTuple: true,
+			expectedSandboxContainerId,
 		};
 		if (!coordinator && session) broadcastStatus(session, "starting");
 		const promoted = await this._coordinateSessionReplacement(id, "promote-goal-lead", (token) =>
@@ -13961,6 +14077,10 @@ export class SessionManager {
 			teamGoalId: { present: own.call(source, "teamGoalId"), value: source.teamGoalId },
 			role: { present: own.call(source, "role"), value: source.role },
 			accessory: { present: own.call(source, "accessory"), value: source.accessory },
+			containerId: {
+				present: own.call(source, "containerId"),
+				value: source.containerId,
+			},
 		};
 	}
 
@@ -14177,12 +14297,23 @@ export class SessionManager {
 		// container transcript and make an apparently successful role change lose
 		// model-visible history.
 		if (replacementSession.sandboxed) {
+			const adoptedExpectedContainerId = this.isCanonicalAdoptedWorkspaceOwner(respawnPersisted ?? persistedBeforeRole!)
+				? respawnPersisted?.containerId?.trim()
+				: undefined;
+			const strictExpectedContainerId = projection?.expectedSandboxContainerId ?? adoptedExpectedContainerId;
+			if (!projection && this.isCanonicalAdoptedWorkspaceOwner(respawnPersisted ?? persistedBeforeRole!) && !strictExpectedContainerId) {
+				throw new Error(`Cannot replace promoted session ${id}: durable sandbox container identity is missing`);
+			}
 			const sandboxApplied = await this.applySandboxWiring(bridgeOptions, id, {
 				projectId: replacementSession.projectId,
 				goalId: replacementSession.goalId ?? replacementSession.teamGoalId,
+				expectedExistingContainerId: strictExpectedContainerId,
 			});
 			if (!sandboxApplied) {
 				throw new Error(`Cannot assign role for sandboxed session ${id}: sandbox realm is unavailable`);
+			}
+			if (strictExpectedContainerId && bridgeOptions.containerId !== strictExpectedContainerId) {
+				throw new Error(`Cannot replace sandboxed session ${id}: container identity changed during staging`);
 			}
 		} else {
 			this.applyScopedGatewayCredentials(bridgeOptions, id, replacementSession.projectId, replacementSession.goalId ?? replacementSession.teamGoalId);
@@ -14284,7 +14415,10 @@ export class SessionManager {
 						teamGoalId: projection.teamGoalId,
 						role: projection.role,
 						accessory: projection.accessory,
-					}
+						...(projection.expectedSandboxContainerId
+							? { containerId: projection.expectedSandboxContainerId }
+							: {}),
+					} as Parameters<SessionStore["update"]>[1]
 					: { role: role.name, accessory: role.accessory });
 			} catch (err) {
 				if (promotionAttachmentBefore) {
@@ -14340,6 +14474,7 @@ export class SessionManager {
 		session.messagesSnapshotCursorProjection = undefined;
 		session.spawnPinnedModel = bridgeOptions.initialModel;
 		session.spawnPinnedThinkingLevel = bridgeOptions.initialThinkingLevel;
+		if (projection?.expectedSandboxContainerId) session.containerId = projection.expectedSandboxContainerId;
 		if (verifiedReplacementTuple) {
 			session.spawnPinnedModel = `${verifiedReplacementTuple.provider}/${verifiedReplacementTuple.modelId}`;
 			session.spawnPinnedThinkingLevel = verifiedReplacementTuple.thinkingLevel;
@@ -15554,8 +15689,24 @@ export class SessionManager {
 		for (const projectCtx of allContexts) {
 			const goalsById = new Map(projectCtx.goalStore.getAll().map(goal => [goal.id, goal]));
 			for (const goal of projectCtx.goalStore.getAll()) {
-				goalRefs.push({ id: goal.id, repoPath: goal.repoPath, worktreePath: goal.worktreePath, cwd: goal.cwd, branch: goal.branch, repoWorktrees: goal.repoWorktrees });
-				addRepoBranches(goal.repoPath, goal.branch, goal.repoWorktrees);
+				goalRefs.push({
+					id: goal.id,
+					repoPath: goal.repoPath,
+					worktreePath: goal.worktreePath,
+					cwd: goal.cwd,
+					branch: goal.branch,
+					repoWorktrees: goal.repoWorktrees,
+					archived: goal.archived,
+					worktreeOwnerSessionId: goal.worktreeOwnerSessionId,
+				});
+				// An archived, exactly matched adopted goal is provenance, not a live
+				// branch owner. Malformed or divergent records fail closed and retain
+				// the branch guard.
+				const adoptedOwner = goal.worktreeOwnerSessionId
+					? projectCtx.sessionStore.get(goal.worktreeOwnerSessionId)
+					: undefined;
+				const exactArchivedAdoption = !!(goal.archived && adoptedOwner && this.goalExactlyAdoptsSession(goal, adoptedOwner));
+				if (!exactArchivedAdoption) addRepoBranches(goal.repoPath, goal.branch, goal.repoWorktrees);
 			}
 			for (const team of projectCtx.teamStore.getAll()) {
 				const ownerGoal = goalsById.get(team.goalId);
@@ -15591,8 +15742,8 @@ export class SessionManager {
 
 	private async archivedSessionWorktreeItems(ps: PersistedSession, ctx: ArchivedWorktreeScanContext, projectName?: string): Promise<ArchivedSessionWorktreeItem[]> {
 		// Borrowed goal worktrees remain goal-owned after the lead is archived;
-		// do not expose them as archived-session cleanup candidates.
-		if (hasGoalOwnedTeamLeadWorktrees(ps)) return [];
+		// exact adopted sources are instead exposed for their final cleanup.
+		if (this.hasGoalOwnedTeamLeadWorktrees(ps)) return [];
 		const specs: Array<{ repo: string; repoPath?: string; worktreePath?: string; branch?: string; source: "repoWorktrees" | "sessionWorktree" }> = [];
 		if (ps.repoWorktrees && Object.keys(ps.repoWorktrees).length > 0) {
 			for (const [repo, wt] of Object.entries(ps.repoWorktrees)) {
@@ -15681,7 +15832,10 @@ export class SessionManager {
 		if (sessionReferenced) {
 			return base({ pathExists, gitWorktreeMetadataExists, localBranchExists, status: "skipped", reason: "referenced-by-live-session", detail: "Another non-archived or runtime session still references this worktree." });
 		}
-		if (this.isWorktreeReferencedByRefs(spec.worktreePath, ctx.goalRefs)) {
+		if (this.isWorktreeReferencedByRefs(spec.worktreePath, ctx.goalRefs, {
+			ownerSessionId: ps.id,
+			goalId: ps.teamGoalId ?? ps.goalId,
+		})) {
 			return base({ pathExists, gitWorktreeMetadataExists, localBranchExists, status: "skipped", reason: "referenced-by-live-goal", detail: "A persisted goal still references this worktree." });
 		}
 		if (this.isWorktreeReferencedByRefs(spec.worktreePath, ctx.teamRefs)) {
@@ -15732,10 +15886,19 @@ export class SessionManager {
 		return normalized === "/workspace" || normalized.startsWith("/workspace/") || normalized === "/workspace-wt" || normalized.startsWith("/workspace-wt/");
 	}
 
-	private isWorktreeReferencedByRefs(candidatePath: string | undefined, refs: ArchivedWorktreeGuardRef[]): boolean {
+	private isWorktreeReferencedByRefs(
+		candidatePath: string | undefined,
+		refs: ArchivedWorktreeGuardRef[],
+		archivedAdoption?: { ownerSessionId: string; goalId?: string },
+	): boolean {
 		const candidate = normalizeWorktreeHostPath(candidatePath);
 		if (!candidate) return false;
 		for (const ref of refs) {
+			if (
+				ref.archived
+				&& archivedAdoption?.goalId === ref.id
+				&& ref.worktreeOwnerSessionId === archivedAdoption?.ownerSessionId
+			) continue;
 			if (normalizeWorktreeHostPath(ref.worktreePath) === candidate) return true;
 			const cwd = normalizeWorktreeHostPath(ref.cwd);
 			if (cwd && (cwd === candidate || cwd.startsWith(`${candidate}/`))) return true;
@@ -15916,6 +16079,14 @@ export class SessionManager {
 			}
 		}
 
+		// Adopted multi-repo cleanup is all-or-nothing. If any component is still
+		// referenced, retain the archived owner record so a later purge can clean
+		// every component and the shared container exactly once.
+		if (this.adoptedWorkspaceHasLiveReference(ps)) {
+			console.warn(`[session-manager] Refusing to purge adopted workspace owner ${ps.id}: another live session still references a component`);
+			return;
+		}
+
 		// Cascade-reap any child agents before destroying the parent's data (§6).
 		// A parent normally cascades at archive time, but purge is a terminal data
 		// destruction — reap here as a final safety net so a child never outlives
@@ -15981,8 +16152,9 @@ export class SessionManager {
 		// Clean up host worktree.  Sandboxed session worktrees also create a host-side
 		// worktree for server bookkeeping, so we clean those up too.  Skip paths that
 		// are container-internal (start with /workspace) — those have no host counterpart.
-		// Skip delegates and non-sandboxed polyrepo leads — both borrow worktrees owned elsewhere.
-		const goalOwnsTeamLeadWorktrees = hasGoalOwnedTeamLeadWorktrees(ps);
+		// Skip delegates and ordinary non-sandboxed polyrepo leads — both borrow
+		// worktrees owned elsewhere. Canonical adopted sources remain final owners.
+		const goalOwnsTeamLeadWorktrees = this.hasGoalOwnedTeamLeadWorktrees(ps);
 		if (ps.worktreePath && ps.repoPath && !ps.worktreePath.startsWith("/workspace") && !ps.delegateOf && !goalOwnsTeamLeadWorktrees) {
 			try {
 				const { cleanupWorktree, removeEmptyWorktreeSetContainer } = await import("../skills/git.js");
@@ -16621,6 +16793,12 @@ export class SessionManager {
 		// kill immediately; recovery must never wait on the bridge being replaced.
 		// Paths remain in the agent's coordinate system — no translation needed.
 		const persistedBeforeAbort = this.resolveStoreForSession(id).get(id);
+		const adoptedExpectedContainerId = persistedBeforeAbort && this.isCanonicalAdoptedWorkspaceOwner(persistedBeforeAbort)
+			? persistedBeforeAbort.containerId?.trim()
+			: undefined;
+		if (persistedBeforeAbort && this.isCanonicalAdoptedWorkspaceOwner(persistedBeforeAbort) && !adoptedExpectedContainerId) {
+			throw new Error(`Cannot force-abort promoted session ${id}: durable sandbox container identity is missing`);
+		}
 		let agentSessionFile = persistedBeforeAbort?.agentSessionFile;
 		if (stateBeforeKill?.success && stateBeforeKill.data?.sessionFile) {
 			agentSessionFile = stateBeforeKill.data.sessionFile;
@@ -16698,6 +16876,7 @@ export class SessionManager {
 				const sandboxApplied = await this.applySandboxWiring(bridgeOptions, id, {
 					projectId: session.projectId,
 					goalId: session.goalId ?? session.teamGoalId,
+					expectedExistingContainerId: adoptedExpectedContainerId,
 				});
 				if (!sandboxApplied) {
 					throw new Error(`Cannot recover sandboxed session ${id}: sandbox realm is unavailable`);

--- a/src/server/agent/session-manager.ts
+++ b/src/server/agent/session-manager.ts
@@ -13841,7 +13841,7 @@ export class SessionManager {
 		}
 		if (!coordinator && session) broadcastStatus(session, "starting");
 		return this._coordinateSessionReplacement(id, "assign-role", (token) =>
-			this._assignRoleStaged(id, role, token), { drainOnRelease: true, cancelOnTerminal: () => false });
+			this._assignRoleStaged(id, role, undefined, token), { drainOnRelease: true, cancelOnTerminal: () => false });
 	}
 
 	/**
@@ -13878,7 +13878,7 @@ export class SessionManager {
 		};
 		if (!coordinator && session) broadcastStatus(session, "starting");
 		const promoted = await this._coordinateSessionReplacement(id, "promote-goal-lead", (token) =>
-			this._assignRoleStaged(id, role, token, projection), {
+			this._assignRoleStaged(id, role, projection, token), {
 				drainOnRelease: true,
 				cancelOnTerminal: () => { throw new Error(`Session ${id} promotion was cancelled by termination`); },
 			});
@@ -13924,8 +13924,8 @@ export class SessionManager {
 	private async _assignRoleStaged(
 		id: string,
 		role: { name: string; promptTemplate: string; accessory: string },
+		projection: SessionRoleReplacementProjection | undefined,
 		token: SessionReplacementToken,
-		projection?: SessionRoleReplacementProjection,
 	): Promise<boolean> {
 		const session = this.sessions.get(id);
 		if (!session) return false;
@@ -14280,8 +14280,11 @@ export class SessionManager {
 		}
 		session.goalId = replacementSession.goalId;
 		session.teamGoalId = replacementSession.teamGoalId;
-		session.role = replacementSession.role ?? role.name;
-		session.accessory = replacementSession.accessory ?? role.accessory;
+		// Ordinary assignment must replace the prior role rather than reading it
+		// back from replacementSession (which aliases the original session). Only
+		// promotion supplies graph metadata as an explicit prospective projection.
+		session.role = projection?.role ?? role.name;
+		session.accessory = projection?.accessory ?? role.accessory;
 		session.allowedTools = effectiveAllowedNames;
 		if (verifiedReplacementTuple) {
 			this.persistSessionModel(

--- a/src/server/agent/session-manager.ts
+++ b/src/server/agent/session-manager.ts
@@ -2979,6 +2979,22 @@ export type SessionTerminationListener = (sessionId: string, info: SessionTermin
 /** Purge-only entry into the gateway's per-session preview operation queue. */
 export type SessionPreviewPurgeOperation = <T>(sessionId: string, operation: () => Promise<T>) => Promise<T>;
 
+export type PromotedSessionLifecycleAction = "archive" | "purge";
+export type PromotedSessionLifecycleGuard = (
+	sessionId: string,
+	action: PromotedSessionLifecycleAction,
+) => string | undefined;
+
+export class PromotedSessionLifecycleConflictError extends Error {
+	readonly statusCode = 409;
+	readonly code = "PROMOTED_SESSION_LIFECYCLE_CONFLICT";
+
+	constructor(sessionId: string, reason: string) {
+		super(`Session ${sessionId} cannot be archived or purged directly: ${reason}`);
+		this.name = "PromotedSessionLifecycleConflictError";
+	}
+}
+
 export interface SessionManagerOptions {
 	/** Override the path to pi-coding-agent cli.js */
 	agentCliPath?: string;
@@ -3031,6 +3047,8 @@ export interface SessionManagerOptions {
 	 * cannot recreate a mount after deletion.
 	 */
 	previewPurgeOperation?: SessionPreviewPurgeOperation;
+	/** Late-bound graph guard supplied by goal/team ownership. A reason blocks direct destruction. */
+	promotedSessionLifecycleGuard?: PromotedSessionLifecycleGuard;
 }
 
 type SessionReplacementToken = {
@@ -3038,6 +3056,18 @@ type SessionReplacementToken = {
 	generation: number;
 	kind: string;
 };
+
+type SessionRoleReplacementProjection = {
+	goalId: string;
+	teamGoalId: string;
+	role: "team-lead";
+	accessory: string;
+	/** Promotion retains the source session's verified tuple instead of adopting role defaults. */
+	preserveModelTuple: true;
+};
+
+type PromotionAttachmentField = "goalId" | "teamGoalId" | "role" | "accessory";
+type PromotionAttachmentSnapshot = Record<PromotionAttachmentField, { present: boolean; value: unknown }>;
 
 type SessionReplacementCoordinator = {
 	tail: Promise<void>;
@@ -3194,6 +3224,7 @@ export class SessionManager {
 	private sessionPurgesInFlight = new Map<string, Promise<void>>();
 	private readonly archiveStat: (filePath: string) => Promise<{ size: number }>;
 	private readonly previewPurgeOperation: SessionPreviewPurgeOperation;
+	private promotedSessionLifecycleGuard?: PromotedSessionLifecycleGuard;
 	/** Heartbeat timer: re-broadcasts the current `session_status` for every
 	 *  active session every STATUS_HEARTBEAT_INTERVAL_MS, WITHOUT bumping
 	 *  `statusVersion`. Self-heals any client that missed a transition frame.
@@ -3874,6 +3905,7 @@ export class SessionManager {
 		this._bootRestoreLagSampler = options?.bootRestoreLagSampler;
 		this.archiveStat = options?.archiveStat ?? ((filePath) => fsp.stat(filePath));
 		this.previewPurgeOperation = options?.previewPurgeOperation ?? (async (_sessionId, operation) => operation());
+		this.promotedSessionLifecycleGuard = options?.promotedSessionLifecycleGuard;
 		sessionManagerModuleClock = this.clock;
 		this.agentCliPath = options?.agentCliPath;
 		this.systemPromptPath = options?.systemPromptPath;
@@ -3922,6 +3954,18 @@ export class SessionManager {
 			SessionManager.STATUS_HEARTBEAT_INTERVAL_MS,
 		);
 		(this._statusHeartbeatTimer as any).unref?.();
+	}
+
+	setPromotedSessionLifecycleGuard(guard: PromotedSessionLifecycleGuard | undefined): void {
+		this.promotedSessionLifecycleGuard = guard;
+	}
+
+	private assertPromotedSessionLifecycleAllowed(
+		sessionId: string,
+		action: PromotedSessionLifecycleAction,
+	): void {
+		const reason = this.promotedSessionLifecycleGuard?.(sessionId, action);
+		if (reason) throw new PromotedSessionLifecycleConflictError(sessionId, reason);
 	}
 
 	setExtensionChannelServices(services: ExtensionChannelServices | undefined): void {
@@ -13800,14 +13844,104 @@ export class SessionManager {
 			this._assignRoleStaged(id, role, token), { drainOnRelease: true, cancelOnTerminal: () => false });
 	}
 
+	/**
+	 * Attach a regular session to an accepted goal and rebuild its runtime as the
+	 * goal's lead without changing its identity, transcript, checkout, or sandbox.
+	 * Exact repeats are a no-op; conflicting attachments are rejected.
+	 */
+	async promoteToGoalLead(id: string, goalId: string): Promise<SessionInfo> {
+		const coordinator = this._sessionReplacementCoordinators.get(id);
+		const session = this.sessions.get(id);
+		if (!session && !coordinator) throw new Error(`Session ${id} not found`);
+		if (!coordinator && session?.status === "streaming") {
+			throw new Error("Cannot promote a session while its agent is streaming");
+		}
+		const goal = this.resolveGoal(goalId);
+		if (!goal) throw new Error(`Cannot promote session: goal ${goalId} was not found`);
+		if (session?.projectId && goal.projectId && session.projectId !== goal.projectId) {
+			throw new Error(`Cannot promote session ${id} across projects`);
+		}
+		if (session?.goalId === goalId && session.teamGoalId === goalId && session.role === "team-lead") {
+			return session;
+		}
+		if (session && (session.goalId || session.teamGoalId || session.role || session.assistantType || session.staffId || session.delegateOf || session.parentSessionId)) {
+			throw new Error(`Session ${id} already has goal, role, staff, assistant, delegate, or child metadata`);
+		}
+		const role = this.resolveSessionRole("team-lead", undefined, session?.projectId);
+		if (!role) throw new Error('Cannot promote session: role "team-lead" is unavailable');
+		const projection: SessionRoleReplacementProjection = {
+			goalId,
+			teamGoalId: goalId,
+			role: "team-lead",
+			accessory: role.accessory ?? "crown",
+			preserveModelTuple: true,
+		};
+		if (!coordinator && session) broadcastStatus(session, "starting");
+		const promoted = await this._coordinateSessionReplacement(id, "promote-goal-lead", (token) =>
+			this._assignRoleStaged(id, role, token, projection), {
+				drainOnRelease: true,
+				cancelOnTerminal: () => { throw new Error(`Session ${id} promotion was cancelled by termination`); },
+			});
+		if (!promoted) throw new Error(`Session ${id} disappeared during promotion`);
+		const canonical = this.sessions.get(id);
+		if (!canonical) throw new Error(`Session ${id} promotion committed without a canonical runtime`);
+		return canonical;
+	}
+
+	private snapshotPromotionAttachment(source: PersistedSession): PromotionAttachmentSnapshot {
+		const own = Object.prototype.hasOwnProperty;
+		return {
+			goalId: { present: own.call(source, "goalId"), value: source.goalId },
+			teamGoalId: { present: own.call(source, "teamGoalId"), value: source.teamGoalId },
+			role: { present: own.call(source, "role"), value: source.role },
+			accessory: { present: own.call(source, "accessory"), value: source.accessory },
+		};
+	}
+
+	private async restorePromotionAttachment(
+		store: SessionStore,
+		id: string,
+		snapshot: PromotionAttachmentSnapshot,
+	): Promise<void> {
+		const values = Object.fromEntries(
+			Object.entries(snapshot).map(([key, entry]) => [key, entry.value]),
+		) as Partial<PersistedSession>;
+		store.update(id, values as Parameters<SessionStore["update"]>[1]);
+		const restored = store.get(id) as Record<string, unknown> | undefined;
+		if (restored) {
+			for (const [key, entry] of Object.entries(snapshot)) {
+				if (!entry.present) delete restored[key];
+			}
+			// Bump the writer generation after deleting absent optional fields. The
+			// immediately scheduled structural write cannot serialize until this turn
+			// yields, so flushAsync publishes only the exact restored shape.
+			store.update(id, { lastActivity: restored.lastActivity as number });
+		}
+		await store.flushAsync();
+	}
+
 	/** Prepare and commit one role replacement while the shared lifecycle coordinator owns the session. */
 	private async _assignRoleStaged(
 		id: string,
 		role: { name: string; promptTemplate: string; accessory: string },
 		token: SessionReplacementToken,
+		projection?: SessionRoleReplacementProjection,
 	): Promise<boolean> {
 		const session = this.sessions.get(id);
 		if (!session) return false;
+		if (projection) {
+			const projectionGoal = this.resolveGoal(projection.goalId);
+			if (!projectionGoal) throw new Error(`Cannot promote session: goal ${projection.goalId} was not found`);
+			if (session.projectId && projectionGoal.projectId && session.projectId !== projectionGoal.projectId) {
+				throw new Error(`Cannot promote session ${id} across projects`);
+			}
+			if (session.goalId === projection.goalId && session.teamGoalId === projection.teamGoalId && session.role === projection.role) {
+				return true;
+			}
+			if (session.goalId || session.teamGoalId || session.role || session.assistantType || session.staffId || session.delegateOf || session.parentSessionId) {
+				throw new Error(`Session ${id} gained conflicting metadata before promotion staging`);
+			}
+		}
 		if (!this._replacementTokenIsCurrent(id, token) || token.coordinator.terminalRequest) {
 			throw new Error(`Session ${id} role replacement was superseded before staging`);
 		}
@@ -13816,8 +13950,13 @@ export class SessionManager {
 		// starts. Re-check the final canonical state here so role assignment never stops
 		// an active bridge merely because a coordinator existed at API-entry time.
 		if (session.status === "streaming") {
-			throw new Error("Cannot assign role while agent is streaming");
+			throw new Error(projection
+				? "Cannot promote a session while its agent is streaming"
+				: "Cannot assign role while agent is streaming");
 		}
+		const replacementSession: SessionInfo = projection
+			? { ...session, ...projection }
+			: session;
 		// Get the agent session file so we can restore conversation. A structured
 		// getState rejection is just as much a fallback case as a thrown RPC error;
 		// start from the durable value and replace it only with a non-empty live one.
@@ -13832,16 +13971,16 @@ export class SessionManager {
 		} catch { /* retain the durable transcript path */ }
 
 		// Reassemble system prompt with role instructions as separate fields
-		const goal = session.goalId ? this.resolveGoal(session.goalId) : undefined;
+		const goal = replacementSession.goalId ? this.resolveGoal(replacementSession.goalId) : undefined;
 		const goalSpec = goal?.spec;
 		// Look up the full role (with toolPolicies) cascade-first so pack-contributed
 		// roles keep their policies during role reassignment.
-		const fullRole = this.resolveSessionRole(role.name, undefined, session.projectId) ?? (role as Role);
+		const fullRole = this.resolveSessionRole(role.name, undefined, replacementSession.projectId) ?? (role as Role);
 		// Filter goal-metadata disabled tools (bobbit.disabledTools) for the
 		// session's effective goal so the reassembled prompt, the activation args,
 		// and the persisted allowedTools all agree after a role reassignment.
-		const respawnEffectiveGoalId = session.goalId ?? session.teamGoalId;
-		const respawnDisabled = this.disabledToolsForGoal(respawnEffectiveGoalId, session.projectId);
+		const respawnEffectiveGoalId = replacementSession.goalId ?? replacementSession.teamGoalId;
+		const respawnDisabled = this.disabledToolsForGoal(respawnEffectiveGoalId, replacementSession.projectId);
 		const effectiveAllowedRaw = this.resolveEffectiveAllowedTools(fullRole);
 		const effectiveAllowed = respawnDisabled
 			? effectiveAllowedRaw.filter(e => !respawnDisabled.has(e.name.toLowerCase()))
@@ -13861,13 +14000,13 @@ export class SessionManager {
 		// the other regular-session sites (previously passed raw — latent bug).
 		const rolePrompt = resolveRolePrompt(fullRole ?? role, {
 			branch: goal?.branch,
-			agentId: `${role.name}-${(session.goalId || session.id).slice(0, 8)}`,
+			agentId: `${role.name}-${(replacementSession.goalId || replacementSession.id).slice(0, 8)}`,
 			roleManager: this.roleManager,
 		});
 
 		const promptPath = this.assemblePrompt(id, {
 			baseSystemPromptPath: this.systemPromptPath,
-			cwd: session.cwd,
+			cwd: replacementSession.cwd,
 			goalTitle: goal?.title,
 			goalState: goal?.state,
 			goalSpec,
@@ -13878,7 +14017,7 @@ export class SessionManager {
 		});
 
 		// Respawn with new system prompt
-		const bridgeOptions: RpcBridgeOptions = { cwd: session.cwd };
+		const bridgeOptions: RpcBridgeOptions = { cwd: replacementSession.cwd };
 		if (this.agentCliPath) bridgeOptions.cliPath = this.agentCliPath;
 		if (promptPath) bridgeOptions.systemPromptPath = promptPath;
 		if (this.toolManager) bridgeOptions.toolManager = this.toolManager;
@@ -13886,10 +14025,10 @@ export class SessionManager {
 			BOBBIT_SESSION_ID: id,
 			BOBBIT_SESSION_SECRET: this.sessionSecretStore.getOrCreateSecret(id),
 		};
-		if (session.goalId) {
-			bridgeOptions.env.BOBBIT_GOAL_ID = session.goalId;
+		if (replacementSession.goalId) {
+			bridgeOptions.env.BOBBIT_GOAL_ID = replacementSession.goalId;
 			// Re-attach extensions: team leads need both team + goal tools, others just goal tools
-			const isTeamLead = session.role === "team-lead";
+			const isTeamLead = replacementSession.role === "team-lead";
 			if (isTeamLead) {
 				bridgeOptions.args = ["--extension", this.getTeamLeadExtensionPath(), "--extension", this.getGoalToolsExtensionPath()];
 			} else if (!bridgeOptions.args?.includes("--extension")) {
@@ -13909,8 +14048,8 @@ export class SessionManager {
 		// Apply tool activation args, including Bobbit extension tools and MCP policy filtering.
 		// `respawnAllowed` is `[]` (NO tools) when a role allowlist was fully removed by
 		// `bobbit.disabledTools`, and `undefined` only for a genuinely unrestricted session.
-		await this.ensureMcpManagerForContext(session.projectId, session.cwd);
-		const respawnActivation = this.buildToolActivationArgs(id, respawnAllowed, fullRole, session.cwd, session.projectId, respawnEffectiveGoalId, session.sessionOnlyGrantedTools);
+		await this.ensureMcpManagerForContext(replacementSession.projectId, replacementSession.cwd);
+		const respawnActivation = this.buildToolActivationArgs(id, respawnAllowed, fullRole, replacementSession.cwd, replacementSession.projectId, respawnEffectiveGoalId, session.sessionOnlyGrantedTools);
 		bridgeOptions.args = [...respawnActivation.args, ...(bridgeOptions.args || [])];
 		bridgeOptions.piExtensions = [...(bridgeOptions.piExtensions ?? []), ...respawnActivation.runtimeExtensions];
 		bridgeOptions.env = { ...(bridgeOptions.env || {}), ...respawnActivation.env };
@@ -13923,14 +14062,21 @@ export class SessionManager {
 			respawnPersisted?.modelProvider && respawnPersisted?.modelId
 				? normalizeAigwModelString(`${respawnPersisted.modelProvider}/${respawnPersisted.modelId}`)
 				: undefined;
-		const rawRoleModel = this.resolveRoleModelValue(role.name, session.projectId);
+		const rawRoleModel = projection?.preserveModelTuple
+			? undefined
+			: this.resolveRoleModelValue(role.name, replacementSession.projectId);
 		const roleModel = rawRoleModel
 			? normalizeAigwModelString(rawRoleModel)
 			: undefined;
-		const roleInitialModel = this.resolveInitialModel(role.name, session.projectId);
-		const roleDefaultModel = this.resolveInitialModel(undefined, session.projectId);
+		const roleInitialModel = this.resolveInitialModel(role.name, replacementSession.projectId);
+		const roleDefaultModel = this.resolveInitialModel(undefined, replacementSession.projectId);
 		const rawRoleDefaultModel = this.preferencesStore?.get("default.sessionModel") as string | undefined;
-		const exactRoleReplacementModel = roleModel ?? respawnPersistedModel ?? rawRoleDefaultModel;
+		const livePinnedModel = replacementSession.spawnPinnedModel
+			? normalizeAigwModelString(replacementSession.spawnPinnedModel)
+			: undefined;
+		const exactRoleReplacementModel = projection?.preserveModelTuple
+			? respawnPersistedModel ?? livePinnedModel ?? rawRoleDefaultModel
+			: roleModel ?? respawnPersistedModel ?? rawRoleDefaultModel;
 		bridgeOptions.initialModel = exactRoleReplacementModel
 			? await this.requireCurrentCatalogSpawnModel(exactRoleReplacementModel)
 			: await this.resolveCurrentCatalogSpawnModel([
@@ -13938,14 +14084,23 @@ export class SessionManager {
 				roleDefaultModel,
 			]);
 		const roleThinkingOverride = isKnownThinkingLevel(
-			this.resolveRoleThinkingLevelValue(role.name, session.projectId),
+			projection?.preserveModelTuple
+				? undefined
+				: this.resolveRoleThinkingLevelValue(role.name, replacementSession.projectId),
 		);
-		const initThinking = await this.resolveCurrentCatalogThinkingLevel(
-			bridgeOptions.initialModel,
-			role.name,
-			session.projectId,
-			roleThinkingOverride ?? respawnPersisted?.effectiveThinkingLevel,
-		);
+		const initThinking = projection?.preserveModelTuple
+			? await this.resolveCurrentCatalogPreferredThinkingLevel(
+				bridgeOptions.initialModel,
+				role.name,
+				replacementSession.projectId,
+				respawnPersisted?.effectiveThinkingLevel ?? replacementSession.spawnPinnedThinkingLevel,
+			)
+			: await this.resolveCurrentCatalogThinkingLevel(
+				bridgeOptions.initialModel,
+				role.name,
+				replacementSession.projectId,
+				roleThinkingOverride ?? respawnPersisted?.effectiveThinkingLevel,
+			);
 		if (initThinking) bridgeOptions.initialThinkingLevel = initThinking;
 
 		// Role assignment is an in-place rehydration, so the replacement must stay
@@ -13955,24 +14110,26 @@ export class SessionManager {
 		// longer be wired; silently launching Pi on the host would strand the
 		// container transcript and make an apparently successful role change lose
 		// model-visible history.
-		if (session.sandboxed) {
+		if (replacementSession.sandboxed) {
 			const sandboxApplied = await this.applySandboxWiring(bridgeOptions, id, {
-				projectId: session.projectId,
-				goalId: session.goalId ?? session.teamGoalId,
+				projectId: replacementSession.projectId,
+				goalId: replacementSession.goalId ?? replacementSession.teamGoalId,
 			});
 			if (!sandboxApplied) {
 				throw new Error(`Cannot assign role for sandboxed session ${id}: sandbox realm is unavailable`);
 			}
 		} else {
-			this.applyScopedGatewayCredentials(bridgeOptions, id, session.projectId, session.goalId ?? session.teamGoalId);
+			this.applyScopedGatewayCredentials(bridgeOptions, id, replacementSession.projectId, replacementSession.goalId ?? replacementSession.teamGoalId);
 		}
 		const spawnProvider = bridgeOptions.initialModel?.slice(0, bridgeOptions.initialModel.indexOf("/"));
-		await this.applyDirectProviderEnv(bridgeOptions, !!session.sandboxed, spawnProvider);
+		await this.applyDirectProviderEnv(bridgeOptions, !!replacementSession.sandboxed, spawnProvider);
 		await this.finalizeSpawnOptions(bridgeOptions, {
 			model: exactRoleReplacementModel ?? bridgeOptions.initialModel,
-			thinkingLevel: roleThinkingOverride ?? respawnPersisted?.effectiveThinkingLevel,
+			thinkingLevel: projection?.preserveModelTuple
+				? respawnPersisted?.effectiveThinkingLevel ?? replacementSession.spawnPinnedThinkingLevel
+				: roleThinkingOverride ?? respawnPersisted?.effectiveThinkingLevel,
 			role: role.name,
-			projectId: session.projectId,
+			projectId: replacementSession.projectId,
 		});
 
 		// Build and fully validate the replacement while the original bridge stays
@@ -13982,6 +14139,9 @@ export class SessionManager {
 		// fails closed without turning a healthy idle session into a dead one.
 		const oldRpcClient = session.rpcClient;
 		const oldUnsubscribe = session.unsubscribe;
+		const promotionAttachmentBefore = projection && persistedBeforeRole
+			? this.snapshotPromotionAttachment(persistedBeforeRole)
+			: undefined;
 		const rpcClient = new RpcBridge(bridgeOptions);
 		let replacementCommitted = false;
 		let oldBridgeStopped = false;
@@ -13999,10 +14159,10 @@ export class SessionManager {
 		});
 
 		bridgeOptions.onPiExtensionDiagnostic = (diagnostic, extension) => this.recordPiExtensionDiagnostic(session, diagnostic, extension);
-		const rolePs = { ...respawnPersisted, ...session, agentSessionFile } as PersistedSession;
+		const rolePs = { ...respawnPersisted, ...replacementSession, agentSessionFile } as PersistedSession;
 		const roleFileCtx = sessionFsContextForAgentFile(rolePs, agentSessionFile);
 		const stagedSession = {
-			...session,
+			...replacementSession,
 			rpcClient,
 			unsubscribe: unsub,
 			spawnPinnedModel: bridgeOptions.initialModel,
@@ -14047,9 +14207,25 @@ export class SessionManager {
 				throw new Error(`Session ${id} role replacement was superseded before old bridge stop`);
 			}
 
-			// Persist the metadata before the irreversible old-process stop. If the
-			// stop rejects, restore the prior durable values and retain its listener.
-			roleStore.update(id, { role: role.name, accessory: role.accessory });
+			// Persist the metadata before the irreversible old-process stop. Promotion
+			// publishes its complete graph attachment in one structural mutation. If
+			// the stop rejects, restore the prior values and their exact optional-field
+			// presence while retaining the old bridge and listener.
+			try {
+				roleStore.update(id, projection
+					? {
+						goalId: projection.goalId,
+						teamGoalId: projection.teamGoalId,
+						role: projection.role,
+						accessory: projection.accessory,
+					}
+					: { role: role.name, accessory: role.accessory });
+			} catch (err) {
+				if (promotionAttachmentBefore) {
+					await this.restorePromotionAttachment(roleStore, id, promotionAttachmentBefore);
+				}
+				throw err;
+			}
 			// The old SessionInfo remains canonical through the stop await. Cancel its
 			// pending activity transactions first so stop-triggered late RPC success
 			// cannot write activity or open the replacement's restore quarantine.
@@ -14058,14 +14234,22 @@ export class SessionManager {
 				await oldRpcClient.stop();
 				oldBridgeStopped = true;
 			} catch (err) {
-				roleStore.update(id, { role: session.role, accessory: session.accessory });
+				if (promotionAttachmentBefore) {
+					await this.restorePromotionAttachment(roleStore, id, promotionAttachmentBefore);
+				} else {
+					roleStore.update(id, { role: session.role, accessory: session.accessory });
+				}
 				throw err;
 			}
 			// The old stop is the irreversible await in the two-phase swap. Revalidate
 			// both identity and ownership afterwards; a stale staged bridge is disposed
 			// by the catch path and can never overwrite a newer canonical process.
 			if (this.sessions.get(id) !== session || !this._replacementTokenIsCurrent(id, token) || token.coordinator.terminalRequest) {
-				roleStore.update(id, { role: session.role, accessory: session.accessory });
+				if (promotionAttachmentBefore) {
+					await this.restorePromotionAttachment(roleStore, id, promotionAttachmentBefore);
+				} else {
+					roleStore.update(id, { role: session.role, accessory: session.accessory });
+				}
 				throw new Error(`Session ${id} role replacement was superseded after old bridge stop`);
 			}
 		} catch (err) {
@@ -14094,8 +14278,10 @@ export class SessionManager {
 			session.spawnPinnedModel = `${verifiedReplacementTuple.provider}/${verifiedReplacementTuple.modelId}`;
 			session.spawnPinnedThinkingLevel = verifiedReplacementTuple.thinkingLevel;
 		}
-		session.role = role.name;
-		session.accessory = role.accessory;
+		session.goalId = replacementSession.goalId;
+		session.teamGoalId = replacementSession.teamGoalId;
+		session.role = replacementSession.role ?? role.name;
+		session.accessory = replacementSession.accessory ?? role.accessory;
 		session.allowedTools = effectiveAllowedNames;
 		if (verifiedReplacementTuple) {
 			this.persistSessionModel(
@@ -14432,7 +14618,8 @@ export class SessionManager {
 		try { return await target.archiveAsync(id); } catch { return false; }
 	}
 
-	async terminateSession(id: string): Promise<boolean> {
+	async terminateSession(id: string, opts?: { allowPromotedGoalLifecycle?: boolean }): Promise<boolean> {
+		if (!opts?.allowPromotedGoalLifecycle) this.assertPromotedSessionLifecycleAllowed(id, "archive");
 		const persisted = this.getPersistedSession(id);
 		const live = this.sessions.get(id);
 		const lifecycleOwnerId = (live?.sandboxed || persisted?.sandboxed)
@@ -14688,7 +14875,8 @@ export class SessionManager {
 	 * Routes through the runtime archive seam (§6) so a dormant parent's live
 	 * children are cascade-reaped before it is archived.
 	 */
-	async storeArchive(id: string): Promise<boolean> {
+	async storeArchive(id: string, opts?: { allowPromotedGoalLifecycle?: boolean }): Promise<boolean> {
+		if (!opts?.allowPromotedGoalLifecycle) this.assertPromotedSessionLifecycleAllowed(id, "archive");
 		const persisted = this.getPersistedSession(id);
 		const lifecycleOwnerId = persisted?.sandboxed
 			? (persisted.borrowsWorktree
@@ -15612,6 +15800,7 @@ export class SessionManager {
 
 	/** Internal purge body — entered only through the per-session owner above. */
 	private async purgeOneSession(ps: PersistedSession): Promise<void> {
+		this.assertPromotedSessionLifecycleAllowed(ps.id, "purge");
 		// SAFETY: refuse to destroy a team-lead session that the team-store
 		// still references for a non-archived goal. Symptom this prevents:
 		// the user's "Audit subgoals branch" team-lead vanished because some

--- a/src/server/agent/session-store.ts
+++ b/src/server/agent/session-store.ts
@@ -282,6 +282,8 @@ export interface PersistedSession {
 	imageModelId?: string;
 	/** Whether this session runs inside a Docker sandbox container */
 	sandboxed?: boolean;
+	/** Exact container identity retained only when the session owns an adopted sandbox workspace. */
+	containerId?: string;
 	/** Per-repo worktree paths (multi-repo only). Single-repo uses flat worktreePath. */
 	repoWorktrees?: Record<string, string>;
 	/** Server-authoritative right-hand side-panel workspace. */
@@ -339,6 +341,7 @@ export type UpdatableSessionFields = Pick<
 	| "imageModelProvider"
 	| "imageModelId"
 	| "sandboxed"
+	| "containerId"
 	| "projectId"
 	| "repoWorktrees"
 	| "sidePanelWorkspace"
@@ -826,7 +829,7 @@ export class SessionStore {
 	private static RECOVERY_CRITICAL_FIELDS: ReadonlyArray<keyof UpdatableSessionFields> = [
 		"agentSessionFile", "branch", "worktreePath", "cwd", "repoPath",
 		"repoWorktrees", "archived", "archivedAt",
-		"sandboxed", "projectId", "goalId", "delegateOf",
+		"sandboxed", "containerId", "projectId", "goalId", "delegateOf",
 		"parentSessionId", "childKind", "readOnly", "childTerminal", "terminalAt",
 		"role", "assistantType", "taskId", "staffId",
 		"teamGoalId", "teamLeadSessionId",

--- a/src/server/agent/team-manager.ts
+++ b/src/server/agent/team-manager.ts
@@ -800,7 +800,13 @@ export class TeamManager {
 	 * are restored). Event subscriptions deferred to resubscribeTeamEvents().
 	 */
 	private async restoreTeams(): Promise<void> {
-		await this.reconcileAdoptedGoalReservations();
+		// Promotion provenance only exists in project-context stores. Keep the
+		// non-PCM restore path synchronous through persisted entry hydration: local
+		// callers have always been able to inspect restored teams immediately after
+		// construction, and awaiting a no-op promise would defer that hydration.
+		if (this.config.projectContextManager) {
+			await this.reconcileAdoptedGoalReservations();
+		}
 
 		// orphan team-store cleanup — Boot-time orphan cleanup. Walk every persisted team
 		// entry FIRST and drop entries whose `goalId` is not present in the

--- a/src/server/agent/team-manager.ts
+++ b/src/server/agent/team-manager.ts
@@ -6,6 +6,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { promisify } from "node:util";
 import type { PromptSource, SessionManager, SessionInfo } from "./session-manager.js";
+import type { PersistedSession } from "./session-store.js";
 import { isNonRetryableAgentError, isProviderBackoffError, isRetryableGenericAgentError, isTransientReviewError } from "./verification-logic.js";
 import { GoalManager } from "./goal-manager.js";
 import { GoalStore, type PersistedGoal } from "./goal-store.js";
@@ -345,6 +346,48 @@ interface StartTeamLock {
 	promise: Promise<SessionInfo>;
 }
 
+function sameStringRecord(left: Record<string, string> | undefined, right: Record<string, string> | undefined): boolean {
+	if (left === undefined || right === undefined) return left === right;
+	const leftKeys = Object.keys(left).sort();
+	const rightKeys = Object.keys(right).sort();
+	return leftKeys.length === rightKeys.length
+		&& leftKeys.every((key, index) => key === rightKeys[index] && left[key] === right[key]);
+}
+
+function matchesAdoptedGoalWorkspace(goal: PersistedGoal, session: PersistedSession, projectId: string): boolean {
+	return goal.projectId === projectId
+		&& session.projectId === projectId
+		&& session.cwd === goal.cwd
+		&& session.worktreePath === goal.worktreePath
+		&& session.branch === goal.branch
+		&& session.repoPath === goal.repoPath
+		&& session.sandboxed === goal.sandboxed
+		&& sameStringRecord(session.repoWorktrees, goal.repoWorktrees);
+}
+
+function hasConflictingPromotionRelation(session: PersistedSession, goalId: string): boolean {
+	return (session.goalId !== undefined && session.goalId !== goalId)
+		|| (session.teamGoalId !== undefined && session.teamGoalId !== goalId)
+		|| (session.role !== undefined && session.role !== "team-lead")
+		|| session.teamLeadSessionId !== undefined
+		|| session.delegateOf !== undefined
+		|| session.parentSessionId !== undefined
+		|| session.childKind !== undefined
+		|| session.staffId !== undefined
+		|| session.assistantType !== undefined
+		|| session.goalAssistant === true
+		|| session.roleAssistant === true
+		|| session.toolAssistant === true
+		|| session.readOnly === true
+		|| session.nonInteractive === true
+		|| session.borrowsWorktree === true
+		|| session.archived === true;
+}
+
+function hasPromotionAttachment(session: PersistedSession | undefined): boolean {
+	return !!session && (session.goalId !== undefined || session.teamGoalId !== undefined || session.role !== undefined);
+}
+
 /** Internal tracking for a team associated with a goal. */
 interface TeamEntry {
 	goalId: string;
@@ -680,10 +723,85 @@ export class TeamManager {
 	}
 
 	/**
+	 * Reconcile promotion provenance before ordinary orphan recovery. A valid
+	 * adopted goal deterministically identifies one same-project source session,
+	 * so missing gates, the empty lead reservation, and exact attachment metadata
+	 * can be repaired without starting a team or creating any runtime/worktree.
+	 */
+	private async reconcileAdoptedGoalReservations(): Promise<void> {
+		const pcm = this.config.projectContextManager;
+		if (!pcm) return;
+		const contexts = [...pcm.all()];
+		for (const ctx of contexts) {
+			for (const goal of ctx.goalStore.getAll()) {
+				const ownerSessionId = goal.worktreeOwnerSessionId;
+				if (!ownerSessionId || goal.archived) continue;
+
+				const sourceLocations = contexts.filter(candidate => candidate.sessionStore.get(ownerSessionId) !== undefined);
+				const source = ctx.sessionStore.get(ownerSessionId);
+				const targetEntry = ctx.teamStore.get(goal.id);
+				const leadClaims = contexts.flatMap(candidate => candidate.teamStore.getAll())
+					.filter(entry => entry.teamLeadSessionId === ownerSessionId);
+				const conflictingClaim = leadClaims.some(entry => entry.goalId !== goal.id);
+				const validSource = sourceLocations.length === 1
+					&& sourceLocations[0] === ctx
+					&& !!source
+					&& matchesAdoptedGoalWorkspace(goal, source, ctx.project.id)
+					&& !hasConflictingPromotionRelation(source, goal.id);
+				const validReservation = !targetEntry || targetEntry.teamLeadSessionId === ownerSessionId;
+
+				if (!validSource || !validReservation || conflictingClaim) {
+					// Compensation is intentionally narrow. Once the source carries any
+					// attachment or the reservation gained workers/changed identity, boot
+					// refuses to guess and leaves the records for an explicit repair.
+					const unchangedReservation = !targetEntry
+						|| (targetEntry.teamLeadSessionId === ownerSessionId && (targetEntry.agents?.length ?? 0) === 0);
+					if (!hasPromotionAttachment(source) && unchangedReservation && !conflictingClaim) {
+						const deleted = await ctx.goalManager.deleteAdoptedGoalAttempt(goal.id, ownerSessionId);
+						if (deleted) {
+							if (targetEntry) ctx.teamStore.remove(goal.id);
+							ctx.gateStore.removeGoalGates(goal.id);
+							await Promise.all([ctx.gateStore.flush(), ctx.sessionStore.flush()]);
+							console.warn(`[team-manager] Boot compensation removed uncommitted adopted goal ${goal.id}`);
+						} else {
+							console.error(`[team-manager] Boot reconciliation refused non-todo adopted goal ${goal.id}`);
+						}
+					} else {
+						console.error(`[team-manager] Boot reconciliation refused ambiguous adopted goal ${goal.id}`);
+					}
+					continue;
+				}
+
+				if (!targetEntry) {
+					ctx.teamStore.put({
+						goalId: goal.id,
+						teamLeadSessionId: ownerSessionId,
+						agents: [],
+						maxConcurrent: 12,
+					});
+				}
+				if (source.goalId !== goal.id || source.teamGoalId !== goal.id || source.role !== "team-lead") {
+					ctx.sessionStore.update(ownerSessionId, {
+						goalId: goal.id,
+						teamGoalId: goal.id,
+						role: "team-lead",
+					});
+				}
+				if (goal.workflow) {
+					ctx.gateStore.initGatesForGoal(goal.id, goal.workflow.gates.map(gate => gate.id));
+				}
+				await Promise.all([ctx.gateStore.flush(), ctx.sessionStore.flush()]);
+			}
+		}
+	}
+
+	/**
 	 * Restore teams from disk. Called from the constructor (before sessions
 	 * are restored). Event subscriptions deferred to resubscribeTeamEvents().
 	 */
 	private async restoreTeams(): Promise<void> {
+		await this.reconcileAdoptedGoalReservations();
+
 		// orphan team-store cleanup — Boot-time orphan cleanup. Walk every persisted team
 		// entry FIRST and drop entries whose `goalId` is not present in the
 		// owning project's goal store. This prevents the zombie-reviewer sweep
@@ -1882,6 +2000,91 @@ export class TeamManager {
 	}
 
 	/**
+	 * Reserve an existing regular session as the sole lead for an adopted goal.
+	 * The reservation changes team metadata only; it never starts, replaces, or
+	 * terminates the source runtime. Exact retries return the established state.
+	 */
+	async adoptExistingLead(goalId: string, sessionId: string): Promise<TeamState> {
+		if (!this.restoreCompleted) await this.restorePromise;
+		// An adopted goal is never allowed to fall through to ordinary lead
+		// creation. If a start raced ahead, it will reject at the provenance guard
+		// in _startTeamImpl; join it before installing the reservation.
+		const starting = this.startTeamLocks.get(goalId);
+		if (starting) {
+			try { await starting.promise; } catch { /* expected for an unreserved adopted goal */ }
+		}
+		const goal = this.resolveGoal(goalId);
+		if (!goal) throw new TeamStartError("GOAL_NOT_FOUND", "Goal not found", 404);
+		if (goal.archived) throw new TeamStartError("GOAL_ARCHIVED", "Goal is archived and cannot adopt a lead");
+		if (goal.worktreeOwnerSessionId !== sessionId) {
+			throw new TeamStartError("ADOPTED_LEAD_PROVENANCE_MISMATCH", "Session does not own this adopted goal workspace");
+		}
+		const source = this.sessionManager.getSession(sessionId);
+		if (!source || source.status === "terminated") {
+			throw new TeamStartError("ADOPTED_LEAD_UNAVAILABLE", "The source session is unavailable for promotion");
+		}
+
+		const existing = this.teams.get(goalId);
+		if (existing) {
+			if (existing.teamLeadSessionId !== sessionId) {
+				throw new TeamStartError("TEAM_ALREADY_ACTIVE", `Team already active for goal: ${goalId}`);
+			}
+			return this.getTeamState(goalId)!;
+		}
+		const mappedGoal = this.sessionToGoal.get(sessionId);
+		if (mappedGoal && mappedGoal !== goalId) {
+			throw new TeamStartError("SESSION_ALREADY_TEAM_MEMBER", "Session already belongs to another team");
+		}
+		for (const [otherGoalId, entry] of this.teams) {
+			if (otherGoalId !== goalId && (entry.teamLeadSessionId === sessionId || entry.agents.some(agent => agent.sessionId === sessionId))) {
+				throw new TeamStartError("SESSION_ALREADY_TEAM_MEMBER", "Session already belongs to another team");
+			}
+		}
+
+		const entry: TeamEntry = {
+			goalId,
+			teamLeadSessionId: sessionId,
+			agents: [],
+			maxConcurrent: 12,
+		};
+		this.teams.set(goalId, entry);
+		this.sessionToGoal.set(sessionId, goalId);
+		try {
+			this.persistEntry(goalId);
+		} catch (error) {
+			this.teams.delete(goalId);
+			if (this.sessionToGoal.get(sessionId) === goalId) this.sessionToGoal.delete(sessionId);
+			throw error;
+		}
+		return this.getTeamState(goalId)!;
+	}
+
+	/**
+	 * Release only an unchanged empty promotion reservation. This is the
+	 * pre-commit compensation path and deliberately leaves the source session,
+	 * runtime, transcript, sandbox, and checkout untouched.
+	 */
+	async releaseAdoptedLead(goalId: string, sessionId: string): Promise<boolean> {
+		if (!this.restoreCompleted) await this.restorePromise;
+		const entry = this.teams.get(goalId);
+		if (!entry) return this.sessionToGoal.get(sessionId) !== goalId;
+		if (entry.teamLeadSessionId !== sessionId || entry.agents.length !== 0) return false;
+		const goal = this.resolveGoal(goalId);
+		if (!goal || goal.worktreeOwnerSessionId !== sessionId) return false;
+
+		entry.unsubscribeTeamLeadEvents?.();
+		entry.unsubscribeTeamLeadEvents = undefined;
+		this.clearIdleNudgeTimer(goalId);
+		this.teams.delete(goalId);
+		if (this.sessionToGoal.get(sessionId) === goalId) this.sessionToGoal.delete(sessionId);
+		this.leadIdleSinceByGoal.delete(goalId);
+		this.lastNudgeAtPerGoal.delete(goalId);
+		this.rearmedCompletedTeams.delete(goalId);
+		this.resolveTeamStore(goalId).remove(goalId);
+		return true;
+	}
+
+	/**
 	 * Start a team for the given goal.
 	 * Creates a Team Lead session and returns it.
 	 */
@@ -1976,6 +2179,12 @@ export class TeamManager {
 		}
 		this.assertGoalCanStart(goal);
 		const existingTeam = this.teams.get(goalId);
+		if (goal.worktreeOwnerSessionId && !existingTeam) {
+			throw new TeamStartError(
+				"ADOPTED_LEAD_RESERVATION_REQUIRED",
+				"This goal adopts its source session and cannot create a second team lead",
+			);
+		}
 		// A paused, authorized start must run the canonical resume lifecycle even
 		// if an earlier attempt already left team tracking behind. Every other
 		// existing-team path is a pure idempotency/error decision: it must not
@@ -3211,6 +3420,13 @@ export class TeamManager {
 		const entry = this.teams.get(goalId);
 		if (!entry) {
 			throw new Error(`No active team for goal: ${goalId}`);
+		}
+		const teardownGoal = this.resolveGoal(goalId);
+		if (teardownGoal?.worktreeOwnerSessionId === entry.teamLeadSessionId && !teardownGoal.archived) {
+			throw new TeamStartError(
+				"PROMOTED_LEAD_TEARDOWN_CONFLICT",
+				"A promoted session cannot be torn down while its goal is live; archive the goal first",
+			);
 		}
 
 		// Cancel any in-flight verifications before teardown — prevents zombie reviewers

--- a/src/server/agent/team-manager.ts
+++ b/src/server/agent/team-manager.ts
@@ -369,7 +369,26 @@ function isBaselineRegularPromotionRole(role: string | undefined): boolean {
 	return role === undefined || role === "general";
 }
 
-function hasConflictingPromotionRelation(session: PersistedSession, goalId: string): boolean {
+type PromotionRelation = Pick<PersistedSession,
+	| "goalId"
+	| "teamGoalId"
+	| "role"
+	| "teamLeadSessionId"
+	| "delegateOf"
+	| "parentSessionId"
+	| "childKind"
+	| "staffId"
+	| "assistantType"
+	| "goalAssistant"
+	| "roleAssistant"
+	| "toolAssistant"
+	| "readOnly"
+	| "nonInteractive"
+	| "borrowsWorktree"
+	| "archived"
+>;
+
+function hasConflictingPromotionRelation(session: PromotionRelation, goalId: string): boolean {
 	return (session.goalId !== undefined && session.goalId !== goalId)
 		|| (session.teamGoalId !== undefined && session.teamGoalId !== goalId)
 		|| (!isBaselineRegularPromotionRole(session.role) && session.role !== "team-lead")
@@ -388,10 +407,24 @@ function hasConflictingPromotionRelation(session: PersistedSession, goalId: stri
 		|| session.archived === true;
 }
 
-function hasPromotionAttachment(session: PersistedSession | undefined): boolean {
+function hasPromotionAttachment(session: Pick<PromotionRelation, "goalId" | "teamGoalId" | "role"> | undefined): boolean {
 	return !!session && (session.goalId !== undefined
 		|| session.teamGoalId !== undefined
 		|| !isBaselineRegularPromotionRole(session.role));
+}
+
+function hasExactAdoptedLeadAttachment(session: PromotionRelation | undefined, goalId: string): boolean {
+	return !!session
+		&& session.goalId === goalId
+		&& session.teamGoalId === goalId
+		&& session.role === "team-lead"
+		&& !hasConflictingPromotionRelation(session, goalId);
+}
+
+function isUnattachedPromotionSource(session: PromotionRelation | undefined, goalId: string): boolean {
+	return !!session
+		&& !hasPromotionAttachment(session)
+		&& !hasConflictingPromotionRelation(session, goalId);
 }
 
 /** Internal tracking for a team associated with a goal. */
@@ -2088,6 +2121,17 @@ export class TeamManager {
 		if (entry.teamLeadSessionId !== sessionId || entry.agents.length !== 0) return false;
 		const goal = this.resolveGoal(goalId);
 		if (!goal || goal.worktreeOwnerSessionId !== sessionId) return false;
+		const liveSource = this.sessionManager.getSession(sessionId);
+		const getPersistedSession = (this.sessionManager as Partial<SessionManager>).getPersistedSession;
+		const persistedSource = typeof getPersistedSession === "function"
+			? getPersistedSession.call(this.sessionManager, sessionId)
+			: undefined;
+		// Compensation owns only the still-unattached source capsule. Once either
+		// canonical view gained a partial or complete relation, fail closed so an
+		// identity-changing race cannot remove the reservation underneath it.
+		if (!isUnattachedPromotionSource(liveSource, goalId) || !isUnattachedPromotionSource(persistedSource, goalId)) {
+			return false;
+		}
 
 		entry.unsubscribeTeamLeadEvents?.();
 		entry.unsubscribeTeamLeadEvents = undefined;
@@ -2481,6 +2525,31 @@ export class TeamManager {
 		return undefined;
 	}
 
+	private assertAdoptedLeadWorkerAdmission(goal: PersistedGoal, entry: TeamEntry): void {
+		const ownerSessionId = goal.worktreeOwnerSessionId;
+		if (!ownerSessionId) return;
+		const liveSource = entry.teamLeadSessionId === ownerSessionId
+			? this.sessionManager.getSession(ownerSessionId)
+			: undefined;
+		const getPersistedSession = (this.sessionManager as Partial<SessionManager>).getPersistedSession;
+		const persistedSource = typeof getPersistedSession === "function"
+			? getPersistedSession.call(this.sessionManager, ownerSessionId)
+			: undefined;
+		// The durable projection is written before the old runtime stops, so it is
+		// not by itself a commit signal. Require both the durable row and canonical
+		// live runtime to carry the exact attachment before creating any worker.
+		if (
+			entry.teamLeadSessionId !== ownerSessionId
+			|| !hasExactAdoptedLeadAttachment(liveSource, goal.id)
+			|| !hasExactAdoptedLeadAttachment(persistedSource, goal.id)
+		) {
+			throw new TeamStartError(
+				"ADOPTED_LEAD_ATTACHMENT_PENDING",
+				"The adopted team lead is still attaching to this goal; wait for promotion to finish",
+			);
+		}
+	}
+
 	async spawnRole(
 		goalId: string,
 		role: string,
@@ -2506,6 +2575,11 @@ export class TeamManager {
 		if (!entry) {
 			throw new Error(`No active team for goal: ${goalId}`);
 		}
+		const goal = this.resolveGoal(goalId);
+		if (!goal) {
+			throw new Error(`Goal not found: ${goalId}`);
+		}
+		this.assertAdoptedLeadWorkerAdmission(goal, entry);
 
 		// Check concurrency limit using the same live-worker semantics as sidebar/listing.
 		this.reapStaleWorkers(goalId, entry);
@@ -2516,10 +2590,6 @@ export class TeamManager {
 			);
 		}
 
-		const goal = this.resolveGoal(goalId);
-		if (!goal) {
-			throw new Error(`Goal not found: ${goalId}`);
-		}
 		// A stale/preparing goal must not be able to create a worker through an
 		// in-process caller that bypasses the REST spawn route.
 		this.assertGoalSetupReady(goal);

--- a/src/server/agent/team-manager.ts
+++ b/src/server/agent/team-manager.ts
@@ -566,6 +566,8 @@ export class TeamManager {
 
 	/** In-flight startTeam operations, including their immutable caller semantics. */
 	private startTeamLocks = new Map<string, StartTeamLock>();
+	/** Serializes adopted-lead finalization with the admitted archive operation. */
+	private adoptedGoalLifecycleLocks = new Map<string, Promise<void>>();
 	private readonly commandRunner: CommandRunner;
 	private readonly recoveryFs: RecoveryFs;
 	private readonly recoverySidecars: TeamRecoverySidecars;
@@ -833,6 +835,9 @@ export class TeamManager {
 				}
 				if (goal.workflow) {
 					ctx.gateStore.initGatesForGoal(goal.id, goal.workflow.gates.map(gate => gate.id));
+				}
+				if (goal.state === "todo") {
+					await ctx.goalManager.updateGoal(goal.id, { state: "in-progress" });
 				}
 				await Promise.all([ctx.gateStore.flush(), ctx.sessionStore.flush()]);
 			}
@@ -2109,6 +2114,104 @@ export class TeamManager {
 		return this.getTeamState(goalId)!;
 	}
 
+	private hasExactAdoptedLeadAttachment(goal: PersistedGoal, entry: TeamEntry | undefined): boolean {
+		const ownerSessionId = goal.worktreeOwnerSessionId;
+		if (!ownerSessionId || entry?.teamLeadSessionId !== ownerSessionId) return false;
+		if (this.sessionToGoal.get(ownerSessionId) !== goal.id) return false;
+		const liveSource = this.sessionManager.getSession(ownerSessionId);
+		const getPersistedSession = (this.sessionManager as Partial<SessionManager>).getPersistedSession;
+		const persistedSource = typeof getPersistedSession === "function"
+			? getPersistedSession.call(this.sessionManager, ownerSessionId)
+			: undefined;
+		return liveSource?.status !== "terminated"
+			&& liveSource?.projectId === goal.projectId
+			&& persistedSource?.projectId === goal.projectId
+			&& hasExactAdoptedLeadAttachment(liveSource, goal.id)
+			&& hasExactAdoptedLeadAttachment(persistedSource, goal.id);
+	}
+
+	private async runAdoptedGoalLifecycleLocked<T>(goalId: string, action: () => Promise<T>): Promise<T> {
+		for (;;) {
+			const previous = this.adoptedGoalLifecycleLocks.get(goalId);
+			if (!previous) break;
+			await previous.catch(() => undefined);
+		}
+		let release!: () => void;
+		const current = new Promise<void>((resolve) => { release = resolve; });
+		this.adoptedGoalLifecycleLocks.set(goalId, current);
+		try {
+			return await action();
+		} finally {
+			if (this.adoptedGoalLifecycleLocks.get(goalId) === current) {
+				this.adoptedGoalLifecycleLocks.delete(goalId);
+			}
+			release();
+		}
+	}
+
+	/**
+	 * Complete the normal active-team lifecycle after SessionManager has committed
+	 * an in-place lead promotion. This installs the ordinary lead subscription and
+	 * activates a todo goal, but deliberately creates no runtime and sends no kickoff.
+	 */
+	async finalizeAdoptedLead(goalId: string): Promise<TeamState> {
+		if (!this.restoreCompleted) await this.restorePromise;
+		return this.runAdoptedGoalLifecycleLocked(goalId, async () => {
+			const goal = this.resolveGoal(goalId);
+			if (!goal) throw new TeamStartError("GOAL_NOT_FOUND", "Goal not found", 404);
+			if (!goal.worktreeOwnerSessionId) {
+				throw new TeamStartError("GOAL_NOT_ADOPTED", "Goal does not adopt an existing session");
+			}
+			if (goal.archived) {
+				throw new TeamStartError("GOAL_ARCHIVED", "Goal is archived and cannot finalize its adopted lead");
+			}
+			const entry = this.teams.get(goalId);
+			if (!this.hasExactAdoptedLeadAttachment(goal, entry)) {
+				throw new TeamStartError(
+					"ADOPTED_LEAD_ATTACHMENT_PENDING",
+					"The adopted team lead is still attaching to this goal; wait for promotion to finish",
+				);
+			}
+			if (!this.subscribeTeamLeadEvents(goalId)) {
+				throw new TeamStartError(
+					"ADOPTED_LEAD_SUBSCRIPTION_FAILED",
+					"The adopted team lead lifecycle could not be activated; retry finalization",
+				);
+			}
+			const lead = this.sessionManager.getSession(goal.worktreeOwnerSessionId);
+			if (lead?.status === "idle") this.startIdleNudgeTimer(goalId);
+			if (goal.state === "todo") {
+				await this.resolveGoalManager(goalId).updateGoal(goalId, { state: "in-progress" });
+			}
+			return this.getTeamState(goalId)!;
+		});
+	}
+
+	/**
+	 * Admit and serialize an adopted-goal archive only after the source runtime and
+	 * durable row both carry the exact committed lead attachment. Ordinary goals
+	 * pass through unchanged. The callback keeps the admission and archive mutation
+	 * under the same per-goal lifecycle lock so the check cannot become stale.
+	 */
+	async withAdoptedGoalArchiveAdmission<T>(goalId: string, archive: () => Promise<T>): Promise<T> {
+		if (!this.restoreCompleted) await this.restorePromise;
+		return this.runAdoptedGoalLifecycleLocked(goalId, async () => {
+			const goal = this.resolveGoal(goalId);
+			if (!goal) throw new TeamStartError("GOAL_NOT_FOUND", "Goal not found", 404);
+			if (
+				goal.worktreeOwnerSessionId
+				&& !goal.archived
+				&& !this.hasExactAdoptedLeadAttachment(goal, this.teams.get(goalId))
+			) {
+				throw new TeamStartError(
+					"PROMOTION_IN_PROGRESS",
+					"Current-session promotion is still in progress; retry goal archive after it finishes",
+				);
+			}
+			return archive();
+		});
+	}
+
 	/**
 	 * Release only an unchanged empty promotion reservation. This is the
 	 * pre-commit compensation path and deliberately leaves the source session,
@@ -2526,23 +2629,11 @@ export class TeamManager {
 	}
 
 	private assertAdoptedLeadWorkerAdmission(goal: PersistedGoal, entry: TeamEntry): void {
-		const ownerSessionId = goal.worktreeOwnerSessionId;
-		if (!ownerSessionId) return;
-		const liveSource = entry.teamLeadSessionId === ownerSessionId
-			? this.sessionManager.getSession(ownerSessionId)
-			: undefined;
-		const getPersistedSession = (this.sessionManager as Partial<SessionManager>).getPersistedSession;
-		const persistedSource = typeof getPersistedSession === "function"
-			? getPersistedSession.call(this.sessionManager, ownerSessionId)
-			: undefined;
+		if (!goal.worktreeOwnerSessionId) return;
 		// The durable projection is written before the old runtime stops, so it is
 		// not by itself a commit signal. Require both the durable row and canonical
-		// live runtime to carry the exact attachment before creating any worker.
-		if (
-			entry.teamLeadSessionId !== ownerSessionId
-			|| !hasExactAdoptedLeadAttachment(liveSource, goal.id)
-			|| !hasExactAdoptedLeadAttachment(persistedSource, goal.id)
-		) {
+		// live runtime to carry the exact same-project attachment before creating a worker.
+		if (!this.hasExactAdoptedLeadAttachment(goal, entry)) {
 			throw new TeamStartError(
 				"ADOPTED_LEAD_ATTACHMENT_PENDING",
 				"The adopted team lead is still attaching to this goal; wait for promotion to finish",

--- a/src/server/agent/team-manager.ts
+++ b/src/server/agent/team-manager.ts
@@ -365,10 +365,14 @@ function matchesAdoptedGoalWorkspace(goal: PersistedGoal, session: PersistedSess
 		&& sameStringRecord(session.repoWorktrees, goal.repoWorktrees);
 }
 
+function isBaselineRegularPromotionRole(role: string | undefined): boolean {
+	return role === undefined || role === "general";
+}
+
 function hasConflictingPromotionRelation(session: PersistedSession, goalId: string): boolean {
 	return (session.goalId !== undefined && session.goalId !== goalId)
 		|| (session.teamGoalId !== undefined && session.teamGoalId !== goalId)
-		|| (session.role !== undefined && session.role !== "team-lead")
+		|| (!isBaselineRegularPromotionRole(session.role) && session.role !== "team-lead")
 		|| session.teamLeadSessionId !== undefined
 		|| session.delegateOf !== undefined
 		|| session.parentSessionId !== undefined
@@ -385,7 +389,9 @@ function hasConflictingPromotionRelation(session: PersistedSession, goalId: stri
 }
 
 function hasPromotionAttachment(session: PersistedSession | undefined): boolean {
-	return !!session && (session.goalId !== undefined || session.teamGoalId !== undefined || session.role !== undefined);
+	return !!session && (session.goalId !== undefined
+		|| session.teamGoalId !== undefined
+		|| !isBaselineRegularPromotionRole(session.role));
 }
 
 /** Internal tracking for a team associated with a goal. */
@@ -780,11 +786,16 @@ export class TeamManager {
 						maxConcurrent: 12,
 					});
 				}
-				if (source.goalId !== goal.id || source.teamGoalId !== goal.id || source.role !== "team-lead") {
+				const teamLeadAccessory = resolveRole(goal, "team-lead", this.resolveRoleSource(goal))?.accessory ?? "crown";
+				if (source.goalId !== goal.id
+					|| source.teamGoalId !== goal.id
+					|| source.role !== "team-lead"
+					|| source.accessory !== teamLeadAccessory) {
 					ctx.sessionStore.update(ownerSessionId, {
 						goalId: goal.id,
 						teamGoalId: goal.id,
 						role: "team-lead",
+						accessory: teamLeadAccessory,
 					});
 				}
 				if (goal.workflow) {

--- a/src/server/proposals/proposal-types.ts
+++ b/src/server/proposals/proposal-types.ts
@@ -60,6 +60,7 @@ const GOAL_FRONTMATTER_KEYS = [
 	"divergencePolicy",  // "strict"|"balanced"|"autonomous" — root-only plan-change autonomy
 	"maxConcurrentChildren", // number [1,8] — root-only concurrent child-team cap
 	"metadata",          // Record<string, unknown> — arbitrary namespaced per-goal metadata (inherited by sub-goals)
+	"worktreeMode",      // human-owned proposal choice; intentionally absent from propose_goal's tool schema
 ] as const;
 
 /**
@@ -201,6 +202,10 @@ function validateGoalInlineFields(fields: Record<string, unknown>): ParseError |
 	const md = fields.metadata;
 	if (md !== undefined && md !== null && !isPlainObject(md)) {
 		return { ok: false, code: "STRUCTURAL_VALIDATION_FAILED", message: "metadata must be a plain object of namespaced key/value pairs" };
+	}
+	const worktreeMode = fields.worktreeMode;
+	if (worktreeMode !== undefined && worktreeMode !== "new-worktree" && worktreeMode !== "current-session") {
+		return { ok: false, code: "STRUCTURAL_VALIDATION_FAILED", message: "worktreeMode must be one of: new-worktree, current-session" };
 	}
 	return null;
 }

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -45,7 +45,7 @@ import { WebSocketServer, type WebSocket } from "ws";
 import { ColorStore } from "./agent/color-store.js";
 import { bfsEnrichArchivedIndexed } from "./agent/archived-session-bfs.js";
 import { PrStatusStore, type PrStatusEntry } from "./agent/pr-status-store.js";
-import { SessionManager, SessionPinNotFoundError, SharedSandboxWorktreeInUseError, type ExtensionChannelServices, type SessionInfo } from "./agent/session-manager.js";
+import { PromotedSessionLifecycleConflictError, SessionManager, SessionPinNotFoundError, SharedSandboxWorktreeInUseError, type ExtensionChannelServices, type SessionInfo } from "./agent/session-manager.js";
 import { WorktreeInventoryService } from "./agent/worktree-inventory.js";
 import { executeCleanupWorktreesRequest } from "./maintenance/cleanup-worktrees-request.js";
 import { RateLimiter } from "./auth/rate-limit.js";
@@ -428,6 +428,18 @@ function collectVisibleSessionWorktreeReferences(projectContextManager: ProjectC
 		sessions.push(...ctx.sessionStore.getAll());
 	}
 	return sessions;
+}
+
+function promotedSessionLifecycleConflictReason(
+	projectContextManager: ProjectContextManager,
+	sessionId: string,
+): string | undefined {
+	const liveAdoptedGoal = projectContextManager.getAllGoals().find(goal =>
+		!goal.archived && goal.worktreeOwnerSessionId === sessionId,
+	);
+	return liveAdoptedGoal
+		? `promoted goal ${liveAdoptedGoal.id} is still active; archive the goal first`
+		: undefined;
 }
 
 function wireGoalManagerResolvers(
@@ -2629,6 +2641,12 @@ export function createGateway(config: GatewayConfig, deps?: GatewayDeps) {
 		previewPurgeOperation: previewOperations.purge,
 	});
 	sessionManager.sandboxTokenStore = sandboxTokenStore;
+	// A promoted source remains the workspace lifecycle owner until its goal has
+	// been durably archived. Resolve that authority only from canonical goal
+	// records so session archive/purge APIs cannot bypass the ordered goal flow.
+	sessionManager.setPromotedSessionLifecycleGuard((sessionId) =>
+		promotedSessionLifecycleConflictReason(projectContextManager, sessionId),
+	);
 
 	// Wire sessionManager into the project context manager so the search
 	// orphan filter can resolve sessions across projects (live, dormant,
@@ -5376,6 +5394,11 @@ async function handleApiRoute(
 		// leaking host paths, source line numbers, and implementation details.
 		console.error(`[api] ${status} error:`, e.stack ?? e.message);
 		json({ error: e.message, ...extra }, status);
+	};
+	const writeSessionLifecycleConflict = (err: unknown): boolean => {
+		if (!(err instanceof PromotedSessionLifecycleConflictError)) return false;
+		json({ error: err.message, code: err.code }, err.statusCode);
+		return true;
 	};
 	const parseStrictUpdateBody = <K extends readonly string[]>(raw: unknown, keys: K, options?: StrictBodyOptions): StrictBody<K> | null => {
 		try {
@@ -14279,7 +14302,10 @@ async function handleApiRoute(
 			// Check if it's an archived session — purge immediately
 			const archivedSession = sessionManager.getArchivedSession(id);
 			if (archivedSession) {
-				await sessionManager.purgeArchivedSession(id);
+				try { await sessionManager.purgeArchivedSession(id); } catch (err) {
+					if (writeSessionLifecycleConflict(err)) return;
+					throw err;
+				}
 				json({ ok: true });
 				return;
 			}
@@ -14287,6 +14313,7 @@ async function handleApiRoute(
 			try {
 				terminated = await sessionManager.terminateSession(id);
 			} catch (err) {
+				if (writeSessionLifecycleConflict(err)) return;
 				if (err instanceof SharedSandboxWorktreeInUseError) {
 					json({ error: err.message, code: err.code }, 409);
 					return;
@@ -14311,6 +14338,7 @@ async function handleApiRoute(
 				try {
 					await sessionManager.storeArchive(id);
 				} catch (err) {
+					if (writeSessionLifecycleConflict(err)) return;
 					if (err instanceof SharedSandboxWorktreeInUseError) {
 						json({ error: err.message, code: err.code }, 409);
 						return;
@@ -14318,14 +14346,20 @@ async function handleApiRoute(
 					throw err;
 				}
 				if (purge) {
-					await sessionManager.purgeArchivedSession(id);
+					try { await sessionManager.purgeArchivedSession(id); } catch (err) {
+						if (writeSessionLifecycleConflict(err)) return;
+						throw err;
+					}
 				}
 				json({ ok: true });
 				return;
 			}
 			// If purge requested, also purge the now-archived session immediately
 			if (purge) {
-				await sessionManager.purgeArchivedSession(id);
+				try { await sessionManager.purgeArchivedSession(id); } catch (err) {
+					if (writeSessionLifecycleConflict(err)) return;
+					throw err;
+				}
 			}
 			json({ ok: true });
 			return;
@@ -15377,6 +15411,15 @@ async function handleApiRoute(
 		}
 		const body = parseStrictUpdateBody(rawBody, STRICT_UPDATE_BODY_KEYS.sessions);
 		if (!body) return;
+		// Fail before applying any sibling PATCH fields; SessionManager rechecks at
+		// the destructive boundary to close races with concurrent goal creation.
+		if (body.archived === true) {
+			const reason = promotedSessionLifecycleConflictReason(projectContextManager, id);
+			if (reason) {
+				writeSessionLifecycleConflict(new PromotedSessionLifecycleConflictError(id, reason));
+				return;
+			}
+		}
 
 		if (typeof body.title === "string") {
 			const ok = sessionManager.setTitle(id, body.title);
@@ -15482,10 +15525,16 @@ async function handleApiRoute(
 			// Try to terminate live session first (which archives it)
 			const session = sessionManager.getSession(id);
 			if (session) {
-				try { await sessionManager.terminateSession(id); } catch {}
+				try { await sessionManager.terminateSession(id); } catch (err) {
+					if (writeSessionLifecycleConflict(err)) return;
+					// Preserve the legacy best-effort behavior for unrelated failures.
+				}
 			} else {
 				// Dormant/store-only session — archive directly in the store
-				await sessionManager.storeArchive(id);
+				try { await sessionManager.storeArchive(id); } catch (err) {
+					if (writeSessionLifecycleConflict(err)) return;
+					throw err;
+				}
 			}
 		}
 
@@ -15655,7 +15704,10 @@ async function handleApiRoute(
 				json(draft, draft.code === "FILE_NOT_FOUND" ? 404 : 400);
 				return;
 			}
-			const writeResult = await writeProposalFile(proposalStateDir, ownerSessionId, "goal", { ...draft.fields, worktreeMode: body.mode });
+			const nextFields = { ...draft.fields };
+			if (body.mode === "current-session") nextFields.worktreeMode = body.mode;
+			else delete nextFields.worktreeMode;
+			const writeResult = await writeProposalFile(proposalStateDir, ownerSessionId, "goal", nextFields);
 			const parsed = await parseProposalFile(proposalStateDir, ownerSessionId, "goal");
 			if (!parsed.ok) { json(parsed, 400); return; }
 			if (_broadcastToSession) {

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -167,6 +167,7 @@ import { BgProcessCreateError, BgProcessManager } from "./agent/bg-process-manag
 import { streamBgWaitResponse } from "./agent/bg-wait-response.js";
 import {
 	sessionFileDeleteContainerOnly,
+	sessionFileExists,
 	sessionFileRead,
 	sessionFileWriteAtomic,
 	sessionFsContextForAgentFile,
@@ -15624,7 +15625,13 @@ async function handleApiRoute(
 			const project = proposalProjectId ? projectRegistry.get(proposalProjectId) : undefined;
 			const targetCtx = proposalProjectId ? projectContextManager.getOrCreate(proposalProjectId) : undefined;
 			const fileSystem = fsImpl ?? fs;
-			const transcriptAvailable = !!persisted?.agentSessionFile && fileSystem.existsSync(persisted.agentSessionFile);
+			let transcriptAvailable = false;
+			if (persisted?.agentSessionFile) {
+				const transcriptContext = sessionFsContextForAgentFile(persisted, persisted.agentSessionFile);
+				transcriptAvailable = transcriptContext.sandboxed
+					? await sessionFileExists(transcriptContext, persisted.agentSessionFile, sandboxManager ?? null)
+					: fileSystem.existsSync(persisted.agentSessionFile);
+			}
 			let workspaceAvailable = false;
 			let sandboxReachable: boolean | undefined;
 			if (live?.cwd && live.branch) {

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -5397,9 +5397,19 @@ async function handleApiRoute(
 		json({ error: e.message, ...extra }, status);
 	};
 	const writeSessionLifecycleConflict = (err: unknown): boolean => {
-		if (!(err instanceof PromotedSessionLifecycleConflictError)) return false;
-		json({ error: err.message, code: err.code }, err.statusCode);
-		return true;
+		if (err instanceof PromotedSessionLifecycleConflictError) {
+			json({ error: err.message, code: err.code }, err.statusCode);
+			return true;
+		}
+		if (
+			err instanceof Error
+			&& (err as any).statusCode === 409
+			&& (err as any).code === "SESSION_GOAL_PROMOTION_IN_PROGRESS"
+		) {
+			json({ error: err.message, code: (err as any).code, retryable: true }, 409);
+			return true;
+		}
+		return false;
 	};
 	const parseStrictUpdateBody = <K extends readonly string[]>(raw: unknown, keys: K, options?: StrictBodyOptions): StrictBody<K> | null => {
 		try {
@@ -9128,7 +9138,10 @@ async function handleApiRoute(
 		// before merged-state updates, verification cancellation, or cascade mutation
 		// can touch any adopted goal in the requested subtree.
 		const pendingPromotion = [rootGoal, ...(cascade ? liveDescendants : [])]
-			.find(goal => goal.worktreeOwnerSessionId && _sessionGoalPromotionFlights.has(goal.worktreeOwnerSessionId));
+			.find(goal => goal.worktreeOwnerSessionId && (
+				_sessionGoalPromotionFlights.has(goal.worktreeOwnerSessionId)
+				|| sessionManager.isSessionGoalPromotionReserved(goal.worktreeOwnerSessionId)
+			));
 		if (pendingPromotion) {
 			json({
 				error: "Current-session promotion is still in progress; retry goal archive after it finishes",
@@ -15442,8 +15455,21 @@ async function handleApiRoute(
 		}
 		const body = parseStrictUpdateBody(rawBody, STRICT_UPDATE_BODY_KEYS.sessions);
 		if (!body) return;
-		// Fail before applying any sibling PATCH fields; SessionManager rechecks at
-		// the destructive boundary to close races with concurrent goal creation.
+		// Fail before applying any sibling PATCH fields. Relation/destructive fields
+		// cannot race the short SessionManager-owned promotion reservation.
+		const promotionSensitiveFields = [
+			"projectId", "roleId", "assistantType", "goalAssistant", "goalId", "accessory",
+			"delegateOf", "teamLeadSessionId", "archived",
+		];
+		if (promotionSensitiveFields.some(key => Object.prototype.hasOwnProperty.call(body, key))) {
+			try {
+				sessionManager.assertSessionGoalPromotionMutationAllowed(id);
+			} catch (err) {
+				const status = typeof (err as any)?.statusCode === "number" ? (err as any).statusCode : 409;
+				jsonError(status, err, { code: (err as any)?.code });
+				return;
+			}
+		}
 		if (body.archived === true) {
 			const reason = promotedSessionLifecycleConflictReason(projectContextManager, id);
 			if (reason) {
@@ -15495,7 +15521,8 @@ async function handleApiRoute(
 				const ok = await sessionManager.assignRole(id, role);
 				if (!ok) { json({ error: "Session not found" }, 404); return; }
 			} catch (err) {
-				jsonError(400, err);
+				const status = typeof (err as any)?.statusCode === "number" ? (err as any).statusCode : 400;
+				jsonError(status, err, (err as any)?.code ? { code: (err as any).code } : undefined);
 				return;
 			}
 		} else if (typeof body.roleId === "string" && body.roleId === "") {
@@ -15793,40 +15820,27 @@ async function handleApiRoute(
 			const runPromotion = async (): Promise<PersistedGoal> => {
 				const existing = lookupSessionGoalPromotion(projectContextManager.getAllGoals(), ownerSessionId);
 				if (existing.status === "conflict") throw Object.assign(new Error("Current session has conflicting goal promotion records."), { statusCode: 409, code: "PROMOTION_CONFLICT" });
-				if (existing.status === "found") {
-					await teamManager.adoptExistingLead(existing.goal.id, ownerSessionId);
-					const retryCtx = projectContextManager.getContextForGoal(existing.goal.id);
-					const retrySource = sessionManager.getSession(ownerSessionId);
-					let retryGeneralRoleCleared = false;
-					let retryCommitted = false;
-					if (retryCtx && retrySource?.role === "general") {
-						retrySource.role = undefined;
-						const persistedSource = retryCtx.sessionStore.get(ownerSessionId) as Record<string, unknown> | undefined;
-						if (persistedSource) {
-							delete persistedSource.role;
-							retryCtx.sessionStore.update(ownerSessionId, { lastActivity: persistedSource.lastActivity as number });
-						}
-						retryGeneralRoleCleared = true;
-					}
-					try {
-						await sessionManager.promoteToGoalLead(ownerSessionId, existing.goal.id);
-						retryCommitted = true;
+				const promotionReservation = sessionManager.reserveSessionGoalPromotion(
+					ownerSessionId,
+					existing.status === "found" ? existing.goal.id : undefined,
+				);
+				// Retain process-local exclusion whenever an attempt-owned graph survives.
+				// Exact retry reclaims the same reservation by its bound goal id.
+				let retainPromotionReservation = existing.status === "found";
+				try {
+					if (existing.status === "found") {
+						await teamManager.adoptExistingLead(existing.goal.id, ownerSessionId);
+						await sessionManager.promoteToGoalLead(ownerSessionId, existing.goal.id, promotionReservation);
 						await teamManager.finalizeAdoptedLead(existing.goal.id);
+						retainPromotionReservation = false;
 						try {
 							await deleteProposalFile(proposalStateDir, ownerSessionId, "goal");
 							_broadcastToSession?.(ownerSessionId, { type: "proposal_cleared", sessionId: ownerSessionId, proposalType: "goal" });
 						} catch (error) {
 							console.warn(`[promotion] Goal ${existing.goal.id} finalized on retry but its proposal draft could not be cleared:`, error);
 						}
-					} catch (error) {
-						if (retryGeneralRoleCleared && !retryCommitted && retryCtx) {
-							sessionManager.updateSessionMeta(ownerSessionId, { role: "general" });
-							await retryCtx.sessionStore.flushAsync().catch(() => undefined);
-						}
-						throw error;
+						return existing.goal as PersistedGoal;
 					}
-					return existing.goal as PersistedGoal;
-				}
 
 				const draft = await readPromotionDraft();
 				if (!draft.ok) throw Object.assign(new Error(draft.message), { statusCode: draft.code === "FILE_NOT_FOUND" ? 404 : 400, code: draft.code });
@@ -15882,7 +15896,6 @@ async function handleApiRoute(
 					: undefined;
 				let goal: PersistedGoal | undefined;
 				let committed = false;
-				let baselineGeneralRoleCleared = false;
 				try {
 					goal = await targetCtx.goalManager.createGoal(body.title.trim(), coordinates.cwd, {
 						spec: typeof body.spec === "string" ? body.spec : "",
@@ -15907,30 +15920,21 @@ async function handleApiRoute(
 							sandboxed: coordinates.sandboxed,
 						},
 					});
+					// From this point, retain the reservation unless finalization succeeds or
+					// exact pre-commit compensation removes the complete attempt graph.
+					sessionManager.bindSessionGoalPromotion(promotionReservation, goal.id);
+					retainPromotionReservation = true;
 					await targetCtx.goalManager.updateGoal(goal.id, { autoStartTeam: false });
 					goal.autoStartTeam = false;
 					if (goal.workflow) targetCtx.gateStore.initGatesForGoal(goal.id, goal.workflow.gates.map(gate => gate.id));
 					await Promise.all([targetCtx.goalStore.flush(), targetCtx.gateStore.flush()]);
 					await teamManager.adoptExistingLead(goal.id, ownerSessionId);
-					// `general` is the baseline role attached to every ordinary session,
-					// not a workflow relationship. SessionManager's staged promotion guard
-					// intentionally rejects real assigned roles, so remove this one baseline
-					// marker immediately before entering its coordinated replacement.
-					const sourceBeforePromotion = sessionManager.getSession(ownerSessionId);
-					if (sourceBeforePromotion?.role === "general") {
-						sourceBeforePromotion.role = undefined;
-						const persistedSource = targetCtx.sessionStore.get(ownerSessionId) as Record<string, unknown> | undefined;
-						if (persistedSource) {
-							delete persistedSource.role;
-							targetCtx.sessionStore.update(ownerSessionId, { lastActivity: persistedSource.lastActivity as number });
-						}
-						baselineGeneralRoleCleared = true;
-					}
-					await sessionManager.promoteToGoalLead(ownerSessionId, goal.id);
+					await sessionManager.promoteToGoalLead(ownerSessionId, goal.id, promotionReservation);
 					// Runtime replacement is the commit point. Finalization is idempotent
 					// post-commit repair: failures retain the exact graph/session for retry.
 					committed = true;
 					await teamManager.finalizeAdoptedLead(goal.id);
+					retainPromotionReservation = false;
 					try {
 						await deleteProposalFile(proposalStateDir, ownerSessionId, "goal");
 						_broadcastToSession?.(ownerSessionId, { type: "proposal_cleared", sessionId: ownerSessionId, proposalType: "goal" });
@@ -15940,10 +15944,6 @@ async function handleApiRoute(
 					broadcastToAll({ type: "goal_state_changed", goalId: goal.id });
 					return goal;
 				} catch (error) {
-					if (baselineGeneralRoleCleared && !committed) {
-						sessionManager.updateSessionMeta(ownerSessionId, { role: "general" });
-						await targetCtx.sessionStore.flushAsync().catch(() => undefined);
-					}
 					if (goal && !committed) {
 						// Goal/gate compensation is safe only after TeamManager confirms the
 						// exact empty owner reservation was released (or was provably absent).
@@ -15953,10 +15953,16 @@ async function handleApiRoute(
 						if (reservationReleased) {
 							targetCtx.gateStore.removeGoalGates(goal.id);
 							await targetCtx.gateStore.flush().catch(() => undefined);
-							await targetCtx.goalManager.deleteAdoptedGoalAttempt(goal.id, ownerSessionId).catch(() => false);
+							const goalDeleted = await targetCtx.goalManager.deleteAdoptedGoalAttempt(goal.id, ownerSessionId).catch(() => false);
+							if (goalDeleted) retainPromotionReservation = false;
 						}
 					}
 					throw error;
+				}
+				} finally {
+					if (!retainPromotionReservation) {
+						sessionManager.releaseSessionGoalPromotion(promotionReservation);
+					}
 				}
 			};
 

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -15842,7 +15842,6 @@ async function handleApiRoute(
 					? body.enabledOptionalSteps as string[]
 					: undefined;
 				let goal: PersistedGoal | undefined;
-				let reserved = false;
 				let committed = false;
 				let baselineGeneralRoleCleared = false;
 				try {
@@ -15874,7 +15873,6 @@ async function handleApiRoute(
 					if (goal.workflow) targetCtx.gateStore.initGatesForGoal(goal.id, goal.workflow.gates.map(gate => gate.id));
 					await Promise.all([targetCtx.goalStore.flush(), targetCtx.gateStore.flush()]);
 					await teamManager.adoptExistingLead(goal.id, ownerSessionId);
-					reserved = true;
 					// `general` is the baseline role attached to every ordinary session,
 					// not a workflow relationship. SessionManager's staged promotion guard
 					// intentionally rejects real assigned roles, so remove this one baseline
@@ -15905,10 +15903,16 @@ async function handleApiRoute(
 						await targetCtx.sessionStore.flushAsync().catch(() => undefined);
 					}
 					if (goal && !committed) {
-						if (reserved) await teamManager.releaseAdoptedLead(goal.id, ownerSessionId).catch(() => false);
-						targetCtx.gateStore.removeGoalGates(goal.id);
-						await targetCtx.gateStore.flush().catch(() => undefined);
-						await targetCtx.goalManager.deleteAdoptedGoalAttempt(goal.id, ownerSessionId).catch(() => false);
+						// Goal/gate compensation is safe only after TeamManager confirms the
+						// exact empty owner reservation was released (or was provably absent).
+						// A false/failed release means the graph changed under this attempt;
+						// retain it intact so retry/boot reconciliation can finish promotion.
+						const reservationReleased = await teamManager.releaseAdoptedLead(goal.id, ownerSessionId).catch(() => false);
+						if (reservationReleased) {
+							targetCtx.gateStore.removeGoalGates(goal.id);
+							await targetCtx.gateStore.flush().catch(() => undefined);
+							await targetCtx.goalManager.deleteAdoptedGoalAttempt(goal.id, ownerSessionId).catch(() => false);
+						}
 					}
 					throw error;
 				}

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -9114,29 +9114,32 @@ async function handleApiRoute(
 		const rootGoal = getGoalAcrossProjects(id);
 		if (!rootGoal) { json({ error: "Goal not found" }, 404); return; }
 
-		if (!cascade) {
-			const liveDescendants = listDescendants(projectContextManager, id, { includeArchived: false });
-			if (liveDescendants.length > 0) {
-				json({
-					error: `Goal has ${liveDescendants.length} live descendant(s). Re-call with ?cascade=true to archive them all.`,
-					code: "HAS_DESCENDANTS",
-					count: liveDescendants.length,
-				}, 409);
-				return;
-			}
+		const liveDescendants = listDescendants(projectContextManager, id, { includeArchived: false });
+		if (!cascade && liveDescendants.length > 0) {
+			json({
+				error: `Goal has ${liveDescendants.length} live descendant(s). Re-call with ?cascade=true to archive them all.`,
+				code: "HAS_DESCENDANTS",
+				count: liveDescendants.length,
+			}, 409);
+			return;
+		}
+
+		// Promotion owns the source session flight. Reject the entire archive request
+		// before merged-state updates, verification cancellation, or cascade mutation
+		// can touch any adopted goal in the requested subtree.
+		const pendingPromotion = [rootGoal, ...(cascade ? liveDescendants : [])]
+			.find(goal => goal.worktreeOwnerSessionId && _sessionGoalPromotionFlights.has(goal.worktreeOwnerSessionId));
+		if (pendingPromotion) {
+			json({
+				error: "Current-session promotion is still in progress; retry goal archive after it finishes",
+				code: "PROMOTION_IN_PROGRESS",
+			}, 409);
+			return;
 		}
 
 		const mergedManually = url.searchParams.get("mergedManually") === "true";
 
-		const archiveOne = async (g: import("./agent/goal-store.js").PersistedGoal): Promise<boolean> => {
-			if (g.archived) {
-				try {
-					await cleanupGateDiagnosticsForGoal(g.id, projectContextManager.getContextForGoal(g.id)?.stateDir);
-				} catch (err) {
-					console.warn(`[api] archive: gate diagnostics cleanup failed for already-archived goal ${g.id}:`, err);
-				}
-				return false;
-			}
+		const performArchiveOne = async (g: import("./agent/goal-store.js").PersistedGoal): Promise<boolean> => {
 			if (mergedManually && g.id === id && g.state !== "complete") {
 				await getGoalManagerForGoal(g.id).updateGoal(g.id, { state: "complete" });
 			}
@@ -9160,10 +9163,8 @@ async function handleApiRoute(
 				if (tl?.branch) agentBranches.push(tl.branch);
 			}
 			const gm = getGoalManagerForGoal(g.id);
-			// A promoted source remains the checkout/sandbox lifecycle owner. Publish
-			// goal archival before TeamManager tears that source down; otherwise its
-			// live-goal guard correctly rejects direct teardown and restart recovery
-			// can misread the ordered shutdown as an incomplete promotion.
+			// A promoted source remains the checkout/sandbox lifecycle owner. Its
+			// durable archived bit must publish before TeamManager tears it down.
 			if (g.worktreeOwnerSessionId) await gm.archiveGoal(g.id);
 			if (teamManager.getTeamState(g.id)) {
 				await teamManager.teardownTeam(g.id);
@@ -9189,9 +9190,33 @@ async function handleApiRoute(
 			return true;
 		};
 
+		const archiveOne = async (g: import("./agent/goal-store.js").PersistedGoal): Promise<boolean> => {
+			if (g.archived) {
+				try {
+					await cleanupGateDiagnosticsForGoal(g.id, projectContextManager.getContextForGoal(g.id)?.stateDir);
+				} catch (err) {
+					console.warn(`[api] archive: gate diagnostics cleanup failed for already-archived goal ${g.id}:`, err);
+				}
+				return false;
+			}
+			// Admission precedes every archive-side mutation, including merged-state
+			// updates and verification cancellation, and holds through durable archive.
+			return g.worktreeOwnerSessionId
+				? teamManager.withAdoptedGoalArchiveAdmission(g.id, () => performArchiveOne(g))
+				: performArchiveOne(g);
+		};
+
 		if (!cascade) {
-			await archiveOne(rootGoal);
-			json({ ok: true, archived: 1 });
+			try {
+				await archiveOne(rootGoal);
+				json({ ok: true, archived: 1 });
+			} catch (error) {
+				if (error instanceof TeamStartError) {
+					json({ error: error.message, code: error.code }, error.status);
+					return;
+				}
+				throw error;
+			}
 			return;
 		}
 
@@ -9207,6 +9232,11 @@ async function handleApiRoute(
 		if (result.errors.length > 0) {
 			for (const e of result.errors) {
 				console.error(`[api] archive cascade: ${e.goalId} failed:`, e.error);
+			}
+			const admissionError = result.errors.find(entry => entry.error instanceof TeamStartError)?.error;
+			if (admissionError instanceof TeamStartError) {
+				json({ error: admissionError.message, code: admissionError.code }, admissionError.status);
+				return;
 			}
 		}
 		json({
@@ -15768,6 +15798,7 @@ async function handleApiRoute(
 					const retryCtx = projectContextManager.getContextForGoal(existing.goal.id);
 					const retrySource = sessionManager.getSession(ownerSessionId);
 					let retryGeneralRoleCleared = false;
+					let retryCommitted = false;
 					if (retryCtx && retrySource?.role === "general") {
 						retrySource.role = undefined;
 						const persistedSource = retryCtx.sessionStore.get(ownerSessionId) as Record<string, unknown> | undefined;
@@ -15779,8 +15810,16 @@ async function handleApiRoute(
 					}
 					try {
 						await sessionManager.promoteToGoalLead(ownerSessionId, existing.goal.id);
+						retryCommitted = true;
+						await teamManager.finalizeAdoptedLead(existing.goal.id);
+						try {
+							await deleteProposalFile(proposalStateDir, ownerSessionId, "goal");
+							_broadcastToSession?.(ownerSessionId, { type: "proposal_cleared", sessionId: ownerSessionId, proposalType: "goal" });
+						} catch (error) {
+							console.warn(`[promotion] Goal ${existing.goal.id} finalized on retry but its proposal draft could not be cleared:`, error);
+						}
 					} catch (error) {
-						if (retryGeneralRoleCleared && retryCtx) {
+						if (retryGeneralRoleCleared && !retryCommitted && retryCtx) {
 							sessionManager.updateSessionMeta(ownerSessionId, { role: "general" });
 							await retryCtx.sessionStore.flushAsync().catch(() => undefined);
 						}
@@ -15888,7 +15927,10 @@ async function handleApiRoute(
 						baselineGeneralRoleCleared = true;
 					}
 					await sessionManager.promoteToGoalLead(ownerSessionId, goal.id);
+					// Runtime replacement is the commit point. Finalization is idempotent
+					// post-commit repair: failures retain the exact graph/session for retry.
 					committed = true;
+					await teamManager.finalizeAdoptedLead(goal.id);
 					try {
 						await deleteProposalFile(proposalStateDir, ownerSessionId, "goal");
 						_broadcastToSession?.(ownerSessionId, { type: "proposal_cleared", sessionId: ownerSessionId, proposalType: "goal" });

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -661,6 +661,14 @@ import { ProjectContextManager } from "./agent/project-context-manager.js";
 import type { ProjectContext } from "./agent/project-context.js";
 import { resolveProjectForRequest, validateExecutionCwd, type CwdOwnershipSource } from "./agent/resolve-project.js";
 import { GoalManager } from "./agent/goal-manager.js";
+import {
+	evaluateSessionGoalPromotion,
+	isSessionGoalWorktreeMode,
+	lookupSessionGoalPromotion,
+	resolveSessionGoalWorktreeMode,
+	type SessionGoalPromotionEligibility,
+	type SessionGoalPromotionWorkspaceClaim,
+} from "./agent/session-goal-promotion.js";
 import { cleanupGateDiagnosticsForGoal } from "./agent/gate-diagnostics-cleanup.js";
 import type { WorktreeReferenceRecord } from "./agent/worktree-reference-guard.js";
 import { worktreeRoot as resolveWorktreeRoot } from "./skills/worktree-paths.js";
@@ -713,6 +721,9 @@ export const WS_MAX_PAYLOAD_BYTES = 256 * 1024 * 1024;
 
 const _goalPendingOverflowCheck = new WeakSet<WebSocket>();
 const _goalWarnedClients = new WeakSet<WebSocket>();
+
+/** Owner-scoped promotion is a single transaction per source session. */
+const _sessionGoalPromotionFlights = new Map<string, Promise<PersistedGoal>>();
 
 const execAsync = promisify(exec);
 let serverCommandRunner: CommandRunner = realCommandRunner;
@@ -9124,6 +9135,12 @@ async function handleApiRoute(
 				const tl = goalProjectCtx?.sessionStore.get(teamEntry.teamLeadSessionId);
 				if (tl?.branch) agentBranches.push(tl.branch);
 			}
+			const gm = getGoalManagerForGoal(g.id);
+			// A promoted source remains the checkout/sandbox lifecycle owner. Publish
+			// goal archival before TeamManager tears that source down; otherwise its
+			// live-goal guard correctly rejects direct teardown and restart recovery
+			// can misread the ordered shutdown as an incomplete promotion.
+			if (g.worktreeOwnerSessionId) await gm.archiveGoal(g.id);
 			if (teamManager.getTeamState(g.id)) {
 				await teamManager.teardownTeam(g.id);
 			}
@@ -9135,11 +9152,12 @@ async function handleApiRoute(
 					console.warn(`[api] archive: notifyChildTerminal failed for ${g.id} (non-fatal):`, err);
 				}
 			}
-			const gm = getGoalManagerForGoal(g.id);
-			await gm.archiveGoal(g.id);
+			if (!g.worktreeOwnerSessionId) await gm.archiveGoal(g.id);
 			prStatusStore.remove(g.id);
 			const archivedGoal = gm.getGoal(g.id);
-			if (archivedGoal?.repoPath) {
+			// An adopted branch is session-owned provenance, not a goal-provisioned
+			// branch. Its remote lifecycle stays with the source session.
+			if (archivedGoal?.repoPath && !archivedGoal.worktreeOwnerSessionId) {
 				deleteRemoteGoalBranches(archivedGoal, agentBranches, archivedGoal.repoPath, commandRunner!, serverRemoteGitPolicy).catch(err => {
 					console.warn(`[api] archive: remote branch cleanup failed for ${g.id}:`, err);
 				});
@@ -15491,6 +15509,373 @@ async function handleApiRoute(
 
 	// ── Editable proposals (file-on-disk source of truth) ──────────────
 	// docs/design/editable-proposals.md §6.4
+
+	const goalWorktreeModeMatch = url.pathname.match(/^\/api\/sessions\/([^/]+)\/proposal\/goal\/(worktree-mode|accept)$/);
+	if (goalWorktreeModeMatch) {
+		const ownerSessionId = goalWorktreeModeMatch[1];
+		const action = goalWorktreeModeMatch[2];
+		if (!/^[A-Za-z0-9_-]+$/.test(ownerSessionId)) {
+			json({ error: "Invalid sessionId" }, 400);
+			return;
+		}
+		const proposalStateDir = bobbitStateDir();
+
+		const readPromotionDraft = async () => {
+			const parsed = await parseProposalFile(proposalStateDir, ownerSessionId, "goal");
+			if (!parsed.ok) return parsed;
+			return { ok: true as const, fields: parsed.value.fields };
+		};
+		const configuredGitRepos = async (ctx: ProjectContext, sandboxed: boolean): Promise<string[]> => {
+			const components = ctx.projectConfigStore.getComponents();
+			const candidates = components.length > 0 ? components.map(component => component.repo) : ["."];
+			const distinct = [...new Set(candidates)];
+			const gitRepos: string[] = [];
+			for (const repo of distinct) {
+				try {
+					if (sandboxed) {
+						const sandbox = sandboxManager?.get(ctx.project.id);
+						if (!sandbox) continue;
+						await sandbox.exec(["git", "rev-parse", "--is-inside-work-tree"], {
+							cwd: repo === "." ? "/workspace" : path.posix.join("/workspace", repo),
+							timeout: 5_000,
+						});
+						gitRepos.push(repo);
+					} else if (await isGitRepo(path.join(ctx.project.rootPath, repo), commandRunner)) {
+						gitRepos.push(repo);
+					}
+				} catch { /* data-only component */ }
+			}
+			return gitRepos.length > 0 ? gitRepos : ["."];
+		};
+		const promotionWorkspaceClaims = (): SessionGoalPromotionWorkspaceClaim[] => {
+			const claims: SessionGoalPromotionWorkspaceClaim[] = [];
+			for (const ctx of projectContextManager.visible()) {
+				for (const session of ctx.sessionStore.getLive()) {
+					claims.push({ kind: "session", id: session.id, sessionId: session.id, projectId: session.projectId, worktreePath: session.worktreePath, repoWorktrees: session.repoWorktrees });
+				}
+				for (const goal of ctx.goalStore.getLive()) {
+					claims.push({ kind: "goal", id: goal.id, goalId: goal.id, projectId: goal.projectId, worktreePath: goal.worktreePath, repoWorktrees: goal.repoWorktrees });
+				}
+				for (const team of ctx.teamStore.getAll()) {
+					for (const agent of team.agents) {
+						claims.push({ kind: "team", id: agent.sessionId, goalId: team.goalId, projectId: ctx.project.id, worktreePath: agent.worktreePath, repoWorktrees: agent.repoWorktrees });
+					}
+				}
+				for (const staff of ctx.staffStore.getAll()) {
+					claims.push({ kind: "staff", id: staff.id, projectId: staff.projectId, worktreePath: staff.worktreePath, repoWorktrees: staff.repoWorktrees });
+				}
+			}
+			return claims;
+		};
+		const evaluateOwner = async (fields: Record<string, unknown>): Promise<SessionGoalPromotionEligibility> => {
+			const live = sessionManager.getSession(ownerSessionId);
+			const sessionCtx = projectContextManager.getContextForSession(ownerSessionId);
+			const persisted = sessionCtx?.sessionStore.get(ownerSessionId) ?? sessionManager.getPersistedSession(ownerSessionId);
+			const proposalProjectId = typeof fields.projectId === "string" ? fields.projectId.trim() : undefined;
+			const project = proposalProjectId ? projectRegistry.get(proposalProjectId) : undefined;
+			const targetCtx = proposalProjectId ? projectContextManager.getOrCreate(proposalProjectId) : undefined;
+			const fileSystem = fsImpl ?? fs;
+			const transcriptAvailable = !!persisted?.agentSessionFile && fileSystem.existsSync(persisted.agentSessionFile);
+			let workspaceAvailable = false;
+			let sandboxReachable: boolean | undefined;
+			if (live?.cwd && live.branch) {
+				const componentWorktrees = live.repoWorktrees?.map(entry => entry.worktreePath) ?? [];
+				const branchProbePaths = componentWorktrees.length > 0 ? componentWorktrees : [live.cwd];
+				try {
+					if (live.sandboxed) {
+						const sandbox = proposalProjectId ? sandboxManager?.get(proposalProjectId) : undefined;
+						const status = sandbox?.getStatus();
+						sandboxReachable = !!sandbox && status?.status === "ready" && status.containerId === live.containerId;
+						if (sandboxReachable) {
+							const branches = await Promise.all(branchProbePaths.map(probePath =>
+								sandbox!.exec(["git", "branch", "--show-current"], { cwd: probePath, timeout: 5_000 }),
+							));
+							workspaceAvailable = branches.every(branch => branch.trim() === live.branch);
+						}
+					} else {
+						const branches = await Promise.all(branchProbePaths.map(probePath =>
+							commandRunner.execFile("git", ["branch", "--show-current"], { cwd: probePath, timeout: 5_000 }),
+						));
+						workspaceAvailable = branches.every(result => String(result.stdout).trim() === live.branch);
+					}
+				} catch { workspaceAvailable = false; }
+			}
+			const gitComponentRepos = targetCtx ? await configuredGitRepos(targetCtx, live?.sandboxed === true) : [];
+			// Every ordinary interactive session is materialized with the baseline
+			// `general` role. It is not a team/assistant relation and therefore must
+			// not make an otherwise regular proposal owner ineligible.
+			const eligibilityLive = live?.role === "general" ? { ...live, role: undefined } : live;
+			const eligibilityPersisted = persisted?.role === "general" ? { ...persisted, role: undefined } : persisted;
+			return evaluateSessionGoalPromotion({
+				ownerSessionId,
+				proposalProjectId,
+				project: project ? { id: project.id, rootPath: project.rootPath } : undefined,
+				liveSession: eligibilityLive,
+				persistedSession: eligibilityPersisted,
+				transcriptAvailable,
+				workspaceAvailable,
+				hasPendingWork: !!live && (live.promptQueue.length > 0 || (live.inFlightSteerTexts?.length ?? 0) > 0),
+				gitComponentRepos,
+				sandboxReachable,
+				workspaceClaims: promotionWorkspaceClaims(),
+				goals: projectContextManager.getAllGoals(),
+			});
+		};
+		const projection = async (fields: Record<string, unknown>) => {
+			const eligibility = await evaluateOwner(fields);
+			const projectedEligibility = eligibility.eligible
+				? {
+					...eligibility,
+					coordinates: {
+						...eligibility.coordinates,
+						componentCount: Object.keys(eligibility.coordinates.repoWorktrees ?? {}).length || 1,
+					},
+				}
+				: eligibility;
+			return { mode: resolveSessionGoalWorktreeMode(fields.worktreeMode), eligibility: projectedEligibility };
+		};
+
+		if (action === "worktree-mode" && req.method === "GET") {
+			const draft = await readPromotionDraft();
+			if (!draft.ok) {
+				json(draft, draft.code === "FILE_NOT_FOUND" ? 404 : 400);
+				return;
+			}
+			json(await projection(draft.fields));
+			return;
+		}
+		if (action === "worktree-mode" && req.method === "PUT") {
+			const body = await readBody(req);
+			if (!body || !isSessionGoalWorktreeMode(body.mode) || Object.keys(body).some(key => key !== "mode")) {
+				json({ error: "mode must be one of: new-worktree, current-session", code: "INVALID_WORKTREE_MODE" }, 400);
+				return;
+			}
+			const draft = await readPromotionDraft();
+			if (!draft.ok) {
+				json(draft, draft.code === "FILE_NOT_FOUND" ? 404 : 400);
+				return;
+			}
+			const writeResult = await writeProposalFile(proposalStateDir, ownerSessionId, "goal", { ...draft.fields, worktreeMode: body.mode });
+			const parsed = await parseProposalFile(proposalStateDir, ownerSessionId, "goal");
+			if (!parsed.ok) { json(parsed, 400); return; }
+			if (_broadcastToSession) {
+				_broadcastToSession(ownerSessionId, {
+					type: "proposal_update",
+					sessionId: ownerSessionId,
+					proposalType: "goal",
+					fields: parsed.value.fields,
+					rev: writeResult.rev,
+					streaming: false,
+					source: "edit",
+				});
+			}
+			json(await projection(parsed.value.fields));
+			return;
+		}
+		if (action === "accept" && req.method === "POST") {
+			const body = await readBody(req);
+			if (!body || typeof body !== "object" || Array.isArray(body)) {
+				json({ error: "body must be a JSON object", code: "INVALID_BODY" }, 400);
+				return;
+			}
+			const allowedFields = new Set([
+				"title", "spec", "workflowId", "workflow", "inlineRoles", "enabledOptionalSteps",
+				"subgoalsAllowed", "maxNestingDepth", "divergencePolicy", "maxConcurrentChildren", "parentGoalId", "metadata",
+			]);
+			const forbiddenAuthority = [
+				"sessionId", "ownerSessionId", "promoteSessionId", "projectId", "cwd", "worktree", "worktreePath",
+				"branch", "repoPath", "repoWorktrees", "sandboxed", "containerId", "autoStartTeam",
+			];
+			const suppliedAuthority = forbiddenAuthority.filter(key => Object.prototype.hasOwnProperty.call(body, key));
+			if (suppliedAuthority.length > 0) {
+				json({ error: `Promotion coordinates are server-owned: ${suppliedAuthority.join(", ")}`, code: "PROMOTION_AUTHORITY_REJECTED" }, 400);
+				return;
+			}
+			const unknownFields = Object.keys(body).filter(key => !allowedFields.has(key));
+			if (unknownFields.length > 0) {
+				json({ error: `Unknown acceptance field(s): ${unknownFields.join(", ")}`, code: "INVALID_BODY" }, 400);
+				return;
+			}
+			if (typeof body.title !== "string" || !body.title.trim()) {
+				json({ error: "Missing title" }, 400);
+				return;
+			}
+
+			const runPromotion = async (): Promise<PersistedGoal> => {
+				const existing = lookupSessionGoalPromotion(projectContextManager.getAllGoals(), ownerSessionId);
+				if (existing.status === "conflict") throw Object.assign(new Error("Current session has conflicting goal promotion records."), { statusCode: 409, code: "PROMOTION_CONFLICT" });
+				if (existing.status === "found") {
+					await teamManager.adoptExistingLead(existing.goal.id, ownerSessionId);
+					const retryCtx = projectContextManager.getContextForGoal(existing.goal.id);
+					const retrySource = sessionManager.getSession(ownerSessionId);
+					let retryGeneralRoleCleared = false;
+					if (retryCtx && retrySource?.role === "general") {
+						retrySource.role = undefined;
+						const persistedSource = retryCtx.sessionStore.get(ownerSessionId) as Record<string, unknown> | undefined;
+						if (persistedSource) {
+							delete persistedSource.role;
+							retryCtx.sessionStore.update(ownerSessionId, { lastActivity: persistedSource.lastActivity as number });
+						}
+						retryGeneralRoleCleared = true;
+					}
+					try {
+						await sessionManager.promoteToGoalLead(ownerSessionId, existing.goal.id);
+					} catch (error) {
+						if (retryGeneralRoleCleared && retryCtx) {
+							sessionManager.updateSessionMeta(ownerSessionId, { role: "general" });
+							await retryCtx.sessionStore.flushAsync().catch(() => undefined);
+						}
+						throw error;
+					}
+					return existing.goal as PersistedGoal;
+				}
+
+				const draft = await readPromotionDraft();
+				if (!draft.ok) throw Object.assign(new Error(draft.message), { statusCode: draft.code === "FILE_NOT_FOUND" ? 404 : 400, code: draft.code });
+				if (resolveSessionGoalWorktreeMode(draft.fields.worktreeMode) !== "current-session") {
+					throw Object.assign(new Error("Select Current session before accepting this proposal."), { statusCode: 409, code: "WORKTREE_MODE_MISMATCH" });
+				}
+				const eligibility = await evaluateOwner(draft.fields);
+				if (!eligibility.eligible) throw Object.assign(new Error(eligibility.reason), { statusCode: 409, code: eligibility.code });
+				const coordinates = eligibility.coordinates;
+				const targetCtx = projectContextManager.getOrCreate(coordinates.projectId);
+				if (!targetCtx) throw Object.assign(new Error("Proposal project is unavailable."), { statusCode: 404, code: "PROJECT_NOT_FOUND" });
+				if (body.parentGoalId) throw Object.assign(new Error("Current-session promotion creates a top-level goal."), { statusCode: 422, code: "PROMOTION_PARENT_UNSUPPORTED" });
+
+				let resolvedWorkflow: Workflow | undefined;
+				let resolvedWorkflowId = typeof body.workflowId === "string" && body.workflowId.trim()
+					? body.workflowId.trim()
+					: typeof draft.fields.workflow === "string" ? draft.fields.workflow : undefined;
+				if (body.workflow && typeof body.workflow === "object" && !Array.isArray(body.workflow)) {
+					resolvedWorkflow = body.workflow as Workflow;
+					resolvedWorkflowId = (body.workflow as { id?: string }).id || resolvedWorkflowId;
+				} else if (resolvedWorkflowId) {
+					resolvedWorkflow = configCascade.resolveWorkflows(coordinates.projectId).find(entry => entry.item.id === resolvedWorkflowId)?.item
+						?? targetCtx.workflowStore.get(resolvedWorkflowId);
+				}
+				if (!resolvedWorkflow && targetCtx.workflowStore.getAll().length === 0) {
+					const components = targetCtx.projectConfigStore.getComponents();
+					const component = components.find(item => Object.keys(item.commands ?? {}).length > 0) ?? components[0];
+					const seeds = buildDefaultWorkflows(component?.name || "project", component ? Object.keys(component.commands ?? {}) : []);
+					seeds.parent = buildParentWorkflow();
+					for (const workflow of Object.values(seeds)) targetCtx.workflowStore.put(workflow as unknown as Workflow);
+					resolvedWorkflow = resolvedWorkflowId ? targetCtx.workflowStore.get(resolvedWorkflowId) : targetCtx.workflowStore.get("general") ?? targetCtx.workflowStore.getAll()[0];
+					resolvedWorkflowId = resolvedWorkflow?.id ?? resolvedWorkflowId;
+				}
+				if (resolvedWorkflowId && !resolvedWorkflow) {
+					throw Object.assign(new Error(`Workflow "${resolvedWorkflowId}" not found`), { statusCode: 400, code: "WORKFLOW_NOT_FOUND" });
+				}
+				if (resolvedWorkflow) {
+					resolvedWorkflow = freezeWorkflowDefinition(resolvedWorkflow, targetCtx.projectConfigStore.getComponents(), resolvedWorkflowId, { validateComponentReferences: false });
+				}
+				const nestingPrefs = readSubgoalNestingPrefs(key => preferencesStore.get(key));
+				const requestedSubgoals = typeof body.subgoalsAllowed === "boolean" ? body.subgoalsAllowed : undefined;
+				const requestedDepth = typeof body.maxNestingDepth === "number" && Number.isFinite(body.maxNestingDepth)
+					? Math.min(clampMaxDepth(body.maxNestingDepth), nestingPrefs.maxNestingDepth)
+					: undefined;
+				const metadata = body.metadata && typeof body.metadata === "object" && !Array.isArray(body.metadata)
+					? body.metadata as Record<string, unknown>
+					: undefined;
+				const inlineRoles = body.inlineRoles && typeof body.inlineRoles === "object" && !Array.isArray(body.inlineRoles)
+					? body.inlineRoles as Record<string, Role>
+					: undefined;
+				const enabledOptionalSteps = Array.isArray(body.enabledOptionalSteps) && body.enabledOptionalSteps.every((step: unknown) => typeof step === "string")
+					? body.enabledOptionalSteps as string[]
+					: undefined;
+				let goal: PersistedGoal | undefined;
+				let reserved = false;
+				let committed = false;
+				let baselineGeneralRoleCleared = false;
+				try {
+					goal = await targetCtx.goalManager.createGoal(body.title.trim(), coordinates.cwd, {
+						spec: typeof body.spec === "string" ? body.spec : "",
+						workflowId: resolvedWorkflowId,
+						workflowStore: targetCtx.workflowStore,
+						resolvedWorkflow,
+						enabledOptionalSteps,
+						projectId: coordinates.projectId,
+						inlineRoles,
+						subgoalsAllowed: requestedSubgoals === undefined ? undefined : requestedSubgoals && nestingPrefs.subgoalsEnabled,
+						maxNestingDepth: requestedDepth,
+						divergencePolicy: body.divergencePolicy === "strict" || body.divergencePolicy === "balanced" || body.divergencePolicy === "autonomous" ? body.divergencePolicy : undefined,
+						maxConcurrentChildren: typeof body.maxConcurrentChildren === "number" && Number.isInteger(body.maxConcurrentChildren) && body.maxConcurrentChildren >= 1 && body.maxConcurrentChildren <= 8 ? body.maxConcurrentChildren : undefined,
+						metadata,
+						adoptedWorkspace: {
+							ownerSessionId,
+							cwd: coordinates.cwd,
+							worktreePath: coordinates.worktreePath,
+							branch: coordinates.branch,
+							repoPath: coordinates.repoPath,
+							repoWorktrees: coordinates.repoWorktrees,
+							sandboxed: coordinates.sandboxed,
+						},
+					});
+					await targetCtx.goalManager.updateGoal(goal.id, { autoStartTeam: false });
+					goal.autoStartTeam = false;
+					if (goal.workflow) targetCtx.gateStore.initGatesForGoal(goal.id, goal.workflow.gates.map(gate => gate.id));
+					await Promise.all([targetCtx.goalStore.flush(), targetCtx.gateStore.flush()]);
+					await teamManager.adoptExistingLead(goal.id, ownerSessionId);
+					reserved = true;
+					// `general` is the baseline role attached to every ordinary session,
+					// not a workflow relationship. SessionManager's staged promotion guard
+					// intentionally rejects real assigned roles, so remove this one baseline
+					// marker immediately before entering its coordinated replacement.
+					const sourceBeforePromotion = sessionManager.getSession(ownerSessionId);
+					if (sourceBeforePromotion?.role === "general") {
+						sourceBeforePromotion.role = undefined;
+						const persistedSource = targetCtx.sessionStore.get(ownerSessionId) as Record<string, unknown> | undefined;
+						if (persistedSource) {
+							delete persistedSource.role;
+							targetCtx.sessionStore.update(ownerSessionId, { lastActivity: persistedSource.lastActivity as number });
+						}
+						baselineGeneralRoleCleared = true;
+					}
+					await sessionManager.promoteToGoalLead(ownerSessionId, goal.id);
+					committed = true;
+					try {
+						await deleteProposalFile(proposalStateDir, ownerSessionId, "goal");
+						_broadcastToSession?.(ownerSessionId, { type: "proposal_cleared", sessionId: ownerSessionId, proposalType: "goal" });
+					} catch (error) {
+						console.warn(`[promotion] Goal ${goal.id} committed but its proposal draft could not be cleared:`, error);
+					}
+					broadcastToAll({ type: "goal_state_changed", goalId: goal.id });
+					return goal;
+				} catch (error) {
+					if (baselineGeneralRoleCleared && !committed) {
+						sessionManager.updateSessionMeta(ownerSessionId, { role: "general" });
+						await targetCtx.sessionStore.flushAsync().catch(() => undefined);
+					}
+					if (goal && !committed) {
+						if (reserved) await teamManager.releaseAdoptedLead(goal.id, ownerSessionId).catch(() => false);
+						targetCtx.gateStore.removeGoalGates(goal.id);
+						await targetCtx.gateStore.flush().catch(() => undefined);
+						await targetCtx.goalManager.deleteAdoptedGoalAttempt(goal.id, ownerSessionId).catch(() => false);
+					}
+					throw error;
+				}
+			};
+
+			let flight = _sessionGoalPromotionFlights.get(ownerSessionId);
+			if (!flight) {
+				flight = runPromotion();
+				_sessionGoalPromotionFlights.set(ownerSessionId, flight);
+				void flight.finally(() => {
+					if (_sessionGoalPromotionFlights.get(ownerSessionId) === flight) _sessionGoalPromotionFlights.delete(ownerSessionId);
+				}).catch(() => undefined);
+			}
+			try {
+				const goal = await flight;
+				json(goal, 201);
+			} catch (error) {
+				const status = typeof (error as any)?.statusCode === "number" ? (error as any).statusCode : 400;
+				jsonError(status, error, (error as any)?.code ? { code: (error as any).code } : undefined);
+			}
+			return;
+		}
+		json({ error: "Method not allowed" }, 405);
+		return;
+	}
+
 	const proposalRouteMatch = url.pathname.match(/^\/api\/sessions\/([^/]+)\/proposal\/([^/]+)(\/edit|\/seed|\/restore|\/snapshot)?$/);
 	if (proposalRouteMatch) {
 		const sessionId = proposalRouteMatch[1];

--- a/tests2/browser/journeys/session-goal-promotion.journey.spec.ts
+++ b/tests2/browser/journeys/session-goal-promotion.journey.spec.ts
@@ -3,14 +3,17 @@
  * Covers the proposal selector, owner-scoped acceptance, continuity across page
  * reload, the unavailable reason, and the unchanged new-worktree control path.
  */
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
 import {
 	test,
 	expect,
 	apiFetch,
 	deleteSession,
-	defaultProject,
 	openApp,
 	navigateToHash,
+	registerProject,
 	waitForSessionStatus,
 } from "../_helpers/journey-fixture.js";
 
@@ -20,15 +23,55 @@ async function responseJson(response: Response): Promise<any> {
 	return text ? JSON.parse(text) : {};
 }
 
-async function createWorktreeSession(): Promise<{ id: string; projectId: string }> {
-	const project = await defaultProject();
-	const response = await apiFetch("/api/sessions", {
-		method: "POST",
-		body: JSON.stringify({ cwd: project.rootPath, projectId: project.id, worktree: true }),
-	});
-	const created = await responseJson(response);
-	await waitForSessionStatus(created.id, "idle", 30_000);
-	return { id: created.id, projectId: project.id };
+type GitSessionFixture = {
+	root: string;
+	id: string;
+	projectId: string;
+};
+
+function git(cwd: string, ...args: string[]): void {
+	execFileSync("git", args, { cwd, stdio: "pipe" });
+}
+
+async function createGitSession(worktree: boolean): Promise<GitSessionFixture> {
+	const runRoot = process.env.BOBBIT_E2E_TMP_ROOT;
+	if (!runRoot) throw new Error("BOBBIT_E2E_TMP_ROOT must identify the browser run root");
+	const root = mkdtempSync(join(runRoot, "session-goal-promotion-"));
+	const repo = join(root, "repo");
+	let projectId = "";
+	try {
+		git(root, "init", "--initial-branch=main", repo);
+		git(repo, "config", "user.name", "Session Goal Promotion Journey");
+		git(repo, "config", "user.email", "session-goal-promotion@example.invalid");
+		writeFileSync(join(repo, "README.md"), "session goal promotion fixture\n");
+		git(repo, "add", "README.md");
+		git(repo, "commit", "-m", "initial fixture");
+		projectId = (await registerProject({
+			name: `session-goal-promotion-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+			rootPath: repo,
+		})).id;
+		const response = await apiFetch("/api/sessions", {
+			method: "POST",
+			body: JSON.stringify({ cwd: repo, projectId, worktree }),
+		});
+		const created = await responseJson(response);
+		await waitForSessionStatus(created.id, "idle", 30_000);
+		return { root, id: created.id, projectId };
+	} catch (error) {
+		if (projectId) await apiFetch(`/api/projects/${projectId}`, { method: "DELETE" }).catch(() => {});
+		rmSync(root, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
+		throw error;
+	}
+}
+
+async function removeGitSession(fixture: GitSessionFixture): Promise<void> {
+	await deleteSession(fixture.id).catch(() => {});
+	await apiFetch(`/api/projects/${fixture.projectId}`, { method: "DELETE" }).catch(() => {});
+	try {
+		rmSync(fixture.root, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
+	} catch {
+		// Git can retain a short-lived handle after session or goal cleanup on Windows.
+	}
 }
 
 async function sessionRecord(id: string): Promise<any> {
@@ -57,6 +100,19 @@ async function liveGoals(): Promise<any[]> {
 	return Array.isArray(body) ? body : body.goals ?? [];
 }
 
+async function waitForGoalSetup(goalId: string): Promise<any> {
+	let goal: any;
+	await expect.poll(async () => {
+		goal = await responseJson(await apiFetch(`/api/goals/${goalId}`));
+		return goal.setupStatus;
+	}, { timeout: 40_000, intervals: [100, 250, 500] }).toBe("ready");
+	return goal;
+}
+
+async function teamRecord(goalId: string): Promise<any> {
+	return responseJson(await apiFetch(`/api/goals/${goalId}/team`));
+}
+
 async function waitForGoalOwnedBy(sessionId: string): Promise<any> {
 	let found: any;
 	await expect.poll(async () => {
@@ -75,7 +131,7 @@ async function openSeededProposal(page: import("@playwright/test").Page, session
 test.describe("Journey: Current-session goal promotion", () => {
 	test("selects Current session, promotes the original lead, and survives reload", async ({ page }) => {
 		test.setTimeout(120_000);
-		const source = await createWorktreeSession();
+		const source = await createGitSession(true);
 		let goalId: string | undefined;
 		try {
 			const before = await sessionRecord(source.id);
@@ -88,7 +144,7 @@ test.describe("Journey: Current-session goal promotion", () => {
 			const currentMode = page.locator("[data-testid='goal-form-worktree-current-session']");
 			await expect(newMode).toBeChecked();
 			await expect(currentMode).toBeEnabled({ timeout: 20_000 });
-			await currentMode.check();
+			await currentMode.locator("xpath=..").click();
 			await expect(currentMode).toBeChecked();
 			await expect(page.locator("[data-testid='goal-form-worktree-branch']")).toHaveText(before.branch);
 			await expect(page.locator("[data-testid='goal-form-worktree-path']")).toHaveText(before.worktreePath);
@@ -102,12 +158,14 @@ test.describe("Journey: Current-session goal promotion", () => {
 			const goal = await waitForGoalOwnedBy(source.id);
 			goalId = goal.id;
 			const after = await sessionRecord(source.id);
+			const team = await teamRecord(goal.id);
 			expect(after.id).toBe(source.id);
 			expect(after.branch).toBe(before.branch);
 			expect(after.worktreePath).toBe(before.worktreePath);
 			expect(after.goalId).toBe(goal.id);
 			expect(after.teamGoalId).toBe(goal.id);
-			expect(goal.teamLeadSessionId).toBe(source.id);
+			expect(team.teamLeadSessionId).toBe(source.id);
+			expect(team.agents ?? []).toHaveLength(0);
 
 			await page.reload();
 			await expect(page.locator("body[data-shortcuts-ready='1']")).toBeVisible({ timeout: 20_000 });
@@ -116,33 +174,28 @@ test.describe("Journey: Current-session goal promotion", () => {
 			expect(restored.worktreePath).toBe(before.worktreePath);
 		} finally {
 			if (goalId) await apiFetch(`/api/goals/${goalId}?cascade=true`, { method: "DELETE" }).catch(() => {});
-			await deleteSession(source.id).catch(() => {});
+			await removeGitSession(source);
 		}
 	});
 
 	test("shows the authoritative reason when Current session is unavailable", async ({ page }) => {
-		const project = await defaultProject();
-		const created = await responseJson(await apiFetch("/api/sessions", {
-			method: "POST",
-			body: JSON.stringify({ cwd: project.rootPath, projectId: project.id, worktree: false }),
-		}));
-		await waitForSessionStatus(created.id, "idle", 30_000);
+		const source = await createGitSession(false);
 		try {
-			await seedGoalProposal(created.id, project.id, `Unavailable promotion ${Date.now()}`);
-			await openSeededProposal(page, created.id);
+			await seedGoalProposal(source.id, source.projectId, `Unavailable promotion ${Date.now()}`);
+			await openSeededProposal(page, source.id);
 			const current = page.locator("[data-testid='goal-form-worktree-current-session']");
 			await expect(current).toBeDisabled({ timeout: 20_000 });
 			await expect(page.locator("[data-testid='goal-form-worktree-current-unavailable']")).toContainText(/.+/);
 			await expect(page.locator("[data-testid='goal-form-worktree-new']")).toBeChecked();
 			await expect(page.locator("[data-testid='proposal-primary-submit'] button")).toBeEnabled();
 		} finally {
-			await deleteSession(created.id).catch(() => {});
+			await removeGitSession(source);
 		}
 	});
 
 	test("keeps New worktree goal creation distinct from the proposal owner", async ({ page }) => {
 		test.setTimeout(120_000);
-		const source = await createWorktreeSession();
+		const source = await createGitSession(true);
 		let goalId: string | undefined;
 		try {
 			const before = await sessionRecord(source.id);
@@ -156,16 +209,18 @@ test.describe("Journey: Current-session goal promotion", () => {
 				if (goal) goalId = goal.id;
 				return goal?.id || "";
 			}, { timeout: 40_000, intervals: [100, 250, 500] }).not.toBe("");
-			const goal = (await liveGoals()).find((candidate) => candidate.id === goalId)!;
+			const goal = await waitForGoalSetup(goalId!);
+			const team = await teamRecord(goal.id);
 			expect(goal.worktreePath).toBeTruthy();
 			expect(goal.worktreePath).not.toBe(before.worktreePath);
 			expect(goal.branch).not.toBe(before.branch);
-			expect(goal.teamLeadSessionId).not.toBe(source.id);
+			expect(team.teamLeadSessionId).toBeTruthy();
+			expect(team.teamLeadSessionId).not.toBe(source.id);
 			const ownerAfter = await sessionRecord(source.id);
 			expect(ownerAfter.goalId).toBeFalsy();
 		} finally {
 			if (goalId) await apiFetch(`/api/goals/${goalId}?cascade=true`, { method: "DELETE" }).catch(() => {});
-			await deleteSession(source.id).catch(() => {});
+			await removeGitSession(source);
 		}
 	});
 });

--- a/tests2/browser/journeys/session-goal-promotion.journey.spec.ts
+++ b/tests2/browser/journeys/session-goal-promotion.journey.spec.ts
@@ -4,8 +4,9 @@
  * reload, the unavailable reason, and the unchanged new-worktree control path.
  */
 import { execFileSync } from "node:child_process";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
+import type { GatewayInfo } from "../gateway-harness.js";
 import {
 	test,
 	expect,
@@ -113,6 +114,24 @@ async function teamRecord(goalId: string): Promise<any> {
 	return responseJson(await apiFetch(`/api/goals/${goalId}/team`));
 }
 
+function transcriptSnapshot(gateway: GatewayInfo, sessionId: string): { path: string; bytes: string } {
+	const transcriptPath = gateway.sessionManager?.getPersistedSession(sessionId)?.agentSessionFile;
+	expect(transcriptPath, `session ${sessionId} should retain its transcript path`).toEqual(expect.any(String));
+	return { path: transcriptPath, bytes: readFileSync(transcriptPath, "utf8") };
+}
+
+async function restartGateway(gateway: GatewayInfo): Promise<void> {
+	await gateway.crash();
+	await gateway.restart();
+	await expect.poll(async () => {
+		try {
+			return (await apiFetch("/health")).ok;
+		} catch {
+			return false;
+		}
+	}, { timeout: 20_000, intervals: [250], message: "gateway should be healthy after restart" }).toBe(true);
+}
+
 async function waitForGoalOwnedBy(sessionId: string): Promise<any> {
 	let found: any;
 	await expect.poll(async () => {
@@ -129,14 +148,15 @@ async function openSeededProposal(page: import("@playwright/test").Page, session
 }
 
 test.describe("Journey: Current-session goal promotion", () => {
-	test("selects Current session, promotes the original lead, and survives reload", async ({ page }) => {
-		test.setTimeout(120_000);
+	test("selects Current session, promotes the original lead, survives restart, and cleans up in order", async ({ page, gateway }) => {
+		test.setTimeout(180_000);
 		const source = await createGitSession(true);
 		let goalId: string | undefined;
 		try {
 			const before = await sessionRecord(source.id);
 			expect(before.branch).toBeTruthy();
 			expect(before.worktreePath).toBeTruthy();
+			const transcriptBefore = transcriptSnapshot(gateway, source.id);
 			await seedGoalProposal(source.id, source.projectId, `Promote browser session ${Date.now()}`);
 			await openSeededProposal(page, source.id);
 
@@ -166,12 +186,80 @@ test.describe("Journey: Current-session goal promotion", () => {
 			expect(after.teamGoalId).toBe(goal.id);
 			expect(team.teamLeadSessionId).toBe(source.id);
 			expect(team.agents ?? []).toHaveLength(0);
+			expect(transcriptSnapshot(gateway, source.id)).toEqual(transcriptBefore);
 
-			await page.reload();
+			await restartGateway(gateway);
+			await waitForSessionStatus(source.id, "idle", 40_000);
+			await page.reload({ waitUntil: "domcontentloaded" });
 			await expect(page.locator("body[data-shortcuts-ready='1']")).toBeVisible({ timeout: 20_000 });
+			await navigateToHash(page, `#/session/${source.id}`);
+			await expect(page.locator("message-editor textarea").first()).toBeVisible({ timeout: 20_000 });
+
 			const restored = await sessionRecord(source.id);
+			const restoredGoal = await responseJson(await apiFetch(`/api/goals/${goal.id}`));
+			const restoredTeam = await teamRecord(goal.id);
+			expect(restored.id).toBe(source.id);
 			expect(restored.goalId).toBe(goal.id);
+			expect(restored.teamGoalId).toBe(goal.id);
+			expect(restored.branch).toBe(before.branch);
 			expect(restored.worktreePath).toBe(before.worktreePath);
+			expect(restoredGoal.worktreeOwnerSessionId).toBe(source.id);
+			expect(restoredGoal.branch).toBe(before.branch);
+			expect(restoredGoal.worktreePath).toBe(before.worktreePath);
+			expect(restoredTeam.teamLeadSessionId).toBe(source.id);
+			expect(restoredTeam.agents ?? []).toHaveLength(0);
+			const transcriptAfterRestart = transcriptSnapshot(gateway, source.id);
+			expect(transcriptAfterRestart.path).toBe(transcriptBefore.path);
+			expect(transcriptAfterRestart.bytes.startsWith(transcriptBefore.bytes), "restart must preserve the complete pre-promotion transcript prefix").toBe(true);
+
+			for (const suffix of ["", "?purge=true"]) {
+				const blocked = await apiFetch(`/api/sessions/${source.id}${suffix}`, { method: "DELETE" });
+				expect(blocked.status, `direct promoted-session cleanup ${suffix || "archive"} must be blocked`).toBe(409);
+				const blockedBody = await blocked.json() as { code?: string };
+				expect(blockedBody.code).toBe("PROMOTED_SESSION_LIFECYCLE_CONFLICT");
+			}
+
+			const guarded = await sessionRecord(source.id);
+			const guardedGoal = await responseJson(await apiFetch(`/api/goals/${goal.id}`));
+			const guardedTeam = await teamRecord(goal.id);
+			expect(guarded).toMatchObject({
+				id: source.id,
+				goalId: goal.id,
+				teamGoalId: goal.id,
+				branch: before.branch,
+				worktreePath: before.worktreePath,
+			});
+			expect(guardedGoal.archived).not.toBe(true);
+			expect(guardedTeam.teamLeadSessionId).toBe(source.id);
+			expect(existsSync(before.worktreePath)).toBe(true);
+			expect(transcriptSnapshot(gateway, source.id)).toEqual(transcriptAfterRestart);
+
+			const archived = await apiFetch(`/api/goals/${goal.id}?cascade=true`, { method: "DELETE" });
+			expect(archived.status, await archived.clone().text()).toBe(200);
+			await expect.poll(async () => (await responseJson(await apiFetch(`/api/goals/${goal.id}`))).archived, {
+				timeout: 20_000,
+				message: "goal archival must be durable before promoted lead teardown",
+			}).toBe(true);
+			await expect.poll(async () => (await apiFetch(`/api/goals/${goal.id}/team`)).status, {
+				timeout: 20_000,
+				message: "ordered archive must remove the active team reservation",
+			}).toBe(404);
+			await expect.poll(async () => (await sessionRecord(source.id)).status, {
+				timeout: 20_000,
+				message: "ordered archive must archive the original promoted lead",
+			}).toBe("archived");
+			expect((await liveGoals()).some(candidate => candidate.id === goal.id)).toBe(false);
+			expect(existsSync(before.worktreePath), "archive alone must preserve the session-owned worktree").toBe(true);
+
+			const purged = await apiFetch(`/api/sessions/${source.id}?purge=true`, { method: "DELETE" });
+			expect(purged.status, await purged.clone().text()).toBe(200);
+			await expect.poll(async () => (await apiFetch(`/api/sessions/${source.id}?include=archived`)).status, {
+				timeout: 20_000,
+				message: "final source purge must remove the archived session row",
+			}).toBe(404);
+			expect((await apiFetch(`/api/goals/${goal.id}/team`)).status).toBe(404);
+			expect((await responseJson(await apiFetch(`/api/goals/${goal.id}`))).archived).toBe(true);
+			expect(existsSync(before.worktreePath), "final purge may clean the unreferenced adopted worktree").toBe(false);
 		} finally {
 			if (goalId) await apiFetch(`/api/goals/${goalId}?cascade=true`, { method: "DELETE" }).catch(() => {});
 			await removeGitSession(source);

--- a/tests2/browser/journeys/session-goal-promotion.journey.spec.ts
+++ b/tests2/browser/journeys/session-goal-promotion.journey.spec.ts
@@ -1,0 +1,171 @@
+/**
+ * Journey: Current-session goal promotion
+ * Covers the proposal selector, owner-scoped acceptance, continuity across page
+ * reload, the unavailable reason, and the unchanged new-worktree control path.
+ */
+import {
+	test,
+	expect,
+	apiFetch,
+	deleteSession,
+	defaultProject,
+	openApp,
+	navigateToHash,
+	waitForSessionStatus,
+} from "../_helpers/journey-fixture.js";
+
+async function responseJson(response: Response): Promise<any> {
+	const text = await response.text();
+	expect(response.ok, text).toBe(true);
+	return text ? JSON.parse(text) : {};
+}
+
+async function createWorktreeSession(): Promise<{ id: string; projectId: string }> {
+	const project = await defaultProject();
+	const response = await apiFetch("/api/sessions", {
+		method: "POST",
+		body: JSON.stringify({ cwd: project.rootPath, projectId: project.id, worktree: true }),
+	});
+	const created = await responseJson(response);
+	await waitForSessionStatus(created.id, "idle", 30_000);
+	return { id: created.id, projectId: project.id };
+}
+
+async function sessionRecord(id: string): Promise<any> {
+	return responseJson(await apiFetch(`/api/sessions/${id}?include=archived`));
+}
+
+async function seedGoalProposal(sessionId: string, projectId: string, title: string): Promise<void> {
+	const workflowsBody = await responseJson(await apiFetch(`/api/workflows?projectId=${encodeURIComponent(projectId)}`));
+	const workflows = Array.isArray(workflowsBody) ? workflowsBody : workflowsBody.workflows;
+	expect(workflows?.length, "journey project needs a workflow").toBeGreaterThan(0);
+	await responseJson(await apiFetch(`/api/sessions/${sessionId}/proposal/goal/seed`, {
+		method: "POST",
+		body: JSON.stringify({
+			args: {
+				title,
+				spec: "Promote the exact proposal owner without replacing its checkout or transcript.",
+				workflow: workflows[0].id,
+				projectId,
+			},
+		}),
+	}));
+}
+
+async function liveGoals(): Promise<any[]> {
+	const body = await responseJson(await apiFetch("/api/goals"));
+	return Array.isArray(body) ? body : body.goals ?? [];
+}
+
+async function waitForGoalOwnedBy(sessionId: string): Promise<any> {
+	let found: any;
+	await expect.poll(async () => {
+		found = (await liveGoals()).find((goal) => goal.worktreeOwnerSessionId === sessionId || goal.teamLeadSessionId === sessionId);
+		return found?.id || "";
+	}, { timeout: 40_000, intervals: [100, 250, 500] }).not.toBe("");
+	return found;
+}
+
+async function openSeededProposal(page: import("@playwright/test").Page, sessionId: string): Promise<void> {
+	await openApp(page);
+	await navigateToHash(page, `#/session/${sessionId}`);
+	await expect(page.locator("[data-testid='goal-form-worktree-mode']")).toBeVisible({ timeout: 20_000 });
+}
+
+test.describe("Journey: Current-session goal promotion", () => {
+	test("selects Current session, promotes the original lead, and survives reload", async ({ page }) => {
+		test.setTimeout(120_000);
+		const source = await createWorktreeSession();
+		let goalId: string | undefined;
+		try {
+			const before = await sessionRecord(source.id);
+			expect(before.branch).toBeTruthy();
+			expect(before.worktreePath).toBeTruthy();
+			await seedGoalProposal(source.id, source.projectId, `Promote browser session ${Date.now()}`);
+			await openSeededProposal(page, source.id);
+
+			const newMode = page.locator("[data-testid='goal-form-worktree-new']");
+			const currentMode = page.locator("[data-testid='goal-form-worktree-current-session']");
+			await expect(newMode).toBeChecked();
+			await expect(currentMode).toBeEnabled({ timeout: 20_000 });
+			await currentMode.check();
+			await expect(currentMode).toBeChecked();
+			await expect(page.locator("[data-testid='goal-form-worktree-branch']")).toHaveText(before.branch);
+			await expect(page.locator("[data-testid='goal-form-worktree-path']")).toHaveText(before.worktreePath);
+
+			await page.reload();
+			await expect(page.locator("body[data-shortcuts-ready='1']")).toBeVisible({ timeout: 20_000 });
+			await expect(page.locator("[data-testid='goal-form-worktree-current-session']")).toBeChecked({ timeout: 20_000 });
+			await expect(page.locator("[data-testid='goal-form-worktree-path']")).toHaveText(before.worktreePath);
+
+			await page.locator("[data-testid='proposal-primary-submit'] button").click();
+			const goal = await waitForGoalOwnedBy(source.id);
+			goalId = goal.id;
+			const after = await sessionRecord(source.id);
+			expect(after.id).toBe(source.id);
+			expect(after.branch).toBe(before.branch);
+			expect(after.worktreePath).toBe(before.worktreePath);
+			expect(after.goalId).toBe(goal.id);
+			expect(after.teamGoalId).toBe(goal.id);
+			expect(goal.teamLeadSessionId).toBe(source.id);
+
+			await page.reload();
+			await expect(page.locator("body[data-shortcuts-ready='1']")).toBeVisible({ timeout: 20_000 });
+			const restored = await sessionRecord(source.id);
+			expect(restored.goalId).toBe(goal.id);
+			expect(restored.worktreePath).toBe(before.worktreePath);
+		} finally {
+			if (goalId) await apiFetch(`/api/goals/${goalId}?cascade=true`, { method: "DELETE" }).catch(() => {});
+			await deleteSession(source.id).catch(() => {});
+		}
+	});
+
+	test("shows the authoritative reason when Current session is unavailable", async ({ page }) => {
+		const project = await defaultProject();
+		const created = await responseJson(await apiFetch("/api/sessions", {
+			method: "POST",
+			body: JSON.stringify({ cwd: project.rootPath, projectId: project.id, worktree: false }),
+		}));
+		await waitForSessionStatus(created.id, "idle", 30_000);
+		try {
+			await seedGoalProposal(created.id, project.id, `Unavailable promotion ${Date.now()}`);
+			await openSeededProposal(page, created.id);
+			const current = page.locator("[data-testid='goal-form-worktree-current-session']");
+			await expect(current).toBeDisabled({ timeout: 20_000 });
+			await expect(page.locator("[data-testid='goal-form-worktree-current-unavailable']")).toContainText(/.+/);
+			await expect(page.locator("[data-testid='goal-form-worktree-new']")).toBeChecked();
+			await expect(page.locator("[data-testid='proposal-primary-submit'] button")).toBeEnabled();
+		} finally {
+			await deleteSession(created.id).catch(() => {});
+		}
+	});
+
+	test("keeps New worktree goal creation distinct from the proposal owner", async ({ page }) => {
+		test.setTimeout(120_000);
+		const source = await createWorktreeSession();
+		let goalId: string | undefined;
+		try {
+			const before = await sessionRecord(source.id);
+			await seedGoalProposal(source.id, source.projectId, `New worktree control ${Date.now()}`);
+			await openSeededProposal(page, source.id);
+			await expect(page.locator("[data-testid='goal-form-worktree-new']")).toBeChecked();
+			await page.locator("[data-testid='proposal-primary-submit'] button").click();
+			await expect.poll(async () => {
+				const goals = await liveGoals();
+				const goal = goals.find((candidate) => candidate.title?.startsWith("New worktree control"));
+				if (goal) goalId = goal.id;
+				return goal?.id || "";
+			}, { timeout: 40_000, intervals: [100, 250, 500] }).not.toBe("");
+			const goal = (await liveGoals()).find((candidate) => candidate.id === goalId)!;
+			expect(goal.worktreePath).toBeTruthy();
+			expect(goal.worktreePath).not.toBe(before.worktreePath);
+			expect(goal.branch).not.toBe(before.branch);
+			expect(goal.teamLeadSessionId).not.toBe(source.id);
+			const ownerAfter = await sessionRecord(source.id);
+			expect(ownerAfter.goalId).toBeFalsy();
+		} finally {
+			if (goalId) await apiFetch(`/api/goals/${goalId}?cascade=true`, { method: "DELETE" }).catch(() => {});
+			await deleteSession(source.id).catch(() => {});
+		}
+	});
+});

--- a/tests2/browser/journeys/session-goal-promotion.journey.spec.ts
+++ b/tests2/browser/journeys/session-goal-promotion.journey.spec.ts
@@ -186,6 +186,7 @@ test.describe("Journey: Current-session goal promotion", () => {
 			expect(after.teamGoalId).toBe(goal.id);
 			expect(team.teamLeadSessionId).toBe(source.id);
 			expect(team.agents ?? []).toHaveLength(0);
+			expect(goal.state).toBe("in-progress");
 			expect(transcriptSnapshot(gateway, source.id)).toEqual(transcriptBefore);
 
 			await restartGateway(gateway);
@@ -204,6 +205,7 @@ test.describe("Journey: Current-session goal promotion", () => {
 			expect(restored.branch).toBe(before.branch);
 			expect(restored.worktreePath).toBe(before.worktreePath);
 			expect(restoredGoal.worktreeOwnerSessionId).toBe(source.id);
+			expect(restoredGoal.state).toBe("in-progress");
 			expect(restoredGoal.branch).toBe(before.branch);
 			expect(restoredGoal.worktreePath).toBe(before.worktreePath);
 			expect(restoredTeam.teamLeadSessionId).toBe(source.id);

--- a/tests2/core/session-goal-promotion-eligibility.test.ts
+++ b/tests2/core/session-goal-promotion-eligibility.test.ts
@@ -1,0 +1,316 @@
+import assert from "node:assert/strict";
+import { describe, it } from "vitest";
+
+import {
+	evaluateSessionGoalPromotion,
+	lookupSessionGoalPromotion,
+	type EvaluateSessionGoalPromotionInput,
+	type SessionGoalPromotionLiveSession,
+	type SessionGoalPromotionPersistedSession,
+} from "../../src/server/agent/session-goal-promotion.js";
+
+const OWNER = "session-owner";
+const PROJECT = "project-one";
+const WORKTREE = "/projects/example-wt/session-owner";
+
+type Fixture = {
+	input: EvaluateSessionGoalPromotionInput;
+	live: SessionGoalPromotionLiveSession;
+	persisted: SessionGoalPromotionPersistedSession;
+};
+
+function fixture(): Fixture {
+	const live: SessionGoalPromotionLiveSession = {
+		id: OWNER,
+		projectId: PROJECT,
+		cwd: `${WORKTREE}/packages/app`,
+		worktreePath: WORKTREE,
+		repoPath: "/projects/example",
+		branch: "session/owner",
+		status: "idle",
+		sandboxed: false,
+	};
+	const persisted: SessionGoalPromotionPersistedSession = {
+		id: OWNER,
+		projectId: PROJECT,
+		cwd: live.cwd,
+		worktreePath: live.worktreePath,
+		repoPath: live.repoPath,
+		branch: live.branch,
+		agentSessionFile: "/state/sessions/session-owner.jsonl",
+		sandboxed: false,
+	};
+	return {
+		live,
+		persisted,
+		input: {
+			ownerSessionId: OWNER,
+			proposalProjectId: PROJECT,
+			project: { id: PROJECT, rootPath: "/projects/example" },
+			liveSession: live,
+			persistedSession: persisted,
+			transcriptAvailable: true,
+			workspaceAvailable: true,
+			gitComponentRepos: ["."],
+		},
+	};
+}
+
+function assertIneligible(input: EvaluateSessionGoalPromotionInput, code: string): void {
+	const result = evaluateSessionGoalPromotion(input);
+	assert.equal(result.eligible, false, JSON.stringify(result));
+	if (!result.eligible) {
+		assert.equal(result.code, code);
+		assert.ok(result.reason.length > 0);
+	}
+}
+
+describe("evaluateSessionGoalPromotion", () => {
+	it("returns exact canonical coordinates for an eligible single-repo session", () => {
+		const { input } = fixture();
+		const result = evaluateSessionGoalPromotion({
+			...input,
+			// Unknown caller-shaped values are ignored rather than becoming authority.
+			branch: "attacker/branch",
+			worktreePath: "/attacker/worktree",
+		} as EvaluateSessionGoalPromotionInput);
+		assert.equal(result.eligible, true, JSON.stringify(result));
+		if (!result.eligible) return;
+		assert.deepEqual(result.coordinates, {
+			sessionId: OWNER,
+			projectId: PROJECT,
+			cwd: `${WORKTREE}/packages/app`,
+			worktreePath: WORKTREE,
+			repoPath: "/projects/example",
+			branch: "session/owner",
+			repoWorktrees: undefined,
+			sandboxed: false,
+			containerId: undefined,
+		});
+	});
+
+	it("returns exact multi-repo coordinates only when every Git component appears once", () => {
+		const { input, live, persisted } = fixture();
+		const repoWorktrees = {
+			api: `${WORKTREE}/api`,
+			web: `${WORKTREE}/web`,
+		};
+		live.repoPath = "/projects/polyrepo";
+		persisted.repoPath = live.repoPath;
+		live.repoWorktrees = [
+			{ repo: "api", worktreePath: repoWorktrees.api },
+			{ repo: "web", worktreePath: repoWorktrees.web },
+		];
+		persisted.repoWorktrees = { ...repoWorktrees };
+		input.gitComponentRepos = ["api", "web"];
+
+		const result = evaluateSessionGoalPromotion(input);
+		assert.equal(result.eligible, true, JSON.stringify(result));
+		if (result.eligible) assert.deepEqual(result.coordinates.repoWorktrees, repoWorktrees);
+	});
+
+	it("preserves an eligible reachable sandbox realm", () => {
+		const { input, live, persisted } = fixture();
+		live.cwd = "/workspace-wt/session/owner/packages/app";
+		live.worktreePath = "/workspace-wt/session/owner";
+		live.repoPath = "/workspace";
+		live.sandboxed = true;
+		live.containerId = "container-existing";
+		persisted.cwd = live.cwd;
+		persisted.worktreePath = live.worktreePath;
+		persisted.repoPath = live.repoPath;
+		persisted.sandboxed = true;
+		input.sandboxReachable = true;
+
+		const result = evaluateSessionGoalPromotion(input);
+		assert.equal(result.eligible, true, JSON.stringify(result));
+		if (result.eligible) {
+			assert.equal(result.coordinates.sandboxed, true);
+			assert.equal(result.coordinates.containerId, "container-existing");
+		}
+	});
+
+	it("rejects every forbidden relation and unsafe session kind", () => {
+		const relationCases: Array<{
+			name: string;
+			target: "live" | "persisted";
+			patch: Record<string, unknown>;
+			code: string;
+		}> = [
+			{ name: "goal", target: "live", patch: { goalId: "goal-1" }, code: "SESSION_HAS_RELATION" },
+			{ name: "team", target: "persisted", patch: { teamGoalId: "goal-1" }, code: "SESSION_HAS_RELATION" },
+			{ name: "team role", target: "live", patch: { role: "coder" }, code: "SESSION_HAS_RELATION" },
+			{ name: "team child", target: "persisted", patch: { teamLeadSessionId: "lead-1" }, code: "SESSION_HAS_RELATION" },
+			{ name: "assistant", target: "live", patch: { assistantType: "goal" }, code: "SESSION_HAS_RELATION" },
+			{ name: "legacy assistant", target: "persisted", patch: { goalAssistant: true }, code: "SESSION_HAS_RELATION" },
+			{ name: "staff", target: "persisted", patch: { staffId: "staff-1" }, code: "SESSION_HAS_RELATION" },
+			{ name: "delegate", target: "live", patch: { delegateOf: "parent" }, code: "SESSION_HAS_RELATION" },
+			{ name: "child", target: "persisted", patch: { parentSessionId: "parent", childKind: "review" }, code: "SESSION_HAS_RELATION" },
+			{ name: "task", target: "live", patch: { taskId: "task-1" }, code: "SESSION_HAS_RELATION" },
+			{ name: "read-only", target: "persisted", patch: { readOnly: true }, code: "SESSION_UNSAFE" },
+			{ name: "noninteractive", target: "live", patch: { nonInteractive: true }, code: "SESSION_UNSAFE" },
+			{ name: "borrower", target: "persisted", patch: { borrowsWorktree: true }, code: "SESSION_UNSAFE" },
+			{ name: "borrowed owner marker", target: "live", patch: { borrowedWorktreeOwnerSessionId: "owner" }, code: "SESSION_UNSAFE" },
+			{ name: "terminal child", target: "persisted", patch: { childTerminal: true }, code: "SESSION_UNSAFE" },
+		];
+
+		for (const testCase of relationCases) {
+			const { input, live, persisted } = fixture();
+			Object.assign(testCase.target === "live" ? live : persisted, testCase.patch);
+			assertIneligible(input, testCase.code);
+		}
+	});
+
+	it("rejects archived, terminal, busy, compacting, dormant, fenced, and pending sessions", () => {
+		const cases: Array<{
+			mutate: (f: Fixture) => void;
+			code: string;
+		}> = [
+			{ mutate: ({ persisted }) => { persisted.archived = true; }, code: "SESSION_NOT_LIVE" },
+			{ mutate: ({ live }) => { live.status = "terminated"; }, code: "SESSION_NOT_IDLE" },
+			{ mutate: ({ live }) => { live.status = "streaming"; }, code: "SESSION_NOT_IDLE" },
+			{ mutate: ({ live }) => { live.isCompacting = true; }, code: "SESSION_NOT_IDLE" },
+			{ mutate: ({ persisted }) => { persisted.wasStreaming = true; }, code: "SESSION_NOT_IDLE" },
+			{ mutate: ({ live }) => { live.restoreStartupWasStreaming = true; }, code: "SESSION_NOT_IDLE" },
+			{ mutate: ({ live }) => { live.dormant = true; }, code: "SESSION_NOT_IDLE" },
+			{ mutate: ({ live }) => { live.lifecycleFenced = true; }, code: "SESSION_NOT_IDLE" },
+			{ mutate: ({ input }) => { input.hasPendingWork = true; }, code: "SESSION_NOT_IDLE" },
+		];
+		for (const testCase of cases) {
+			const f = fixture();
+			testCase.mutate(f);
+			assertIneligible(f.input, testCase.code);
+		}
+	});
+
+	it("requires the proposal owner and both canonical records to identify the same registered project", () => {
+		const missing = fixture();
+		missing.input.project = undefined;
+		assertIneligible(missing.input, "PROJECT_UNAVAILABLE");
+
+		const proposalMismatch = fixture();
+		proposalMismatch.input.proposalProjectId = "project-two";
+		assertIneligible(proposalMismatch.input, "PROJECT_UNAVAILABLE");
+
+		const liveMismatch = fixture();
+		liveMismatch.live.projectId = "project-two";
+		assertIneligible(liveMismatch.input, "PROJECT_MISMATCH");
+
+		const wrongOwner = fixture();
+		wrongOwner.input.ownerSessionId = "arbitrary-caller-session";
+		assertIneligible(wrongOwner.input, "SESSION_NOT_LIVE");
+	});
+
+	it("rejects missing, stale, mismatched, or non-dedicated workspace metadata", () => {
+		const cases: Array<{
+			mutate: (f: Fixture) => void;
+			code: string;
+		}> = [
+			{ mutate: ({ input }) => { input.transcriptAvailable = false; }, code: "TRANSCRIPT_UNAVAILABLE" },
+			{ mutate: ({ persisted }) => { persisted.agentSessionFile = ""; }, code: "TRANSCRIPT_UNAVAILABLE" },
+			{ mutate: ({ live }) => { live.branch = undefined; }, code: "WORKTREE_UNAVAILABLE" },
+			{ mutate: ({ persisted }) => { persisted.worktreePath = undefined; }, code: "WORKTREE_UNAVAILABLE" },
+			{ mutate: ({ input }) => { input.workspaceAvailable = false; }, code: "WORKTREE_UNAVAILABLE" },
+			{ mutate: ({ live }) => { live.branch = "different/branch"; }, code: "WORKSPACE_MISMATCH" },
+			{ mutate: ({ persisted }) => { persisted.cwd = `${WORKTREE}/other`; }, code: "WORKSPACE_MISMATCH" },
+			{ mutate: ({ live, persisted }) => {
+				live.cwd = "/projects/example";
+				live.worktreePath = "/projects/example";
+				persisted.cwd = live.cwd;
+				persisted.worktreePath = live.worktreePath;
+			}, code: "WORKTREE_UNAVAILABLE" },
+		];
+		for (const testCase of cases) {
+			const f = fixture();
+			testCase.mutate(f);
+			assertIneligible(f.input, testCase.code);
+		}
+	});
+
+	it("rejects incomplete, extra, duplicate, divergent, and aliased multi-repo coordinates", () => {
+		function multi(): Fixture {
+			const f = fixture();
+			const repoWorktrees = { api: `${WORKTREE}/api`, web: `${WORKTREE}/web` };
+			f.live.repoWorktrees = Object.entries(repoWorktrees).map(([repo, worktreePath]) => ({ repo, worktreePath }));
+			f.persisted.repoWorktrees = { ...repoWorktrees };
+			f.input.gitComponentRepos = ["api", "web"];
+			return f;
+		}
+		const cases: Array<(f: Fixture) => void> = [
+			f => { f.input.gitComponentRepos = ["api", "api"]; },
+			f => { delete (f.persisted.repoWorktrees as Record<string, string>).web; },
+			f => { (f.persisted.repoWorktrees as Record<string, string>).docs = `${WORKTREE}/docs`; },
+			f => { (f.live.repoWorktrees as Array<{ repo: string; worktreePath: string }>)[1].repo = "api"; },
+			f => { (f.live.repoWorktrees as Array<{ repo: string; worktreePath: string }>)[1].worktreePath = `${WORKTREE}/api`; },
+			f => { (f.live.repoWorktrees as Array<{ repo: string; worktreePath: string }>)[1].worktreePath = "/outside/web"; },
+		];
+		for (const mutate of cases) {
+			const f = multi();
+			mutate(f);
+			assertIneligible(f.input, "MULTI_REPO_MISMATCH");
+		}
+	});
+
+	it("requires the exact existing sandbox container to remain reachable", () => {
+		for (const mutate of [
+			(f: Fixture) => { f.live.containerId = undefined; },
+			(f: Fixture) => { f.input.sandboxReachable = false; },
+		]) {
+			const f = fixture();
+			f.live.cwd = "/workspace-wt/session/owner";
+			f.live.worktreePath = f.live.cwd;
+			f.live.repoPath = "/workspace";
+			f.live.sandboxed = true;
+			f.live.containerId = "container-existing";
+			f.persisted.cwd = f.live.cwd;
+			f.persisted.worktreePath = f.live.worktreePath;
+			f.persisted.repoPath = f.live.repoPath;
+			f.persisted.sandboxed = true;
+			f.input.sandboxReachable = true;
+			mutate(f);
+			assertIneligible(f.input, "SANDBOX_UNAVAILABLE");
+		}
+	});
+
+	it("rejects conflicting claims but allows the source session and exact retry provenance", () => {
+		const conflict = fixture();
+		conflict.input.workspaceClaims = [{
+			kind: "staff",
+			id: "staff-one",
+			projectId: PROJECT,
+			worktreePath: WORKTREE,
+		}];
+		assertIneligible(conflict.input, "WORKSPACE_CLAIMED");
+
+		const allowed = fixture();
+		allowed.input.goals = [{ id: "goal-retry", projectId: PROJECT, worktreeOwnerSessionId: OWNER }];
+		allowed.input.workspaceClaims = [
+			{ kind: "session", id: OWNER, sessionId: OWNER, projectId: PROJECT, worktreePath: WORKTREE },
+			{ kind: "goal", id: "goal-retry", goalId: "goal-retry", projectId: PROJECT, worktreePath: WORKTREE },
+		];
+		assert.equal(evaluateSessionGoalPromotion(allowed.input).eligible, true);
+
+		const duplicate = fixture();
+		duplicate.input.goals = [
+			{ id: "goal-one", projectId: PROJECT, worktreeOwnerSessionId: OWNER },
+			{ id: "goal-two", projectId: PROJECT, worktreeOwnerSessionId: OWNER },
+		];
+		assertIneligible(duplicate.input, "PROMOTION_CONFLICT");
+	});
+});
+
+describe("lookupSessionGoalPromotion", () => {
+	it("uses only live server-owned provenance and fails closed on duplicates", () => {
+		const archived = { id: "archived", archived: true, worktreeOwnerSessionId: OWNER };
+		const unrelated = { id: "same-path-is-irrelevant" };
+		assert.deepEqual(lookupSessionGoalPromotion([archived, unrelated], OWNER), { status: "none" });
+
+		const goal = { id: "goal-one", projectId: PROJECT, worktreeOwnerSessionId: OWNER };
+		assert.deepEqual(lookupSessionGoalPromotion([archived, goal], OWNER), { status: "found", goal });
+
+		const other = { id: "goal-two", projectId: PROJECT, worktreeOwnerSessionId: OWNER };
+		const conflict = lookupSessionGoalPromotion([goal, other], OWNER);
+		assert.equal(conflict.status, "conflict");
+		if (conflict.status === "conflict") assert.deepEqual(conflict.goals, [goal, other]);
+	});
+});

--- a/tests2/core/session-goal-promotion-proposal.test.ts
+++ b/tests2/core/session-goal-promotion-proposal.test.ts
@@ -1,0 +1,145 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, it } from "vitest";
+
+import { copyProposalDirIfPresent } from "../../src/server/agent/continue-archived.js";
+import { resolveSessionGoalWorktreeMode } from "../../src/server/agent/session-goal-promotion.js";
+import {
+	editProposalFile,
+	latestRev,
+	parseProposalFile,
+	proposalFilePath,
+	readProposalFile,
+	readSnapshot,
+	restoreSnapshot,
+	writeProposalFile,
+} from "../../src/server/proposals/proposal-files.js";
+
+const roots: string[] = [];
+
+function fixtureRoot(): string {
+	const root = fs.mkdtempSync(path.join(os.tmpdir(), "bobbit-session-goal-proposal-"));
+	roots.push(root);
+	return root;
+}
+
+afterEach(() => {
+	for (const root of roots.splice(0)) fs.rmSync(root, { recursive: true, force: true });
+});
+
+describe("session-goal promotion proposal mode", () => {
+	it("keeps absent legacy drafts byte-compatible and defaults them to new-worktree", async () => {
+		const stateDir = fixtureRoot();
+		await writeProposalFile(stateDir, "legacy-owner", "goal", {
+			title: "Legacy",
+			spec: "Body.\n",
+		});
+
+		const raw = await readProposalFile(stateDir, "legacy-owner", "goal");
+		assert.equal(raw, "---\ntitle: Legacy\n---\nBody.\n");
+		const parsed = await parseProposalFile(stateDir, "legacy-owner", "goal");
+		assert.equal(parsed.ok, true);
+		if (!parsed.ok) return;
+		assert.equal(parsed.value.fields.worktreeMode, undefined);
+		assert.equal(resolveSessionGoalWorktreeMode(parsed.value.fields.worktreeMode), "new-worktree");
+	});
+
+	it("round-trips current-session through edits, reload, snapshots, and archived continuation copy", async () => {
+		const stateDir = fixtureRoot();
+		const sourceId = "proposal-owner";
+		await writeProposalFile(stateDir, sourceId, "goal", {
+			title: "Promote this session",
+			spec: "Keep the existing checkout.\n",
+			worktreeMode: "new-worktree",
+		});
+		const rev1 = await readSnapshot(stateDir, sourceId, "goal", 1);
+		assert.match(rev1!, /worktreeMode: new-worktree/);
+
+		const edited = await editProposalFile(
+			stateDir,
+			sourceId,
+			"goal",
+			"worktreeMode: new-worktree",
+			"worktreeMode: current-session",
+		);
+		assert.equal(edited.ok, true, JSON.stringify(edited));
+		assert.equal(await latestRev(stateDir, sourceId, "goal"), 2);
+
+		const reloaded = await parseProposalFile(stateDir, sourceId, "goal");
+		assert.equal(reloaded.ok, true, JSON.stringify(reloaded));
+		if (!reloaded.ok) return;
+		assert.equal(reloaded.value.fields.worktreeMode, "current-session");
+
+		const continuedId = "continued-owner";
+		copyProposalDirIfPresent(sourceId, continuedId, stateDir);
+		assert.equal(
+			fs.readFileSync(proposalFilePath(stateDir, continuedId, "goal"), "utf8"),
+			fs.readFileSync(proposalFilePath(stateDir, sourceId, "goal"), "utf8"),
+		);
+		const continued = await parseProposalFile(stateDir, continuedId, "goal");
+		assert.equal(continued.ok, true, JSON.stringify(continued));
+		if (continued.ok) assert.equal(continued.value.fields.worktreeMode, "current-session");
+
+		const restored = await restoreSnapshot(stateDir, sourceId, "goal", 1);
+		assert.equal(restored.ok, true, JSON.stringify(restored));
+		if (restored.ok) assert.equal(restored.fields.worktreeMode, "new-worktree");
+		const restoredRaw = await readProposalFile(stateDir, sourceId, "goal");
+		assert.equal(restoredRaw, rev1);
+	});
+
+	it("rejects invalid worktree modes without changing the owning draft", async () => {
+		const stateDir = fixtureRoot();
+		const ownerId = "invalid-owner";
+		await writeProposalFile(stateDir, ownerId, "goal", {
+			title: "Valid goal",
+			spec: "Body.\n",
+			worktreeMode: "current-session",
+		});
+		const before = await readProposalFile(stateDir, ownerId, "goal");
+
+		const edit = await editProposalFile(
+			stateDir,
+			ownerId,
+			"goal",
+			"worktreeMode: current-session",
+			"worktreeMode: arbitrary-worktree",
+		);
+		assert.equal(edit.ok, false);
+		if (!edit.ok) {
+			assert.equal("code" in edit ? edit.code : undefined, "STRUCTURAL_VALIDATION_FAILED");
+		}
+		assert.equal(await readProposalFile(stateDir, ownerId, "goal"), before);
+	});
+
+	it("updates only the proposal owner's draft and never serializes coordinate authority", async () => {
+		const stateDir = fixtureRoot();
+		for (const sessionId of ["owner-a", "owner-b"]) {
+			await writeProposalFile(stateDir, sessionId, "goal", {
+				title: `Goal ${sessionId}`,
+				spec: "Body.\n",
+				worktreeMode: "new-worktree",
+			});
+		}
+		const otherBefore = await readProposalFile(stateDir, "owner-b", "goal");
+
+		await writeProposalFile(stateDir, "owner-a", "goal", {
+			title: "Goal owner-a",
+			spec: "Body.\n",
+			worktreeMode: "current-session",
+			promoteSessionId: "attacker-selected-session",
+			worktreePath: "/attacker/worktree",
+			branch: "attacker/branch",
+			repoPath: "/attacker/repo",
+			containerId: "attacker-container",
+		});
+
+		const ownerRaw = await readProposalFile(stateDir, "owner-a", "goal");
+		assert.match(ownerRaw!, /worktreeMode: current-session/);
+		for (const forbidden of ["promoteSessionId", "worktreePath", "branch", "repoPath", "containerId"]) {
+			assert.doesNotMatch(ownerRaw!, new RegExp(forbidden));
+		}
+		assert.equal(await readProposalFile(stateDir, "owner-b", "goal"), otherBefore);
+	});
+});

--- a/tests2/core/session-goal-promotion-session-runtime.test.ts
+++ b/tests2/core/session-goal-promotion-session-runtime.test.ts
@@ -1,0 +1,390 @@
+import { guardProcessEnv } from "./helpers/env-guard.js";
+guardProcessEnv();
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, afterEach, describe, expect, it, vi } from "vitest";
+import { createMemFs } from "../harness/mem-fs.js";
+
+const root = fs.mkdtempSync(path.join(os.tmpdir(), "session-goal-promotion-runtime-"));
+process.env.BOBBIT_DIR = root;
+process.env.BOBBIT_AGENT_DIR = path.join(root, "agent");
+
+const { activeAgentSessionsDir } = await import("../../src/server/agent/agent-session-path.ts");
+const { EventBuffer } = await import("../../src/server/agent/event-buffer.ts");
+const { invalidateModelCache } = await import("../../src/server/agent/model-registry.ts");
+const { PreferencesStore } = await import("../../src/server/agent/preferences-store.ts");
+const { PromptQueue } = await import("../../src/server/agent/prompt-queue.ts");
+const { registerRpcBridgeFactory } = await import("../../src/server/agent/rpc-bridge.ts");
+const { loadOrCreateToken } = await import("../../src/server/auth/token.ts");
+const {
+	PromotedSessionLifecycleConflictError,
+	SessionManager,
+} = await import("../../src/server/agent/session-manager.ts");
+
+loadOrCreateToken();
+
+const provider = "promotion-runtime";
+const modelId = "continuity-model";
+const thinkingLevel = "off";
+const preferencesStore = new PreferencesStore(path.resolve("/memfs/session-goal-promotion-runtime"), createMemFs());
+preferencesStore.set("customProviders", [{
+	id: provider,
+	name: provider,
+	type: "manual",
+	baseUrl: "http://127.0.0.1:9",
+	apiKey: "test-key",
+	models: [{
+		id: modelId,
+		name: "Continuity model",
+		reasoning: true,
+		thinkingLevelMap: { off: null, high: "high" },
+	}],
+}]);
+preferencesStore.set("default.sessionModel", `${provider}/${modelId}`);
+preferencesStore.set("default.sessionThinkingLevel", thinkingLevel);
+
+const teamLeadRole = {
+	name: "team-lead",
+	label: "Team Lead",
+	promptTemplate: "Lead {{AGENT_ID}} on {{GOAL_BRANCH}}",
+	accessory: "crown",
+	// Promotion must ignore these role defaults and preserve the source tuple.
+	model: "other-provider/other-model",
+	thinkingLevel: "high",
+	createdAt: 1,
+	updatedAt: 1,
+};
+
+const managers: any[] = [];
+const files: string[] = [];
+
+afterEach(() => {
+	registerRpcBridgeFactory(null);
+	invalidateModelCache();
+	vi.restoreAllMocks();
+	while (managers.length) {
+		const manager = managers.pop();
+		if (manager._statusHeartbeatTimer) clearInterval(manager._statusHeartbeatTimer);
+		manager.sessions.clear();
+	}
+	while (files.length) fs.rmSync(files.pop()!, { force: true });
+});
+
+afterAll(() => fs.rmSync(root, { recursive: true, force: true }));
+
+function transcript(name: string): string {
+	const dir = path.join(activeAgentSessionsDir(), "--promotion-runtime--");
+	fs.mkdirSync(dir, { recursive: true });
+	const file = path.join(dir, `${name}.jsonl`);
+	fs.writeFileSync(file, `${JSON.stringify({
+		type: "message",
+		id: "existing-user-message",
+		parentId: null,
+		message: { role: "user", content: [{ type: "text", text: "work already in progress" }] },
+	})}\n`, "utf8");
+	files.push(file);
+	return file;
+}
+
+function bridge(initial: { provider?: string; modelId?: string; thinkingLevel?: string } = {}): any {
+	let selectedProvider = initial.provider ?? provider;
+	let selectedModel = initial.modelId ?? modelId;
+	let selectedThinking = initial.thinkingLevel ?? thinkingLevel;
+	let listener: ((event: unknown) => void) | undefined;
+	return {
+		running: true,
+		start: vi.fn(async () => {}),
+		stop: vi.fn(async function (this: any) { this.running = false; }),
+		prompt: vi.fn(async () => ({ success: true })),
+		promptWhenReady: vi.fn(async () => ({ success: true })),
+		steer: vi.fn(async () => ({ success: true })),
+		abort: vi.fn(async () => ({ success: true })),
+		getMessages: vi.fn(async () => ({ success: true, data: { messages: [] } })),
+		getState: vi.fn(async () => ({
+			success: true,
+			data: {
+				sessionFile: undefined,
+				model: { provider: selectedProvider, id: selectedModel },
+				thinkingLevel: selectedThinking,
+			},
+		})),
+		setModel: vi.fn(async (nextProvider: string, nextModel: string) => {
+			selectedProvider = nextProvider;
+			selectedModel = nextModel;
+			return { success: true };
+		}),
+		setThinkingLevel: vi.fn(async (next: string) => {
+			selectedThinking = next;
+			return { success: true };
+		}),
+		sendCommand: vi.fn(async () => ({ success: true })),
+		onEvent: vi.fn((next: (event: unknown) => void) => {
+			listener = next;
+			return vi.fn(() => { listener = undefined; });
+		}),
+		emit: (event: unknown) => listener?.(event),
+	};
+}
+
+function fixture(name: string, overrides: Record<string, unknown> = {}): {
+	manager: any;
+	persisted: any;
+	live: any;
+	oldBridge: any;
+	store: any;
+} {
+	const file = transcript(name);
+	const persisted: any = {
+		id: name,
+		title: "Existing regular session",
+		cwd: path.join(root, "repo-wt", "session", name),
+		agentSessionFile: file,
+		createdAt: 10,
+		lastActivity: 20,
+		projectId: "project-promotion",
+		worktreePath: path.join(root, "repo-wt", "session", name),
+		repoPath: path.join(root, "repo"),
+		branch: `session/${name}`,
+		repoWorktrees: {
+			".": path.join(root, "repo-wt", "session", name),
+			api: path.join(root, "repo-wt", "session", `${name}-api`),
+		},
+		modelProvider: provider,
+		modelId,
+		effectiveThinkingLevel: thinkingLevel,
+		sandboxed: false,
+		...overrides,
+	};
+	const updates: Record<string, unknown>[] = [];
+	const store = {
+		get: vi.fn(() => persisted),
+		getLive: vi.fn(() => [persisted]),
+		update: vi.fn((_id: string, patch: Record<string, unknown>) => {
+			updates.push({ ...patch });
+			Object.assign(persisted, patch);
+		}),
+		flushAsync: vi.fn(async () => {}),
+		put: vi.fn(),
+		archive: vi.fn(),
+		archiveAsync: vi.fn(async () => {
+			persisted.archived = true;
+			persisted.archivedAt = Date.now();
+			return true;
+		}),
+		updates,
+	};
+	const roleManager = {
+		getRole: vi.fn((roleName: string) => roleName === "team-lead" ? teamLeadRole : undefined),
+		listRoles: vi.fn(() => [teamLeadRole]),
+	};
+	const manager: any = new SessionManager({ preferencesStore, roleManager: roleManager as any });
+	manager._testStore = store;
+	manager.resolveGoal = vi.fn((goalId: string) => ({
+		id: goalId,
+		title: "Promoted goal",
+		state: "active",
+		spec: "Keep all existing work and continue as lead.",
+		branch: persisted.branch,
+		projectId: persisted.projectId,
+	}));
+	managers.push(manager);
+
+	const oldBridge = bridge();
+	oldBridge.getState = vi.fn(async () => ({
+		success: true,
+		data: {
+			sessionFile: file,
+			model: { provider, id: modelId },
+			thinkingLevel,
+		},
+	}));
+	const clients = new Set<any>([{ readyState: 1 }]);
+	const eventBuffer = new EventBuffer();
+	eventBuffer.seedNextSeq(18);
+	const promptQueue = new PromptQueue();
+	const unsubscribe = vi.fn();
+	const live: any = {
+		id: persisted.id,
+		title: persisted.title,
+		titleGenerated: true,
+		cwd: persisted.cwd,
+		status: "idle",
+		statusVersion: 9,
+		createdAt: persisted.createdAt,
+		lastActivity: persisted.lastActivity,
+		clients,
+		rpcClient: oldBridge,
+		eventBuffer,
+		promptQueue,
+		unsubscribe,
+		isCompacting: false,
+		projectId: persisted.projectId,
+		worktreePath: persisted.worktreePath,
+		repoPath: persisted.repoPath,
+		branch: persisted.branch,
+		repoWorktrees: Object.entries(persisted.repoWorktrees).map(([repo, worktreePath]) => ({
+			repo,
+			repoPath: repo === "." ? persisted.repoPath : path.join(persisted.repoPath, repo),
+			worktreePath,
+		})),
+		sandboxed: persisted.sandboxed,
+		spawnPinnedModel: `${provider}/${modelId}`,
+		spawnPinnedThinkingLevel: thinkingLevel,
+	};
+	manager.sessions.set(persisted.id, live);
+	return { manager, persisted, live, oldBridge, store };
+}
+
+describe("SessionManager current-session runtime promotion", () => {
+	it("commits goal/team runtime context while preserving the exact session capsule", async () => {
+		const fx = fixture("promotion-success");
+		const replacement = bridge();
+		let options: any;
+		registerRpcBridgeFactory((nextOptions: any) => {
+			options = nextOptions;
+			return replacement;
+		});
+		const oldUnsubscribe = fx.live.unsubscribe;
+		const before = {
+			id: fx.live.id,
+			title: fx.live.title,
+			cwd: fx.live.cwd,
+			worktreePath: fx.live.worktreePath,
+			repoPath: fx.live.repoPath,
+			branch: fx.live.branch,
+			repoWorktrees: fx.live.repoWorktrees,
+			clients: fx.live.clients,
+			eventBuffer: fx.live.eventBuffer,
+			promptQueue: fx.live.promptQueue,
+		};
+		const beforeStatusVersion = fx.live.statusVersion;
+
+		const promoted = await fx.manager.promoteToGoalLead(fx.live.id, "goal-promoted");
+
+		expect(promoted).toBe(fx.live);
+		expect(fx.manager.getSession(fx.live.id)).toBe(fx.live);
+		expect({
+			id: promoted.id,
+			title: promoted.title,
+			cwd: promoted.cwd,
+			worktreePath: promoted.worktreePath,
+			repoPath: promoted.repoPath,
+			branch: promoted.branch,
+			repoWorktrees: promoted.repoWorktrees,
+			clients: promoted.clients,
+			eventBuffer: promoted.eventBuffer,
+			promptQueue: promoted.promptQueue,
+		}).toEqual(before);
+		expect(promoted.statusVersion).toBeGreaterThan(beforeStatusVersion);
+		expect(promoted).toMatchObject({
+			goalId: "goal-promoted",
+			teamGoalId: "goal-promoted",
+			role: "team-lead",
+			accessory: "crown",
+			spawnPinnedModel: `${provider}/${modelId}`,
+			spawnPinnedThinkingLevel: thinkingLevel,
+		});
+		expect(fx.persisted).toMatchObject({
+			goalId: "goal-promoted",
+			teamGoalId: "goal-promoted",
+			role: "team-lead",
+			accessory: "crown",
+			modelProvider: provider,
+			modelId,
+			effectiveThinkingLevel: thinkingLevel,
+		});
+		expect(options.initialModel).toBe(`${provider}/${modelId}`);
+		expect(options.initialThinkingLevel).toBe(thinkingLevel);
+		expect(options.env).toMatchObject({ BOBBIT_SESSION_ID: fx.live.id, BOBBIT_GOAL_ID: "goal-promoted" });
+		const normalizedArgs = options.args.join(" ").replaceAll("\\", "/");
+		expect(normalizedArgs).toContain("tools/team/extension.ts");
+		expect(normalizedArgs).toContain("tools/tasks/extension.ts");
+		expect(replacement.sendCommand).toHaveBeenCalledWith(
+			{ type: "switch_session", sessionPath: fx.persisted.agentSessionFile },
+			15_000,
+		);
+		expect(fx.oldBridge.stop).toHaveBeenCalledTimes(1);
+		expect(oldUnsubscribe).toHaveBeenCalledTimes(1);
+		expect(fx.live.unsubscribe).not.toBe(oldUnsubscribe);
+
+		await expect(fx.manager.promoteToGoalLead(fx.live.id, "goal-promoted")).resolves.toBe(fx.live);
+		expect(replacement.start).toHaveBeenCalledTimes(1);
+	});
+
+	it("reuses the existing sandbox realm and never requests worktree provisioning", async () => {
+		const fx = fixture("promotion-sandbox", {
+			agentSessionFile: "",
+			sandboxed: true,
+			cwd: "/workspace-wt/session/promotion-sandbox",
+			worktreePath: "/workspace-wt/session/promotion-sandbox",
+		});
+		fx.live.cwd = fx.persisted.cwd;
+		fx.live.worktreePath = fx.persisted.worktreePath;
+		fx.live.sandboxed = true;
+		const replacement = bridge();
+		let options: any;
+		registerRpcBridgeFactory((nextOptions: any) => {
+			options = nextOptions;
+			return replacement;
+		});
+		fx.manager.applySandboxWiring = vi.fn(async (bridgeOptions: any, sessionId: string, opts: any) => {
+			expect(sessionId).toBe(fx.live.id);
+			expect(opts).toEqual({ projectId: fx.live.projectId, goalId: "goal-sandbox" });
+			bridgeOptions.sandboxed = true;
+			bridgeOptions.containerId = "existing-container";
+			bridgeOptions.cwd = fx.live.cwd;
+			return true;
+		});
+
+		await fx.manager.promoteToGoalLead(fx.live.id, "goal-sandbox");
+
+		expect(fx.manager.applySandboxWiring).toHaveBeenCalledTimes(1);
+		expect(options).toMatchObject({
+			sandboxed: true,
+			containerId: "existing-container",
+			cwd: fx.live.cwd,
+		});
+		expect(options).not.toHaveProperty("sandboxBranch");
+		expect(options).not.toHaveProperty("sandboxBaseBranch");
+		expect(fx.persisted.worktreePath).toBe("/workspace-wt/session/promotion-sandbox");
+	});
+
+	it("restores exact optional metadata and the original runtime when old stop rejects", async () => {
+		const fx = fixture("promotion-stop-rollback");
+		const replacement = bridge();
+		registerRpcBridgeFactory(() => replacement);
+		fx.oldBridge.stop = vi.fn(async () => { throw new Error("old bridge refused stop"); });
+		for (const field of ["goalId", "teamGoalId", "role", "accessory"]) {
+			expect(Object.prototype.hasOwnProperty.call(fx.persisted, field)).toBe(false);
+			expect(Object.prototype.hasOwnProperty.call(fx.live, field)).toBe(false);
+		}
+
+		await expect(fx.manager.promoteToGoalLead(fx.live.id, "goal-rollback"))
+			.rejects.toThrow("old bridge refused stop");
+
+		expect(fx.manager.getSession(fx.live.id)).toBe(fx.live);
+		expect(fx.live.rpcClient).toBe(fx.oldBridge);
+		expect(fx.live.unsubscribe).toBeInstanceOf(Function);
+		for (const field of ["goalId", "teamGoalId", "role", "accessory"]) {
+			expect(Object.prototype.hasOwnProperty.call(fx.persisted, field)).toBe(false);
+			expect(Object.prototype.hasOwnProperty.call(fx.live, field)).toBe(false);
+		}
+		expect(fx.store.flushAsync).toHaveBeenCalledTimes(1);
+		expect(replacement.stop).toHaveBeenCalledTimes(1);
+	});
+
+	it("blocks direct archive and purge through the ownership guard while allowing ordered goal teardown", async () => {
+		const fx = fixture("promotion-lifecycle-guard");
+		fx.manager.setPromotedSessionLifecycleGuard((sessionId: string, action: string) =>
+			sessionId === fx.live.id ? `live promoted goal owns ${action}` : undefined);
+
+		await expect(fx.manager.storeArchive(fx.live.id)).rejects.toBeInstanceOf(PromotedSessionLifecycleConflictError);
+		expect(fx.manager.getSession(fx.live.id)).toBe(fx.live);
+		expect(fx.persisted.archived).toBeUndefined();
+
+		await expect(fx.manager.storeArchive(fx.live.id, { allowPromotedGoalLifecycle: true })).resolves.toBe(true);
+		expect(fx.persisted.archived).toBe(true);
+	});
+});

--- a/tests2/core/session-goal-promotion-session-runtime.test.ts
+++ b/tests2/core/session-goal-promotion-session-runtime.test.ts
@@ -238,12 +238,20 @@ function fixture(name: string, overrides: Record<string, unknown> = {}): {
 			worktreePath,
 		})),
 		sandboxed: persisted.sandboxed,
+		...(persisted.role ? { role: persisted.role } : {}),
+		...(persisted.accessory ? { accessory: persisted.accessory } : {}),
 		...(persisted.containerId ? { containerId: persisted.containerId } : {}),
 		spawnPinnedModel: `${provider}/${modelId}`,
 		spawnPinnedThinkingLevel: thinkingLevel,
 	};
 	manager.sessions.set(persisted.id, live);
 	return { manager, persisted, live, oldBridge, store };
+}
+
+function reservePromotion(fx: ReturnType<typeof fixture>, goalId: string): any {
+	const reservation = fx.manager.reserveSessionGoalPromotion(fx.live.id);
+	fx.manager.bindSessionGoalPromotion(reservation, goalId);
+	return reservation;
 }
 
 describe("SessionManager current-session runtime promotion", () => {
@@ -270,7 +278,8 @@ describe("SessionManager current-session runtime promotion", () => {
 		};
 		const beforeStatusVersion = fx.live.statusVersion;
 
-		const promoted = await fx.manager.promoteToGoalLead(fx.live.id, "goal-promoted");
+		const reservation = reservePromotion(fx, "goal-promoted");
+		const promoted = await fx.manager.promoteToGoalLead(fx.live.id, "goal-promoted", reservation);
 
 		expect(promoted).toBe(fx.live);
 		expect(fx.manager.getSession(fx.live.id)).toBe(fx.live);
@@ -318,8 +327,30 @@ describe("SessionManager current-session runtime promotion", () => {
 		expect(oldUnsubscribe).toHaveBeenCalledTimes(1);
 		expect(fx.live.unsubscribe).not.toBe(oldUnsubscribe);
 
-		await expect(fx.manager.promoteToGoalLead(fx.live.id, "goal-promoted")).resolves.toBe(fx.live);
+		await expect(fx.manager.promoteToGoalLead(fx.live.id, "goal-promoted", reservation)).resolves.toBe(fx.live);
 		expect(replacement.start).toHaveBeenCalledTimes(1);
+	});
+
+	it("rejects competing role and destructive lifecycle mutations while the promotion reservation is held", async () => {
+		const fx = fixture("promotion-reservation", { role: "general", accessory: "spark" });
+		const reservation = fx.manager.reserveSessionGoalPromotion(fx.live.id);
+		const competingRole = { name: "reviewer", promptTemplate: "Review", accessory: "search" };
+
+		await expect(fx.manager.assignRole(fx.live.id, competingRole)).rejects.toMatchObject({
+			statusCode: 409,
+			code: "SESSION_GOAL_PROMOTION_IN_PROGRESS",
+			retryable: true,
+		});
+		await expect(fx.manager.terminateSession(fx.live.id)).rejects.toMatchObject({
+			statusCode: 409,
+			code: "SESSION_GOAL_PROMOTION_IN_PROGRESS",
+		});
+		expect(fx.live).toMatchObject({ role: "general", accessory: "spark", status: "idle" });
+		expect(fx.persisted).toMatchObject({ role: "general", accessory: "spark" });
+		expect(fx.oldBridge.stop).not.toHaveBeenCalled();
+		expect(fx.manager.releaseSessionGoalPromotion({ ...reservation })).toBe(false);
+		expect(fx.manager.releaseSessionGoalPromotion(reservation)).toBe(true);
+		expect(() => fx.manager.assertSessionGoalPromotionMutationAllowed(fx.live.id)).not.toThrow();
 	});
 
 	it("reuses the existing sandbox realm and never requests worktree provisioning", async () => {
@@ -352,7 +383,8 @@ describe("SessionManager current-session runtime promotion", () => {
 			return true;
 		});
 
-		await fx.manager.promoteToGoalLead(fx.live.id, "goal-sandbox");
+		const reservation = reservePromotion(fx, "goal-sandbox");
+		await fx.manager.promoteToGoalLead(fx.live.id, "goal-sandbox", reservation);
 
 		expect(fx.manager.applySandboxWiring).toHaveBeenCalledTimes(1);
 		expect(options).toMatchObject({
@@ -369,7 +401,7 @@ describe("SessionManager current-session runtime promotion", () => {
 		fx.manager.applySandboxWiring = vi.fn(async () => {
 			throw new Error("existing container was replaced");
 		});
-		await expect(fx.manager.promoteToGoalLead(fx.live.id, "goal-sandbox"))
+		await expect(fx.manager.promoteToGoalLead(fx.live.id, "goal-sandbox", reservation))
 			.rejects.toThrow("existing container was replaced");
 		expect(replacement.start).toHaveBeenCalledTimes(1);
 	});
@@ -403,7 +435,8 @@ describe("SessionManager current-session runtime promotion", () => {
 		};
 		const before = structuredClone(fx.persisted);
 
-		await expect(fx.manager.promoteToGoalLead(fx.live.id, "goal-sandbox-race"))
+		const reservation = reservePromotion(fx, "goal-sandbox-race");
+		await expect(fx.manager.promoteToGoalLead(fx.live.id, "goal-sandbox-race", reservation))
 			.rejects.toThrow(/expected ready container|container identity changed/);
 
 		expect(ensureForProject).not.toHaveBeenCalled();
@@ -424,7 +457,8 @@ describe("SessionManager current-session runtime promotion", () => {
 			expect(Object.prototype.hasOwnProperty.call(fx.live, field)).toBe(false);
 		}
 
-		await expect(fx.manager.promoteToGoalLead(fx.live.id, "goal-rollback"))
+		const reservation = reservePromotion(fx, "goal-rollback");
+		await expect(fx.manager.promoteToGoalLead(fx.live.id, "goal-rollback", reservation))
 			.rejects.toThrow("old bridge refused stop");
 
 		expect(fx.manager.getSession(fx.live.id)).toBe(fx.live);
@@ -436,6 +470,21 @@ describe("SessionManager current-session runtime promotion", () => {
 		}
 		expect(fx.store.flushAsync).toHaveBeenCalledTimes(1);
 		expect(replacement.stop).toHaveBeenCalledTimes(1);
+	});
+
+	it("restores the exact canonical general baseline when promotion fails before commit", async () => {
+		const fx = fixture("promotion-general-rollback", { role: "general", accessory: "spark" });
+		const replacement = bridge();
+		registerRpcBridgeFactory(() => replacement);
+		fx.oldBridge.stop = vi.fn(async () => { throw new Error("old bridge refused stop"); });
+		const reservation = reservePromotion(fx, "goal-general-rollback");
+
+		await expect(fx.manager.promoteToGoalLead(fx.live.id, "goal-general-rollback", reservation))
+			.rejects.toThrow("old bridge refused stop");
+
+		expect(fx.live).toMatchObject({ role: "general", accessory: "spark", status: "idle" });
+		expect(fx.persisted).toMatchObject({ role: "general", accessory: "spark" });
+		expect(fx.store.flushAsync).toHaveBeenCalledTimes(1);
 	});
 
 	it("keeps a promoted source dormant and byte-stable when its transcript cannot be recovered", async () => {

--- a/tests2/core/session-goal-promotion-session-runtime.test.ts
+++ b/tests2/core/session-goal-promotion-session-runtime.test.ts
@@ -157,6 +157,9 @@ function fixture(name: string, overrides: Record<string, unknown> = {}): {
 		sandboxed: false,
 		...overrides,
 	};
+	if (persisted.sandboxed && persisted.goalId) {
+		persisted.containerId ??= "same-container";
+	}
 	const updates: Record<string, unknown>[] = [];
 	const store = {
 		get: vi.fn(() => persisted),
@@ -189,6 +192,10 @@ function fixture(name: string, overrides: Record<string, unknown> = {}): {
 		spec: "Keep all existing work and continue as lead.",
 		branch: persisted.branch,
 		projectId: persisted.projectId,
+		repoPath: persisted.repoPath,
+		worktreePath: persisted.worktreePath,
+		repoWorktrees: persisted.repoWorktrees,
+		worktreeOwnerSessionId: persisted.id,
 	}));
 	managers.push(manager);
 
@@ -231,6 +238,7 @@ function fixture(name: string, overrides: Record<string, unknown> = {}): {
 			worktreePath,
 		})),
 		sandboxed: persisted.sandboxed,
+		...(persisted.containerId ? { containerId: persisted.containerId } : {}),
 		spawnPinnedModel: `${provider}/${modelId}`,
 		spawnPinnedThinkingLevel: thinkingLevel,
 	};
@@ -318,6 +326,7 @@ describe("SessionManager current-session runtime promotion", () => {
 		const fx = fixture("promotion-sandbox", {
 			agentSessionFile: "",
 			sandboxed: true,
+			containerId: "existing-container",
 			cwd: "/workspace-wt/session/promotion-sandbox",
 			worktreePath: "/workspace-wt/session/promotion-sandbox",
 		});
@@ -332,7 +341,11 @@ describe("SessionManager current-session runtime promotion", () => {
 		});
 		fx.manager.applySandboxWiring = vi.fn(async (bridgeOptions: any, sessionId: string, opts: any) => {
 			expect(sessionId).toBe(fx.live.id);
-			expect(opts).toEqual({ projectId: fx.live.projectId, goalId: "goal-sandbox" });
+			expect(opts).toEqual({
+				projectId: fx.live.projectId,
+				goalId: "goal-sandbox",
+				expectedExistingContainerId: "existing-container",
+			});
 			bridgeOptions.sandboxed = true;
 			bridgeOptions.containerId = "existing-container";
 			bridgeOptions.cwd = fx.live.cwd;
@@ -350,6 +363,55 @@ describe("SessionManager current-session runtime promotion", () => {
 		expect(options).not.toHaveProperty("sandboxBranch");
 		expect(options).not.toHaveProperty("sandboxBaseBranch");
 		expect(fx.persisted.worktreePath).toBe("/workspace-wt/session/promotion-sandbox");
+		expect(fx.persisted.containerId).toBe("existing-container");
+		expect(fx.live.containerId).toBe("existing-container");
+
+		fx.manager.applySandboxWiring = vi.fn(async () => {
+			throw new Error("existing container was replaced");
+		});
+		await expect(fx.manager.promoteToGoalLead(fx.live.id, "goal-sandbox"))
+			.rejects.toThrow("existing container was replaced");
+		expect(replacement.start).toHaveBeenCalledTimes(1);
+	});
+
+	it.each([
+		["non-ready", { status: "starting", containerId: "existing-container" }],
+		["replacement", { status: "ready", containerId: "replacement-container" }],
+	])("fails closed on a %s sandbox without bootstrap or candidate start", async (_case, status) => {
+		const fx = fixture(`promotion-sandbox-${_case}`, {
+			agentSessionFile: "",
+			sandboxed: true,
+			containerId: "existing-container",
+			cwd: `/workspace-wt/session/promotion-sandbox-${_case}`,
+			worktreePath: `/workspace-wt/session/promotion-sandbox-${_case}`,
+		});
+		fx.live.cwd = fx.persisted.cwd;
+		fx.live.worktreePath = fx.persisted.worktreePath;
+		fx.live.sandboxed = true;
+		const replacement = bridge();
+		const factory = vi.fn(() => replacement);
+		registerRpcBridgeFactory(factory);
+		const ensureForProject = vi.fn(async () => { throw new Error("strict promotion must not bootstrap"); });
+		const getContainerId = vi.fn(async () => status.containerId);
+		fx.manager.projectConfigStore = {
+			get: (key: string) => key === "sandbox" ? "docker" : undefined,
+			getSandboxTokens: () => [],
+		};
+		fx.manager.sandboxManager = {
+			ensureForProject,
+			get: vi.fn(() => ({ getStatus: () => status, getContainerId })),
+		};
+		const before = structuredClone(fx.persisted);
+
+		await expect(fx.manager.promoteToGoalLead(fx.live.id, "goal-sandbox-race"))
+			.rejects.toThrow(/expected ready container|container identity changed/);
+
+		expect(ensureForProject).not.toHaveBeenCalled();
+		expect(factory).not.toHaveBeenCalled();
+		expect(replacement.start).not.toHaveBeenCalled();
+		expect(fx.oldBridge.stop).not.toHaveBeenCalled();
+		expect(fx.manager.getSession(fx.live.id)).toBe(fx.live);
+		expect(fx.persisted).toEqual(before);
 	});
 
 	it("restores exact optional metadata and the original runtime when old stop rejects", async () => {
@@ -357,7 +419,7 @@ describe("SessionManager current-session runtime promotion", () => {
 		const replacement = bridge();
 		registerRpcBridgeFactory(() => replacement);
 		fx.oldBridge.stop = vi.fn(async () => { throw new Error("old bridge refused stop"); });
-		for (const field of ["goalId", "teamGoalId", "role", "accessory"]) {
+		for (const field of ["goalId", "teamGoalId", "role", "accessory", "containerId"]) {
 			expect(Object.prototype.hasOwnProperty.call(fx.persisted, field)).toBe(false);
 			expect(Object.prototype.hasOwnProperty.call(fx.live, field)).toBe(false);
 		}
@@ -368,7 +430,7 @@ describe("SessionManager current-session runtime promotion", () => {
 		expect(fx.manager.getSession(fx.live.id)).toBe(fx.live);
 		expect(fx.live.rpcClient).toBe(fx.oldBridge);
 		expect(fx.live.unsubscribe).toBeInstanceOf(Function);
-		for (const field of ["goalId", "teamGoalId", "role", "accessory"]) {
+		for (const field of ["goalId", "teamGoalId", "role", "accessory", "containerId"]) {
 			expect(Object.prototype.hasOwnProperty.call(fx.persisted, field)).toBe(false);
 			expect(Object.prototype.hasOwnProperty.call(fx.live, field)).toBe(false);
 		}
@@ -483,6 +545,46 @@ describe("SessionManager current-session runtime promotion", () => {
 		expect(fx.persisted).toEqual(before);
 	});
 
+	it("quarantines a promoted source when restart sees a replacement container without bootstrapping", async () => {
+		const fx = fixture("promotion-sandbox-replaced-on-restart", {
+			goalId: "goal-promoted",
+			teamGoalId: "goal-promoted",
+			role: "team-lead",
+			sandboxed: true,
+			containerId: "original-container",
+			cwd: "/workspace-wt/session/promotion-sandbox-replaced-on-restart",
+			worktreePath: "/workspace-wt/session/promotion-sandbox-replaced-on-restart",
+		});
+		fx.manager.sessions.clear();
+		fx.manager.setPromotedSessionLifecycleGuard((sessionId: string) =>
+			sessionId === fx.persisted.id ? "live adopted goal still owns source" : undefined);
+		const ensureForProject = vi.fn(async () => { throw new Error("must not bootstrap"); });
+		fx.manager.projectConfigStore = {
+			get: (key: string) => key === "sandbox" ? "docker" : undefined,
+			getSandboxTokens: () => [],
+		};
+		fx.manager.sandboxManager = {
+			ensureForProject,
+			get: vi.fn(() => ({
+				getStatus: () => ({ status: "ready", containerId: "replacement-container" }),
+				getContainerId: vi.fn(async () => "replacement-container"),
+			})),
+		};
+		const before = structuredClone(fx.persisted);
+
+		await fx.manager.restoreOneSession(fx.persisted);
+
+		expect(ensureForProject).not.toHaveBeenCalled();
+		expect(fx.persisted).toEqual(before);
+		expect(fx.manager.getSession(fx.persisted.id)).toMatchObject({
+			dormant: true,
+			sandboxed: true,
+			containerId: "original-container",
+			goalId: "goal-promoted",
+			teamGoalId: "goal-promoted",
+		});
+	});
+
 	it("quarantines a promoted source instead of downgrading an unavailable sandbox realm", async () => {
 		const fx = fixture("promotion-sandbox-unavailable", {
 			goalId: "goal-promoted",
@@ -533,13 +635,43 @@ describe("SessionManager current-session runtime promotion", () => {
 
 		await fx.manager.recoverSandboxSessions(fx.persisted.projectId, "replacement-container-id");
 
-		expect(execFile).toHaveBeenCalledTimes(1);
-		expect(execFile.mock.calls[0][1]).not.toContain("repair");
+		expect(execFile).not.toHaveBeenCalled();
 		expect(createWorktree).not.toHaveBeenCalled();
 		expect(fx.store.archive).not.toHaveBeenCalled();
 		expect(fx.store.archiveAsync).not.toHaveBeenCalled();
 		expect(fx.manager.getSession(fx.persisted.id)).toBe(fx.live);
 		expect(fx.live.status).toBe("idle");
+	});
+
+	it("uses strict adopted container identity during force-abort replacement", async () => {
+		const fx = fixture("promotion-force-abort", {
+			goalId: "goal-promoted",
+			teamGoalId: "goal-promoted",
+			role: "team-lead",
+			sandboxed: true,
+			containerId: "force-abort-container",
+			cwd: "/workspace-wt/session/promotion-force-abort",
+			worktreePath: "/workspace-wt/session/promotion-force-abort",
+		});
+		Object.assign(fx.live, {
+			goalId: "goal-promoted",
+			teamGoalId: "goal-promoted",
+			role: "team-lead",
+			sandboxed: true,
+			containerId: "force-abort-container",
+			status: "streaming",
+		});
+		fx.live.clients.clear();
+		fx.manager.applySandboxWiring = vi.fn(async (_options: any, _id: string, opts: any) => {
+			expect(opts.expectedExistingContainerId).toBe("force-abort-container");
+			throw new Error("stop after strict wiring assertion");
+		});
+
+		await expect(fx.manager.forceAbort(fx.live.id, 0)).rejects.toThrow("stop after strict wiring assertion");
+
+		expect(fx.manager.applySandboxWiring).toHaveBeenCalledTimes(1);
+		expect(fx.oldBridge.stop).toHaveBeenCalledTimes(1);
+		expect(fx.persisted.containerId).toBe("force-abort-container");
 	});
 
 	it("does not run boot host recovery against any promoted multi-repo workspace", async () => {
@@ -564,6 +696,70 @@ describe("SessionManager current-session runtime promotion", () => {
 		expect(fx.store.archive).not.toHaveBeenCalled();
 		expect(fx.persisted).toEqual(before);
 		expect(fx.persisted.repoWorktrees).toEqual(before.repoWorktrees);
+	});
+
+	it("classifies only exact canonical adopted multi-repo coordinates as source-owned cleanup", async () => {
+		const fx = fixture("promotion-adopted-cleanup", {
+			goalId: "goal-promoted",
+			teamGoalId: "goal-promoted",
+			role: "team-lead",
+			archived: true,
+		});
+		const archivedGoal = {
+			...fx.manager.resolveGoal("goal-promoted"),
+			archived: true,
+		};
+		fx.manager.resolveGoal = vi.fn(() => archivedGoal);
+
+		expect(fx.manager.isCanonicalAdoptedWorkspaceOwner(fx.persisted)).toBe(true);
+		expect(fx.manager.hasGoalOwnedTeamLeadWorktrees(fx.persisted)).toBe(false);
+		const borrower = {
+			...fx.persisted,
+			id: "live-borrower",
+			archived: false,
+			goalId: undefined,
+			teamGoalId: undefined,
+			role: undefined,
+			cwd: path.join(fx.persisted.repoWorktrees.api, "packages", "api"),
+			worktreePath: fx.persisted.repoWorktrees.api,
+			repoWorktrees: undefined,
+		};
+		fx.store.getAll.mockReturnValue([fx.persisted, borrower]);
+		expect(fx.manager.adoptedWorkspaceHasLiveReference(fx.persisted)).toBe(true);
+		fx.store.getAll.mockReturnValue([fx.persisted]);
+		expect(fx.manager.adoptedWorkspaceHasLiveReference(fx.persisted)).toBe(false);
+
+		const ordinary = { ...fx.persisted, id: "ordinary-lead" };
+		fx.manager.resolveGoal = vi.fn(() => ({ ...archivedGoal, worktreeOwnerSessionId: undefined }));
+		expect(fx.manager.hasGoalOwnedTeamLeadWorktrees(ordinary)).toBe(true);
+
+		fx.manager.resolveGoal = vi.fn(() => archivedGoal);
+		const divergent = {
+			...fx.persisted,
+			repoWorktrees: { ...fx.persisted.repoWorktrees, api: `${fx.persisted.repoWorktrees.api}-other` },
+		};
+		expect(fx.manager.isCanonicalAdoptedWorkspaceOwner(divergent)).toBe(false);
+		expect(fx.manager.hasGoalOwnedTeamLeadWorktrees(divergent)).toBe(true);
+
+		fx.manager.readGitWorktreeRefs = vi.fn(async () => ({ entries: [] }));
+		fx.manager.localBranchExists = vi.fn(async () => false);
+		const scanContext = {
+			candidateContexts: [],
+			sessionPathRecords: [fx.persisted],
+			goalRefs: [{
+				...archivedGoal,
+				id: "goal-promoted",
+			}],
+			teamRefs: [],
+			staffRefs: [],
+			branchGuardsByRepo: new Map(),
+			archivedBranchGuardsByRepo: new Map(),
+			gitRefsCache: new Map(),
+			branchExistsCache: new Map(),
+		};
+		const items = await fx.manager.archivedSessionWorktreeItems(fx.persisted, scanContext, "Project");
+		expect(items).toHaveLength(2);
+		expect(items.map((item: any) => item.reason)).toEqual(["already-cleaned", "already-cleaned"]);
 	});
 
 	it("preserves ordinary missing-transcript archival and sandbox worktree recovery behavior", async () => {

--- a/tests2/core/session-goal-promotion-session-runtime.test.ts
+++ b/tests2/core/session-goal-promotion-session-runtime.test.ts
@@ -161,6 +161,7 @@ function fixture(name: string, overrides: Record<string, unknown> = {}): {
 	const store = {
 		get: vi.fn(() => persisted),
 		getLive: vi.fn(() => [persisted]),
+		getAll: vi.fn(() => [persisted]),
 		update: vi.fn((_id: string, patch: Record<string, unknown>) => {
 			updates.push({ ...patch });
 			Object.assign(persisted, patch);
@@ -375,16 +376,258 @@ describe("SessionManager current-session runtime promotion", () => {
 		expect(replacement.stop).toHaveBeenCalledTimes(1);
 	});
 
-	it("blocks direct archive and purge through the ownership guard while allowing ordered goal teardown", async () => {
+	it("keeps a promoted source dormant and byte-stable when its transcript cannot be recovered", async () => {
+		const fx = fixture("promotion-missing-transcript", {
+			agentSessionFile: undefined,
+			goalId: "goal-promoted",
+			teamGoalId: "goal-promoted",
+			role: "team-lead",
+			accessory: "crown",
+			sandboxed: true,
+		});
+		fx.manager.sessions.clear();
+		fx.manager.recoverSessionFile = vi.fn(() => null);
+		fx.manager.setPromotedSessionLifecycleGuard((sessionId: string) =>
+			sessionId === fx.persisted.id ? "live adopted goal still owns source" : undefined);
+		const before = structuredClone(fx.persisted);
+
+		await fx.manager.restoreOneSession(fx.persisted);
+		await fx.manager.restoreOneSession(fx.persisted);
+
+		expect(fx.store.archive).not.toHaveBeenCalled();
+		expect(fx.store.archiveAsync).not.toHaveBeenCalled();
+		expect(fx.persisted).toEqual(before);
+		expect(fx.manager.getSession(fx.persisted.id)).toMatchObject({
+			id: fx.persisted.id,
+			dormant: true,
+			goalId: "goal-promoted",
+			teamGoalId: "goal-promoted",
+			role: "team-lead",
+			cwd: before.cwd,
+			worktreePath: before.worktreePath,
+			repoPath: before.repoPath,
+			branch: before.branch,
+			sandboxed: true,
+		});
+		expect(fx.manager.getSession(fx.persisted.id).repoWorktrees).toEqual(fx.live.repoWorktrees);
+	});
+
+	it("retains a promoted sandbox source when its recorded transcript file is missing", async () => {
+		const fx = fixture("promotion-missing-transcript-file", {
+			agentSessionFile: "/home/node/.bobbit/agent/sessions/promotion-missing.jsonl",
+			goalId: "goal-promoted",
+			teamGoalId: "goal-promoted",
+			role: "team-lead",
+			sandboxed: true,
+		});
+		fx.manager.sessions.clear();
+		fx.manager.setPromotedSessionLifecycleGuard((sessionId: string) =>
+			sessionId === fx.persisted.id ? "live adopted goal still owns source" : undefined);
+		const sandboxExec = vi.fn(async (args: string[]) => {
+			if (args[0] === "test") throw new Error("transcript missing");
+		});
+		fx.manager.sandboxManager = { get: vi.fn(() => ({ exec: sandboxExec })) };
+		const before = structuredClone(fx.persisted);
+
+		await fx.manager.restoreOneSession(fx.persisted);
+
+		expect(sandboxExec).toHaveBeenCalledTimes(2);
+		expect(fx.store.archive).not.toHaveBeenCalled();
+		expect(fx.persisted).toEqual(before);
+		expect(fx.manager.getSession(fx.persisted.id)).toMatchObject({
+			dormant: true,
+			goalId: "goal-promoted",
+			teamGoalId: "goal-promoted",
+			worktreePath: before.worktreePath,
+			repoPath: before.repoPath,
+			branch: before.branch,
+			sandboxed: true,
+		});
+	});
+
+	it("fails closed before promoted sandbox worktree repair or recreation on repeated restore", async () => {
+		const fx = fixture("promotion-missing-sandbox-worktree", {
+			goalId: "goal-promoted",
+			teamGoalId: "goal-promoted",
+			role: "team-lead",
+			accessory: "crown",
+			sandboxed: true,
+			cwd: "/workspace-wt/session/promotion-missing-sandbox-worktree",
+			worktreePath: "/workspace-wt/session/promotion-missing-sandbox-worktree",
+		});
+		fx.manager.sessions.clear();
+		fx.manager.setPromotedSessionLifecycleGuard((sessionId: string) =>
+			sessionId === fx.persisted.id ? "live adopted goal still owns source" : undefined);
+		fx.manager.applySandboxWiring = vi.fn(async (options: any) => {
+			options.containerId = "same-container";
+			options.cwd = fx.persisted.cwd;
+			return true;
+		});
+		const execFile = vi.fn(async (...args: any[]) => {
+			if (args[1]?.includes("test")) throw new Error("worktree missing");
+			throw new Error("repair must not run");
+		});
+		fx.manager.commandRunner = { execFile };
+		const createWorktree = vi.fn(async () => { throw new Error("recreation must not run"); });
+		fx.manager.sandboxManager = { get: vi.fn(() => ({ createWorktree })) };
+		const before = structuredClone(fx.persisted);
+
+		await expect(fx.manager.restoreSession(fx.persisted)).rejects.toBeInstanceOf(PromotedSessionLifecycleConflictError);
+		await expect(fx.manager.restoreSession(fx.persisted)).rejects.toBeInstanceOf(PromotedSessionLifecycleConflictError);
+
+		expect(execFile).toHaveBeenCalledTimes(2);
+		for (const call of execFile.mock.calls) expect(call[1]).not.toContain("repair");
+		expect(createWorktree).not.toHaveBeenCalled();
+		expect(fx.store.archive).not.toHaveBeenCalled();
+		expect(fx.store.archiveAsync).not.toHaveBeenCalled();
+		expect(fx.persisted).toEqual(before);
+	});
+
+	it("quarantines a promoted source instead of downgrading an unavailable sandbox realm", async () => {
+		const fx = fixture("promotion-sandbox-unavailable", {
+			goalId: "goal-promoted",
+			teamGoalId: "goal-promoted",
+			role: "team-lead",
+			sandboxed: true,
+			cwd: "/workspace-wt/session/promotion-sandbox-unavailable",
+			worktreePath: "/workspace-wt/session/promotion-sandbox-unavailable",
+		});
+		fx.manager.sessions.clear();
+		fx.manager.setPromotedSessionLifecycleGuard((sessionId: string) =>
+			sessionId === fx.persisted.id ? "live adopted goal still owns source" : undefined);
+		fx.manager.applySandboxWiring = vi.fn(async () => false);
+		const before = structuredClone(fx.persisted);
+
+		await fx.manager.restoreOneSession(fx.persisted);
+
+		expect(fx.store.updates).not.toContainEqual({ sandboxed: false });
+		expect(fx.persisted).toEqual(before);
+		expect(fx.manager.getSession(fx.persisted.id)).toMatchObject({
+			dormant: true,
+			sandboxed: true,
+			goalId: "goal-promoted",
+			teamGoalId: "goal-promoted",
+			cwd: before.cwd,
+			worktreePath: before.worktreePath,
+		});
+	});
+
+	it("does not repair, recreate, archive, or terminate a live promoted source during container recovery", async () => {
+		const fx = fixture("promotion-live-container-recovery", {
+			goalId: "goal-promoted",
+			teamGoalId: "goal-promoted",
+			role: "team-lead",
+			sandboxed: true,
+			cwd: "/workspace-wt/session/promotion-live-container-recovery",
+			worktreePath: "/workspace-wt/session/promotion-live-container-recovery",
+		});
+		fx.live.cwd = fx.persisted.cwd;
+		fx.live.worktreePath = fx.persisted.worktreePath;
+		fx.live.sandboxed = true;
+		fx.manager.setPromotedSessionLifecycleGuard((sessionId: string) =>
+			sessionId === fx.persisted.id ? "live adopted goal still owns source" : undefined);
+		const execFile = vi.fn(async (..._args: any[]) => { throw new Error("worktree missing"); });
+		fx.manager.commandRunner = { execFile };
+		const createWorktree = vi.fn();
+		fx.manager.sandboxManager = { get: vi.fn(() => ({ createWorktree })) };
+
+		await fx.manager.recoverSandboxSessions(fx.persisted.projectId, "replacement-container-id");
+
+		expect(execFile).toHaveBeenCalledTimes(1);
+		expect(execFile.mock.calls[0][1]).not.toContain("repair");
+		expect(createWorktree).not.toHaveBeenCalled();
+		expect(fx.store.archive).not.toHaveBeenCalled();
+		expect(fx.store.archiveAsync).not.toHaveBeenCalled();
+		expect(fx.manager.getSession(fx.persisted.id)).toBe(fx.live);
+		expect(fx.live.status).toBe("idle");
+	});
+
+	it("does not run boot host recovery against any promoted multi-repo workspace", async () => {
+		const fx = fixture("promotion-host-recovery", {
+			goalId: "goal-promoted",
+			teamGoalId: "goal-promoted",
+			role: "team-lead",
+			sandboxed: false,
+		});
+		fx.manager.sessions.clear();
+		fx.manager.restoreOneSession = vi.fn(async () => {});
+		fx.manager.setPromotedSessionLifecycleGuard((sessionId: string) =>
+			sessionId === fx.persisted.id ? "live adopted goal still owns source" : undefined);
+		const execFile = vi.fn(async () => { throw new Error("host git must not run"); });
+		fx.manager.commandRunner = { execFile };
+		const before = structuredClone(fx.persisted);
+
+		await fx.manager.restoreSessions();
+
+		expect(fx.manager.restoreOneSession).toHaveBeenCalledTimes(1);
+		expect(execFile).not.toHaveBeenCalled();
+		expect(fx.store.archive).not.toHaveBeenCalled();
+		expect(fx.persisted).toEqual(before);
+		expect(fx.persisted.repoWorktrees).toEqual(before.repoWorktrees);
+	});
+
+	it("preserves ordinary missing-transcript archival and sandbox worktree recovery behavior", async () => {
+		const missingTranscript = fixture("ordinary-missing-transcript", { agentSessionFile: undefined });
+		missingTranscript.manager.sessions.clear();
+		missingTranscript.manager.recoverSessionFile = vi.fn(() => null);
+		await missingTranscript.manager.restoreOneSession(missingTranscript.persisted);
+		expect(missingTranscript.store.archive).toHaveBeenCalledWith(missingTranscript.persisted.id);
+
+		const sandbox = fixture("ordinary-missing-sandbox-worktree", {
+			sandboxed: true,
+			cwd: "/workspace-wt/session/ordinary-missing-sandbox-worktree",
+			worktreePath: "/workspace-wt/session/ordinary-missing-sandbox-worktree",
+		});
+		sandbox.manager.sessions.clear();
+		sandbox.manager.applySandboxWiring = vi.fn(async (options: any) => {
+			options.containerId = "ordinary-container";
+			return true;
+		});
+		const execFile = vi.fn(async () => { throw new Error("missing or unrepaired"); });
+		sandbox.manager.commandRunner = { execFile };
+		const createWorktree = vi.fn(async () => { throw new Error("recreation failed"); });
+		sandbox.manager.sandboxManager = { get: vi.fn(() => ({ createWorktree })) };
+
+		await sandbox.manager.restoreSession(sandbox.persisted);
+
+		expect(execFile.mock.calls.some((call: any[]) => call[1]?.includes("repair"))).toBe(true);
+		expect(createWorktree).toHaveBeenCalledTimes(1);
+		expect(sandbox.store.archive).toHaveBeenCalledWith(sandbox.persisted.id);
+
+		const unavailable = fixture("ordinary-sandbox-unavailable", {
+			sandboxed: true,
+			cwd: "/workspace-wt/session/ordinary-sandbox-unavailable",
+			worktreePath: "/workspace-wt/session/ordinary-sandbox-unavailable",
+		});
+		unavailable.manager.sessions.clear();
+		unavailable.manager.applySandboxWiring = vi.fn(async () => false);
+		registerRpcBridgeFactory(() => bridge());
+		await unavailable.manager.restoreSession(unavailable.persisted);
+		expect(unavailable.persisted.sandboxed).toBe(false);
+		expect(unavailable.store.updates).toContainEqual({ sandboxed: false });
+	});
+
+	it("guards archiveWithCascade before child teardown and allows ordered goal archival", async () => {
 		const fx = fixture("promotion-lifecycle-guard");
+		let goalArchived = false;
 		fx.manager.setPromotedSessionLifecycleGuard((sessionId: string, action: string) =>
-			sessionId === fx.live.id ? `live promoted goal owns ${action}` : undefined);
+			sessionId === fx.live.id && !goalArchived ? `live promoted goal owns ${action}` : undefined);
+		fx.manager.cascadeReapOwner = vi.fn(async () => {});
 
 		await expect(fx.manager.storeArchive(fx.live.id)).rejects.toBeInstanceOf(PromotedSessionLifecycleConflictError);
+		await expect(fx.manager.storeArchive(fx.live.id, { allowPromotedGoalLifecycle: true }))
+			.rejects.toBeInstanceOf(PromotedSessionLifecycleConflictError);
+		await expect(fx.manager.terminateSession(fx.live.id, { allowPromotedGoalLifecycle: true }))
+			.rejects.toBeInstanceOf(PromotedSessionLifecycleConflictError);
+		await expect(fx.manager.archiveWithCascade(fx.live.id, fx.store)).rejects.toBeInstanceOf(PromotedSessionLifecycleConflictError);
+		expect(fx.manager.cascadeReapOwner).not.toHaveBeenCalled();
 		expect(fx.manager.getSession(fx.live.id)).toBe(fx.live);
 		expect(fx.persisted.archived).toBeUndefined();
 
-		await expect(fx.manager.storeArchive(fx.live.id, { allowPromotedGoalLifecycle: true })).resolves.toBe(true);
+		// The ordered goal endpoint durably archives the goal before team/source teardown.
+		goalArchived = true;
+		await expect(fx.manager.storeArchive(fx.live.id)).resolves.toBe(true);
+		expect(fx.manager.cascadeReapOwner).toHaveBeenCalledTimes(1);
 		expect(fx.persisted.archived).toBe(true);
 	});
 });

--- a/tests2/core/team-manager-async-recovery.test.ts
+++ b/tests2/core/team-manager-async-recovery.test.ts
@@ -246,6 +246,11 @@ async function makeAdoptedAdmissionFixture() {
 		paused: false,
 		worktreeOwnerSessionId: ownerSessionId,
 	};
+	let subscriptionCount = 0;
+	let unsubscribeCount = 0;
+	let activeSubscriptions = 0;
+	let promptCount = 0;
+	let failNextTransition = false;
 	const source = {
 		id: ownerSessionId,
 		title: "Regular session",
@@ -253,6 +258,19 @@ async function makeAdoptedAdmissionFixture() {
 		cwd: goal.cwd,
 		status: "idle",
 		role: "general",
+		rpcClient: {
+			onEvent: () => {
+				subscriptionCount += 1;
+				activeSubscriptions += 1;
+				let active = true;
+				return () => {
+					if (!active) return;
+					active = false;
+					unsubscribeCount += 1;
+					activeSubscriptions -= 1;
+				};
+			},
+		},
 		createdAt: 1,
 		lastActivity: 1,
 	};
@@ -261,9 +279,20 @@ async function makeAdoptedAdmissionFixture() {
 	const teams = new MemoryTeamStore([]);
 	const liveSessions = new Map<string, any>();
 	let workerSequence = 0;
+	const goalManager = {
+		updateGoal: async (goalId: string, patch: any) => {
+			if (failNextTransition) {
+				failNextTransition = false;
+				throw new Error("injected transition failure");
+			}
+			goals.update(goalId, patch);
+			return goals.get(goalId);
+		},
+	};
 	const context = {
 		project: { id: projectId },
 		goalStore: goals,
+		goalManager,
 		teamStore: teams,
 		sessionStore: sessions,
 	};
@@ -305,7 +334,10 @@ async function makeAdoptedAdmissionFixture() {
 			return !!live;
 		},
 		resolveSessionAgentAuthor: () => undefined,
-		enqueuePrompt: async () => ({ status: "dispatched" }),
+		enqueuePrompt: async () => {
+			promptCount += 1;
+			return { status: "dispatched" };
+		},
 		isSandboxEnabled: false,
 		getSandboxManager: () => undefined,
 		dispatchGoalProvisionedForWorktree: async () => {},
@@ -342,7 +374,21 @@ async function makeAdoptedAdmissionFixture() {
 	liveSessions.set(source.id, { ...source });
 	await manager.adoptExistingLead(goal.id, source.id);
 
-	return { manager, goal, source, goals, sessions, teams, liveSessions, get workerCount() { return workerSequence; } };
+	return {
+		manager,
+		goal,
+		source,
+		goals,
+		sessions,
+		teams,
+		liveSessions,
+		failNextTransition: () => { failNextTransition = true; },
+		get workerCount() { return workerSequence; },
+		get subscriptionCount() { return subscriptionCount; },
+		get unsubscribeCount() { return unsubscribeCount; },
+		get activeSubscriptions() { return activeSubscriptions; },
+		get promptCount() { return promptCount; },
+	};
 }
 
 function makeAdoptedGoalRestartFixture(options: { reservation: boolean; role: string }) {
@@ -405,6 +451,10 @@ function makeAdoptedGoalRestartFixture(options: { reservation: boolean; role: st
 				deletedAttempts.push(goalId);
 				return false;
 			},
+			updateGoal: async (goalId: string, patch: any) => {
+				goals.update(goalId, patch);
+				return goals.get(goalId);
+			},
 		},
 	};
 	const projectContextManager = {
@@ -434,7 +484,7 @@ function makeAdoptedGoalRestartFixture(options: { reservation: boolean; role: st
 		recoverySidecars: new MemoryRecoverySidecars(),
 	} as any, undefined, noTimerClock as any);
 
-	return { manager, goal, source, sessions, teams, initializedGates, deletedAttempts };
+	return { manager, goal, source, goals, sessions, teams, initializedGates, deletedAttempts };
 }
 
 describe("TeamManager adopted-lead worker admission", () => {
@@ -522,6 +572,116 @@ describe("TeamManager adopted-lead worker admission", () => {
 	});
 });
 
+describe("TeamManager adopted-lead finalization", () => {
+	it("activates the reserved lead without a kickoff and stays single-subscribed across retries", async () => {
+		const fixture = await makeAdoptedAdmissionFixture();
+		try {
+			const attachment = { goalId: fixture.goal.id, teamGoalId: fixture.goal.id, role: "team-lead" };
+			Object.assign(fixture.liveSessions.get(fixture.source.id), attachment);
+			fixture.sessions.update(fixture.source.id, attachment);
+
+			const first = await fixture.manager.finalizeAdoptedLead(fixture.goal.id);
+			assert.equal(first.teamLeadSessionId, fixture.source.id);
+			assert.equal(fixture.goals.get(fixture.goal.id)?.state, "in-progress");
+			assert.equal(fixture.subscriptionCount, 1);
+			assert.equal(fixture.activeSubscriptions, 1);
+			assert.equal(fixture.promptCount, 0);
+			assert.equal(fixture.workerCount, 0);
+
+			const retry = await fixture.manager.finalizeAdoptedLead(fixture.goal.id);
+			assert.equal(retry.teamLeadSessionId, fixture.source.id);
+			assert.equal(fixture.subscriptionCount, 2);
+			assert.equal(fixture.unsubscribeCount, 1);
+			assert.equal(fixture.activeSubscriptions, 1, "retry replaces rather than duplicates the lead listener");
+			assert.equal(fixture.goals.updates.length, 1, "in-progress transition is idempotent");
+			assert.equal(fixture.promptCount, 0, "finalization never sends the normal startTeam kickoff");
+		} finally {
+			fixture.manager.dispose();
+		}
+	});
+
+	it("retries cleanly after the todo transition fails", async () => {
+		const fixture = await makeAdoptedAdmissionFixture();
+		try {
+			const attachment = { goalId: fixture.goal.id, teamGoalId: fixture.goal.id, role: "team-lead" };
+			Object.assign(fixture.liveSessions.get(fixture.source.id), attachment);
+			fixture.sessions.update(fixture.source.id, attachment);
+			fixture.failNextTransition();
+
+			await assert.rejects(
+				() => fixture.manager.finalizeAdoptedLead(fixture.goal.id),
+				/injected transition failure/,
+			);
+			assert.equal(fixture.goals.get(fixture.goal.id)?.state, "todo");
+			assert.equal(fixture.activeSubscriptions, 1);
+
+			await fixture.manager.finalizeAdoptedLead(fixture.goal.id);
+			assert.equal(fixture.goals.get(fixture.goal.id)?.state, "in-progress");
+			assert.equal(fixture.subscriptionCount, 2);
+			assert.equal(fixture.unsubscribeCount, 1);
+			assert.equal(fixture.activeSubscriptions, 1);
+			assert.equal(fixture.promptCount, 0);
+			assert.equal(fixture.workerCount, 0);
+		} finally {
+			fixture.manager.dispose();
+		}
+	});
+});
+
+describe("TeamManager adopted-goal archive admission", () => {
+	for (const scenario of ["pending", "live-only", "durable-only", "partial", "identity-mismatch"] as const) {
+		it(`rejects ${scenario} promotion state before running archive`, async () => {
+			const fixture = await makeAdoptedAdmissionFixture();
+			try {
+				const exact = { goalId: fixture.goal.id, teamGoalId: fixture.goal.id, role: "team-lead" };
+				if (scenario === "live-only") Object.assign(fixture.liveSessions.get(fixture.source.id), exact);
+				if (scenario === "durable-only") fixture.sessions.update(fixture.source.id, exact);
+				if (scenario === "partial") {
+					Object.assign(fixture.liveSessions.get(fixture.source.id), { goalId: fixture.goal.id });
+					fixture.sessions.update(fixture.source.id, { goalId: fixture.goal.id });
+				}
+				if (scenario === "identity-mismatch") {
+					Object.assign(fixture.liveSessions.get(fixture.source.id), exact, { teamGoalId: "other-goal" });
+					fixture.sessions.update(fixture.source.id, exact);
+				}
+				let archiveCalls = 0;
+				await assert.rejects(
+					() => fixture.manager.withAdoptedGoalArchiveAdmission(fixture.goal.id, async () => { archiveCalls += 1; }),
+					(error: any) => error?.code === "PROMOTION_IN_PROGRESS" && error?.status === 409,
+				);
+				assert.equal(archiveCalls, 0);
+				assert.equal(fixture.goals.get(fixture.goal.id)?.archived, false);
+			} finally {
+				fixture.manager.dispose();
+			}
+		});
+	}
+
+	it("admits an exact committed attachment and leaves ordinary goals unchanged", async () => {
+		const fixture = await makeAdoptedAdmissionFixture();
+		try {
+			const exact = { goalId: fixture.goal.id, teamGoalId: fixture.goal.id, role: "team-lead" };
+			Object.assign(fixture.liveSessions.get(fixture.source.id), exact);
+			fixture.sessions.update(fixture.source.id, exact);
+			const adoptedResult = await fixture.manager.withAdoptedGoalArchiveAdmission(
+				fixture.goal.id,
+				async () => "adopted-archive",
+			);
+			assert.equal(adoptedResult, "adopted-archive");
+
+			const ordinaryGoal = { ...fixture.goal, id: "ordinary-goal", worktreeOwnerSessionId: undefined };
+			fixture.goals.put(ordinaryGoal);
+			const ordinaryResult = await fixture.manager.withAdoptedGoalArchiveAdmission(
+				ordinaryGoal.id,
+				async () => "ordinary-archive",
+			);
+			assert.equal(ordinaryResult, "ordinary-archive");
+		} finally {
+			fixture.manager.dispose();
+		}
+	});
+});
+
 describe("TeamManager adopted-goal restart reconciliation", () => {
 	for (const reservation of [true, false]) {
 		it(`repairs a baseline general session with ${reservation ? "an empty" : "no"} lead reservation`, async () => {
@@ -542,6 +702,8 @@ describe("TeamManager adopted-goal restart reconciliation", () => {
 				maxConcurrent: 12,
 			});
 			assert.deepEqual(fixture.initializedGates, [fixture.goal.id]);
+			assert.equal(fixture.sessions.records.size, 1);
+			assert.equal(fixture.goals.get(fixture.goal.id)?.state, "in-progress");
 			assert.deepEqual(fixture.deletedAttempts, []);
 			assert.deepEqual(fixture.teams.mutations, reservation ? [] : [`put:${fixture.goal.id}`]);
 			fixture.manager.dispose();

--- a/tests2/core/team-manager-async-recovery.test.ts
+++ b/tests2/core/team-manager-async-recovery.test.ts
@@ -35,6 +35,7 @@ class MemoryStore<T extends { id: string }> {
 		this.records.set(id, { ...current, ...patch });
 		this.updates.push(id);
 	}
+	async flush(): Promise<void> {}
 }
 
 class MemoryTeamStore {
@@ -230,6 +231,137 @@ function makeFixture(options: { deferFirstScan?: boolean } = {}) {
 		agentTranscript,
 	};
 }
+
+function makeAdoptedGoalRestartFixture(options: { reservation: boolean; role: string }) {
+	const ownerSessionId = "regular-owner";
+	const projectId = "project-adopted";
+	const goal = {
+		id: "goal-adopted",
+		title: "Adopted goal",
+		projectId,
+		state: "todo",
+		team: true,
+		cwd: "/worktrees/session-owner",
+		worktreePath: "/worktrees/session-owner",
+		repoPath: "/repo",
+		branch: "session/owner",
+		repoWorktrees: { app: "/worktrees/session-owner/app" },
+		sandboxed: true,
+		archived: false,
+		worktreeOwnerSessionId: ownerSessionId,
+		workflow: { gates: [{ id: "design-doc" }] },
+	};
+	const source = {
+		id: ownerSessionId,
+		title: "Regular session",
+		projectId,
+		cwd: goal.cwd,
+		worktreePath: goal.worktreePath,
+		repoPath: goal.repoPath,
+		branch: goal.branch,
+		repoWorktrees: goal.repoWorktrees,
+		sandboxed: goal.sandboxed,
+		role: options.role,
+		accessory: "regular-cap",
+		createdAt: 1,
+		lastActivity: 1,
+	};
+	const goals = new MemoryStore<any>([goal]);
+	const sessions = new MemoryStore<any>([source]);
+	const teams = new MemoryTeamStore(options.reservation ? [{
+		goalId: goal.id,
+		teamLeadSessionId: ownerSessionId,
+		agents: [],
+		maxConcurrent: 12,
+	}] : []);
+	const initializedGates: string[] = [];
+	const gateStore = {
+		initGatesForGoal: (goalId: string) => { initializedGates.push(goalId); },
+		removeGoalGates: () => {},
+		flush: async () => {},
+	};
+	const deletedAttempts: string[] = [];
+	const context = {
+		project: { id: projectId },
+		goalStore: goals,
+		teamStore: teams,
+		sessionStore: sessions,
+		gateStore,
+		goalManager: {
+			deleteAdoptedGoalAttempt: async (goalId: string) => {
+				deletedAttempts.push(goalId);
+				return false;
+			},
+		},
+	};
+	const projectContextManager = {
+		all: () => [context],
+		getContextForGoal: (goalId: string) => goals.get(goalId) ? context : undefined,
+	};
+	const recoveryFs = new TeamRecoveryFsFake();
+	for (const root of trustedAgentSessionsRoots()) recoveryFs.dir(root, []);
+	const sessionManager = {
+		getSession: () => undefined,
+		getSessionInfo: () => undefined,
+	};
+	const role = {
+		name: "team-lead",
+		label: "Team Lead",
+		promptTemplate: "Lead the goal",
+		accessory: "lead-crown",
+		createdAt: 0,
+		updatedAt: 0,
+	};
+	const manager = new TeamManager(sessionManager as any, {
+		projectContextManager,
+		roleStore: { get: (name: string) => name === role.name ? role : undefined, getAll: () => [role] },
+		taskManager: { getTasksByGoal: () => [], getTasksForSession: () => [] },
+		colorStore: { get: () => undefined, set: () => {}, remove: () => {}, getAll: () => ({}) },
+		recoveryFs,
+		recoverySidecars: new MemoryRecoverySidecars(),
+	} as any, undefined, noTimerClock as any);
+
+	return { manager, goal, source, sessions, teams, initializedGates, deletedAttempts };
+}
+
+describe("TeamManager adopted-goal restart reconciliation", () => {
+	for (const reservation of [true, false]) {
+		it(`repairs a baseline general session with ${reservation ? "an empty" : "no"} lead reservation`, async () => {
+			const fixture = makeAdoptedGoalRestartFixture({ reservation, role: "general" });
+			await fixture.manager.waitForRestore();
+
+			assert.deepEqual(fixture.sessions.get(fixture.source.id), {
+				...fixture.source,
+				goalId: fixture.goal.id,
+				teamGoalId: fixture.goal.id,
+				role: "team-lead",
+				accessory: "lead-crown",
+			});
+			assert.deepEqual(fixture.manager.getTeamState(fixture.goal.id), {
+				goalId: fixture.goal.id,
+				teamLeadSessionId: fixture.source.id,
+				agents: [],
+				maxConcurrent: 12,
+			});
+			assert.deepEqual(fixture.initializedGates, [fixture.goal.id]);
+			assert.deepEqual(fixture.deletedAttempts, []);
+			assert.deepEqual(fixture.teams.mutations, reservation ? [] : [`put:${fixture.goal.id}`]);
+			fixture.manager.dispose();
+		});
+	}
+
+	it("leaves a non-general relation unchanged instead of attaching or compensating it", async () => {
+		const fixture = makeAdoptedGoalRestartFixture({ reservation: true, role: "coder" });
+		await fixture.manager.waitForRestore();
+
+		assert.deepEqual(fixture.sessions.get(fixture.source.id), fixture.source);
+		assert.deepEqual(fixture.sessions.updates, []);
+		assert.deepEqual(fixture.initializedGates, []);
+		assert.deepEqual(fixture.deletedAttempts, []);
+		assert.equal(fixture.manager.getTeamState(fixture.goal.id)?.teamLeadSessionId, fixture.source.id);
+		fixture.manager.dispose();
+	});
+});
 
 describe("TeamManager awaited async recovery", () => {
 	it("keeps restore pending and team indexes incomplete until deferred recovery I/O settles", async () => {

--- a/tests2/core/team-manager-async-recovery.test.ts
+++ b/tests2/core/team-manager-async-recovery.test.ts
@@ -232,6 +232,119 @@ function makeFixture(options: { deferFirstScan?: boolean } = {}) {
 	};
 }
 
+async function makeAdoptedAdmissionFixture() {
+	const ownerSessionId = "regular-owner";
+	const projectId = "project-admission";
+	const goal = {
+		id: "goal-admission",
+		title: "Adopted admission goal",
+		projectId,
+		state: "todo",
+		team: true,
+		cwd: "/worktrees/session-owner",
+		archived: false,
+		paused: false,
+		worktreeOwnerSessionId: ownerSessionId,
+	};
+	const source = {
+		id: ownerSessionId,
+		title: "Regular session",
+		projectId,
+		cwd: goal.cwd,
+		status: "idle",
+		role: "general",
+		createdAt: 1,
+		lastActivity: 1,
+	};
+	const goals = new MemoryStore<any>();
+	const sessions = new MemoryStore<any>();
+	const teams = new MemoryTeamStore([]);
+	const liveSessions = new Map<string, any>();
+	let workerSequence = 0;
+	const context = {
+		project: { id: projectId },
+		goalStore: goals,
+		teamStore: teams,
+		sessionStore: sessions,
+	};
+	const projectContextManager = {
+		all: () => [context],
+		getContextForGoal: (goalId: string) => goals.get(goalId) ? context : undefined,
+	};
+	const sessionManager = {
+		getSession: (id: string) => liveSessions.get(id),
+		getSessionInfo: (id: string) => liveSessions.get(id),
+		getPersistedSession: (id: string) => sessions.get(id),
+		createSession: async (cwd: string, _args?: string[], goalId?: string) => {
+			const id = `worker-${++workerSequence}`;
+			const worker = {
+				id,
+				title: "Worker",
+				cwd,
+				status: "idle",
+				goalId,
+				titleGenerated: false,
+				rpcClient: { onEvent: () => () => {}, prompt: async () => {} },
+				clients: new Set(),
+				createdAt: 2,
+				lastActivity: 2,
+			};
+			liveSessions.set(id, worker);
+			sessions.put(worker);
+			return worker;
+		},
+		setTitle: (id: string, title: string) => {
+			const live = liveSessions.get(id);
+			if (live) live.title = title;
+			return !!live;
+		},
+		updateSessionMeta: (id: string, patch: any) => {
+			const live = liveSessions.get(id);
+			if (live) Object.assign(live, patch);
+			if (sessions.get(id)) sessions.update(id, patch);
+			return !!live;
+		},
+		resolveSessionAgentAuthor: () => undefined,
+		enqueuePrompt: async () => ({ status: "dispatched" }),
+		isSandboxEnabled: false,
+		getSandboxManager: () => undefined,
+		dispatchGoalProvisionedForWorktree: async () => {},
+	};
+	const recoveryFs = new TeamRecoveryFsFake();
+	for (const root of trustedAgentSessionsRoots()) recoveryFs.dir(root, []);
+	const roles = [{
+		name: "team-lead",
+		label: "Team Lead",
+		promptTemplate: "Lead the goal",
+		accessory: "lead-crown",
+		createdAt: 0,
+		updatedAt: 0,
+	}, {
+		name: "coder",
+		label: "Coder",
+		promptTemplate: "Implement the task",
+		accessory: "headphones",
+		createdAt: 0,
+		updatedAt: 0,
+	}];
+	const manager = new TeamManager(sessionManager as any, {
+		projectContextManager,
+		roleStore: { get: (name: string) => roles.find(role => role.name === name), getAll: () => roles },
+		taskManager: { getTasksByGoal: () => [], getTasksForSession: () => [] },
+		colorStore: { get: () => undefined, set: () => {}, remove: () => {}, getAll: () => ({}) },
+		recoveryFs,
+		recoverySidecars: new MemoryRecoverySidecars(),
+	} as any, undefined, noTimerClock as any);
+	await manager.waitForRestore();
+
+	goals.put(goal);
+	sessions.put(source);
+	liveSessions.set(source.id, { ...source });
+	await manager.adoptExistingLead(goal.id, source.id);
+
+	return { manager, goal, source, goals, sessions, teams, liveSessions, get workerCount() { return workerSequence; } };
+}
+
 function makeAdoptedGoalRestartFixture(options: { reservation: boolean; role: string }) {
 	const ownerSessionId = "regular-owner";
 	const projectId = "project-adopted";
@@ -323,6 +436,91 @@ function makeAdoptedGoalRestartFixture(options: { reservation: boolean; role: st
 
 	return { manager, goal, source, sessions, teams, initializedGates, deletedAttempts };
 }
+
+describe("TeamManager adopted-lead worker admission", () => {
+	it("rejects a worker in the pending window after reservation and releases the untouched reservation", async () => {
+		const fixture = await makeAdoptedAdmissionFixture();
+		try {
+			await assert.rejects(
+				() => fixture.manager.spawnRole(fixture.goal.id, "coder", "must not start yet"),
+				(error: any) => error?.code === "ADOPTED_LEAD_ATTACHMENT_PENDING",
+			);
+			assert.equal(fixture.workerCount, 0);
+			assert.deepEqual(fixture.manager.getTeamState(fixture.goal.id)?.agents, []);
+			assert.equal(await fixture.manager.releaseAdoptedLead(fixture.goal.id, fixture.source.id), true);
+			assert.equal(fixture.manager.getTeamState(fixture.goal.id), undefined);
+		} finally {
+			fixture.manager.dispose();
+		}
+	});
+
+	it("allows workers only after both the live and durable source carry the exact committed attachment", async () => {
+		const fixture = await makeAdoptedAdmissionFixture();
+		try {
+			const attachment = { goalId: fixture.goal.id, teamGoalId: fixture.goal.id, role: "team-lead" };
+			Object.assign(fixture.liveSessions.get(fixture.source.id), attachment);
+			fixture.sessions.update(fixture.source.id, attachment);
+
+			const worker = await fixture.manager.spawnRole(fixture.goal.id, "coder", "start after commit");
+			assert.equal(worker.sessionId, "worker-1");
+			assert.equal(fixture.manager.getTeamState(fixture.goal.id)?.agents.length, 1);
+		} finally {
+			fixture.manager.dispose();
+		}
+	});
+
+	it("keeps ordinary team worker admission unchanged", async () => {
+		const fixture = await makeAdoptedAdmissionFixture();
+		try {
+			const ordinaryGoal = { ...fixture.goal, id: "goal-ordinary", title: "Ordinary goal", worktreeOwnerSessionId: undefined };
+			const ordinaryLead = {
+				...fixture.source,
+				id: "ordinary-lead",
+				goalId: ordinaryGoal.id,
+				teamGoalId: ordinaryGoal.id,
+				role: "team-lead",
+			};
+			fixture.goals.put(ordinaryGoal);
+			fixture.sessions.put(ordinaryLead);
+			fixture.liveSessions.set(ordinaryLead.id, ordinaryLead);
+			(fixture.manager as any).teams.set(ordinaryGoal.id, {
+				goalId: ordinaryGoal.id,
+				teamLeadSessionId: ordinaryLead.id,
+				agents: [],
+				maxConcurrent: 12,
+			});
+			(fixture.manager as any).sessionToGoal.set(ordinaryLead.id, ordinaryGoal.id);
+
+			const worker = await fixture.manager.spawnRole(ordinaryGoal.id, "coder", "ordinary spawn");
+			assert.equal(worker.sessionId, "worker-1");
+			assert.equal(fixture.manager.getTeamState(ordinaryGoal.id)?.agents.length, 1);
+		} finally {
+			fixture.manager.dispose();
+		}
+	});
+
+	it("fails closed on a partial identity change and refuses to release its reservation", async () => {
+		const fixture = await makeAdoptedAdmissionFixture();
+		try {
+			Object.assign(fixture.liveSessions.get(fixture.source.id), {
+				goalId: fixture.goal.id,
+				teamGoalId: "different-goal",
+				role: "team-lead",
+			});
+			fixture.sessions.update(fixture.source.id, { goalId: fixture.goal.id });
+
+			await assert.rejects(
+				() => fixture.manager.spawnRole(fixture.goal.id, "coder", "identity changed"),
+				(error: any) => error?.code === "ADOPTED_LEAD_ATTACHMENT_PENDING",
+			);
+			assert.equal(await fixture.manager.releaseAdoptedLead(fixture.goal.id, fixture.source.id), false);
+			assert.ok(fixture.manager.getTeamState(fixture.goal.id), "failed defense must retain the reservation");
+			assert.equal(fixture.teams.get(fixture.goal.id)?.teamLeadSessionId, fixture.source.id);
+		} finally {
+			fixture.manager.dispose();
+		}
+	});
+});
 
 describe("TeamManager adopted-goal restart reconciliation", () => {
 	for (const reservation of [true, false]) {

--- a/tests2/dom/session-goal-promotion-panel.test.ts
+++ b/tests2/dom/session-goal-promotion-panel.test.ts
@@ -1,0 +1,216 @@
+import { beforeAll as __syncBeforeAll } from "vitest";
+import { syncCustomElements as __syncCE } from "./_setup/custom-elements.js";
+__syncBeforeAll(() => __syncCE());
+
+import { render } from "lit";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { PanelWorkspaceTab } from "../../src/app/panel-workspace.js";
+import type { Project } from "../../src/app/state.js";
+import type { Workflow } from "../../src/app/api.js";
+
+vi.mock("../../src/app/lazy-review.js", () => ({ ensureReviewComponents: vi.fn() }));
+
+const OWNER = "proposal-owner";
+const OTHER = "active-but-not-owner";
+const now = 1_786_912_000_000;
+const project: Project = {
+	id: "project-1",
+	name: "Promotion Project",
+	rootPath: "/repo",
+	colorLight: "#fff",
+	colorDark: "#000",
+};
+const workflow: Workflow = {
+	id: "general",
+	name: "General",
+	description: "General workflow",
+	gates: [],
+	createdAt: now,
+	updatedAt: now,
+};
+
+let state: typeof import("../../src/app/state.js").state;
+let setRenderApp: typeof import("../../src/app/state.js").setRenderApp;
+let proposalPanelContent: typeof import("../../src/app/proposal-panels.js").proposalPanelContent;
+let host: HTMLElement;
+let requests: Array<{ path: string; method: string; body?: Record<string, unknown> }>;
+let eligibility: Record<string, unknown>;
+
+function json(body: unknown, status = 200): Response {
+	return new Response(JSON.stringify(body), { status, headers: { "Content-Type": "application/json" } });
+}
+
+function tab(): PanelWorkspaceTab {
+	return {
+		id: `proposal:goal:${OWNER}`,
+		kind: "proposal",
+		title: "Goal Proposal",
+		label: "Goal",
+		legacyTab: "goal",
+		source: { type: "proposal", proposalType: "goal", sessionId: OWNER },
+	};
+}
+
+function installFetch(): void {
+	vi.stubGlobal("fetch", vi.fn(async (input: RequestInfo | URL, init: RequestInit = {}) => {
+		const url = new URL(String(input), window.location.origin);
+		const method = (init.method || "GET").toUpperCase();
+		const body = typeof init.body === "string" ? JSON.parse(init.body) : undefined;
+		requests.push({ path: url.pathname, method, body });
+		if (url.pathname === `/api/sessions/${OWNER}/proposal/goal/worktree-mode`) {
+			if (method === "PUT") return json({ ...eligibility, mode: body?.mode });
+			return json(eligibility);
+		}
+		if (url.pathname === `/api/sessions/${OWNER}/proposal/goal/accept` && method === "POST") {
+			return json({
+				id: "goal-1", title: String(body?.title || "Promoted"), cwd: "/repo-wt/session-owner",
+				projectId: project.id, state: "in-progress", spec: String(body?.spec || ""),
+				createdAt: now, updatedAt: now, branch: "session/proposal", worktreePath: "/repo-wt/session-owner",
+			});
+		}
+		if (url.pathname === "/api/workflows") return json({ workflows: [workflow] });
+		if (url.pathname === `/api/projects/${project.id}/structured`) return json({ components: [{ name: "default", repo: "." }] });
+		if (url.pathname === `/api/projects/${project.id}/qa-testing-config`) return json({ configured: false });
+		if (url.pathname === "/api/roles") return json({ roles: [] });
+		if (url.pathname === "/api/tools") return json({ tools: [], diagnostics: [] });
+		if (url.pathname === "/api/tool-group-policies") return json({});
+		if (url.pathname === "/api/sessions") return json({ sessions: state.gatewaySessions, generation: 2 });
+		if (url.pathname === "/api/goals") return json({ goals: state.goals, generation: 2 });
+		if (url.pathname === "/api/projects") return json({ projects: [project] });
+		if (url.pathname.includes("/archived")) return json({ sessions: [], goals: [] });
+		return json({});
+	}) as unknown as typeof fetch);
+}
+
+async function frame(): Promise<void> {
+	await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+	await Promise.resolve();
+}
+
+async function waitFor(assertion: () => void): Promise<void> {
+	let last: unknown;
+	for (let i = 0; i < 40; i++) {
+		try { assertion(); return; } catch (err) { last = err; await frame(); }
+	}
+	throw last;
+}
+
+function resetState(worktreeMode?: "current-session"): void {
+	const fields: Record<string, unknown> = {
+		title: "Promote this session",
+		spec: "Keep this transcript and checkout.",
+		cwd: "/repo",
+		workflow: "general",
+		projectId: project.id,
+	};
+	if (worktreeMode) fields.worktreeMode = worktreeMode;
+	state.projects = [project];
+	state.goals = [];
+	state.gatewaySessions = [
+		{ id: OWNER, title: "Owner", cwd: "/repo-wt/session-owner", projectId: project.id, status: "idle", createdAt: now, lastActivity: now, clientCount: 1, branch: "session/proposal", worktreePath: "/repo-wt/session-owner" } as any,
+		{ id: OTHER, title: "Other", cwd: "/repo", projectId: project.id, status: "idle", createdAt: now, lastActivity: now, clientCount: 1 } as any,
+	];
+	state.activeProposals = { goal: { sessionId: OWNER, fields, streaming: false, rev: 1 } };
+	state.goalWorktreeModeBySession = {};
+	state.previewProjectId = project.id;
+	state.selectedSessionId = OTHER;
+	state.connectingSessionId = null;
+	state.remoteAgent = null;
+	state.assistantType = null;
+	state.chatPanel = null;
+	state.appView = "authenticated";
+	state.connectionStatus = "connected" as any;
+	state.sessionsGeneration = -1;
+	state.goalsGeneration = -1;
+	state.sandboxStatus = { configured: true, available: true, imageExists: true };
+	state.roles = [];
+	state.archivedSessions = [];
+	state.previewMetadataRows = [];
+}
+
+async function mount(mode?: "current-session"): Promise<void> {
+	resetState(mode);
+	setRenderApp(() => render(proposalPanelContent(tab(), () => null), host));
+	render(proposalPanelContent(tab(), () => null), host);
+	await waitFor(() => expect(host.querySelector("[data-testid='goal-form-worktree-mode']")).not.toBeNull());
+}
+
+beforeEach(async () => {
+	document.body.innerHTML = '<div id="host"></div>';
+	host = document.getElementById("host")!;
+	requests = [];
+	eligibility = {
+		mode: "new-worktree",
+		eligible: true,
+		branch: "session/proposal",
+		worktreePath: "/repo-wt/session-owner",
+		componentCount: 1,
+		sandboxed: true,
+	};
+	installFetch();
+	({ state, setRenderApp } = await import("../../src/app/state.js"));
+	({ proposalPanelContent } = await import("../../src/app/proposal-panels.js"));
+});
+
+afterEach(() => {
+	setRenderApp?.(() => {});
+	if (host) render(null, host);
+	document.body.innerHTML = "";
+	vi.restoreAllMocks();
+	vi.unstubAllGlobals();
+});
+
+describe("current-session goal proposal panel", () => {
+	it("defaults to New worktree and derives eligibility from the proposal owner, not the active tab", async () => {
+		await mount();
+		await waitFor(() => expect(requests.some((r) => r.path === `/api/sessions/${OWNER}/proposal/goal/worktree-mode` && r.method === "GET")).toBe(true));
+		expect(requests.some((r) => r.path.includes(OTHER) && r.path.includes("worktree-mode"))).toBe(false);
+		expect((host.querySelector("[data-testid='goal-form-worktree-new']") as HTMLInputElement).checked).toBe(true);
+		expect(host.querySelector("[data-testid='goal-form-worktree-summary']")?.textContent).toContain("New worktree");
+	});
+
+	it("persists Current session, renders authoritative coordinates, disables inherited controls, and accepts without coordinate authority", async () => {
+		await mount();
+		await waitFor(() => expect((host.querySelector("[data-testid='goal-form-worktree-current-session']") as HTMLInputElement).disabled).toBe(false));
+		const current = host.querySelector("[data-testid='goal-form-worktree-current-session']") as HTMLInputElement;
+		current.click();
+		await waitFor(() => expect(requests.some((r) => r.method === "PUT" && r.path.endsWith("/proposal/goal/worktree-mode"))).toBe(true));
+		expect(requests.find((r) => r.method === "PUT")?.body).toEqual({ mode: "current-session" });
+		await waitFor(() => expect(host.querySelector("[data-testid='goal-form-worktree-branch']")?.textContent).toBe("session/proposal"));
+		expect(host.querySelector("[data-testid='goal-form-worktree-path']")?.textContent).toBe("/repo-wt/session-owner");
+		const toggles = [...host.querySelectorAll<HTMLInputElement>("input.toggle-switch")];
+		expect(toggles.slice(0, 2).every((input) => input.disabled)).toBe(true);
+
+		const create = host.querySelector("[data-testid='proposal-primary-submit'] button") as HTMLButtonElement;
+		expect(create.disabled).toBe(false);
+		create.click();
+		await waitFor(() => expect(requests.some((r) => r.method === "POST" && r.path.endsWith("/proposal/goal/accept"))).toBe(true));
+		const accept = requests.find((r) => r.method === "POST" && r.path.endsWith("/proposal/goal/accept"))!;
+		expect(accept.path).toBe(`/api/sessions/${OWNER}/proposal/goal/accept`);
+		expect(accept.body).not.toHaveProperty("sessionId");
+		expect(accept.body).not.toHaveProperty("cwd");
+		expect(accept.body).not.toHaveProperty("branch");
+		expect(accept.body).not.toHaveProperty("worktreePath");
+		expect(accept.body).not.toHaveProperty("repoPath");
+		expect(accept.body).not.toHaveProperty("sandboxed");
+		expect(requests.some((r) => r.method === "POST" && r.path === "/api/goals")).toBe(false);
+	});
+
+	it("retains an ineligible restored Current session selection, blocks Create, and recovers through New worktree", async () => {
+		eligibility = {
+			mode: "current-session",
+			eligible: false,
+			reason: "Current session unavailable — this session already belongs to a goal.",
+		};
+		await mount("current-session");
+		await waitFor(() => expect(host.querySelector("[data-testid='goal-form-worktree-current-unavailable']")?.textContent).toContain("already belongs to a goal"));
+		const current = host.querySelector("[data-testid='goal-form-worktree-current-session']") as HTMLInputElement;
+		expect(current.checked).toBe(true);
+		expect(current.disabled).toBe(true);
+		expect((host.querySelector("[data-testid='proposal-primary-submit'] button") as HTMLButtonElement).disabled).toBe(true);
+
+		(host.querySelector("[data-testid='goal-form-worktree-new']") as HTMLInputElement).click();
+		await waitFor(() => expect(requests.some((r) => r.method === "PUT" && r.body?.mode === "new-worktree")).toBe(true));
+		await waitFor(() => expect((host.querySelector("[data-testid='proposal-primary-submit'] button") as HTMLButtonElement).disabled).toBe(false));
+	});
+});

--- a/tests2/dom/session-goal-promotion-panel.test.ts
+++ b/tests2/dom/session-goal-promotion-panel.test.ts
@@ -32,9 +32,12 @@ const workflow: Workflow = {
 let state: typeof import("../../src/app/state.js").state;
 let setRenderApp: typeof import("../../src/app/state.js").setRenderApp;
 let proposalPanelContent: typeof import("../../src/app/proposal-panels.js").proposalPanelContent;
+let updateLocalSessionStatus: typeof import("../../src/app/api.js").updateLocalSessionStatus;
+let refreshSessions: typeof import("../../src/app/api.js").refreshSessions;
 let host: HTMLElement;
 let requests: Array<{ path: string; method: string; body?: Record<string, unknown> }>;
 let eligibility: Record<string, unknown>;
+let sessionSnapshot: Array<Record<string, unknown>> | undefined;
 
 function json(body: unknown, status = 200): Response {
 	return new Response(JSON.stringify(body), { status, headers: { "Content-Type": "application/json" } });
@@ -74,7 +77,7 @@ function installFetch(): void {
 		if (url.pathname === "/api/roles") return json({ roles: [] });
 		if (url.pathname === "/api/tools") return json({ tools: [], diagnostics: [] });
 		if (url.pathname === "/api/tool-group-policies") return json({});
-		if (url.pathname === "/api/sessions") return json({ sessions: state.gatewaySessions, generation: 2 });
+		if (url.pathname === "/api/sessions") return json({ sessions: sessionSnapshot ?? state.gatewaySessions, generation: state.sessionsGeneration + 1 });
 		if (url.pathname === "/api/goals") return json({ goals: state.goals, generation: 2 });
 		if (url.pathname === "/api/projects") return json({ projects: [project] });
 		if (url.pathname.includes("/archived")) return json({ sessions: [], goals: [] });
@@ -112,6 +115,7 @@ function resetState(worktreeMode?: "current-session"): void {
 	];
 	state.activeProposals = { goal: { sessionId: OWNER, fields, streaming: false, rev: 1 } };
 	state.goalWorktreeModeBySession = {};
+	state.goalWorktreeModeRevisionBySession = {};
 	state.previewProjectId = project.id;
 	state.selectedSessionId = OTHER;
 	state.connectingSessionId = null;
@@ -139,6 +143,7 @@ beforeEach(async () => {
 	document.body.innerHTML = '<div id="host"></div>';
 	host = document.getElementById("host")!;
 	requests = [];
+	sessionSnapshot = undefined;
 	eligibility = {
 		mode: "new-worktree",
 		eligible: true,
@@ -149,6 +154,7 @@ beforeEach(async () => {
 	};
 	installFetch();
 	({ state, setRenderApp } = await import("../../src/app/state.js"));
+	({ updateLocalSessionStatus, refreshSessions } = await import("../../src/app/api.js"));
 	({ proposalPanelContent } = await import("../../src/app/proposal-panels.js"));
 });
 
@@ -212,5 +218,84 @@ describe("current-session goal proposal panel", () => {
 		(host.querySelector("[data-testid='goal-form-worktree-new']") as HTMLInputElement).click();
 		await waitFor(() => expect(requests.some((r) => r.method === "PUT" && r.body?.mode === "new-worktree")).toBe(true));
 		await waitFor(() => expect((host.querySelector("[data-testid='proposal-primary-submit'] button") as HTMLButtonElement).disabled).toBe(false));
+	});
+
+	it("refreshes eligibility across owner idle → streaming → idle status transitions", async () => {
+		eligibility.mode = "current-session";
+		await mount("current-session");
+		await waitFor(() => expect((host.querySelector("[data-testid='goal-form-worktree-current-session']") as HTMLInputElement).disabled).toBe(false));
+		const initialGets = requests.filter((request) => request.method === "GET" && request.path.endsWith("/worktree-mode")).length;
+
+		eligibility = {
+			mode: "current-session",
+			eligible: false,
+			reason: "Current session must be idle.",
+		};
+		updateLocalSessionStatus(OWNER, "streaming");
+		await waitFor(() => expect((host.querySelector("[data-testid='goal-form-worktree-current-session']") as HTMLInputElement).disabled).toBe(true));
+		await waitFor(() => expect(host.querySelector("[data-testid='goal-form-worktree-current-unavailable']")?.textContent).toContain("must be idle"));
+		expect(requests.filter((request) => request.method === "GET" && request.path.endsWith("/worktree-mode")).length).toBeGreaterThan(initialGets);
+		expect((host.querySelector("[data-testid='proposal-primary-submit'] button") as HTMLButtonElement).disabled).toBe(true);
+
+		eligibility = {
+			mode: "current-session",
+			eligible: true,
+			branch: "session/proposal",
+			worktreePath: "/repo-wt/session-owner",
+			componentCount: 1,
+		};
+		updateLocalSessionStatus(OWNER, "idle");
+		await waitFor(() => expect((host.querySelector("[data-testid='goal-form-worktree-current-session']") as HTMLInputElement).disabled).toBe(false));
+		expect((host.querySelector("[data-testid='proposal-primary-submit'] button") as HTMLButtonElement).disabled).toBe(false);
+	});
+
+	it("refreshes eligibility when a session-list snapshot changes owner relation metadata", async () => {
+		eligibility.mode = "current-session";
+		await mount("current-session");
+		await waitFor(() => expect((host.querySelector("[data-testid='goal-form-worktree-current-session']") as HTMLInputElement).disabled).toBe(false));
+
+		eligibility = {
+			mode: "current-session",
+			eligible: false,
+			reason: "Current session already belongs to another Bobbit workflow.",
+		};
+		sessionSnapshot = state.gatewaySessions.map((session) => session.id === OWNER
+			? { ...session, role: "reviewer" }
+			: { ...session });
+		await refreshSessions();
+		await waitFor(() => expect(host.querySelector("[data-testid='goal-form-worktree-current-unavailable']")?.textContent).toContain("already belongs"));
+		expect((host.querySelector("[data-testid='goal-form-worktree-current-session']") as HTMLInputElement).disabled).toBe(true);
+		expect((host.querySelector("[data-testid='proposal-primary-submit'] button") as HTMLButtonElement).disabled).toBe(true);
+
+		eligibility = {
+			mode: "current-session",
+			eligible: true,
+			branch: "session/proposal",
+			worktreePath: "/repo-wt/session-owner",
+			componentCount: 1,
+		};
+		sessionSnapshot = state.gatewaySessions.map((session) => session.id === OWNER
+			? { ...session, role: undefined }
+			: { ...session });
+		await refreshSessions();
+		await waitFor(() => expect((host.querySelector("[data-testid='goal-form-worktree-current-session']") as HTMLInputElement).disabled).toBe(false));
+	});
+
+	it("revalidates immediately before acceptance and blocks a newly ineligible owner", async () => {
+		eligibility.mode = "current-session";
+		await mount("current-session");
+		await waitFor(() => expect((host.querySelector("[data-testid='proposal-primary-submit'] button") as HTMLButtonElement).disabled).toBe(false));
+		const getsBeforeCreate = requests.filter((request) => request.method === "GET" && request.path.endsWith("/worktree-mode")).length;
+		eligibility = {
+			mode: "current-session",
+			eligible: false,
+			reason: "Current session must be idle.",
+		};
+
+		(host.querySelector("[data-testid='proposal-primary-submit'] button") as HTMLButtonElement).click();
+		await waitFor(() => expect(host.querySelector("[data-testid='goal-form-worktree-current-unavailable']")?.textContent).toContain("must be idle"));
+		expect(requests.filter((request) => request.method === "GET" && request.path.endsWith("/worktree-mode")).length).toBeGreaterThan(getsBeforeCreate);
+		expect(requests.some((request) => request.method === "POST" && request.path.endsWith("/proposal/goal/accept"))).toBe(false);
+		expect((host.querySelector("[data-testid='proposal-primary-submit'] button") as HTMLButtonElement).disabled).toBe(true);
 	});
 });

--- a/tests2/integration/session-goal-promotion.test.ts
+++ b/tests2/integration/session-goal-promotion.test.ts
@@ -26,7 +26,146 @@ async function expectPromotionLifecycleConflict(response: Response): Promise<voi
 	expect((await jsonResponse(response)).code).toBe("PROMOTED_SESSION_LIFECYCLE_CONFLICT");
 }
 
+async function createPromotionCandidate(gateway: any, label: string): Promise<{
+	ownerId: string;
+	context: any;
+}> {
+	const projectRoot = path.join(gateway.bobbitDir, `promotion-${label}-${randomUUID()}`);
+	copyGitTemplate(projectRoot);
+	const project = await registerProject({
+		name: `promotion-${label}-${Date.now()}`,
+		rootPath: projectRoot,
+		components: [{ name: "app", repo: "." }],
+		workflows: {
+			general: {
+				name: "General",
+				description: "Promotion compensation fixture",
+				gates: [{ id: "implementation", name: "Implementation", depends_on: [] }],
+			},
+		},
+	});
+	const ownerId = await createSession({ projectId: project.id, cwd: projectRoot });
+	await waitForSessionStatus(ownerId, "idle", 30_000);
+	const seeded = await apiFetch(`/api/sessions/${ownerId}/proposal/goal/seed`, {
+		method: "POST",
+		body: JSON.stringify({
+			args: {
+				title: `Promote ${label}`,
+				spec: "Exercise promotion compensation.",
+				workflow: "general",
+				projectId: project.id,
+			},
+		}),
+	});
+	expect(seeded.status, await seeded.clone().text()).toBe(200);
+	const selected = await apiFetch(`/api/sessions/${ownerId}/proposal/goal/worktree-mode`, {
+		method: "PUT",
+		body: JSON.stringify({ mode: "current-session" }),
+	});
+	expect(selected.status, await selected.clone().text()).toBe(200);
+	return {
+		ownerId,
+		context: gateway.projectContextManager.getOrCreate(project.id),
+	};
+}
+
 test.describe("current-session goal promotion API", () => {
+	test("removes gates and goal after an exact reservation release, then permits a clean retry", async ({ gateway, scope }) => {
+		const { ownerId, context } = await createPromotionCandidate(gateway, "released-compensation");
+		const goalManager = context.goalManager as any;
+		const sessionManager = gateway.sessionManager as any;
+		const originalCreateGoal = goalManager.createGoal;
+		const originalPromote = sessionManager.promoteToGoalLead;
+		let attemptedGoalId: string | undefined;
+		goalManager.createGoal = async function (...args: any[]) {
+			const goal = await originalCreateGoal.apply(this, args);
+			attemptedGoalId = goal.id;
+			return goal;
+		};
+		sessionManager.promoteToGoalLead = async () => {
+			throw new Error("forced pre-commit promotion failure");
+		};
+
+		let failed: Response;
+		try {
+			failed = await apiFetch(`/api/sessions/${ownerId}/proposal/goal/accept`, {
+				method: "POST",
+				body: JSON.stringify({ title: "Promote released compensation" }),
+			});
+		} finally {
+			goalManager.createGoal = originalCreateGoal;
+			sessionManager.promoteToGoalLead = originalPromote;
+		}
+		expect(failed!.status).toBe(400);
+		expect(attemptedGoalId).toBeTruthy();
+		expect(context.goalStore.get(attemptedGoalId!)).toBeUndefined();
+		expect(context.gateStore.getGatesForGoal(attemptedGoalId!)).toEqual([]);
+		expect(gateway.teamManager.getTeamState(attemptedGoalId!)).toBeUndefined();
+
+		const retry = await apiFetch(`/api/sessions/${ownerId}/proposal/goal/accept`, {
+			method: "POST",
+			body: JSON.stringify({ title: "Promote released compensation" }),
+		});
+		expect(retry.status, await retry.clone().text()).toBe(201);
+		const retriedGoal = await jsonResponse(retry);
+		scope.trackGoal(retriedGoal.id);
+		expect(retriedGoal.id).not.toBe(attemptedGoalId);
+		expect((await sessionRecord(ownerId))).toMatchObject({
+			goalId: retriedGoal.id,
+			teamGoalId: retriedGoal.id,
+			role: "team-lead",
+		});
+	});
+
+	test("retains the recoverable goal, gates, and lead when reservation release is refused", async ({ gateway, scope }) => {
+		const { ownerId, context } = await createPromotionCandidate(gateway, "refused-compensation");
+		const teamManager = gateway.teamManager as any;
+		const sessionManager = gateway.sessionManager as any;
+		const originalRelease = teamManager.releaseAdoptedLead;
+		const originalPromote = sessionManager.promoteToGoalLead;
+		teamManager.releaseAdoptedLead = async () => false;
+		sessionManager.promoteToGoalLead = async () => {
+			throw new Error("forced pre-commit promotion failure");
+		};
+
+		let failed: Response;
+		try {
+			failed = await apiFetch(`/api/sessions/${ownerId}/proposal/goal/accept`, {
+				method: "POST",
+				body: JSON.stringify({ title: "Promote refused compensation" }),
+			});
+		} finally {
+			teamManager.releaseAdoptedLead = originalRelease;
+			sessionManager.promoteToGoalLead = originalPromote;
+		}
+		expect(failed!.status).toBe(400);
+		const retainedGoals = context.goalStore.getAll()
+			.filter((goal: any) => goal.worktreeOwnerSessionId === ownerId && !goal.archived);
+		expect(retainedGoals).toHaveLength(1);
+		const retainedGoal = retainedGoals[0];
+		expect(context.gateStore.getGatesForGoal(retainedGoal.id)).toHaveLength(1);
+		expect(gateway.teamManager.getTeamState(retainedGoal.id)).toMatchObject({
+			teamLeadSessionId: ownerId,
+			agents: [],
+		});
+		expect(await sessionRecord(ownerId)).toMatchObject({ role: "general" });
+
+		const retry = await apiFetch(`/api/sessions/${ownerId}/proposal/goal/accept`, {
+			method: "POST",
+			body: JSON.stringify({ title: "Promote refused compensation" }),
+		});
+		expect(retry.status, await retry.clone().text()).toBe(201);
+		const retriedGoal = await jsonResponse(retry);
+		scope.trackGoal(retriedGoal.id);
+		expect(retriedGoal.id).toBe(retainedGoal.id);
+		expect(context.gateStore.getGatesForGoal(retainedGoal.id)).toHaveLength(1);
+		expect(await sessionRecord(ownerId)).toMatchObject({
+			goalId: retainedGoal.id,
+			teamGoalId: retainedGoal.id,
+			role: "team-lead",
+		});
+	});
+
 	test("persists owner mode, rejects authority, and promotes exactly in place", async ({ gateway, scope }) => {
 		const projectRoot = path.join(gateway.bobbitDir, `promotion-api-${randomUUID()}`);
 		copyGitTemplate(projectRoot);

--- a/tests2/integration/session-goal-promotion.test.ts
+++ b/tests2/integration/session-goal-promotion.test.ts
@@ -12,9 +12,17 @@ async function jsonResponse(response: Response): Promise<any> {
 }
 
 async function sessionRecord(id: string): Promise<any> {
-	const response = await apiFetch(`/api/sessions/${id}?include=archived`);
+	const response = await apiFetch("/api/sessions?include=archived");
 	expect(response.status).toBe(200);
-	return jsonResponse(response);
+	const body = await jsonResponse(response);
+	const record = body.sessions?.find((session: any) => session.id === id);
+	expect(record, `session ${id} missing from list`).toBeTruthy();
+	return record;
+}
+
+async function expectPromotionLifecycleConflict(response: Response): Promise<void> {
+	expect(response.status).toBe(409);
+	expect((await jsonResponse(response)).code).toBe("PROMOTED_SESSION_LIFECYCLE_CONFLICT");
 }
 
 test.describe("current-session goal promotion API", () => {
@@ -57,15 +65,34 @@ test.describe("current-session goal promotion API", () => {
 		expect(initialBody.eligibility.eligible, JSON.stringify(initialBody)).toBe(true);
 		expect(initialBody.eligibility.coordinates.branch).toBe(before.branch);
 		expect(initialBody.eligibility.coordinates.worktreePath).toBe(before.worktreePath);
+		const legacyDraft = await (await apiFetch(`/api/sessions/${ownerId}/proposal/goal`)).text();
+		expect(legacyDraft).not.toContain("worktreeMode:");
 
-		const update = await apiFetch(`/api/sessions/${ownerId}/proposal/goal/worktree-mode`, {
+		const explicitNew = await apiFetch(`/api/sessions/${ownerId}/proposal/goal/worktree-mode`, {
+			method: "PUT",
+			body: JSON.stringify({ mode: "new-worktree" }),
+		});
+		expect(explicitNew.status).toBe(200);
+		expect((await jsonResponse(explicitNew)).mode).toBe("new-worktree");
+		expect(await (await apiFetch(`/api/sessions/${ownerId}/proposal/goal`)).text()).toBe(legacyDraft);
+
+		const selectCurrent = async () => apiFetch(`/api/sessions/${ownerId}/proposal/goal/worktree-mode`, {
 			method: "PUT",
 			body: JSON.stringify({ mode: "current-session" }),
 		});
+		const update = await selectCurrent();
 		expect(update.status).toBe(200);
 		expect((await jsonResponse(update)).mode).toBe("current-session");
-		const rawDraft = await (await apiFetch(`/api/sessions/${ownerId}/proposal/goal`)).text();
-		expect(rawDraft).toContain("worktreeMode: current-session");
+		expect(await (await apiFetch(`/api/sessions/${ownerId}/proposal/goal`)).text()).toContain("worktreeMode: current-session");
+
+		const resetToNew = await apiFetch(`/api/sessions/${ownerId}/proposal/goal/worktree-mode`, {
+			method: "PUT",
+			body: JSON.stringify({ mode: "new-worktree" }),
+		});
+		expect(resetToNew.status).toBe(200);
+		expect((await jsonResponse(resetToNew)).mode).toBe("new-worktree");
+		expect(await (await apiFetch(`/api/sessions/${ownerId}/proposal/goal`)).text()).toBe(legacyDraft);
+		expect((await selectCurrent()).status).toBe(200);
 
 		const rejected = await apiFetch(`/api/sessions/${ownerId}/proposal/goal/accept`, {
 			method: "POST",
@@ -116,5 +143,46 @@ test.describe("current-session goal promotion API", () => {
 		const goals = Array.isArray(goalsBody) ? goalsBody : goalsBody.goals;
 		expect(goals.filter((candidate: any) => candidate.worktreeOwnerSessionId === ownerId)).toHaveLength(1);
 		expect((await apiFetch(`/api/sessions/${ownerId}/proposal/goal`)).status).toBe(404);
+
+		const transcriptPath = gateway.sessionManager.getPersistedSession(ownerId)?.agentSessionFile;
+		expect(transcriptPath).toBeTruthy();
+		expect(fs.existsSync(transcriptPath)).toBe(true);
+		const teamBeforeConflict = await jsonResponse(await apiFetch(`/api/goals/${goal.id}/team`));
+		expect(teamBeforeConflict.teamLeadSessionId).toBe(ownerId);
+
+		await expectPromotionLifecycleConflict(await apiFetch(`/api/sessions/${ownerId}`, {
+			method: "PATCH",
+			body: JSON.stringify({ title: "must-not-apply", archived: true }),
+		}));
+		await expectPromotionLifecycleConflict(await apiFetch(`/api/sessions/${ownerId}`, { method: "DELETE" }));
+		await expectPromotionLifecycleConflict(await apiFetch(`/api/sessions/${ownerId}?purge=true`, { method: "DELETE" }));
+
+		const preserved = await sessionRecord(ownerId);
+		expect(preserved.archived).not.toBe(true);
+		expect(preserved.title).toBe(after.title);
+		expect(preserved.goalId).toBe(goal.id);
+		expect(preserved.teamGoalId).toBe(goal.id);
+		expect(preserved.worktreePath).toBe(before.worktreePath);
+		expect(gateway.sessionManager.getPersistedSession(ownerId)?.agentSessionFile).toBe(transcriptPath);
+		expect(fs.existsSync(transcriptPath)).toBe(true);
+		expect(fs.readFileSync(staged, "utf8")).toBe("staged before promotion\n");
+		expect(fs.readFileSync(untracked, "utf8")).toBe("untracked before promotion\n");
+		expect(String((await runner.execFile("git", ["status", "--porcelain"], { cwd: worktree })).stdout)).toBe(statusBefore);
+		const teamAfterConflict = await jsonResponse(await apiFetch(`/api/goals/${goal.id}/team`));
+		expect(teamAfterConflict.teamLeadSessionId).toBe(ownerId);
+
+		// Goal archival publishes the durable archived bit before team teardown, so
+		// the same production guard now permits termination of the adopted source.
+		const archivedGoalResponse = await apiFetch(`/api/goals/${goal.id}?cascade=true`, { method: "DELETE" });
+		expect(archivedGoalResponse.status, await archivedGoalResponse.clone().text()).toBe(200);
+		const archivedGoal = await jsonResponse(await apiFetch(`/api/goals/${goal.id}`));
+		expect(archivedGoal.archived).toBe(true);
+		expect((await apiFetch(`/api/goals/${goal.id}/team`)).status).toBe(404);
+		expect((await sessionRecord(ownerId)).archived).toBe(true);
+
+		const permittedPurge = await apiFetch(`/api/sessions/${ownerId}?purge=true`, { method: "DELETE" });
+		expect(permittedPurge.status).toBe(200);
+		const sessionsAfterPurge = await jsonResponse(await apiFetch("/api/sessions?include=archived"));
+		expect(sessionsAfterPurge.sessions.some((session: any) => session.id === ownerId)).toBe(false);
 	});
 });

--- a/tests2/integration/session-goal-promotion.test.ts
+++ b/tests2/integration/session-goal-promotion.test.ts
@@ -117,6 +117,68 @@ test.describe("current-session goal promotion API", () => {
 		});
 	});
 
+	test("rejects a concurrent role PATCH and preserves the baseline after failed promotion compensation", async ({ gateway }) => {
+		const { ownerId, context } = await createPromotionCandidate(gateway, "role-race-compensation");
+		const sessionManager = gateway.sessionManager as any;
+		const originalPromote = sessionManager.promoteToGoalLead;
+		const sourceBefore = sessionManager.getSession(ownerId);
+		const baseline = {
+			role: sourceBefore.role,
+			accessory: sourceBefore.accessory,
+			allowedTools: sourceBefore.allowedTools ? [...sourceBefore.allowedTools] : undefined,
+		};
+		let releasePromotion!: () => void;
+		const blocked = new Promise<void>(resolve => { releasePromotion = resolve; });
+		let enteredPromotion!: () => void;
+		const entered = new Promise<void>(resolve => { enteredPromotion = resolve; });
+		sessionManager.promoteToGoalLead = async () => {
+			enteredPromotion();
+			await blocked;
+			throw new Error("forced promotion failure after reservation");
+		};
+
+		const acceptance = apiFetch(`/api/sessions/${ownerId}/proposal/goal/accept`, {
+			method: "POST",
+			body: JSON.stringify({ title: "Promote role race compensation" }),
+		});
+		let failed: Response;
+		let pendingGoalId: string | undefined;
+		try {
+			await entered;
+			pendingGoalId = context.goalStore.getAll().find((goal: any) => goal.worktreeOwnerSessionId === ownerId)?.id;
+			expect(pendingGoalId).toBeTruthy();
+			const rolePatch = await apiFetch(`/api/sessions/${ownerId}`, {
+				method: "PATCH",
+				body: JSON.stringify({ roleId: "coder" }),
+			});
+			expect(rolePatch.status).toBe(409);
+			expect(await jsonResponse(rolePatch)).toMatchObject({
+				code: "SESSION_GOAL_PROMOTION_IN_PROGRESS",
+			});
+			releasePromotion();
+			failed = await acceptance;
+		} finally {
+			releasePromotion();
+			sessionManager.promoteToGoalLead = originalPromote;
+		}
+
+		expect(failed!.status).toBe(400);
+		const liveAfter = sessionManager.getSession(ownerId);
+		expect({
+			role: liveAfter.role,
+			accessory: liveAfter.accessory,
+			allowedTools: liveAfter.allowedTools,
+		}).toEqual(baseline);
+		expect(await sessionRecord(ownerId)).toMatchObject({
+			role: baseline.role,
+			accessory: baseline.accessory,
+		});
+		const attemptGoals = context.goalStore.getAll().filter((goal: any) => goal.worktreeOwnerSessionId === ownerId);
+		expect(attemptGoals).toEqual([]);
+		expect(context.gateStore.getGatesForGoal(pendingGoalId!)).toEqual([]);
+		expect(gateway.teamManager.getTeamState(pendingGoalId!)).toBeUndefined();
+	});
+
 	test("retains the recoverable goal, gates, and lead when reservation release is refused", async ({ gateway, scope }) => {
 		const { ownerId, context } = await createPromotionCandidate(gateway, "refused-compensation");
 		const teamManager = gateway.teamManager as any;

--- a/tests2/integration/session-goal-promotion.test.ts
+++ b/tests2/integration/session-goal-promotion.test.ts
@@ -1,0 +1,120 @@
+import fs from "node:fs";
+import path from "node:path";
+import { randomUUID } from "node:crypto";
+
+import { test, expect } from "./_e2e/in-process-harness.js";
+import { copyGitTemplate } from "../harness/git-template.js";
+import { apiFetch, createSession, registerProject, waitForSessionStatus } from "./_e2e/e2e-setup.js";
+
+async function jsonResponse(response: Response): Promise<any> {
+	const text = await response.text();
+	return text ? JSON.parse(text) : {};
+}
+
+async function sessionRecord(id: string): Promise<any> {
+	const response = await apiFetch(`/api/sessions/${id}?include=archived`);
+	expect(response.status).toBe(200);
+	return jsonResponse(response);
+}
+
+test.describe("current-session goal promotion API", () => {
+	test("persists owner mode, rejects authority, and promotes exactly in place", async ({ gateway, scope }) => {
+		const projectRoot = path.join(gateway.bobbitDir, `promotion-api-${randomUUID()}`);
+		copyGitTemplate(projectRoot);
+		const project = await registerProject({
+			name: `promotion-api-${Date.now()}`,
+			rootPath: projectRoot,
+			components: [{ name: "app", repo: "." }],
+			workflows: {
+				general: {
+					name: "General",
+					description: "Promotion integration fixture",
+					gates: [{ id: "implementation", name: "Implementation", depends_on: [] }],
+				},
+			},
+		});
+		const ownerId = await createSession({ projectId: project.id, cwd: projectRoot });
+		await waitForSessionStatus(ownerId, "idle", 30_000);
+		const before = await sessionRecord(ownerId);
+		expect(before.worktreePath).toBeTruthy();
+		expect(before.branch).toBeTruthy();
+
+		const seed = await apiFetch(`/api/sessions/${ownerId}/proposal/goal/seed`, {
+			method: "POST",
+			body: JSON.stringify({
+				args: {
+					title: "Promote API owner",
+					spec: "Keep the exact session checkout.",
+					workflow: "general",
+					projectId: ownerId && before.projectId,
+				},
+			}),
+		});
+		expect(seed.status, await seed.text()).toBe(200);
+
+		const initialBody = await jsonResponse(await apiFetch(`/api/sessions/${ownerId}/proposal/goal/worktree-mode`));
+		expect(initialBody.mode).toBe("new-worktree");
+		expect(initialBody.eligibility.eligible, JSON.stringify(initialBody)).toBe(true);
+		expect(initialBody.eligibility.coordinates.branch).toBe(before.branch);
+		expect(initialBody.eligibility.coordinates.worktreePath).toBe(before.worktreePath);
+
+		const update = await apiFetch(`/api/sessions/${ownerId}/proposal/goal/worktree-mode`, {
+			method: "PUT",
+			body: JSON.stringify({ mode: "current-session" }),
+		});
+		expect(update.status).toBe(200);
+		expect((await jsonResponse(update)).mode).toBe("current-session");
+		const rawDraft = await (await apiFetch(`/api/sessions/${ownerId}/proposal/goal`)).text();
+		expect(rawDraft).toContain("worktreeMode: current-session");
+
+		const rejected = await apiFetch(`/api/sessions/${ownerId}/proposal/goal/accept`, {
+			method: "POST",
+			body: JSON.stringify({ title: "Attack", branch: "attacker/branch", worktreePath: "/tmp/attacker" }),
+		});
+		expect(rejected.status).toBe(400);
+		expect((await jsonResponse(rejected)).code).toBe("PROMOTION_AUTHORITY_REJECTED");
+
+		const runner = gateway.sessionManager.commandRunner;
+		const worktree = before.worktreePath as string;
+		const staged = path.join(worktree, "promotion-staged.txt");
+		const untracked = path.join(worktree, "promotion-untracked.txt");
+		fs.writeFileSync(staged, "staged before promotion\n");
+		fs.writeFileSync(untracked, "untracked before promotion\n");
+		await runner.execFile("git", ["add", path.basename(staged)], { cwd: worktree });
+		const statusBefore = String((await runner.execFile("git", ["status", "--porcelain"], { cwd: worktree })).stdout);
+
+		const accepted = await apiFetch(`/api/sessions/${ownerId}/proposal/goal/accept`, {
+			method: "POST",
+			body: JSON.stringify({ title: "Promote API owner", spec: "Keep the exact session checkout." }),
+		});
+		expect(accepted.status, await accepted.clone().text()).toBe(201);
+		const goal = await jsonResponse(accepted);
+		scope.trackGoal(goal.id);
+		expect(goal.worktreeOwnerSessionId).toBe(ownerId);
+		expect(goal.worktreePath).toBe(before.worktreePath);
+		expect(goal.branch).toBe(before.branch);
+		expect(goal.setupStatus).toBe("ready");
+
+		const after = await sessionRecord(ownerId);
+		expect(after.id).toBe(ownerId);
+		expect(after.goalId).toBe(goal.id);
+		expect(after.teamGoalId).toBe(goal.id);
+		expect(after.role).toBe("team-lead");
+		expect(after.worktreePath).toBe(before.worktreePath);
+		expect(after.branch).toBe(before.branch);
+		expect(fs.readFileSync(staged, "utf8")).toBe("staged before promotion\n");
+		expect(fs.readFileSync(untracked, "utf8")).toBe("untracked before promotion\n");
+		expect(String((await runner.execFile("git", ["status", "--porcelain"], { cwd: worktree })).stdout)).toBe(statusBefore);
+
+		const retry = await apiFetch(`/api/sessions/${ownerId}/proposal/goal/accept`, {
+			method: "POST",
+			body: JSON.stringify({ title: "Promote API owner", spec: "retry" }),
+		});
+		expect(retry.status).toBe(201);
+		expect((await jsonResponse(retry)).id).toBe(goal.id);
+		const goalsBody = await jsonResponse(await apiFetch("/api/goals"));
+		const goals = Array.isArray(goalsBody) ? goalsBody : goalsBody.goals;
+		expect(goals.filter((candidate: any) => candidate.worktreeOwnerSessionId === ownerId)).toHaveLength(1);
+		expect((await apiFetch(`/api/sessions/${ownerId}/proposal/goal`)).status).toBe(404);
+	});
+});

--- a/tests2/integration/session-goal-promotion.test.ts
+++ b/tests2/integration/session-goal-promotion.test.ts
@@ -5,6 +5,7 @@ import { randomUUID } from "node:crypto";
 import { test, expect } from "./_e2e/in-process-harness.js";
 import { copyGitTemplate } from "../harness/git-template.js";
 import { apiFetch, createSession, registerProject, waitForSessionStatus } from "./_e2e/e2e-setup.js";
+import { SandboxSessionFilesystem } from "../harness/sandbox-session-filesystem.js";
 
 async function jsonResponse(response: Response): Promise<any> {
 	const text = await response.text();
@@ -184,5 +185,154 @@ test.describe("current-session goal promotion API", () => {
 		expect(permittedPurge.status).toBe(200);
 		const sessionsAfterPurge = await jsonResponse(await apiFetch("/api/sessions?include=archived"));
 		expect(sessionsAfterPurge.sessions.some((session: any) => session.id === ownerId)).toBe(false);
+	});
+
+	test("probes a sandbox owner's transcript in its container realm before promotion", async ({ gateway, scope }) => {
+		const projectRoot = path.join(gateway.bobbitDir, `promotion-sandbox-${randomUUID()}`);
+		copyGitTemplate(projectRoot);
+		const project = await registerProject({
+			name: `promotion-sandbox-${Date.now()}`,
+			rootPath: projectRoot,
+			components: [{ name: "app", repo: "." }],
+		});
+		const ownerId = await createSession({ projectId: project.id, cwd: projectRoot });
+		await waitForSessionStatus(ownerId, "idle", 30_000);
+
+		const manager = gateway.sessionManager as any;
+		const sandboxManager = manager.sandboxManager as any;
+		const live = manager.getSession(ownerId) as any;
+		const persisted = manager.getPersistedSession(ownerId) as any;
+		expect(live).toBeTruthy();
+		expect(persisted).toBeTruthy();
+
+		const branch = `session/promotion-sandbox-${randomUUID().slice(0, 8)}`;
+		const worktreePath = `/workspace-wt/${branch}`;
+		const transcriptPath = `/home/node/.bobbit/agent/sessions/--workspace--/${ownerId}.jsonl`;
+		const containerId = `promotion-container-${randomUUID()}`;
+		const sandboxFs = new SandboxSessionFilesystem({
+			root: path.join(gateway.bobbitDir, `promotion-container-fs-${randomUUID()}`),
+			hostAgentSessionsDir: path.join(gateway.bobbitDir, "agent-sessions"),
+		});
+		const baseExec = sandboxFs.exec.bind(sandboxFs);
+		const sandbox = sandboxFs as any;
+		sandbox.getStatus = () => ({ status: "ready", projectId: project.id, containerId });
+		sandbox.getContainerId = async () => containerId;
+		sandbox.exec = async (args: string[]) => {
+			if (args[0] === "git" && args[1] === "branch" && args[2] === "--show-current") return `${branch}\n`;
+			if (args[0] === "git" && args[1] === "rev-parse" && args[2] === "--is-inside-work-tree") return "true\n";
+			return baseExec(args);
+		};
+
+		const store = manager.getSessionStore(project.id);
+		store.update(ownerId, {
+			agentSessionFile: transcriptPath,
+			cwd: worktreePath,
+			worktreePath,
+			repoPath: "/workspace",
+			branch,
+			sandboxed: true,
+		});
+		Object.assign(live, {
+			cwd: worktreePath,
+			worktreePath,
+			repoPath: "/workspace",
+			branch,
+			sandboxed: true,
+			containerId,
+		});
+		live.rpcClient.getState = async () => ({ success: true, data: { sessionFile: transcriptPath } });
+
+		const originalGet = sandboxManager.get.bind(sandboxManager);
+		const originalEnsure = sandboxManager.ensureForProject.bind(sandboxManager);
+		const originalApplySandboxWiring = manager.applySandboxWiring.bind(manager);
+		let provisioningCalls = 0;
+		let acceptedGoalId: string | undefined;
+		sandboxManager.get = (candidateProjectId: string) => candidateProjectId === project.id ? sandbox : originalGet(candidateProjectId);
+		sandboxManager.ensureForProject = async () => { provisioningCalls += 1; throw new Error("promotion must not provision a sandbox"); };
+		manager.applySandboxWiring = async (options: any) => {
+			options.sandboxed = true;
+			options.containerId = containerId;
+			return true;
+		};
+
+		try {
+			const seed = await apiFetch(`/api/sessions/${ownerId}/proposal/goal/seed`, {
+				method: "POST",
+				body: JSON.stringify({
+					args: {
+						title: "Promote sandbox owner",
+						spec: "Keep the exact sandbox session.",
+						workflow: "general",
+						projectId: project.id,
+					},
+				}),
+			});
+			expect(seed.status, await seed.clone().text()).toBe(200);
+
+			const missing = await jsonResponse(await apiFetch(`/api/sessions/${ownerId}/proposal/goal/worktree-mode`));
+			expect(missing.eligibility).toMatchObject({ eligible: false, code: "TRANSCRIPT_UNAVAILABLE" });
+			expect(sandboxFs.calls.some(call => call.args[0] === "test" && call.args[1] === "-f" && call.args[2] === transcriptPath)).toBe(true);
+
+			const transcriptHostPath = sandboxFs.hostPath(transcriptPath);
+			fs.mkdirSync(path.dirname(transcriptHostPath), { recursive: true });
+			fs.writeFileSync(transcriptHostPath, '{"type":"message","message":{"role":"user","content":"sandbox history"}}\n');
+
+			const projection = await jsonResponse(await apiFetch(`/api/sessions/${ownerId}/proposal/goal/worktree-mode`));
+			expect(projection.eligibility.eligible, JSON.stringify(projection)).toBe(true);
+			expect(projection.eligibility.coordinates).toMatchObject({
+				branch,
+				worktreePath,
+				sandboxed: true,
+			});
+
+			const selection = await apiFetch(`/api/sessions/${ownerId}/proposal/goal/worktree-mode`, {
+				method: "PUT",
+				body: JSON.stringify({ mode: "current-session" }),
+			});
+			expect(selection.status, await selection.clone().text()).toBe(200);
+			const sessionCountBefore = (await jsonResponse(await apiFetch("/api/sessions?include=archived"))).sessions
+				.filter((session: any) => session.projectId === project.id).length;
+
+			const accepted = await apiFetch(`/api/sessions/${ownerId}/proposal/goal/accept`, {
+				method: "POST",
+				body: JSON.stringify({ title: "Promote sandbox owner", spec: "Keep the exact sandbox session." }),
+			});
+			expect(accepted.status, await accepted.clone().text()).toBe(201);
+			const goal = await jsonResponse(accepted);
+			acceptedGoalId = goal.id;
+			scope.trackGoal(goal.id);
+
+			const promoted = manager.getSession(ownerId);
+			expect(promoted.id).toBe(ownerId);
+			expect(promoted.containerId).toBe(containerId);
+			expect(promoted.worktreePath).toBe(worktreePath);
+			expect(promoted.branch).toBe(branch);
+			expect(manager.getPersistedSession(ownerId).agentSessionFile).toBe(transcriptPath);
+			expect(goal).toMatchObject({
+				worktreeOwnerSessionId: ownerId,
+				worktreePath,
+				branch,
+				sandboxed: true,
+			});
+			const sessionCountAfter = (await jsonResponse(await apiFetch("/api/sessions?include=archived"))).sessions
+				.filter((session: any) => session.projectId === project.id).length;
+			expect(sessionCountAfter).toBe(sessionCountBefore);
+			expect(provisioningCalls).toBe(0);
+			expect(sandboxFs.calls.some(call => call.args[0] === "mkdir" || (call.args[0] === "git" && call.args.includes("worktree")))).toBe(false);
+
+			const archived = await apiFetch(`/api/goals/${goal.id}?cascade=true`, { method: "DELETE" });
+			expect(archived.status, await archived.clone().text()).toBe(200);
+			acceptedGoalId = undefined;
+			const purged = await apiFetch(`/api/sessions/${ownerId}?purge=true`, { method: "DELETE" });
+			expect(purged.status, await purged.clone().text()).toBe(200);
+		} finally {
+			if (acceptedGoalId) {
+				await apiFetch(`/api/goals/${acceptedGoalId}?cascade=true`, { method: "DELETE" }).catch(() => undefined);
+				await apiFetch(`/api/sessions/${ownerId}?purge=true`, { method: "DELETE" }).catch(() => undefined);
+			}
+			manager.applySandboxWiring = originalApplySandboxWiring;
+			sandboxManager.ensureForProject = originalEnsure;
+			sandboxManager.get = originalGet;
+		}
 	});
 });

--- a/tests2/integration/session-goal-promotion.test.ts
+++ b/tests2/integration/session-goal-promotion.test.ts
@@ -166,6 +166,100 @@ test.describe("current-session goal promotion API", () => {
 		});
 	});
 
+	test("keeps a committed lead attached when finalization fails, then finalizes the exact goal on retry", async ({ gateway, scope }) => {
+		const { ownerId, context } = await createPromotionCandidate(gateway, "finalizer-retry");
+		const teamManager = gateway.teamManager as any;
+		const originalFinalize = teamManager.finalizeAdoptedLead;
+		let finalizeCalls = 0;
+		teamManager.finalizeAdoptedLead = async () => {
+			finalizeCalls += 1;
+			throw new Error("forced post-commit finalizer failure");
+		};
+
+		let failed: Response;
+		try {
+			failed = await apiFetch(`/api/sessions/${ownerId}/proposal/goal/accept`, {
+				method: "POST",
+				body: JSON.stringify({ title: "Promote finalizer retry" }),
+			});
+		} finally {
+			teamManager.finalizeAdoptedLead = originalFinalize;
+		}
+		expect(failed!.status).toBe(400);
+		expect(finalizeCalls).toBe(1);
+		const retained = context.goalStore.getAll().filter((goal: any) => goal.worktreeOwnerSessionId === ownerId && !goal.archived);
+		expect(retained).toHaveLength(1);
+		const goal = retained[0];
+		scope.trackGoal(goal.id);
+		expect(goal.state).toBe("todo");
+		expect(await sessionRecord(ownerId)).toMatchObject({
+			goalId: goal.id,
+			teamGoalId: goal.id,
+			role: "team-lead",
+		});
+		expect(gateway.teamManager.getTeamState(goal.id)).toMatchObject({ teamLeadSessionId: ownerId, agents: [] });
+		expect((await apiFetch(`/api/sessions/${ownerId}/proposal/goal`)).status).toBe(200);
+
+		const retry = await apiFetch(`/api/sessions/${ownerId}/proposal/goal/accept`, {
+			method: "POST",
+			body: JSON.stringify({ title: "Promote finalizer retry" }),
+		});
+		expect(retry.status, await retry.clone().text()).toBe(201);
+		expect((await jsonResponse(retry)).id).toBe(goal.id);
+		expect(context.goalStore.get(goal.id)?.state).toBe("in-progress");
+		expect(gateway.teamManager.getTeamState(goal.id)).toMatchObject({ teamLeadSessionId: ownerId, agents: [] });
+		expect(context.goalStore.getAll().filter((candidate: any) => candidate.worktreeOwnerSessionId === ownerId)).toHaveLength(1);
+		expect((await apiFetch(`/api/sessions/${ownerId}/proposal/goal`)).status).toBe(404);
+	});
+
+	test("rejects archive before mutation while promotion is in flight, then permits ordered archive", async ({ gateway }) => {
+		const { ownerId, context } = await createPromotionCandidate(gateway, "archive-flight");
+		const sessionManager = gateway.sessionManager as any;
+		const originalPromote = sessionManager.promoteToGoalLead;
+		let releasePromotion!: () => void;
+		const promotionBlocked = new Promise<void>(resolve => { releasePromotion = resolve; });
+		let enteredPromotion!: () => void;
+		const promotionEntered = new Promise<void>(resolve => { enteredPromotion = resolve; });
+		sessionManager.promoteToGoalLead = async (...args: any[]) => {
+			enteredPromotion();
+			await promotionBlocked;
+			return originalPromote.apply(sessionManager, args);
+		};
+
+		const acceptance = apiFetch(`/api/sessions/${ownerId}/proposal/goal/accept`, {
+			method: "POST",
+			body: JSON.stringify({ title: "Promote archive flight" }),
+		});
+		let pendingGoal: any;
+		let accepted: Response;
+		let released = false;
+		try {
+			await promotionEntered;
+			pendingGoal = context.goalStore.getAll().find((goal: any) => goal.worktreeOwnerSessionId === ownerId && !goal.archived);
+			expect(pendingGoal).toBeTruthy();
+			const gatesBefore = context.gateStore.getGatesForGoal(pendingGoal.id).length;
+			const archive = await apiFetch(`/api/goals/${pendingGoal.id}?cascade=true&mergedManually=true`, { method: "DELETE" });
+			expect(archive.status).toBe(409);
+			expect((await jsonResponse(archive)).code).toBe("PROMOTION_IN_PROGRESS");
+			expect(context.goalStore.get(pendingGoal.id)).toMatchObject({ state: "todo" });
+			expect(context.goalStore.get(pendingGoal.id)?.archived).not.toBe(true);
+			expect(context.gateStore.getGatesForGoal(pendingGoal.id)).toHaveLength(gatesBefore);
+			expect(gateway.teamManager.getTeamState(pendingGoal.id)).toMatchObject({ teamLeadSessionId: ownerId, agents: [] });
+
+			releasePromotion();
+			released = true;
+			accepted = await acceptance;
+		} finally {
+			if (!released) releasePromotion();
+			sessionManager.promoteToGoalLead = originalPromote;
+		}
+		expect(accepted!.status, await accepted!.clone().text()).toBe(201);
+		expect(context.goalStore.get(pendingGoal.id)?.state).toBe("in-progress");
+		const archived = await apiFetch(`/api/goals/${pendingGoal.id}?cascade=true`, { method: "DELETE" });
+		expect(archived.status, await archived.clone().text()).toBe(200);
+		expect(context.goalStore.get(pendingGoal.id)?.archived).toBe(true);
+	});
+
 	test("persists owner mode, rejects authority, and promotes exactly in place", async ({ gateway, scope }) => {
 		const projectRoot = path.join(gateway.bobbitDir, `promotion-api-${randomUUID()}`);
 		copyGitTemplate(projectRoot);
@@ -261,6 +355,7 @@ test.describe("current-session goal promotion API", () => {
 		expect(goal.worktreePath).toBe(before.worktreePath);
 		expect(goal.branch).toBe(before.branch);
 		expect(goal.setupStatus).toBe("ready");
+		expect(goal.state).toBe("in-progress");
 
 		const after = await sessionRecord(ownerId);
 		expect(after.id).toBe(ownerId);
@@ -324,6 +419,75 @@ test.describe("current-session goal promotion API", () => {
 		expect(permittedPurge.status).toBe(200);
 		const sessionsAfterPurge = await jsonResponse(await apiFetch("/api/sessions?include=archived"));
 		expect(sessionsAfterPurge.sessions.some((session: any) => session.id === ownerId)).toBe(false);
+	});
+
+	test("preserves a real two-component worktree set through archive and removes it on final purge", async ({ gateway }) => {
+		const projectRoot = path.join(gateway.bobbitDir, `promotion-multi-${randomUUID()}`);
+		fs.mkdirSync(projectRoot, { recursive: true });
+		copyGitTemplate(path.join(projectRoot, "alpha"));
+		copyGitTemplate(path.join(projectRoot, "packages", "beta"));
+		const project = await registerProject({
+			name: `promotion-multi-${Date.now()}`,
+			rootPath: projectRoot,
+			components: [
+				{ name: "alpha", repo: "alpha" },
+				{ name: "beta", repo: "packages/beta" },
+			],
+			workflows: {
+				general: {
+					name: "General",
+					description: "Multi-repo promotion fixture",
+					gates: [{ id: "implementation", name: "Implementation", depends_on: [] }],
+				},
+			},
+		});
+		const ownerId = await createSession({ projectId: project.id, cwd: projectRoot });
+		await waitForSessionStatus(ownerId, "idle", 30_000);
+		const before = await sessionRecord(ownerId);
+		const repoWorktrees = before.repoWorktrees as Record<string, string>;
+		expect(Object.keys(repoWorktrees).sort()).toEqual(["alpha", "packages/beta"]);
+		const componentPaths = Object.values(repoWorktrees);
+		for (const componentPath of componentPaths) expect(fs.existsSync(componentPath)).toBe(true);
+		expect(fs.existsSync(path.join(before.worktreePath, ".git"))).toBe(false);
+
+		const seed = await apiFetch(`/api/sessions/${ownerId}/proposal/goal/seed`, {
+			method: "POST",
+			body: JSON.stringify({ args: {
+				title: "Promote multi-repo owner",
+				spec: "Keep both component worktrees.",
+				workflow: "general",
+				projectId: project.id,
+			} }),
+		});
+		expect(seed.status, await seed.clone().text()).toBe(200);
+		const selected = await apiFetch(`/api/sessions/${ownerId}/proposal/goal/worktree-mode`, {
+			method: "PUT",
+			body: JSON.stringify({ mode: "current-session" }),
+		});
+		expect(selected.status, await selected.clone().text()).toBe(200);
+		const accepted = await apiFetch(`/api/sessions/${ownerId}/proposal/goal/accept`, {
+			method: "POST",
+			body: JSON.stringify({ title: "Promote multi-repo owner" }),
+		});
+		expect(accepted.status, await accepted.clone().text()).toBe(201);
+		const goal = await jsonResponse(accepted);
+		expect(goal.repoWorktrees).toEqual(repoWorktrees);
+		expect((await sessionRecord(ownerId)).repoWorktrees).toEqual(repoWorktrees);
+
+		const archived = await apiFetch(`/api/goals/${goal.id}?cascade=true`, { method: "DELETE" });
+		expect(archived.status, await archived.clone().text()).toBe(200);
+		for (const componentPath of componentPaths) expect(fs.existsSync(componentPath)).toBe(true);
+		expect(fs.existsSync(before.worktreePath)).toBe(true);
+		const inventory = await jsonResponse(await apiFetch("/api/maintenance/archived-session-worktrees?includeAlreadyCleaned=1"));
+		const archivedSource = inventory.sessions.find((session: any) => session.id === ownerId);
+		expect(archivedSource?.worktrees).toHaveLength(2);
+		expect(new Set(archivedSource.worktrees.map((item: any) => item.path))).toEqual(new Set(componentPaths));
+		expect(archivedSource.worktrees.every((item: any) => item.disposition !== "protected")).toBe(true);
+
+		const purged = await apiFetch(`/api/sessions/${ownerId}?purge=true`, { method: "DELETE" });
+		expect(purged.status, await purged.clone().text()).toBe(200);
+		for (const componentPath of componentPaths) expect(fs.existsSync(componentPath)).toBe(false);
+		expect(fs.existsSync(before.worktreePath)).toBe(false);
 	});
 
 	test("probes a sandbox owner's transcript in its container realm before promotion", async ({ gateway, scope }) => {

--- a/tests2/tests-map.json
+++ b/tests2/tests-map.json
@@ -3392,6 +3392,10 @@
       "type": "smoke-journey"
     },
     {
+      "path": "tests2/browser/journeys/session-goal-promotion.journey.spec.ts",
+      "type": "smoke-journey"
+    },
+    {
       "path": "tests2/browser/journeys/session-lifecycle.journey.spec.ts",
       "type": "smoke-journey"
     },

--- a/tests2/tests-map.json
+++ b/tests2/tests-map.json
@@ -30,6 +30,60 @@
       }
     },
     {
+      "path": "tests2/core/session-goal-promotion-proposal.test.ts",
+      "reason": "Core coverage for legacy-default proposal compatibility, durable current-session selection, snapshots, archive continuation, validation, and server-owned coordinate authority.",
+      "execution": {
+        "runner": "vitest",
+        "tier": "unit",
+        "project": "core"
+      }
+    },
+    {
+      "path": "tests2/core/session-goal-promotion-eligibility.test.ts",
+      "reason": "Core policy coverage for current-session promotion eligibility, canonical coordinates, forbidden relationships, workspace conflicts, multi-repo fidelity, and sandbox reachability.",
+      "execution": {
+        "runner": "vitest",
+        "tier": "unit",
+        "project": "core"
+      }
+    },
+    {
+      "path": "tests2/core/session-goal-promotion-session-runtime.test.ts",
+      "reason": "Core runtime coverage for staged same-session role replacement, identity and sandbox continuity, exact rollback, and serialized idempotent promotion.",
+      "execution": {
+        "runner": "vitest",
+        "tier": "unit",
+        "project": "core"
+      }
+    },
+    {
+      "path": "tests2/dom/session-goal-promotion-panel.test.ts",
+      "reason": "DOM coverage for the accessible New worktree and Current session selector, authoritative coordinate projection, unavailable reasons, and owner-scoped acceptance dispatch.",
+      "execution": {
+        "runner": "vitest",
+        "tier": "unit",
+        "project": "dom"
+      }
+    },
+    {
+      "path": "tests2/integration/session-goal-promotion.test.ts",
+      "reason": "Integration coverage for owner-scoped worktree-mode routes, authority rejection, in-place acceptance, idempotency, coordinate continuity, and proposal cleanup.",
+      "execution": {
+        "runner": "vitest",
+        "tier": "unit",
+        "project": "integration"
+      }
+    },
+    {
+      "path": "tests2/browser/journeys/session-goal-promotion.journey.spec.ts",
+      "reason": "Browser journey for selecting Current session, accepting in place with the original session, reload continuity, unavailable reasons, safe archive, and unchanged new-worktree creation.",
+      "execution": {
+        "runner": "playwright",
+        "tier": "browser",
+        "project": "browser"
+      }
+    },
+    {
       "path": "tests2/integration/strict-update-body-routes.test.ts",
       "reason": "Regression contract for strict finite-shape update bodies: exact route allow-lists, accepted representative updates, unknown-key rejection, no mutation, goal policy guidance, and immutable staff sandboxing.",
       "execution": {


### PR DESCRIPTION
## Summary
- add New worktree / Current session selection to goal proposals with authoritative eligibility and byte-compatible defaults
- promote the proposal-owning regular session in place while preserving its ID, transcript, checkout, multi-repo coordinates, sandbox, and dirty work
- add idempotent lead adoption, active-team finalization, restart recovery, lifecycle reservations, cleanup guards, and ordered archival
- document the feature and owner-scoped REST endpoints

## Testing
- full implementation workflow: build, type-check, unit, browser, E2E, conformance, integrated review, security review, and QA
- focused promotion integration: 8 cases
- focused browser journey: 3 cases with real gateway restart and cleanup
- affected-test inventory: 184 tests

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)