### PR TITLE
fix(review): keep review_open schema Bedrock-compatible

### DIFF
--- a/defaults/tools/review/extension.ts
+++ b/defaults/tools/review/extension.ts
@@ -44,24 +44,18 @@ const reviewFileSchema = Type.Union([
 	}, { additionalProperties: false }),
 ]);
 
-const reviewOpenSchema = Type.Union([
-	Type.Object({
-		...commonOpenProperties,
-		markdown: Type.String({ description: "Inline Markdown content." }),
-	}, { additionalProperties: false }),
-	Type.Object({
-		...commonOpenProperties,
-		file: Type.String({ description: "Path to a Markdown file on disk." }),
-	}, { additionalProperties: false }),
-	Type.Object({
-		...commonOpenProperties,
-		files: Type.Array(reviewFileSchema, {
-			minItems: 1,
-			maxItems: MAX_REVIEW_FILES,
-			description: "Ordered Markdown files belonging to this review.",
-		}),
-	}, { additionalProperties: false }),
-]);
+// Bedrock requires every tool's top-level input schema to be an object.
+// The runtime validator below keeps the three source modes mutually exclusive.
+const reviewOpenSchema = Type.Object({
+	...commonOpenProperties,
+	markdown: Type.Optional(Type.String({ description: "Inline Markdown content." })),
+	file: Type.Optional(Type.String({ description: "Path to a Markdown file on disk." })),
+	files: Type.Optional(Type.Array(reviewFileSchema, {
+		minItems: 1,
+		maxItems: MAX_REVIEW_FILES,
+		description: "Ordered Markdown files belonging to this review.",
+	})),
+}, { additionalProperties: false });
 
 type ReviewFileInput = { title?: string; markdown: string } | { title?: string; file: string };
 type ReviewOpenInput =

