### PR TITLE
Fix manual workflow fixture seeds

### DIFF
--- a/tests/manual-integration/agent-tool-use.spec.ts
+++ b/tests/manual-integration/agent-tool-use.spec.ts
@@ -63,17 +63,18 @@ const HAS_DOCKER = hasDocker();
 // Project registration body
 // ---------------------------------------------------------------------------
 function projectRegistrationBody(name: string, rootPath: string, opts: { upsert?: boolean } = {}) {
+	const commands = {
+		build: "echo build ok",
+		check: "echo check ok",
+		unit: "echo unit ok",
+		e2e: "echo e2e ok",
+	};
 	const components = [{
 		name,
 		repo: ".",
-		commands: {
-			build: "echo build ok",
-			check: "echo check ok",
-			unit: "echo unit ok",
-			e2e: "echo e2e ok",
-		},
+		commands,
 	}];
-	const workflows = buildDefaultWorkflows(name);
+	const workflows = buildDefaultWorkflows(name, Object.keys(commands));
 	return { name, rootPath, components, workflows, ...opts };
 }
 

--- a/tests/manual-integration/nested-project-root.spec.ts
+++ b/tests/manual-integration/nested-project-root.spec.ts
@@ -224,20 +224,21 @@ test.describe("Nested project root — integration", () => {
 		console.log(`  Gateway :${port}  repo=${repoRoot}  projectDir=${projectDir}`);
 
 		// 5. Register the project at the NESTED rootPath.
+		const commands = {
+			build: "echo build ok",
+			check: "echo check ok",
+			unit: "echo unit ok",
+			e2e: "echo e2e ok",
+		};
 		const body = {
 			name: "Nested Project",
 			rootPath: projectDir,
 			components: [{
 				name: "Nested Project",
 				repo: ".",
-				commands: {
-					build: "echo build ok",
-					check: "echo check ok",
-					unit: "echo unit ok",
-					e2e: "echo e2e ok",
-				},
+				commands,
 			}],
-			workflows: buildDefaultWorkflows("Nested Project"),
+			workflows: buildDefaultWorkflows("Nested Project", Object.keys(commands)),
 		};
 		const res = await api(gw, "/api/projects", { method: "POST", body: JSON.stringify(body) });
 		const txt = await res.text();

--- a/tests/manual-integration/poly-repo.spec.ts
+++ b/tests/manual-integration/poly-repo.spec.ts
@@ -270,9 +270,8 @@ test.describe("Poly Repo — integration", () => {
 		console.log(`  Gateway :${port}  rootPath=${rootPath}`);
 
 		// 5.  Register the multi-repo project.
-		// Default workflows reference one component name; pin them to repo1 (must
-		// match an entry in components[] or the project-config validator rejects).
-		const workflows = buildDefaultWorkflows("repo1");
+		// Pin workflows to repo1 and include only the commands that component supports.
+		const workflows = buildDefaultWorkflows("repo1", Object.keys(components[0].commands));
 		const body = {
 			name: "Poly Repo",
 			rootPath,

--- a/tests/manual-integration/reliable-agent-context-pressure.spec.ts
+++ b/tests/manual-integration/reliable-agent-context-pressure.spec.ts
@@ -252,20 +252,21 @@ function api(gateway: Gateway, path: string, init: RequestInit = {}): Promise<Re
 
 function projectRegistrationBody(rootPath: string): Record<string, unknown> {
 	const name = "Reliable context pressure";
+	const commands = {
+		build: "echo build ok",
+		check: "echo check ok",
+		unit: "echo unit ok",
+		e2e: "echo e2e ok",
+	};
 	return {
 		name,
 		rootPath,
 		components: [{
 			name,
 			repo: ".",
-			commands: {
-				build: "echo build ok",
-				check: "echo check ok",
-				unit: "echo unit ok",
-				e2e: "echo e2e ok",
-			},
+			commands,
 		}],
-		workflows: buildDefaultWorkflows(name),
+		workflows: buildDefaultWorkflows(name, Object.keys(commands)),
 	};
 }
 

--- a/tests/manual-integration/session-resilience.spec.ts
+++ b/tests/manual-integration/session-resilience.spec.ts
@@ -39,21 +39,17 @@ const PROJECT_ROOT = resolve(import.meta.dirname, "..", "..");
  * This helper mimics what `propose_project` would supply.
  */
 function projectRegistrationBody(name: string, rootPath: string, opts: { upsert?: boolean } = {}) {
-	// Component must declare every command name referenced by the seeded
-	// workflows (build/check/unit/e2e), otherwise validateAllWorkflows rejects
-	// the registration. Stub them with `echo ok` — these tests never run them
-	// to completion, only check goal creation and team start.
-	const components = [{
-		name,
-		repo: ".",
-		commands: {
-			build: "echo build ok",
-			check: "echo check ok",
-			unit: "echo unit ok",
-			e2e: "echo e2e ok",
-		},
-	}];
-	const workflows = buildDefaultWorkflows(name);
+	// Derive persisted workflows from the component's command map so unavailable
+	// canonical steps are filtered before validation. These commands are stubs —
+	// the scenarios only check goal creation and team start.
+	const commands = {
+		build: "echo build ok",
+		check: "echo check ok",
+		unit: "echo unit ok",
+		e2e: "echo e2e ok",
+	};
+	const components = [{ name, repo: ".", commands }];
+	const workflows = buildDefaultWorkflows(name, Object.keys(commands));
 	return { name, rootPath, components, workflows, ...opts };
 }
 const SERVER_CLI = join(PROJECT_ROOT, "dist", "server", "cli.js");


### PR DESCRIPTION
## Summary
- derive persisted default workflows from each manual fixture component command map
- filter unsupported browser steps without fake commands or validation changes
- preserve canonical one-argument workflow generation and inherited-model preflight behavior

## Validation
- `npx vitest run tests2/core/seed-default-workflows.test.ts`
- full implementation workflow: build, type check, unit, browser, E2E, conformance, implementation, and security reviews
- focused nested-root and poly-repo manual scenarios advanced past project registration

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)