### PR TITLE
Upgrade better-sqlite3 to 13.0.3

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -22,11 +22,15 @@
 #    node_modules/@earendil-works/pi-coding-agent/npm-shrinkwrap.json.
 # 3. Run `npm install --package-lock=true` while this file is out of the repo.
 # 4. Restore ONLY this .npmrc; never restore the deleted old shrinkwrap.
-# 5. Verify npm freshly extracted the selected-version coding-agent shrinkwrap,
+# 5. npm 10 and 11 strip better-sqlite3's published `gypfile: false` from
+#    regenerated lock metadata. Re-add the exact boolean field at
+#    packages["node_modules/better-sqlite3"].gypfile and parse-check it is false;
+#    without it `npm ci` synthesizes an unwanted node-gyp rebuild.
+# 6. Verify npm freshly extracted the selected-version coding-agent shrinkwrap,
 #    all three Pi packages are aligned exactly at 0.82.1, every protobufjs is
 #    7.6.5+, and root/non-shrinkwrapped ws is 8.21+; keep the shrinkwrap-owned
 #    brace-expansion@5.0.7 high advisory visible in audit reporting.
-# 6. Pack and install Bobbit in an empty project, then audit that consumer.
+# 7. Pack and install Bobbit in an empty project, then audit that consumer.
 #    Record the exact non-zero brace-expansion result for the approved 0.82.1
 #    exception. Any changed or additional finding, or unavailable audit service,
 #    remains blocking unless separately reviewed and explicitly accepted.

--- a/docs/design/gate-store-sqlite-persistence.md
+++ b/docs/design/gate-store-sqlite-persistence.md
@@ -33,7 +33,7 @@ The JSON adapter preserves the public API and whole-array fixture format. Produc
 
 ## Layout and schema
 