--- a/scripts/affected/impact-rules.mjs
+++ b/scripts/affected/impact-rules.mjs
@@ -768,7 +768,7 @@ export const DYNAMIC_EXECUTABLE_CONSUMER_AUDIT = Object.freeze([
 	{
 		consumer: "tests2/core/tool-description-budget.test.ts",
 		operations: frozen([
-			declaredExecutableOperation("import-meta-glob", "\"../../defaults/tools/{agent,ask,bobbit,browser,html,images,inbox,mcp,proposals,review,shell,skills,tasks,team,web}/extension.ts\"", ["impact:builtin-tools"]),
+			declaredExecutableOperation("import-meta-glob", "\"../../defaults/tools/*/extension.ts\"", ["impact:builtin-tools"]),
 		]),
 	},
 	{

--- a/tests2/core/review-extension.test.ts
+++ b/tests2/core/review-extension.test.ts
@@ -212,22 +212,22 @@ describe("review_open durable receipt contract", () => {
 		assert.equal(uploads.length, 0);
 	});
 
-	it("publishes a closed schema with exactly one source mode and bounded file count", () => {
+	it("publishes a Bedrock-valid closed object schema with bounded file inputs", () => {
 		const schema = reviewOpen.parameters;
+		assert.equal(schema.type, "object");
 		const valid = [
+			{},
 			{ markdown: "" },
 			{ file: "architecture.md" },
+			{ markdown: "inline", file: "architecture.md" },
 			{ title: "Bundle", replace: false, files: [{ markdown: "one" }] },
 			{ files: [{ title: "Inline", markdown: "one" }, { file: "notes.md" }] },
 		];
 		for (const params of valid) assert.equal(Value.Check(schema, params), true, JSON.stringify(params));
 
 		const invalid = [
-			{},
-			{ markdown: "inline", file: "architecture.md" },
 			{ files: [] },
 			{ files: Array.from({ length: MAX_REVIEW_FILES + 1 }, () => ({ markdown: "x" })) },
-			{ markdown: "inline", files: [{ markdown: "nested" }] },
 			{ files: [{}] },
 			{ files: [{ markdown: "nested", file: "notes.md" }] },
 			{ files: [{ markdown: 42 }] },
@@ -240,6 +240,8 @@ describe("review_open durable receipt contract", () => {
 		const invalid = [
 			{},
 			{ markdown: "inline", file: "architecture.md" },
+			{ markdown: "inline", files: [{ markdown: "nested" }] },
+			{ file: "architecture.md", files: [{ file: "notes.md" }] },
 			{ files: [] },
 			{ files: Array.from({ length: MAX_REVIEW_FILES + 1 }, () => ({ markdown: "x" })) },
 			{ files: [{}] },

--- a/tests2/core/tool-description-budget.test.ts
+++ b/tests2/core/tool-description-budget.test.ts
@@ -51,7 +51,10 @@ const EXTENSION_GROUPS = [
 
 // Vite resolves this eager glob into static module imports in one transform pass.
 // Unlike sequential import(url), extension discovery has no per-group async tax.
-const EXTENSION_MODULES = import.meta.glob<{ default: ExtensionFactory }>(
+const EXTENSION_MODULES = import.meta.glob<{
+	default: ExtensionFactory;
+	installBrowserTools?: (pi: any, backend: { ensurePage(): Promise<never>; cleanup(): Promise<void> }) => void;
+}>(
 	"../../defaults/tools/*/extension.ts",
 	{ eager: true },
 );
@@ -113,7 +116,26 @@ beforeAll(() => {
 
 	for (const [modulePath, module] of Object.entries(EXTENSION_MODULES)) {
 		assert.ok(typeof module.default === "function", `${modulePath} has no callable default export`);
-		captureTools(module.default, modulePath, bedrockCaptured);
+		if (modulePath.endsWith("/browser/extension.ts") && module.installBrowserTools) {
+			// Unit forks intentionally cannot require Playwright. Inject the browser
+			// extension's supported inert backend so its schemas still enter the inventory.
+			module.installBrowserTools({
+				registerTool(def: any) {
+					bedrockCaptured.push({
+						name: def?.name ?? "<unnamed>",
+						description: def?.description,
+						parameters: def?.parameters,
+						source: modulePath,
+					});
+				},
+				on() {},
+			}, {
+				ensurePage: async () => { throw new Error("schema inventory does not execute browser tools"); },
+				cleanup: async () => {},
+			});
+		} else {
+			captureTools(module.default, modulePath, bedrockCaptured);
+		}
 	}
 
 	assert.ok(captured.length >= 13, `expected at least 13 tools registered, got ${captured.length}`);
@@ -164,6 +186,12 @@ function collectAllDescriptions(
 }
 
 describe("default tool provider schema compatibility", () => {
+	it("captures tools from every discovered default extension", () => {
+		const coveredSources = new Set(bedrockCaptured.map((tool) => tool.source));
+		const missing = Object.keys(EXTENSION_MODULES).filter((modulePath) => !coveredSources.has(modulePath));
+		assert.deepEqual(missing, [], `default extension(s) registered no tools under the inventory fixture: ${missing.join(", ")}`);
+	});
+
 	it("every default tool has a Bedrock-compatible top-level object input schema", () => {
 		const violations = bedrockCaptured
 			.filter((tool) => !tool.parameters || typeof tool.parameters !== "object" || (tool.parameters as any).type !== "object")

--- a/tests2/core/tool-description-budget.test.ts
+++ b/tests2/core/tool-description-budget.test.ts
@@ -14,14 +14,14 @@ guardProcessEnv();
  * regress.
  *
  * Limits:
+ *   - every default tool schema has a top-level `type: "object"` for Bedrock
  *   - tool.description.length            ≤ 150 chars
  *   - JSON Schema property description   ≤  80 chars (recursive)
  *   - buildMetaToolDescription output    ≤ 150 chars, no inlined op enumeration
  *
- * The first two are checked by importing each `defaults/tools/<group>/extension.ts`
- * with a fake `pi` that captures every `registerTool({...})` invocation. The
- * third hits `buildMetaToolDescription` directly with a synthetic 50-op list of
- * long names.
+ * The schema guard imports every `defaults/tools/<group>/extension.ts`. The
+ * description checks cover the budgeted group list below. The final checks hit
+ * `buildMetaToolDescription` directly with a synthetic 50-op list of long names.
  */
 
 import { describe, it, beforeAll } from "vitest";
@@ -52,7 +52,7 @@ const EXTENSION_GROUPS = [
 // Vite resolves this eager glob into static module imports in one transform pass.
 // Unlike sequential import(url), extension discovery has no per-group async tax.
 const EXTENSION_MODULES = import.meta.glob<{ default: ExtensionFactory }>(
-	"../../defaults/tools/{agent,ask,bobbit,browser,html,images,inbox,mcp,proposals,review,shell,skills,tasks,team,web}/extension.ts",
+	"../../defaults/tools/*/extension.ts",
 	{ eager: true },
 );
 
@@ -67,6 +67,23 @@ interface CapturedTool {
 }
 
 const captured: CapturedTool[] = [];
+const bedrockCaptured: CapturedTool[] = [];
+
+function captureTools(factory: ExtensionFactory, source: string, destination: CapturedTool[]): void {
+	factory({
+		registerTool(def: any) {
+			destination.push({
+				name: def?.name ?? "<unnamed>",
+				description: def?.description,
+				parameters: def?.parameters,
+				source,
+			});
+		},
+		on() {
+			// no-op — we don't drive the lifecycle in this test
+		},
+	});
+}
 
 beforeAll(() => {
 	// Ensure staff-gated tools (inbox) register so their descriptions are budget-checked.
@@ -77,6 +94,10 @@ beforeAll(() => {
 	if (!process.env.BOBBIT_SESSION_ID) {
 		process.env.BOBBIT_SESSION_ID = "00000000-0000-0000-0000-000000000000";
 	}
+	if (!process.env.BOBBIT_GOAL_ID) {
+		process.env.BOBBIT_GOAL_ID = "00000000-0000-0000-0000-000000000000";
+	}
+	process.env.BOBBIT_BUILTIN_TOOLS = "edit,find,grep,ls,read,write";
 	// The bobbit extension gates on gateway credentials (not on a goal/session).
 	// Provide non-empty env creds so its three tools register and get budget-checked.
 	if (!process.env.BOBBIT_TOKEN) process.env.BOBBIT_TOKEN = "test-token";
@@ -87,23 +108,16 @@ beforeAll(() => {
 		const factory = EXTENSION_MODULES[modulePath]?.default;
 		assert.ok(typeof factory === "function", `${group}/extension.ts has no callable default export`);
 
-		const pi = {
-			registerTool(def: any) {
-				captured.push({
-					name: def?.name ?? "<unnamed>",
-					description: def?.description,
-					parameters: def?.parameters,
-					source: `${group}/extension.ts`,
-				});
-			},
-			on() {
-				// no-op — we don't drive the lifecycle in this test
-			},
-		};
-		factory(pi);
+		captureTools(factory, `${group}/extension.ts`, captured);
+	}
+
+	for (const [modulePath, module] of Object.entries(EXTENSION_MODULES)) {
+		assert.ok(typeof module.default === "function", `${modulePath} has no callable default export`);
+		captureTools(module.default, modulePath, bedrockCaptured);
 	}
 
 	assert.ok(captured.length >= 13, `expected at least 13 tools registered, got ${captured.length}`);
+	assert.ok(bedrockCaptured.length >= captured.length, "Bedrock schema inventory must cover every budgeted tool");
 });
 
 /** Walk a TypeBox / JSON Schema tree and collect every `description` string with a path. */
@@ -148,6 +162,19 @@ function collectAllDescriptions(
 	}
 	return out;
 }
+
+describe("default tool provider schema compatibility", () => {
+	it("every default tool has a Bedrock-compatible top-level object input schema", () => {
+		const violations = bedrockCaptured
+			.filter((tool) => !tool.parameters || typeof tool.parameters !== "object" || (tool.parameters as any).type !== "object")
+			.map((tool) => `  ${tool.source} :: ${tool.name}`);
+		assert.equal(
+			violations.length,
+			0,
+			`${violations.length} tool schema(s) do not declare top-level type \"object\":\n${violations.join("\n")}`,
+		);
+	});
+});
 
 describe("tool description budget", () => {
 	it("every registered tool has description.length <= 150", () => {


### PR DESCRIPTION
## Summary
- expose review_open with a Bedrock-compatible top-level object schema
- preserve mutually exclusive source modes through existing runtime validation
- guard every default tool against non-object top-level input schemas

## Tests
- npm run check
- npx vitest run tests2/core/review-extension.test.ts tests2/core/review-large-payload-receipt.test.ts tests2/core/tool-description-budget.test.ts

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)