### PR TITLE
fix(agent): keep read_session schema Bedrock-compatible

### DIFF
--- a/defaults/tools/agent/extension.ts
+++ b/defaults/tools/agent/extension.ts
@@ -351,6 +351,9 @@ const extension: ExtensionFactory = (pi) => {
 			if (p.operation === "inspect" && (p.pattern !== undefined || p.case_sensitive !== undefined || p.context !== undefined)) {
 				return fail("read_session inspect does not accept list filtering fields");
 			}
+			if (p.operation === "inspect" && p.result_index === undefined && (p.offset !== undefined || p.limit !== undefined)) {
+				return fail("read_session inspect offset/limit require result_index");
+			}
 			if (p.operation === "inspect" && typeof p.offset === "number" && p.offset < 0) {
 				return fail("read_session inspect offset must be >= 0");
 			}

--- a/defaults/tools/agent/extension.ts
+++ b/defaults/tools/agent/extension.ts
@@ -325,32 +325,38 @@ const extension: ExtensionFactory = (pi) => {
 			"Use operation:'inspect' with one message_index for semantic message detail",
 			"Add one result_index only when you need that exact result excerpt; continue with offset and limit",
 		],
-		parameters: Type.Union([
-			Type.Object({
-				operation: Type.Literal("list"),
-				session_id: Type.String(),
-				offset: Type.Optional(Type.Integer({ description: "Default 0. Negative indexes from end." })),
-				limit: Type.Optional(Type.Integer({ minimum: 1, maximum: 200, description: "Default 20." })),
-				pattern: Type.Optional(Type.String({ description: "Regex filter on message text and tool diagnostics." })),
-				case_sensitive: Type.Optional(Type.Boolean()),
-				context: Type.Optional(Type.Integer({ minimum: 0, maximum: 5, description: "Expand each match by ±N neighbours." })),
-			}, { additionalProperties: false }),
-			Type.Object({
-				operation: Type.Literal("inspect"),
-				session_id: Type.String(),
-				message_index: Type.Integer({ minimum: 0 }),
-			}, { additionalProperties: false }),
-			Type.Object({
-				operation: Type.Literal("inspect"),
-				session_id: Type.String(),
-				message_index: Type.Integer({ minimum: 0 }),
-				result_index: Type.Integer({ minimum: 0 }),
-				offset: Type.Optional(Type.Integer({ minimum: 0, description: "Character offset. Default 0." })),
-				limit: Type.Optional(Type.Integer({ minimum: 1, maximum: 8_000, description: "Excerpt characters. Default 2000." })),
-			}, { additionalProperties: false }),
-		]),
+		// Bedrock requires every tool's top-level input schema to be an object.
+		// Keep the list/inspect discriminator inside that object and enforce the
+		// operation-specific required fields in execute.
+		parameters: Type.Object({
+			operation: Type.Union([Type.Literal("list"), Type.Literal("inspect")]),
+			session_id: Type.String(),
+			offset: Type.Optional(Type.Integer({ description: "List: message offset (negative from end). Inspect result: character offset." })),
+			limit: Type.Optional(Type.Integer({ minimum: 1, maximum: 8_000, description: "List: messages (max 200). Inspect: excerpt characters (max 8000)." })),
+			pattern: Type.Optional(Type.String({ description: "List only: regex filter on message text and tool diagnostics." })),
+			case_sensitive: Type.Optional(Type.Boolean({ description: "List only." })),
+			context: Type.Optional(Type.Integer({ minimum: 0, maximum: 5, description: "List only: expand matches by ±N neighbours." })),
+			message_index: Type.Optional(Type.Integer({ minimum: 0, description: "Required for inspect." })),
+			result_index: Type.Optional(Type.Integer({ minimum: 0, description: "Inspect only: select one tool result." })),
+		}, { additionalProperties: false }),
 
 		async execute(_toolCallId, params) {
+			const p = params as Record<string, unknown>;
+			if (p.operation === "inspect" && !Number.isInteger(p.message_index)) {
+				return fail("read_session inspect requires message_index");
+			}
+			if (p.operation === "list" && (p.message_index !== undefined || p.result_index !== undefined)) {
+				return fail("read_session list does not accept message_index/result_index");
+			}
+			if (p.operation === "inspect" && (p.pattern !== undefined || p.case_sensitive !== undefined || p.context !== undefined)) {
+				return fail("read_session inspect does not accept list filtering fields");
+			}
+			if (p.operation === "inspect" && typeof p.offset === "number" && p.offset < 0) {
+				return fail("read_session inspect offset must be >= 0");
+			}
+			if (p.operation === "list" && typeof p.limit === "number" && p.limit > 200) {
+				return fail("read_session list limit must be <= 200");
+			}
 			let result: { ok: boolean; status: number; body: any };
 			try {
 				result = await callReadSessionEndpoint(params as ReadSessionParams);

--- a/tests2/core/focused-tool-contract-refresh.test.ts
+++ b/tests2/core/focused-tool-contract-refresh.test.ts
@@ -520,13 +520,17 @@ describe("focused tool contract refresh", () => {
 		const providerSchemas = JSON.parse(JSON.stringify({ bobbit_read: bobbitTool.parameters, read_session: readSession.parameters }));
 		assert.equal(JSON.stringify(providerSchemas).includes("verbose"), false);
 		assert.equal(providerSchemas.bobbit_read.additionalProperties, false);
-		assert.ok(providerSchemas.read_session.anyOf.every((branch: any) => branch.additionalProperties === false));
+		assert.equal(providerSchemas.read_session.type, "object");
+		assert.equal(providerSchemas.read_session.additionalProperties, false);
 		const validate = (tool: any, args: Record<string, unknown>) => validateToolArguments(tool, {
 			type: "toolCall", id: "validate", name: tool.name, arguments: args,
 		});
 		assert.deepEqual(validate(readSession, { operation: "list", session_id: ps.id }), { operation: "list", session_id: ps.id });
 		assert.deepEqual(validate(readSession, { operation: "inspect", session_id: ps.id, message_index: 1 }), { operation: "inspect", session_id: ps.id, message_index: 1 });
-		assert.throws(() => validate(readSession, { operation: "list", session_id: ps.id, message_index: 1 }));
+		await assert.rejects(
+			() => readSession.execute("invalid", { operation: "list", session_id: ps.id, message_index: 1 }),
+			/read_session list does not accept message_index\/result_index/,
+		);
 		assert.throws(() => validate(bobbitTool, { operation: "health", verbose: true }), /Unrecognized field: verbose/);
 
 		process.env.BOBBIT_GATEWAY_URL = "https://focused-runtime.invalid";

--- a/tests2/core/read-session-extension.test.ts
+++ b/tests2/core/read-session-extension.test.ts
@@ -37,7 +37,9 @@ describe("read_session discriminated tool contract", () => {
 			{ operation: "list", session_id: "s", message_index: 1 },
 			{ operation: "inspect", session_id: "s", message_index: 1, pattern: "x" },
 			{ operation: "inspect", session_id: "s", message_index: 1, context: 1 },
-			{ operation: "inspect", session_id: "s", message_index: 1, offset: -1 },
+			{ operation: "inspect", session_id: "s", message_index: 1, offset: 1 },
+			{ operation: "inspect", session_id: "s", message_index: 1, limit: 40 },
+			{ operation: "inspect", session_id: "s", message_index: 1, result_index: 0, offset: -1 },
 			{ operation: "list", session_id: "s", limit: 201 },
 		]) {
 			const result = await tool.execute("invalid", value);

--- a/tests2/core/read-session-extension.test.ts
+++ b/tests2/core/read-session-extension.test.ts
@@ -17,12 +17,32 @@ describe("read_session discriminated tool contract", () => {
 		registerAgentExtension({ registerTool(config: any) { if (config.name === "read_session") tool = config; } } as any);
 	});
 	afterAll(() => { globalThis.fetch = realFetch; for (const [key, value] of Object.entries(previous)) value === undefined ? delete process.env[key] : process.env[key] = value; });
-	it("accepts only the closed list and exact inspect variants", () => {
-		const cases: [boolean, any[]][] = [
-			[true, [{ operation: "list", session_id: "s", offset: -20, limit: 20, pattern: "error", case_sensitive: true, context: 2 }, { operation: "inspect", session_id: "s", message_index: 7 }, { operation: "inspect", session_id: "s", message_index: 7, result_index: 1, offset: 5, limit: 40 }]],
-			[false, [{ session_id: "s" }, { operation: "inspect", session_id: "s" }, ...["verbose", "include_tool_results", "includeToolResults"].map((flag) => ({ operation: "list", session_id: "s", [flag]: true })), { operation: "list", session_id: "s", message_index: 1 }, { operation: "inspect", session_id: "s", message_index: 1, pattern: "x" }, { operation: "inspect", session_id: "s", message_index: 1, context: 1 }]],
-		];
-		for (const [expected, values] of cases) for (const value of values) assert.equal(Value.Check(tool.parameters, value), expected, JSON.stringify(value));
+	it("uses a Bedrock-valid top-level object schema", () => {
+		assert.equal(tool.parameters.type, "object");
+		for (const value of [
+			{ operation: "list", session_id: "s", offset: -20, limit: 20, pattern: "error", case_sensitive: true, context: 2 },
+			{ operation: "inspect", session_id: "s", message_index: 7 },
+			{ operation: "inspect", session_id: "s", message_index: 7, result_index: 1, offset: 5, limit: 40 },
+		]) assert.equal(Value.Check(tool.parameters, value), true, JSON.stringify(value));
+		for (const value of [
+			{ session_id: "s" },
+			{ operation: "other", session_id: "s" },
+			...["verbose", "include_tool_results", "includeToolResults"].map((flag) => ({ operation: "list", session_id: "s", [flag]: true })),
+		]) assert.equal(Value.Check(tool.parameters, value), false, JSON.stringify(value));
+	});
+
+	it("enforces operation-specific closed variants at runtime", async () => {
+		for (const value of [
+			{ operation: "inspect", session_id: "s" },
+			{ operation: "list", session_id: "s", message_index: 1 },
+			{ operation: "inspect", session_id: "s", message_index: 1, pattern: "x" },
+			{ operation: "inspect", session_id: "s", message_index: 1, context: 1 },
+			{ operation: "inspect", session_id: "s", message_index: 1, offset: -1 },
+			{ operation: "list", session_id: "s", limit: 201 },
+		]) {
+			const result = await tool.execute("invalid", value);
+			assert.equal(result.isError, true, JSON.stringify(value));
+		}
 	});
 
 	it("forwards list discovery and exact-result bounds without compatibility flags", async () => {


### PR DESCRIPTION
## Summary
- expose read_session with a Bedrock-compatible top-level object schema
- enforce list and inspect mode constraints at runtime
- cover schema shape and runtime validation

## Tests
- npm run check
- npx vitest run tests2/core/read-session-extension.test.ts

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)