-The MVP pins `better-sqlite3` 12.11.1 and opens:
+The MVP pins `better-sqlite3` 13.0.3 and opens:
 
 ```text
 <project-root>/.bobbit/state/gates.sqlite

--- a/docs/design/gate-store-sqlite-persistence.md
+++ b/docs/design/gate-store-sqlite-persistence.md
@@ -224,7 +224,7 @@ The final ordered qualification ran without source edits on the exact close-fenc
 | `npm run test:browser` | Passed (381 s; 717 passed, 9 skipped; browser budget passed) |
 | `npm run test:e2e` | Passed (379 s; groups A, B, C, and D passed) |
 | `npm run test:bundle` | Passed (7 s; 2 files, 4 tests) |
-| Packed-consumer bundled-prebuild native/store smoke | Passed before the separate registry audit: direct binding load, native write/read/close, installed-store round trip, and handle cleanup |
+| Historical packed-consumer native `better-sqlite3` rebuild and write/read smoke (pre-v13 rebuild-era baseline) | Passed before the separate registry audit |
 
 A read-only snapshot of representative production gate state was copied into an owned temporary directory, migrated, closed, reopened, queried directly, and removed. Source, post-migration, reopened, and SQLite counts were all 16. Sorted composite identities and every per-gate payload hash matched, and the retired JSON backup was byte-exact. The sorted-identity SHA-256 was `0f06c43d044c35b6d40d2fb5f8aeab2efd7c5540a77d7d907b6e1a65d745eb5e`; the identity-plus-payload-hash manifest SHA-256 was `d3a5b491925f4f7941756e226edf4fabff3a283facc670cf361b8dad9e27d3e1`. Before and after the exercise, the live source remained byte-for-byte unchanged at SHA-256 `c1a015d2f28cebe27ceff104f230f133a213fd6644e7b8607fe2638ab5504240`, 44,685 bytes, with modification time `2026-08-07T07:55:00.694Z`.
 

--- a/docs/design/gate-store-sqlite-persistence.md
+++ b/docs/design/gate-store-sqlite-persistence.md
@@ -210,7 +210,7 @@ The memfs unit adapter continues to cover the public `GateStore` logic and JSON 
 - transient and persistent final-flush failures, shared concurrent-close outcomes, and handle release after persistent close and startup failures; and
 - the close mutation fence across every public mutator and reset variant, including durable pre-fence work, post-fence map/observer isolation, and strict-reset compensation.
 
-The packed-consumer test retains the existing npm rebuild invocation, but with `better-sqlite3` 13.0.3 packaging (`gypfile: false`, no install lifecycle, and bundled prebuilds) that step is effectively a harmless no-op. The meaningful check loads the bundled native binding and performs an in-memory create/write/read/close smoke.
+Packed-consumer qualification deliberately does not run `npm rebuild`. Although `better-sqlite3` 13.0.3 declares `gypfile: false`, has no install lifecycle, and ships bundled prebuilds, npm omits `gypfile: false` from lockfile and hidden-lockfile package metadata. A targeted rebuild can therefore synthesize a `node-gyp rebuild` lifecycle and attempt an unintended local source build. Qualification instead loads the installed bundled prebuild directly, performs an in-memory native create/write/read/close smoke, and exercises the installed goal and task stores through a durable write/read/reopen/close round trip. This tests the artifact consumers receive without replacing its native binding with a locally compiled binary.
 
 ## MVP landing qualification
 
@@ -224,7 +224,7 @@ The final ordered qualification ran without source edits on the exact close-fenc
 | `npm run test:browser` | Passed (381 s; 717 passed, 9 skipped; browser budget passed) |
 | `npm run test:e2e` | Passed (379 s; groups A, B, C, and D passed) |
 | `npm run test:bundle` | Passed (7 s; 2 files, 4 tests) |
-| Packed-consumer native `better-sqlite3` rebuild and write/read smoke | Passed before the separate registry audit |
+| Packed-consumer bundled-prebuild native/store smoke | Passed before the separate registry audit: direct binding load, native write/read/close, installed-store round trip, and handle cleanup |
 
 A read-only snapshot of representative production gate state was copied into an owned temporary directory, migrated, closed, reopened, queried directly, and removed. Source, post-migration, reopened, and SQLite counts were all 16. Sorted composite identities and every per-gate payload hash matched, and the retired JSON backup was byte-exact. The sorted-identity SHA-256 was `0f06c43d044c35b6d40d2fb5f8aeab2efd7c5540a77d7d907b6e1a65d745eb5e`; the identity-plus-payload-hash manifest SHA-256 was `d3a5b491925f4f7941756e226edf4fabff3a283facc670cf361b8dad9e27d3e1`. Before and after the exercise, the live source remained byte-for-byte unchanged at SHA-256 `c1a015d2f28cebe27ceff104f230f133a213fd6644e7b8607fe2638ab5504240`, 44,685 bytes, with modification time `2026-08-07T07:55:00.694Z`.
 

--- a/docs/design/gate-store-sqlite-persistence.md
+++ b/docs/design/gate-store-sqlite-persistence.md
@@ -210,7 +210,7 @@ The memfs unit adapter continues to cover the public `GateStore` logic and JSON 
 - transient and persistent final-flush failures, shared concurrent-close outcomes, and handle release after persistent close and startup failures; and
 - the close mutation fence across every public mutator and reset variant, including durable pre-fence work, post-fence map/observer isolation, and strict-reset compensation.
 
-The packed-consumer test also rebuilds the installed native dependency with lifecycle scripts enabled only for `better-sqlite3`, then loads the binding and executes an in-memory create/insert/select/close smoke.
+The packed-consumer test retains the existing npm rebuild invocation, but with `better-sqlite3` 13.0.3 packaging (`gypfile: false`, no install lifecycle, and bundled prebuilds) that step is effectively a harmless no-op. The meaningful check loads the bundled native binding and performs an in-memory create/write/read/close smoke.
 
 ## MVP landing qualification
 

--- a/docs/design/goal-task-store-sqlite-persistence.md
+++ b/docs/design/goal-task-store-sqlite-persistence.md
@@ -244,7 +244,7 @@ The test split keeps native setup focused:
 - lifecycle tests cover constructor cleanup and `ProjectContext`/`ProjectContextManager` close behavior; and
 - the daily E2E upgrade journey boots a real gateway from legacy per-project JSON, verifies collision-safe retirement, mutates and deletes through supported APIs, gracefully restarts, and directly inspects authoritative rows after shutdown.
 
-Packed-consumer qualification must rebuild/load the installed `better-sqlite3` binding and execute a native write/read/close smoke. That check belongs in bundle qualification rather than the general unit lane.
+Packed-consumer qualification retains the existing npm rebuild invocation, but with `better-sqlite3` 13.0.3 packaging (`gypfile: false`, no install lifecycle, and bundled prebuilds) that step is effectively a harmless no-op. The meaningful check loads the bundled native binding and performs an in-memory create/write/read/close smoke. That check belongs in bundle qualification rather than the general unit lane.
 
 ## Benchmark and qualification evidence
 

--- a/docs/design/goal-task-store-sqlite-persistence.md
+++ b/docs/design/goal-task-store-sqlite-persistence.md
@@ -244,7 +244,7 @@ The test split keeps native setup focused:
 - lifecycle tests cover constructor cleanup and `ProjectContext`/`ProjectContextManager` close behavior; and
 - the daily E2E upgrade journey boots a real gateway from legacy per-project JSON, verifies collision-safe retirement, mutates and deletes through supported APIs, gracefully restarts, and directly inspects authoritative rows after shutdown.
 
-Packed-consumer qualification retains the existing npm rebuild invocation, but with `better-sqlite3` 13.0.3 packaging (`gypfile: false`, no install lifecycle, and bundled prebuilds) that step is effectively a harmless no-op. The meaningful check loads the bundled native binding and performs an in-memory create/write/read/close smoke. That check belongs in bundle qualification rather than the general unit lane.
+Packed-consumer qualification deliberately does not run `npm rebuild`. Although `better-sqlite3` 13.0.3 declares `gypfile: false`, has no install lifecycle, and ships bundled prebuilds, npm omits `gypfile: false` from lockfile and hidden-lockfile package metadata. A targeted rebuild can therefore synthesize a `node-gyp rebuild` lifecycle and attempt an unintended local source build. Qualification instead loads the installed bundled prebuild directly, performs an in-memory native create/write/read/close smoke, and exercises the installed `GoalStore` and `TaskStore` through durable write/read/reopen/close round trips with handle cleanup. This tests the artifact consumers receive without replacing its native binding with a locally compiled binary. The check belongs in bundle qualification rather than the general unit lane.
 
 ## Benchmark and qualification evidence
 
@@ -285,7 +285,7 @@ The required sequence passed on baseline `de0fde14221bdb4ef0074aec89710258085fe5
 | `npm run test:browser` | Passed in 476 s; 718 passed, 8 skipped, 1 flaky retry; browser budget passed |
 | `npm run test:e2e` | Passed in 427 s; groups A, B, C, and D passed; browser phases passed 52 + 90 with 12 skipped; fidelity Vitest passed 181 with 1 skipped |
 | `npm run test:bundle` | Passed in 7 s; 2 files and 4 tests passed |
