### PR TITLE
Fix worktree ownership logs

### DIFF
--- a/docs/design/preserve-user-worktrees.md
+++ b/docs/design/preserve-user-worktrees.md
@@ -10,15 +10,29 @@ Related lifecycle details remain in [Async background cleanup](async-background-
 
 Bobbit previously treated worktree branch and directory naming as ownership proof. Boot sweeping, Maintenance cleanup, and pool startup reclaim could therefore repair, remove, or adopt a manually created worktree merely because it looked Bobbit-related.
 
-The fail-closed correction removes shape-based mutation and adoption. That exposes a separate orderly-restart lifecycle issue: gateway shutdown intentionally left ready pool entries on disk because the next process reclaimed them. Once startup reclaim is disabled, each successful restart would otherwise leave the old ready pool unreachable and create another target-sized pool.
+The fail-closed correction removes shape-based mutation and adoption. It also distinguishes intentionally retained archived-session worktrees from unverified discoveries. Without that distinction, boot diagnostics warn about worktrees whose durable session records already prove why they remain.
+
+A separate orderly-restart issue arises because startup no longer reclaims ready pool entries. Graceful shutdown therefore drains entries still owned by the running pool so successful restarts do not leave an unreachable pool behind.
 
 ## Ownership boundary
 
 Bobbit may mutate a discovered worktree only when an existing durable record proves its exact repository, worktree path, and non-empty branch. Branch naming, root placement, and Git discovery are diagnostic hints only.
 
+Host team workers persist those coordinates in the initial session record, for both single- and multi-repository worktrees. Recording ownership during creation, rather than relying on a later metadata update, closes the crash window in which a provisioned worktree could outlive an incomplete session record. Later metadata updates and dismissal/archive preserve the same coordinates so ownership evidence survives the worker lifecycle.
+
 A live `WorktreePool` has one additional, narrow source of authority: entries still held in that instance's private `pool` array. Those entries were created and tracked by the current process. A successful `claim()` removes its entry from the array before it becomes a session or goal worktree, so claimed worktrees are outside shutdown-drain authority.
 
 No filesystem scan, Git worktree discovery, branch-prefix test, or prior-process pool entry may populate the shutdown drain set.
+
+## Boot diagnostics and archived retention
+
+The boot sweep is diagnostic-only. It may inspect Git worktrees and durable ownership records, but it does not adopt, repair, clean, or delete a discovered worktree.
+
+An exact archived-session repository, worktree path, and branch identity means the worktree is retained as expected and is omitted from the ownership-unverified warning. Multi-repository sessions apply the same contract to each recorded component. This classification explains why the worktree remains; it does not grant the boot sweep mutation authority.
+
+Incomplete coordinates or any identity mismatch fail closed: they do not prove expected retention or authorize mutation. Naming, location, or a branch-only match cannot fill missing evidence, so such worktrees remain preserved and diagnostically unverified where reported.
+
+Archived sessions continue to retain their worktrees for review. Explicit Maintenance cleanup remains the operator-controlled cleanup path and keeps its existing preview, eligibility, and immediate identity-revalidation rules.
 
 ## Current design: graceful current-instance drain
 
@@ -60,7 +74,7 @@ This is deliberately best effort:
 - A claim failure may schedule best-effort cleanup after the entry leaves the ready array. That cleanup remains tracked by the same live pool, is local-only, and participates in the stop barrier.
 - A stop failure or timeout skips that pool's drain. A drain failure or timeout may leak affected ready entries. Either way, shutdown continues with later pools and teardown phases.
 - A hard crash, `SIGKILL`, forced timeout, or interrupted drain may also leave pool-shaped worktrees.
-- A later process does not adopt, repair, or delete any such leftover by shape. It remains an ownership-unverified diagnostic.
+- A later process does not adopt, repair, or delete any such leftover by shape. Unless an exact archived-session identity proves expected retention, it remains ownership-unverified.
 
 Repeated orderly restarts therefore avoid accumulating another target-sized set when their bounded local cleanup succeeds. Crash and timeout cleanup are not guaranteed.
 
@@ -68,10 +82,11 @@ Repeated orderly restarts therefore avoid accumulating another target-sized set 
 
 The graceful drain composes with the original correction:
 
-- `src/server/agent/worktree-sweeper.ts` scans and reports discovered orphans without repair, cleanup, or branch deletion.
-- `src/server/agent/worktree-inventory.ts` classifies unproven Git worktrees as non-actionable `needs-attention` diagnostics.
-- Archived-session cleanup requires an exact repository/path/non-empty-branch record and immediately revalidates the originally selected triple.
-- `src/server/agent/worktree-pool.ts::initialize()` does not discover or adopt pool entries by branch/path/root shape.
+- Boot discovery reports unverified worktrees without repair, cleanup, adoption, or branch deletion.
+- Exact durable archived-session identities are recognized as expected retention rather than unverified ownership.
+- Unproven Git worktrees remain non-actionable `needs-attention` diagnostics.
+- Archived-session cleanup requires an exact repository/path/non-empty-branch record and immediately revalidates the originally selected identity.
+- Pool initialization does not discover or adopt entries by branch, path, or root shape.
 
 Primary worktrees, live session/goal/team/staff records, delegates and shared paths, container paths, multi-repository component paths, and current-instance fill/claim/freshen behavior retain their existing protections.
 
@@ -96,25 +111,22 @@ A manifest remains viable as a separate goal if warm restart reuse becomes a req
 
 ## Implementation surface
 
-Production changes remain limited to:
+The implementation is contained in the session and team lifecycle, worktree discovery and inventory, pool lifecycle, and gateway startup/shutdown modules.
 
-- `src/server/agent/worktree-sweeper.ts`
-- `src/server/agent/worktree-inventory.ts`
-- `src/server/agent/worktree-pool.ts`
-- `src/server/server.ts`, only for the shutdown pool phase and obsolete explanation
-
-No new API, UI, durable state, provenance marker, locking framework, or manual deletion flow is introduced.
+It reuses existing session ownership fields and Maintenance cleanup. No new API, UI, durable store, provenance marker, locking framework, or manual deletion flow is introduced.
 
 ## Focused verification
 
-Add registered v2 coverage proving:
+Registered v2 coverage proves:
 
-1. Startup does not adopt or mutate an exact pool-shaped worktree discovered from Git/filesystem shape alone.
-2. Same-instance fill and claim continue to work.
-3. `drain()` cleans only entries still held by that instance; a claimed entry is excluded.
-4. Single- and multi-repository drain cleanup, plus tracked claim-failure cleanup, always receives `skipRemotePush: true`.
-5. Every pool's stop starts before the first gateway-shutdown drain, and each stop/drain operation is bounded to 15 seconds.
-6. A stop failure or timeout skips that pool's drain; a drain failure or timeout does not prevent later drains or subsequent shutdown phases.
-7. Bounded cleanup and existing explicit project-removal drain behavior are preserved.
+1. Host single-repository workers persist the complete ownership identity in their initial session record.
+2. An exact archived-session identity is expected retention, while incomplete or mismatched records remain unverified.
+3. Startup does not adopt or mutate an exact pool-shaped worktree discovered from Git/filesystem shape alone.
+4. Same-instance fill and claim continue to work.
+5. `drain()` cleans only entries still held by that instance; a claimed entry is excluded.
+6. Single- and multi-repository drain cleanup, plus tracked claim-failure cleanup, always receives `skipRemotePush: true`.
+7. Every pool's stop starts before the first gateway-shutdown drain, and each stop/drain operation is bounded.
+8. A stop failure or timeout skips that pool's drain; a drain failure or timeout does not prevent later drains or subsequent shutdown phases.
+9. Bounded cleanup and existing explicit project-removal drain behavior are preserved.
 
 Run the focused worktree suite and `npm run check`; full workflow verification remains authoritative for broader regression coverage.

--- a/src/server/agent/session-manager.ts
+++ b/src/server/agent/session-manager.ts
@@ -11800,9 +11800,9 @@ export class SessionManager {
 			borrowsWorktree: opts?.borrowsWorktree,
 			borrowedWorktreeOwnerSessionId: opts?.borrowedWorktreeOwnerSessionId,
 			sessionScopedAllowedTools,
-			// Prebuilt host multi-repo worktrees already have all ordinary-cleanup
-			// coordinates. Carry them into persistOnce instead of adding them only
-			// after createSession returns.
+			// Prebuilt host worktrees already have all ordinary-cleanup coordinates.
+			// Carry them into persistOnce instead of adding them only after
+			// createSession returns.
 			worktreePath: opts?.worktreePath,
 			repoPath: opts?.repoPath,
 			branch: opts?.branch,

--- a/src/server/agent/team-manager.ts
+++ b/src/server/agent/team-manager.ts
@@ -2510,14 +2510,14 @@ export class TeamManager {
 				undefined,
 				{
 					rolePrompt, roleName: role, workflowContext, sandboxed: memberSandboxed,
-					// A host multi-repo worker is already fully provisioned. Thread its
-					// ordinary-cleanup coordinates into createSession so the initial
-					// persisted session row owns them before createSession returns.
-					...(workerRepoWorktrees ? {
-						worktreePath: worktreeResult?.worktreePath,
+					// A host worker worktree is already fully provisioned. Thread every
+					// ownership coordinate into createSession so the initial persisted
+					// row proves its exact repo/path/branch identity before return.
+					...(worktreeResult && goal.repoPath ? {
+						worktreePath: worktreeResult.worktreePath,
 						repoPath: goal.repoPath,
 						branch: branchName,
-						repoWorktrees: workerRepoWorktrees,
+						...(workerRepoWorktrees ? { repoWorktrees: workerRepoWorktrees } : {}),
 					} : {}),
 					// Pass branch info so applySandboxWiring creates the worktree inside the container.
 					// The base branch is local-ref-first because sandbox goal branches may be unpublished.
@@ -2544,10 +2544,10 @@ export class TeamManager {
 				role,
 				teamGoalId: goalId,
 				worktreePath: actualWorktreePath,
-				...(workerRepoWorktrees ? {
+				...(worktreeResult && goal.repoPath ? {
 					repoPath: goal.repoPath,
 					branch: branchName,
-					repoWorktrees: workerRepoWorktrees,
+					...(workerRepoWorktrees ? { repoWorktrees: workerRepoWorktrees } : {}),
 				} : {}),
 				accessory: roleAccessory,
 				teamLeadSessionId: entry.teamLeadSessionId ?? undefined,
@@ -2883,11 +2883,9 @@ export class TeamManager {
 			this.sessionManager.updateSessionMeta(sessionId, {
 				worktreePath: agent.worktreePath,
 				teamGoalId: goalId,
-				...(agent.repoWorktrees ? {
-					repoPath: goal.repoPath,
-					branch: agent.branch,
-					repoWorktrees: agent.repoWorktrees,
-				} : {}),
+				repoPath: goal.repoPath,
+				branch: agent.branch,
+				...(agent.repoWorktrees ? { repoWorktrees: agent.repoWorktrees } : {}),
 			} as any);
 			// Store repo coordinates for later purge cleanup. Multi-repo workers
 			// retain their component map so purge never probes the branch container.

--- a/src/server/agent/worktree-sweeper.ts
+++ b/src/server/agent/worktree-sweeper.ts
@@ -72,6 +72,7 @@ export interface SweepRecord {
 	branch?: string;
 	worktreePath?: string;
 	cwd?: string;
+	repoPath?: string;
 	archived?: boolean;
 	/** Per-repo worktree paths (multi-repo). Each is treated as separately owned. */
 	repoWorktrees?: Record<string, string>;
@@ -133,7 +134,7 @@ function ownershipPaths(ownership: SweepOwnership): Array<string | undefined> {
 		...ownership.sessions,
 		...(ownership.teams ?? []),
 		...ownership.staff,
-	].flatMap(record => [record.worktreePath, record.cwd, ...Object.values(record.repoWorktrees ?? {})]);
+	].flatMap(record => [record.repoPath, record.worktreePath, record.cwd, ...Object.values(record.repoWorktrees ?? {})]);
 }
 
 type SweepFs = Pick<RecoveryFs, "access"> & { realpath?: (value: string) => Promise<string> };
@@ -152,20 +153,27 @@ interface SweptWorktree extends ParsedWorktree {
 interface OwnershipGuards {
 	ownedBranches: Set<string>;
 	ownedPaths: Set<string>;
-	archivedBranches: Set<string>;
+	archivedIdentities: Set<string>;
 	teamContainerPaths: Set<string>;
 	branchToExpectedPath: Map<string, string>;
 	allRecords: SweepRecord[];
 }
 
+function worktreeIdentityKey(repoPath: string | undefined, worktreePath: string | undefined, branch: string | undefined, aliases: CanonicalPaths): string | undefined {
+	const repo = canonicalPath(repoPath, aliases);
+	const worktree = canonicalPath(worktreePath, aliases);
+	return repo && worktree && branch ? `${repo}\0${worktree}\0${branch}` : undefined;
+}
+
 function buildOwnershipGuards(ownership: SweepOwnership, aliases: CanonicalPaths = new Map()): OwnershipGuards {
 	const ownedBranches = new Set<string>();
 	const ownedPaths = new Set<string>();
-	const archivedBranches = new Set<string>();
+	const archivedIdentities = new Set<string>();
 	const teamContainerPaths = new Set<string>();
 	const branchToExpectedPath = new Map<string, string>();
 	const teamRecords = (ownership.teams ?? []).map(rec => ({ ...rec, archived: false }));
 	const teamIds = new Set(teamRecords.map(rec => rec.id));
+	const archivedSessionRecords = new Set(ownership.sessions.filter(rec => rec.archived));
 	const allRecords = [...ownership.goals, ...ownership.sessions, ...teamRecords, ...ownership.staff];
 	const addPathAliases = (paths: Set<string>, value: string | undefined): string | undefined => {
 		const lexical = normalize(value);
@@ -176,7 +184,23 @@ function buildOwnershipGuards(ownership: SweepOwnership, aliases: CanonicalPaths
 	};
 	for (const rec of allRecords) {
 		if (rec.archived) {
-			if (rec.branch) archivedBranches.add(rec.branch);
+			// Only archived sessions are retained for review. Archived goals and
+			// other record types do not prove that a leftover is expected here.
+			if (!archivedSessionRecords.has(rec)) continue;
+			if (rec.repoWorktrees && rec.repoPath && rec.branch) {
+				for (const [repo, worktreePath] of Object.entries(rec.repoWorktrees)) {
+					const key = worktreeIdentityKey(
+						repo === "." ? rec.repoPath : path.join(rec.repoPath, repo),
+						worktreePath,
+						rec.branch,
+						aliases,
+					);
+					if (key) archivedIdentities.add(key);
+				}
+			} else {
+				const key = worktreeIdentityKey(rec.repoPath, rec.worktreePath, rec.branch, aliases);
+				if (key) archivedIdentities.add(key);
+			}
 			continue;
 		}
 		if (rec.branch) ownedBranches.add(rec.branch);
@@ -201,7 +225,7 @@ function buildOwnershipGuards(ownership: SweepOwnership, aliases: CanonicalPaths
 			Object.entries(record.repoWorktrees).map(([repo, worktreePath]) => [repo, canonicalPath(worktreePath, aliases) ?? worktreePath]),
 		),
 	}));
-	return { ownedBranches, ownedPaths, archivedBranches, teamContainerPaths, branchToExpectedPath, allRecords: [...allRecords, ...canonicalRecords] };
+	return { ownedBranches, ownedPaths, archivedIdentities, teamContainerPaths, branchToExpectedPath, allRecords: [...allRecords, ...canonicalRecords] };
 }
 
 function ownershipForWorktree(
@@ -383,6 +407,15 @@ export async function sweepOrphanedWorktrees(opts: {
 				// Exact path ownership (including shared cwd, delegate, team-container,
 				// and multi-repo component guards) remains an ordinary protected row.
 				if (ownership.ownedByPath) {
+					outcomes.push({ kind: "none" });
+					continue;
+				}
+
+				// Archived-session retention is expected, not an ownership warning. An
+				// exact durable repo/path/branch triple proves where the worktree came
+				// from without granting this diagnostic-only sweeper mutation authority.
+				const archivedIdentity = worktreeIdentityKey(wt.repoPath, wt.path, branch, aliases);
+				if (archivedIdentity && initialGuards.archivedIdentities.has(archivedIdentity)) {
 					outcomes.push({ kind: "none" });
 					continue;
 				}

--- a/src/server/agent/worktree-sweeper.ts
+++ b/src/server/agent/worktree-sweeper.ts
@@ -187,10 +187,11 @@ function buildOwnershipGuards(ownership: SweepOwnership, aliases: CanonicalPaths
 			// Only archived sessions are retained for review. Archived goals and
 			// other record types do not prove that a leftover is expected here.
 			if (!archivedSessionRecords.has(rec)) continue;
-			if (rec.repoWorktrees && rec.repoPath && rec.branch) {
-				for (const [repo, worktreePath] of Object.entries(rec.repoWorktrees)) {
+			const repoWorktrees = Object.entries(rec.repoWorktrees ?? {});
+			if (repoWorktrees.length > 0) {
+				for (const [repo, worktreePath] of repoWorktrees) {
 					const key = worktreeIdentityKey(
-						repo === "." ? rec.repoPath : path.join(rec.repoPath, repo),
+						rec.repoPath ? (repo === "." ? rec.repoPath : path.join(rec.repoPath, repo)) : undefined,
 						worktreePath,
 						rec.branch,
 						aliases,

--- a/src/server/agent/worktree-sweeper.ts
+++ b/src/server/agent/worktree-sweeper.ts
@@ -9,7 +9,7 @@
  *   - Discovered worktrees without an exact durable identity are reported and
  *     preserved; branch or path shape never authorizes repair or cleanup.
  *
- * The sweeper runs once after the listener starts and may overlap pool fill.
+ * The sweeper runs once after the listener starts, before pool initialization.
  * It never mutates discovered Git worktrees or branches.
  */
 
@@ -371,9 +371,9 @@ export async function sweepOrphanedWorktrees(opts: {
 			| { kind: "reclaimed" }
 			| { kind: "needs-attention"; worktree: SweptWorktree; branch: string };
 
-		// Reconcile different repos in parallel, but keep worktrees within one repo
-		// sequential. This avoids concurrent Git metadata mutations in the same repo
-		// and prevents nested concurrency multiplication.
+		// Classify different repos in parallel, but keep worktrees within one repo
+		// sequential so diagnostic ordering stays deterministic and nested
+		// concurrency does not multiply.
 		const outcomesByRepo = await mapWithConcurrency(scans, RECOVERY_IO_CONCURRENCY, async (worktrees): Promise<SweepOutcome[]> => {
 			const outcomes: SweepOutcome[] = [];
 			for (const wt of worktrees) {

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -4725,8 +4725,8 @@ export function createGateway(config: GatewayConfig, deps?: GatewayDeps) {
 			// claim, which costs real CPU on tests that don't need git at all.
 			//
 			// Boot sweeper + pool fill run AFTER `server.listen()` as a background
-			// chain — the sweeper shells out to `git worktree list/repair` per repo
-			// with 10–15s timeouts, and the pool readiness check awaits `isGitRepo`
+			// chain — the sweeper shells out to `git worktree list` per repo with a
+			// 10s timeout, and the pool readiness check awaits `isGitRepo`
 			// per project. Doing them before listen used to leave the gateway
 			// unreachable for many seconds on installs with stale worktrees.
 			//
@@ -4774,8 +4774,8 @@ export function createGateway(config: GatewayConfig, deps?: GatewayDeps) {
 							const sessions: SweepOwnerSnapshot[] = [];
 							const teams: SweepOwnerSnapshot[] = [];
 							const staff: SweepOwnerSnapshot[] = [];
-							// Read the currently visible stores synchronously so no request can
-							// interleave between this snapshot and the sweeper's mutation call.
+							// Read the currently visible stores synchronously so diagnostic
+							// classification uses one internally consistent ownership snapshot.
 							for (const ctx of projectContextManager.visible()) {
 								if (ctx.project.id === HEADQUARTERS_PROJECT_ID || ctx.project.kind === "headquarters") continue;
 								for (const goal of ctx.goalStore.getAll()) {

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -2107,11 +2107,7 @@ export function createPreviewSessionOperationQueue(): PreviewSessionOperationQue
 	return { run, purge };
 }
 
-/**
- * Initialize post-listen project pools one at a time. Each pool owns the shared
- * candidate-level I/O ceiling during orphan reclaim, so project-level
- * parallelism here would multiply that bound across visible projects.
- */
+/** Initialize post-listen project pools in deterministic project order. */
 export async function initializeBootProjectPools<T>(
 	projects: readonly T[],
 	initialize: (project: T, index: number) => Promise<void>,
@@ -2204,16 +2200,15 @@ export async function drainWorktreePoolsForShutdown(
 }
 
 /**
- * Serialize the boot-time worktree ownership transition. The sweeper rechecks
- * live durable owners at every mutation boundary, while a pool entry must not
- * be exposed for claim (and renamed out of the pool namespace) until its scan
- * and deletion phase has settled. Both phases remain post-listen background work.
+ * Keep boot-time diagnostic discovery ahead of pool initialization so the
+ * sweeper observes one stable pre-fill inventory. Neither phase adopts or
+ * mutates worktrees discovered only from Git/path shape.
  */
 export async function coordinateBootWorktreeLifecycle(
-	runSweepDeletionPhase: () => Promise<void>,
+	runSweepDiscoveryPhase: () => Promise<void>,
 	initializePools: () => Promise<void>,
 ): Promise<void> {
-	await runSweepDeletionPhase();
+	await runSweepDiscoveryPhase();
 	await initializePools();
 }
 
@@ -4736,14 +4731,11 @@ export function createGateway(config: GatewayConfig, deps?: GatewayDeps) {
 			// unreachable for many seconds on installs with stale worktrees.
 			//
 			// Ownership ordering: the sweeper starts from a durable-owner snapshot
-			// for deterministic scan results, then refreshes visible project stores
-			// immediately before every repair or cleanup. Pool initialization still
-			// waits for the deletion phase so a claimed entry cannot be renamed out
-			// of the pool namespace while its old listing is being reconciled. Both
-			// phases run after listen(), so health and session requests remain
-			// available (sessions use the normal cold fallback until pools are ready).
-			// Project pools initialize sequentially afterwards so each reclaim scan
-			// exclusively owns the shared candidate-level I/O ceiling.
+			// for deterministic diagnostics. Pool initialization waits for discovery
+			// so the scan observes one stable pre-fill inventory; neither phase adopts
+			// worktrees based only on branch/path shape. Both phases run after listen(),
+			// so health and session requests remain available (sessions use the normal
+			// cold fallback until pools are ready).
 			const runBootBackgroundTasks = async (): Promise<void> => {
 				const t0 = Date.now();
 
@@ -4771,7 +4763,7 @@ export function createGateway(config: GatewayConfig, deps?: GatewayDeps) {
 					const tStart = Date.now();
 					try {
 						const { sweepOrphanedWorktrees } = await import("./agent/worktree-sweeper.js");
-						type SweepOwnerSnapshot = { id: string; branch?: string; worktreePath?: string; cwd?: string; archived?: boolean; repoWorktrees?: Record<string, string> };
+						type SweepOwnerSnapshot = { id: string; branch?: string; worktreePath?: string; cwd?: string; repoPath?: string; archived?: boolean; repoWorktrees?: Record<string, string> };
 						const snapshotSweepOwnership = (): {
 							goals: SweepOwnerSnapshot[];
 							sessions: SweepOwnerSnapshot[];
@@ -4788,13 +4780,13 @@ export function createGateway(config: GatewayConfig, deps?: GatewayDeps) {
 								if (ctx.project.id === HEADQUARTERS_PROJECT_ID || ctx.project.kind === "headquarters") continue;
 								for (const goal of ctx.goalStore.getAll()) {
 									goals.push({
-										id: goal.id, branch: goal.branch, worktreePath: goal.worktreePath, cwd: goal.cwd, archived: !!goal.archived,
+										id: goal.id, branch: goal.branch, worktreePath: goal.worktreePath, cwd: goal.cwd, repoPath: goal.repoPath, archived: !!goal.archived,
 										repoWorktrees: (goal as { repoWorktrees?: Record<string, string> }).repoWorktrees,
 									});
 								}
 								for (const session of ctx.sessionStore.getAll()) {
 									sessions.push({
-										id: session.id, branch: session.branch, worktreePath: session.worktreePath, cwd: session.cwd, archived: !!session.archived,
+										id: session.id, branch: session.branch, worktreePath: session.worktreePath, cwd: session.cwd, repoPath: session.repoPath, archived: !!session.archived,
 										repoWorktrees: session.repoWorktrees,
 									});
 								}
@@ -4812,7 +4804,7 @@ export function createGateway(config: GatewayConfig, deps?: GatewayDeps) {
 								}
 								for (const member of ctx.staffStore.getAll()) {
 									staff.push({
-										id: member.id, branch: member.branch, worktreePath: member.worktreePath, cwd: member.cwd,
+										id: member.id, branch: member.branch, worktreePath: member.worktreePath, cwd: member.cwd, repoPath: member.repoPath,
 										repoWorktrees: member.repoWorktrees,
 									});
 								}

--- a/tests2/core/team-manager.test.ts
+++ b/tests2/core/team-manager.test.ts
@@ -1864,6 +1864,21 @@ describe("TeamManager", () => {
 			assert.ok(session, "session should exist");
 			assert.equal(session.cwd, result.worktreePath, "session cwd should be the production-created worktree");
 			assert.equal(session.worktreePath, result.worktreePath, "session metadata should retain the member worktree");
+			assert.equal(session.repoPath, fixture.repoPath, "single-repo worker metadata must retain its source repository");
+			assert.equal(session.branch, agents[0].branch, "single-repo worker metadata must retain its exact branch");
+			assert.deepEqual(
+				{
+					worktreePath: session.createOpts.worktreePath,
+					repoPath: session.createOpts.repoPath,
+					branch: session.createOpts.branch,
+				},
+				{
+					worktreePath: result.worktreePath,
+					repoPath: fixture.repoPath,
+					branch: agents[0].branch,
+				},
+				"the initial persisted row must own the exact single-repo worktree identity before createSession returns",
+			);
 			assert.equal(session.rpcClient.prompt.mock.calls.length, 1);
 			assert.deepEqual(
 				sm.enqueuePrompt.mock.calls[0],

--- a/tests2/core/worktree-sweeper-multi.test.ts
+++ b/tests2/core/worktree-sweeper-multi.test.ts
@@ -396,7 +396,7 @@ describe("worktree-sweeper — bounded asynchronous sweep", () => {
 		assert.deepEqual(cleanupCalls, []);
 	});
 
-	it("does not report an exact archived-session worktree as ownership-unverified", async () => {
+	it("does not report an exact archived-session worktree with an empty component map as ownership-unverified", async () => {
 		const repo = path.resolve("virtual-archived-owner", "repo");
 		const worktreePath = path.resolve("virtual-archived-owner-wt", "worker");
 		const branch = "goal/archived/coder-abcd";
@@ -409,7 +409,7 @@ describe("worktree-sweeper — bounded asynchronous sweep", () => {
 			const result = await sweepOrphanedWorktrees({
 				projects: [{ id: "project", rootPath: repo }],
 				goals: [],
-				sessions: [{ id: "archived-worker", repoPath: repo, worktreePath, branch, archived: true }],
+				sessions: [{ id: "archived-worker", repoPath: repo, worktreePath, branch, archived: true, repoWorktrees: {} }],
 				staff: [],
 				fs: { access: async () => {} },
 				commandRunner: runner,
@@ -417,6 +417,42 @@ describe("worktree-sweeper — bounded asynchronous sweep", () => {
 
 			assert.deepEqual(result, { reclaimed: 0, cleaned: 0, repaired: 0 });
 			assert.deepEqual(log.mock.calls, [], "an exact archived repo/path/branch triple is expected retention, not an ownership warning");
+		} finally {
+			log.mockRestore();
+		}
+	});
+
+	it("reports an archived-session worktree when a non-empty component map mismatches its exact flat tuple", async () => {
+		const repo = path.resolve("virtual-archived-component-owner", "repo");
+		const worktreePath = path.resolve("virtual-archived-component-owner-wt", "worker");
+		const mismatchedWorktreePath = path.resolve("virtual-archived-component-owner-wt", "other-worker");
+		const branch = "goal/archived/coder-mismatch";
+		const { runner } = cannedRunner(new Map([[
+			repo,
+			[porcelainWorktree(repo, "master"), porcelainWorktree(worktreePath, branch)].join("\n"),
+		]]));
+		const log = vi.spyOn(console, "log").mockImplementation(() => {});
+		try {
+			const result = await sweepOrphanedWorktrees({
+				projects: [{ id: "project", rootPath: repo }],
+				goals: [],
+				sessions: [{
+					id: "archived-worker",
+					repoPath: repo,
+					worktreePath,
+					branch,
+					archived: true,
+					repoWorktrees: { ".": mismatchedWorktreePath },
+				}],
+				staff: [],
+				fs: { access: async () => {} },
+				commandRunner: runner,
+			});
+
+			assert.deepEqual(result, { reclaimed: 0, cleaned: 0, repaired: 0 });
+			assert.deepEqual(log.mock.calls, [[
+				`[sweeper] Preserved unverified worktree: ${worktreePath} (branch: ${branch}, repo: ${repo})`,
+			]], "a non-empty component map remains authoritative over an exact flat tuple");
 		} finally {
 			log.mockRestore();
 		}

--- a/tests2/core/worktree-sweeper-multi.test.ts
+++ b/tests2/core/worktree-sweeper-multi.test.ts
@@ -396,6 +396,32 @@ describe("worktree-sweeper — bounded asynchronous sweep", () => {
 		assert.deepEqual(cleanupCalls, []);
 	});
 
+	it("does not report an exact archived-session worktree as ownership-unverified", async () => {
+		const repo = path.resolve("virtual-archived-owner", "repo");
+		const worktreePath = path.resolve("virtual-archived-owner-wt", "worker");
+		const branch = "goal/archived/coder-abcd";
+		const { runner } = cannedRunner(new Map([[
+			repo,
+			[porcelainWorktree(repo, "master"), porcelainWorktree(worktreePath, branch)].join("\n"),
+		]]));
+		const log = vi.spyOn(console, "log").mockImplementation(() => {});
+		try {
+			const result = await sweepOrphanedWorktrees({
+				projects: [{ id: "project", rootPath: repo }],
+				goals: [],
+				sessions: [{ id: "archived-worker", repoPath: repo, worktreePath, branch, archived: true }],
+				staff: [],
+				fs: { access: async () => {} },
+				commandRunner: runner,
+			});
+
+			assert.deepEqual(result, { reclaimed: 0, cleaned: 0, repaired: 0 });
+			assert.deepEqual(log.mock.calls, [], "an exact archived repo/path/branch triple is expected retention, not an ownership warning");
+		} finally {
+			log.mockRestore();
+		}
+	});
+
 	it("preserves manually registered unverified worktrees inside and outside configured roots", async () => {
 		const { result, cleanupCalls, repairCalls } = await observeManualSweep("virtual-manual-worktrees");
 		assert.deepEqual({


### PR DESCRIPTION
## Summary
- persist exact single- and multi-repo worker ownership coordinates at initial session creation and before archive
- classify exact archived-session repo/path/branch identities as expected retention in the diagnostic boot sweep
- keep incomplete or mismatched metadata fail-closed and leave Maintenance cleanup behavior unchanged
- document the ownership and retention contract

## Testing
- `npm run build`
- `npm run check`
- `npm run test:unit`
- `npm run test:browser`
- `npm run test:e2e`
- focused TeamManager real-Git and worktree sweeper suites

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)