-| Packed-consumer native smoke | Passed during a 98 s packed-consumer run: native rebuild and binding load, GoalStore/TaskStore durable write/read, and handle cleanup |
+| Packed-consumer bundled-prebuild native/store smoke | Passed: direct binding load, native write/read/close, `GoalStore`/`TaskStore` durable write/read/reopen, and handle cleanup |
 
 The check-through-bundle sequence took 1,253 seconds (20m53s). The gate-store qualification document records a historical single run of 1,027 seconds (17m07s: 40/18/202/381/379/7 seconds by phase). That older run is an uncontrolled historical observation, not a causal baseline: suite contents, machine load, caches, and other conditions were not controlled between runs.
 

--- a/docs/design/goal-task-store-sqlite-persistence.md
+++ b/docs/design/goal-task-store-sqlite-persistence.md
@@ -285,7 +285,7 @@ The required sequence passed on baseline `de0fde14221bdb4ef0074aec89710258085fe5
 | `npm run test:browser` | Passed in 476 s; 718 passed, 8 skipped, 1 flaky retry; browser budget passed |
 | `npm run test:e2e` | Passed in 427 s; groups A, B, C, and D passed; browser phases passed 52 + 90 with 12 skipped; fidelity Vitest passed 181 with 1 skipped |
 | `npm run test:bundle` | Passed in 7 s; 2 files and 4 tests passed |
-| Packed-consumer bundled-prebuild native/store smoke | Passed: direct binding load, native write/read/close, `GoalStore`/`TaskStore` durable write/read/reopen, and handle cleanup |
+| Historical packed-consumer native smoke (pre-v13 rebuild-era baseline) | Passed during a 98 s packed-consumer run: native rebuild and binding load, `GoalStore`/`TaskStore` durable write/read, and handle cleanup |
 
 The check-through-bundle sequence took 1,253 seconds (20m53s). The gate-store qualification document records a historical single run of 1,027 seconds (17m07s: 40/18/202/381/379/7 seconds by phase). That older run is an uncontrolled historical observation, not a causal baseline: suite contents, machine load, caches, and other conditions were not controlled between runs.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@xterm/addon-fit": "^0.11.0",
         "@xterm/xterm": "^6.0.0",
         "acme-client": "^5.4.0",
-        "better-sqlite3": "12.11.1",
+        "better-sqlite3": "13.0.3",
         "docx-preview": "^0.3.7",
         "flexsearch": "0.8.158",
         "jsonc-parser": "^3.3.1",
@@ -6037,17 +6037,15 @@
       "license": "MIT"
     },
     "node_modules/better-sqlite3": {
-      "version": "12.11.1",
-      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.11.1.tgz",
-      "integrity": "sha512-dq9AtApgg5PGFtBzPFSBl3HZQjHok5gaQCM6zh2Yk0aSmDCs1CbnVI8/HgASQkNKsWFpseIO9beg5xxpYhbIfA==",
-      "hasInstallScript": true,
+      "version": "13.0.3",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-13.0.3.tgz",
+      "integrity": "sha512-RbOBxmLBG8uvFUc15X9+9SFemKcQ0WBuISBVkpuiaUB2qblC8UWlHEjdWVoZ8AdhSwmoEgsiXKfopX0CQxaACQ==",
       "license": "MIT",
       "dependencies": {
-        "bindings": "^1.5.0",
-        "prebuild-install": "^7.1.1"
+        "node-addon-api": "^8.0.0"
       },
       "engines": {
-        "node": "20.x || 22.x || 23.x || 24.x || 25.x || 26.x"
+        "node": ">=22"
       }
     },
     "node_modules/bignumber.js": {
@@ -6057,15 +6055,6 @@
       "license": "MIT",
       "engines": {
         "node": "*"
-      }
-    },
-    "node_modules/bindings": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-      "license": "MIT",
-      "dependencies": {
-        "file-uri-to-path": "1.0.0"
       }
     },
     "node_modules/bl": {
@@ -7070,12 +7059,6 @@
       "engines": {
         "node": "^12.20 || >= 14.13"
       }
-    },
-    "node_modules/file-uri-to-path": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-      "license": "MIT"
     },
     "node_modules/fill-range": {
       "version": "7.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6041,6 +6041,7 @@
       "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-13.0.3.tgz",
       "integrity": "sha512-RbOBxmLBG8uvFUc15X9+9SFemKcQ0WBuISBVkpuiaUB2qblC8UWlHEjdWVoZ8AdhSwmoEgsiXKfopX0CQxaACQ==",
       "license": "MIT",
+      "gypfile": false,
       "dependencies": {
         "node-addon-api": "^8.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/xterm": "^6.0.0",
     "acme-client": "^5.4.0",
-    "better-sqlite3": "12.11.1",
+    "better-sqlite3": "13.0.3",
     "docx-preview": "^0.3.7",
     "flexsearch": "0.8.158",
     "jsonc-parser": "^3.3.1",

--- a/scripts/release-packed-consumer-audit.mjs
+++ b/scripts/release-packed-consumer-audit.mjs
@@ -238,11 +238,6 @@ export function packedConsumerInstallArgs(tarballPath) {
 	return ["install", "--ignore-scripts", tarballPath];
 }
 
-/** Enable lifecycle scripts only for the one native dependency after isolated install. */
-export function packedConsumerNativeRebuildArgs() {
-	return ["rebuild", "better-sqlite3", "--foreground-scripts"];
-}
-
 function requireSuccess(label, result) {
 	if (result.code === 0) return;
 	throw new Error(
@@ -428,14 +423,6 @@ async function performPackedConsumerAudit(tempRoot, npmRunner, commandRunner) {
 	});
 	requireSuccess("clean consumer install", installed);
 	await stat(join(consumerDir, "package-lock.json"));
-
-	console.log("[audit:packed-consumer] Installing the packaged SQLite native binding...");
-	const rebuiltNative = await npmRunner(packedConsumerNativeRebuildArgs(), {
-		cwd: consumerDir,
-		env: { ...restrictedNpmEnv, npm_config_ignore_scripts: "false" },
-		timeoutMs: 5 * 60_000,
-	});
-	requireSuccess("packed SQLite native rebuild", rebuiltNative);
 
 	console.log("[audit:packed-consumer] Loading the packaged SQLite native binding...");
 	const sqliteSmoke = await commandRunner(process.execPath, ["-e", `

--- a/tests2/core/release-skill-preflight-order.test.ts
+++ b/tests2/core/release-skill-preflight-order.test.ts
@@ -9,7 +9,6 @@ import {
 	buildRestrictedNpmEnv,
 	evaluatePackedConsumerAudit,
 	packedConsumerInstallArgs,
-	packedConsumerNativeRebuildArgs,
 	packedConsumerPackArgs,
 	packedConsumerTempPrefix,
 	parseAuditJson,
@@ -773,7 +772,7 @@ describe("release skill pre-flight order", () => {
 });
 
 describe("packed-consumer audit subprocess isolation", () => {
-	it("disables lifecycle scripts for pack/install and enables only the targeted native rebuild", () => {
+	it("disables lifecycle scripts for pack and install", () => {
 		const packArgs = packedConsumerPackArgs("isolated-pack-dir");
 		assert.equal(packArgs[0], "pack");
 		assert.equal(packArgs.filter((arg: string) => arg === "--ignore-scripts").length, 1);
@@ -782,11 +781,6 @@ describe("packed-consumer audit subprocess isolation", () => {
 			"install",
 			"--ignore-scripts",
 			"bobbit.tgz",
-		]);
-		assert.deepEqual(packedConsumerNativeRebuildArgs(), [
-			"rebuild",
-			"better-sqlite3",
-			"--foreground-scripts",
 		]);
 	});
 
@@ -829,8 +823,6 @@ describe("packed-consumer audit subprocess isolation", () => {
 				result.stdout = "true\n";
 			} else if (args[0] === "install") {
 				writeFileSync(join(options.cwd, "package-lock.json"), "{}\n");
-			} else if (args[0] === "rebuild") {
-				assert.deepEqual(args, ["rebuild", "better-sqlite3", "--foreground-scripts"]);
 			} else if (args[0] === "audit") {
 				result.stdout = JSON.stringify({
 					auditReportVersion: 2,
@@ -858,7 +850,7 @@ describe("packed-consumer audit subprocess isolation", () => {
 			Object.assign(process.env, secretEnv);
 			await runPackedConsumerAudit({ npmRunner, commandRunner });
 
-			assert.deepEqual(calls.map(call => call.args[0]), ["pack", "config", "install", "rebuild", "audit"]);
+			assert.deepEqual(calls.map(call => call.args[0]), ["pack", "config", "install", "audit"]);
 			assert.equal(nativeCalls.length, 1);
 			assert.equal(nativeCalls[0].command, process.execPath);
 			assert.ok(nativeCalls[0].args.join(" ").includes("better-sqlite3"));
@@ -872,7 +864,7 @@ describe("packed-consumer audit subprocess isolation", () => {
 					assert.equal(childKeys.has(forbiddenKey), false, `${forbiddenKey} reached ${call.args[0]}`);
 				}
 				assert.equal(call.env.npm_config_registry, "https://registry.npmjs.org/");
-				assert.equal(call.env.npm_config_ignore_scripts, call.args[0] === "rebuild" ? "false" : "true");
+				assert.equal(call.env.npm_config_ignore_scripts, "true");
 				assert.notEqual(call.env.npm_config_userconfig, secretEnv.npm_config_userconfig);
 				assert.notEqual(call.env.npm_config_globalconfig, secretEnv.npm_config_globalconfig);
 				assert.match(call.env.npm_config_userconfig, /user\.npmrc$/);


### PR DESCRIPTION
## Summary
- pin better-sqlite3 13.0.3 and regenerate the npm lockfile
- adopt the v13 N-API/node-addon-api packaging path without changing SQLite schemas, migrations, durability, or close behavior
- update SQLite persistence documentation for the pinned version and bundled-prebuild qualification

## Validation
- npm run check
- npm run build:server
- existing goal/task/gate SQLite and lifecycle tests: 62 passed
- full workflow verification: build, type-check, unit, browser, E2E, conformance, implementation, and security checks passed

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)