### PR TITLE
Add pack local data directories

### DIFF
--- a/docs/extension-host-authoring.md
+++ b/docs/extension-host-authoring.md
@@ -221,9 +221,11 @@ All four `localData` fields are required and their supported values are fixed:
 The portable path rules deliberately produce the same result on Windows and POSIX. Bobbit rejects
 empty or whitespace-padded values; absolute, drive-relative, UNC, or device paths; backslashes,
 colons/alternate data streams, control characters, and Windows-invalid punctuation; empty, `.`,
-or `..` components; Windows reserved device names; and components ending in a dot or space. An
-invalid declaration rejects the pack instead of silently removing the capability. Schema-1 packs
-do not activate `localData`; packs with no declaration retain their previous manifest/runtime shape.
+or `..` components; Windows reserved device names; components ending in a dot or space; and paths
+equal to or below Bobbit-managed marketplace roots (`.bobbit/config/market-packs` and Headquarters
+`config/market-packs`, compared case-insensitively). An invalid declaration rejects the pack instead
+of silently removing the capability. Schema-1 packs do not activate `localData`; packs with no
+declaration retain their previous manifest/runtime shape.
 
 #### Resolution and project identity
 

--- a/docs/extension-host-authoring.md
+++ b/docs/extension-host-authoring.md
@@ -223,12 +223,17 @@ empty or whitespace-padded values; absolute, drive-relative, UNC, or device path
 colons/alternate data streams, control characters, and Windows-invalid punctuation; empty, `.`,
 or `..` components; Windows reserved device names; components ending in a dot or space; and paths
 equal to or below Bobbit-managed marketplace roots (`.bobbit/config/market-packs` and Headquarters
-`config/market-packs`, compared case-insensitively). At resolution time Bobbit also checks the fully
-resolved candidate against the live server, global-user, and every registered project's marketplace
-root. This protects ancestor-project layouts where the managed root is not a direct relative prefix
-of the declaring project. An invalid declaration rejects the pack instead of silently removing the
-capability. Schema-1 packs do not activate `localData`; packs with no declaration retain their
-previous manifest/runtime shape.
+`config/market-packs`, compared case-insensitively).
+
+Resolution also rejects the candidate against a live list of the server, global-user, and every
+registered project's managed marketplace root before creating any directory. Both lexical and
+canonical spellings are compared. When a root does not exist yet, Bobbit canonicalizes its nearest
+existing ancestor and appends the missing suffix, so an ancestor-project layout or a root reached
+through a POSIX symlink or Windows junction cannot evade the check merely because its final
+`config/market-packs` components are absent. The live list is read again for every resolution, so a
+project registered after startup is protected too. An invalid declaration rejects the pack instead
+of silently removing the capability. Schema-1 packs do not activate `localData`; packs with no
+declaration retain their previous manifest/runtime shape.
 
 #### Resolution and project identity
 
@@ -302,6 +307,13 @@ persistent staff sessions, goal/team/delegate worktrees, and restored or respawn
 Consequently, every host worktree for one project sees the same host directory; restoration does
 not persist or reconstruct a worktree-relative path. The environment variable is omitted entirely
 when no active pack declares local data.
+
+The map is also why local-data-aware Pi activation follows pack precedence. For each Pi
+contribution that shares a structural pack id with the winner, Bobbit omits the shadowed
+contribution when either one declares `localData`; uninstalling the winner lets the next winner
+activate with its own directory binding. Same-id pairs where neither contribution declares
+`localData` preserve the legacy behavior and both enabled Pi extension entries may load. See
+[Marketplace pi-extension activation](marketplace.md#install-activation-and-runtime-loading).
 
 #### Sandbox mapping and lifecycle
 

--- a/docs/extension-host-authoring.md
+++ b/docs/extension-host-authoring.md
@@ -235,6 +235,14 @@ project registered after startup is protected too. An invalid declaration reject
 of silently removing the capability. Schema-1 packs do not activate `localData`; packs with no
 declaration retain their previous manifest/runtime shape.
 
+Effective pack activation gates the entire extension runtime surface. Only an effectively enabled,
+winning pack exposes its browser or server Host APIs, Pi contributions, agent runtime binding, or
+sandbox mount. Installing a pack with `defaultDisabled: true` leaves all of those inert until an
+explicit enable, while its raw Marketplace listing and activation configuration remain visible.
+Clearing that enable returns the pack to its default-off state: new or refreshed sessions omit its Pi
+extension and `BOBBIT_PACK_LOCAL_DATA_JSON` entry, and sandbox reconciliation removes its mount.
+This changes exposure only; the existing directory and every file remain byte-for-byte untouched.
+
 #### Resolution and project identity
 
 On first use or mount planning, Bobbit resolves:
@@ -331,10 +339,11 @@ set changes, Bobbit reconciles the immutable Docker mount set and recreates affe
 containers when necessary; restored containers with missing, stale, extra, or read-only bindings
 are not treated as current.
 
-Disabling, shadowing, uninstalling, or updating a pack removes or changes **exposure**, never data.
-Bobbit does not delete the declared directory or any file in it. Reinstalling the same declaration
-reuses the preserved directory; changing `directory` leaves the old location untouched. Explicit
-data deletion belongs to the extension or user.
+Disabling (including clearing a default-disabled pack's explicit enable), shadowing, uninstalling,
+or updating a pack removes or changes **exposure**, never data. Bobbit does not delete the declared
+directory or alter any file in it. Reinstalling the same declaration reuses the preserved directory;
+changing `directory` leaves the old location untouched. Explicit data deletion belongs to the
+extension or user.
 
 Pack Local Data assumes installed extension code, browser panel code, the agent runtime, and bespoke
 tools are trusted. It does not isolate intentionally malicious extension code, restrict browser

--- a/docs/extension-host-authoring.md
+++ b/docs/extension-host-authoring.md
@@ -3,7 +3,7 @@
 This guide walks through making a **marketplace pack** that contributes Extension Host
 surfaces — a chat-block **renderer**, an interactive **server action handler**, side
 **panels**, long-lived **channels**, pack-owned **routes**, non-chat **entrypoints**, implicit
-pack-scoped **stores**, and **session** access. By the end you will understand every
+pack-scoped **stores**, optional project-scoped **local data**, and **session** access. By the end you will understand every
 contribution point, *where each one is declared on disk*, and the one mediated **Host API**
 they all flow through — with no privileged escape hatch.
 
@@ -29,7 +29,7 @@ This guide is the practical how-to.
 - [docs/design/extension-host.md](design/extension-host.md) — the contribution-point model, two-host architecture, the frozen Host API, the security guard sequence, the adapter layer, and the isolation model. The *why* and the contract. (Its per-tool schema examples predate V1 — read them through [pack-schema-v1-rationalisation.md](design/pack-schema-v1-rationalisation.md).)
 - [docs/design/extension-channels-host-channels.md](design/extension-channels-host-channels.md) and [docs/design/extension-channels-terminal-ux.md](design/extension-channels-terminal-ux.md) — the design record for generic channels and the first-party terminal pack.
 
-**Status:** renderers, actions, panels, channels, routes, entrypoints, implicit stores, session access, and worker isolation are all **implemented**. `HOST_API_VERSION` is `1`; `HOST_CONTRACT_VERSION` is `4`; `host.capabilities` reports all flags `true` on a current host.
+**Status:** renderers, actions, panels, channels, routes, entrypoints, implicit stores, project-scoped local data, session access, and worker isolation are all **implemented**. `HOST_API_VERSION` is `1`; `HOST_CONTRACT_VERSION` is `4`. Base capabilities report `true` on a current host; the additive `localData` capability is present only for a winning pack that declares it.
 
 The renderer+action working example lives at `tests/fixtures/market-sources/retry-demo-src/retry-demo/`; the full pack-scoped surface set is exercised by `market-packs/artifacts/` (a tool + panel + deep-link pack), `market-packs/pr-walkthrough/` (a first-party tool + role + panel + route + entrypoint pack), `market-packs/terminal/` (the first-party xterm terminal over `host.channels`), and no-tools fixture packs such as `tests/fixtures/market-sources/no-tools-pack-src/no-tools-pack/`.
 
@@ -44,6 +44,7 @@ The renderer+action working example lives at `tests/fixtures/market-sources/retr
 | **Pack routes** | `pack.yaml` `routes:` | Gateway (confined worker) | called via `host.callRoute` |
 | **Entrypoints** | `entrypoints/<ep>.yaml` (listed in `contents`) | Browser (launchers + deep-link routes) | `host.ui.navigate` / `openPanel` |
 | **Pack store** | *implicit* — no declaration | Gateway | `host.store.{get,read,put,list,delete,deletePrefix,stats}` (pack-namespaced; `read` returns a tri-state durable-read outcome, while `get` is legacy and lossy) |
+| **Project local data** *(schema 2)* | top-level `pack.yaml` `localData:` | Browser, Gateway, and agent runtime | `host.localData.directory()` or the pack-keyed agent binding |
 | **Providers** *(schema 2; all hooks wired via the Lifecycle Hub)* | `providers/<id>.yaml` (listed in `contents.providers`) | Server (Lifecycle Hub, worker tier) | default-export hook object — see [docs/lifecycle-hub.md](lifecycle-hub.md) |
 | **Hook metadata** *(schema 2; inert)* | `hooks/<name>.yaml` (listed in `contents.hooks`) | Registry metadata only | Does not load the module or create a runtime surface |
 | **Standalone pi extensions** *(schema 2; not Extension Host surfaces)* | `pi-extensions/<id>/` or `pi-extensions/<id>.ts/.js/.mjs/.cjs` (listed in `contents.pi-extensions`) | Agent runtime via pi `--extension` | Plain pi extension API — see [Marketplace pi extensions](marketplace.md#marketplace-pi-extensions) |
@@ -181,6 +182,150 @@ reject an in-pack symlink that escapes, and do not trust an outside mutable syml
 it currently targets an in-pack file. A missing candidate may pass the spelling check so callers
 can retain their normal not-found handling; other resolution failures fail closed. This keeps shared
 `lib/` modules reachable without weakening the containment invariant.
+
+### Project local data (`localData`) — schema 2
+
+Pack Local Data gives trusted extension code and its agents one stable, project-scoped filesystem
+location. Use it for arbitrary files that server modules and agents read/write while browser
+surfaces coordinate those operations, and that must remain shared across worktrees, restored
+sessions, and sandboxes. It is a **location binding**, not a replacement for `host.store`: Bobbit
+supplies and validates the directory but does not define file formats, inspect
+contents, or mediate filesystem operations.
+
+Declare the capability at the top level of a schema-2 `pack.yaml`:
+
+```yaml
+name: performance-optimisation
+schema: 2
+description: Performance analysis and optimisation tools.
+version: 1.0.0
+localData:
+  scope: project
+  directory: .performance-optimisation
+  access: read-write
+  preserveOnUninstall: true
+contents:
+  roles: []
+  tools: []
+  skills: []
+```
+
+All four `localData` fields are required and their supported values are fixed:
+
+- `scope` is exactly `project`.
+- `directory` is a non-empty, already-trimmed, forward-slash-separated relative path. Nested
+  paths such as `.performance-optimisation/cache` are valid.
+- `access` is exactly `read-write`.
+- `preserveOnUninstall` is exactly `true`.
+
+The portable path rules deliberately produce the same result on Windows and POSIX. Bobbit rejects
+empty or whitespace-padded values; absolute, drive-relative, UNC, or device paths; backslashes,
+colons/alternate data streams, control characters, and Windows-invalid punctuation; empty, `.`,
+or `..` components; Windows reserved device names; and components ending in a dot or space. An
+invalid declaration rejects the pack instead of silently removing the capability. Schema-1 packs
+do not activate `localData`; packs with no declaration retain their previous manifest/runtime shape.
+
+#### Resolution and project identity
+
+On first use or mount planning, Bobbit resolves:
+
+```text
+<registered-project-root>/<localData.directory>
+```
+
+The root is the project's registered canonical `rootPath`, never `process.cwd()`, a Git top-level
+inferred from the caller, a component repository, or a session/goal/staff worktree. This matters
+because those working directories are disposable while project data must remain shared. In a
+polyrepo, the root is still the registered polyrepo container root; component roots do not change
+the binding.
+
+The directory is created lazily. Bobbit walks and validates every component, requires existing
+components to be directories, canonicalizes them, and rejects lexical escapes, non-directory
+components, POSIX symbolic links, Windows junctions, and reparse-point redirects. Resolution fails
+closed if the project, active winning pack, declaration, or filesystem path cannot be verified. A
+successful host-side resolution returns the absolute real path.
+
+#### Browser and server Host APIs
+
+Browser renderers, panels, and entrypoints belonging to the declared winning pack receive an
+optional, asynchronous API:
+
+```js
+if (host.capabilities.has("localData")) {
+  const directory = await host.localData.directory();
+  // This is the unrestricted host absolute path; perform file I/O in pack server code.
+}
+```
+
+`host.localData` and `host.capabilities.localData` are omitted when the pack has no declaration.
+The browser supplies no project id, pack id, or path: the host derives the authenticated session's
+project and the surface's winning pack identity.
+
+Bound server actions, routes, and provider hooks receive the synchronous equivalent:
+
+```js
+const directory = ctx.host.localData.directory();
+```
+
+Feature-detect with `ctx.host.capabilities.has("localData")` before use. The binding is a plain
+pre-resolved string in the worker, so no resolver or caller-controlled path crosses the worker
+boundary. Server modules can then use normal `node:fs` APIs directly.
+
+#### Pi extensions and ordinary agents
+
+Agent processes receive one structural environment carrier when at least one active winning pack
+declares local data:
+
+```text
+BOBBIT_PACK_LOCAL_DATA_JSON={"performance-optimisation":"/absolute/or/realm/path"}
+```
+
+The JSON object is keyed by the exact pack id, so multiple packs coexist without lossy environment
+variable names. A Pi extension selects its own pack entry; bespoke model-facing tools should not
+accept a project or directory argument:
+
+```js
+const bindings = JSON.parse(process.env.BOBBIT_PACK_LOCAL_DATA_JSON || "{}");
+const directory = bindings["performance-optimisation"];
+if (!directory) throw new Error("Pack Local Data is unavailable");
+```
+
+The same environment binding is available to ordinary agents through their normal shell and
+filesystem tools. Bobbit derives it from project and winning pack identity, not the current working
+directory. It is applied through the common session setup/activation paths for ordinary and
+persistent staff sessions, goal/team/delegate worktrees, and restored or respawned sessions.
+Consequently, every host worktree for one project sees the same host directory; restoration does
+not persist or reconstruct a worktree-relative path. The environment variable is omitted entirely
+when no active pack declares local data.
+
+#### Sandbox mapping and lifecycle
+
+Host processes receive the absolute host directory. Sandboxed agent processes instead receive a
+stable realm path:
+
+```text
+/bobbit/local-data/<encoded-pack-id>
+```
+
+Bobbit mounts the canonical host directory read-write at that path. The mount is the same directory,
+not a copy: a sandbox/Pi/tool write is immediately visible to host routes and browser-backed server
+code, and a host write is immediately visible inside the container. When the effective declaration
+set changes, Bobbit reconciles the immutable Docker mount set and recreates affected project
+containers when necessary; restored containers with missing, stale, extra, or read-only bindings
+are not treated as current.
+
+Disabling, shadowing, uninstalling, or updating a pack removes or changes **exposure**, never data.
+Bobbit does not delete the declared directory or any file in it. Reinstalling the same declaration
+reuses the preserved directory; changing `directory` leaves the old location untouched. Explicit
+data deletion belongs to the extension or user.
+
+Pack Local Data assumes installed extension code, browser panel code, the agent runtime, and bespoke
+tools are trusted. It does not isolate intentionally malicious extension code, restrict browser
+access to the returned path, inspect/classify/redact files, impose quotas, manage secrets or
+backups, define database schemas/migrations/locking, or publish change notifications. Those are
+separate responsibilities; this capability only establishes a stable shared location. A pack
+without the declaration causes no local-data directory creation, Host API namespace, agent
+environment bytes, or sandbox mount.
 
 ## Step 1 — the tool YAML (renderer + actions only)
 
@@ -369,6 +514,8 @@ The server-side `ctx.host` carries:
 - `ctx.host.session.{readTranscript,readToolCall}` — own-session reads through the adapter.
 - `ctx.host.agents.{spawn,prompt,dismiss,list,read,status}` — launch + orchestrate child
   agents owned by the bound session (poll-based, ambient). See [`host.agents`](#hostagents--launch-and-orchestrate-child-agents).
+- `ctx.host.localData.directory()` — synchronous, bound project-local filesystem directory,
+  present only when the winning pack declares [Pack Local Data](#project-local-data-localdata--schema-2).
 
 There is deliberately **no** `ctx.host.callRoute` or `ctx.host.ui` server-side: a server
 handler reaches its own pack's route by calling the function directly, and a server module has
@@ -457,9 +604,11 @@ if (host.capabilities.has("callRoute")) { /* true on a current host */ }
 if (host.capabilities.channels) { /* safe to use host.channels */ }
 ```
 
-A current host reports all client flags `true` — `{ invokeAction, requestRender, callRoute,
-session, ui, store, channels }`. The **server-side** capabilities are `{ session, store, agents }` (a
-current host reports all three `true`). `host.version` (`HOST_API_VERSION`, `1`) and `host.contractVersion`
+A current host reports the base client flags `true` — `{ invokeAction, requestRender, callRoute,
+session, ui, store, channels }`. A declared winning pack additionally receives `localData: true`;
+otherwise that flag and namespace are absent. The **server-side** base capabilities are `{ session,
+store, agents }`, with `localData: true` added only for a bound declared directory. `host.version`
+(`HOST_API_VERSION`, `1`) and `host.contractVersion`
 (`HOST_CONTRACT_VERSION`) identify the contract revision. All capabilities are purely additive
 (no signature churn), so code written against `capabilities` stays forward/backward-compatible.
 
@@ -1561,10 +1710,10 @@ built-in band, but it is **dormant until a Hindsight URL is configured**, so an 
 install still produces no Dynamic Context section. See
 [docs/lifecycle-hub.md → Session-setup wiring](lifecycle-hub.md#session-setup-wiring-g13) and [Per-turn + lifecycle wiring](lifecycle-hub.md#per-turn--lifecycle-wiring-g14).
 
-Unlike every other contribution in this guide, a provider has **no `ctx.host` Host-API
-surface** — it is not reached through the panel/entrypoint/route Host API. Instead, when the Hub
-dispatches it, the provider runs as a module on the worker tier and returns context
-blocks (see the [provider module contract](#provider-module-contract) below).
+A provider runs as a module on the worker tier and returns context blocks rather than being
+reached through the panel/entrypoint/route Host API. Its optional least-privilege `ctx.host`
+contains the pack store and, when declared, Pack Local Data; session and agent capabilities remain
+unavailable. See the [provider module contract](#provider-module-contract) below.
 
 Key author-facing rules (full reference, field table, defaults, and clamps live in
 [docs/marketplace.md → Provider contributions](marketplace.md#provider-contributions-providersidyaml)):
@@ -1602,7 +1751,8 @@ export default {
   async sessionSetup(ctx) {
     // ctx carries: sessionId, projectId, scope, cwd, goalId?, roleName?, prompt?, turn?,
     //   optional advisory scopeContext (see Lifecycle Hub), budget.maxTokens (this provider's
-    //   clamped allowance), config (the YAML `config`), and gateway { baseUrl, token }.
+    //   clamped allowance), config (the YAML `config`), gateway { baseUrl, token }, and
+    //   least-privilege ctx.host (store plus declared localData; no session/agents).
     return {
       blocks: [{
         id: "recent-decisions",
@@ -2077,6 +2227,7 @@ sandbox/read-only enforcement. As an author, your obligations are:
 - [ ] **Handle channel backpressure and close events** — every `open`/`attach`/`send`/`close` promise can reject, and `onClose` is the lifecycle source of truth.
 - [ ] **Request `sessionPty` only for terminal-like trusted-pack channels** — generic handlers do not receive `ctx.host.pty`, and read-only/sandbox/cwd/env/quota/cleanup policy is enforced by the helper.
 - [ ] **Keep paths inside the pack root** — `renderer`, `actions.module`, panel `entry`, channel `module`, and `routes.module` resolve relative to their declaring file; `../lib/...` is fine, escaping the pack root is rejected.
+- [ ] **Use the bound Pack Local Data directory** — declare the fixed schema-2 `localData` block and call `host.localData.directory()` or select your exact pack id from `BOBBIT_PACK_LOCAL_DATA_JSON`; never reconstruct a project root from `cwd` or accept a caller-supplied directory.
 - [ ] **Server modules are trusted code with full ambient parity** — `child_process`/`fs`/network/`process.env` are available directly (no declaration). The worker is resource/crash isolation only; design handlers to be fast.
 - [ ] **Standalone pi extensions are host/runtime code** — source-level trust is required before executable discovery, and enabled extensions load into matching agent sessions by default via `--extension`.
 - [ ] **Feature-detect via `host.capabilities`**, never member presence.
@@ -2102,7 +2253,7 @@ the contract adapter, and the worker isolation model — is documented in
 - Pack-scoped contribution loaders + registry: `src/server/agent/pack-contributions.ts`, `src/server/extension-host/pack-contribution-registry.ts`
 - Tool-scoped contribution parser: `src/server/agent/tool-contributions.ts`
 - Internal→contract adapter: `src/server/extension-host/contract-adapter.ts`
-- Pack store + worker isolation: `pack-store.ts`, `module-host-worker.ts`, `module-host-bootstrap.ts`, `confinement-loader.ts`
+- Pack store, Pack Local Data, and worker isolation: `pack-store.ts`, `pack-local-data.ts`, `module-host-worker.ts`, `module-host-bootstrap.ts`, `confinement-loader.ts`
 - Activation persistence: `src/server/agent/project-config-store.ts` (`pack_activation`)
 - Client registries: `src/app/pack-renderers.ts`, `pack-panels.ts`, `pack-entrypoints.ts`, `host-api.ts`, `channel-bridge.ts`
 - Renderer render-context type: `src/ui/tools/types.ts`

--- a/docs/extension-host-authoring.md
+++ b/docs/extension-host-authoring.md
@@ -223,9 +223,12 @@ empty or whitespace-padded values; absolute, drive-relative, UNC, or device path
 colons/alternate data streams, control characters, and Windows-invalid punctuation; empty, `.`,
 or `..` components; Windows reserved device names; components ending in a dot or space; and paths
 equal to or below Bobbit-managed marketplace roots (`.bobbit/config/market-packs` and Headquarters
-`config/market-packs`, compared case-insensitively). An invalid declaration rejects the pack instead
-of silently removing the capability. Schema-1 packs do not activate `localData`; packs with no
-declaration retain their previous manifest/runtime shape.
+`config/market-packs`, compared case-insensitively). At resolution time Bobbit also checks the fully
+resolved candidate against the live server, global-user, and every registered project's marketplace
+root. This protects ancestor-project layouts where the managed root is not a direct relative prefix
+of the declaring project. An invalid declaration rejects the pack instead of silently removing the
+capability. Schema-1 packs do not activate `localData`; packs with no declaration retain their
+previous manifest/runtime shape.
 
 #### Resolution and project identity
 

--- a/docs/marketplace.md
+++ b/docs/marketplace.md
@@ -309,6 +309,14 @@ Scope follows marketplace install scope:
 - **Global-user** installs apply to sessions for the current OS user.
 - **Project** installs apply only to sessions in that project context. In multi-project setups, project pi extensions do not bleed into sibling projects.
 
+**Local-data precedence.** Two installed packs in different precedence bands can have the same
+structural pack id. A Pack Local Data binding has only one entry for that id, so Bobbit compares
+each same-id Pi contribution with the winner. If either one declares `localData`, the shadowed
+contribution is omitted; removing the winner exposes the next winner, whose Pi extension and
+directory bind on the next session activation. This prevents a shadowed extension from receiving
+the winner's directory. Same-id pairs where neither contribution declares `localData` keep the
+existing behavior and both enabled Pi extension entries may load.
+
 ### Discovery, metadata, and diagnostics
 
 Bobbit performs best-effort deterministic discovery to identify model-facing tools exposed by an extension. Discovery exists to improve UI provenance and map explicit Bobbit tool policies; it is not a gate for runtime loading.

--- a/docs/marketplace.md
+++ b/docs/marketplace.md
@@ -170,6 +170,19 @@ contributions: providers, hook metadata, MCP, and pi extensions. Support surface
 routes, stores, renderers, actions, `lib/` — are **not** independently toggleable (panels may be
 shown read-only as "support surfaces").
 
+Whole-pack effective activation is the prerequisite for all of those contributions and support
+surfaces. A normal pack is active by default and then follows its per-entity toggles. An installed
+or shipped pack with `defaultDisabled: true` instead contributes nothing until its explicit enable
+override is set; only effectively enabled packs participate in precedence and expose Host APIs, Pi
+contributions, runtime environment bindings, or sandbox mounts. The raw Marketplace listing and
+activation configuration remain visible while the pack is off, so it can still be inspected and
+re-enabled.
+
+Clearing the explicit enable returns a default-disabled pack to its inert state. Host exposure is
+removed, new or refreshed sessions omit its Pi/runtime bindings, and affected sandboxes reconcile
+away its mounts. This never deletes or rewrites Pack Local Data: existing directories and files are
+preserved byte-for-byte. A later enable reuses the same declared directory.
+
 > **Extension Platform (`schema: 2`).** The activation system covers `providers`, `hooks`,
 > `mcp`, `piExtensions`, and the reserved `runtimes` / `workflows` siblings. They are first-class
 > in `DisabledRefs` and `ACTIVATION_KINDS`, and the `pack-activation` catalogue includes their
@@ -628,7 +641,7 @@ The Market **Sources** tab shows a distinct, labelled **Built-in** section. It i
 
 ### Disabling a shipped feature
 
-Built-in packs appear in the **Installed** tab in their own *Built-in (shipped)* group, flagged `builtin: true`, with **enable/disable toggles only — no Uninstall and no Update**. Disabling reuses the [#734 activation-override system](#activation-controls) verbatim: it writes `pack_activation` under the **`server` scope** (a shipped feature is a server-wide admin decision, so disabling applies across projects) and removes exactly the toggled user-facing entries (roles/tools/skills/entrypoints) from resolution. Panels and routes stay as support surfaces and are not independently toggleable or force-closed. For a launcher-only feature such as the file explorer, removing its entrypoints removes the supported way to open a new panel; a feature with a declared deep-link instead degrades that route to the standard unavailable state. Toggling invalidates resolver caches synchronously, so the change takes effect with no restart/reload, and the disabled state **persists across reload and restart** (it lives in server config).
+Built-in packs appear in the **Installed** tab in their own *Built-in (shipped)* group, flagged `builtin: true`, with **activation toggles only — no Uninstall and no Update**. Per-entity disabling reuses the [activation system](#activation-controls) under the **`server` scope** (a shipped feature is a server-wide admin decision, so it applies across projects) and removes exactly the toggled user-facing entries (roles/tools/skills/entrypoints) from resolution. Panels and routes stay as non-toggleable support surfaces for those per-entity changes. A `defaultDisabled: true` pack's explicit enable is instead a whole-pack prerequisite; clearing it returns every contribution and support surface to the inert state described above while the raw Installed row remains visible. For a launcher-only feature such as the file explorer, removing its entrypoints removes the supported way to open a new panel; a feature with a declared deep-link instead degrades that route to the standard unavailable state. Activation changes take effect without a restart/reload and persist across both.
 
 ### Tool activation diagnostics for inactive packs
 

--- a/docs/marketplace.md
+++ b/docs/marketplace.md
@@ -15,7 +15,7 @@ This version makes **the pack directory itself the unit of truth**:
 - **Update** = re-pull and replace it.
 - **Resolve** = walk one ordered list of packs and let later packs shadow earlier ones.
 
-There is no separate ledger. The pack directory plus its generated `.pack-meta.yaml` *is* the install record. Uninstall removes exactly what install added, because they are the same directory.
+There is no separate ledger. The pack directory plus its generated `.pack-meta.yaml` *is* the install record. Uninstall removes exactly what install added, because they are the same directory. A schema-2 pack's declared [Pack Local Data](extension-host-authoring.md#project-local-data-localdata--schema-2) is deliberately outside that install directory and is preserved as extension/user-owned project data.
 
 ## Core concept: one resolver over one ordered list
 
@@ -135,7 +135,19 @@ Why two fields instead of one boolean? A single "update available" flag can't di
 ### Updating and uninstalling
 
 - **Update** re-syncs the originating source, re-resolves the commit/fingerprint, and atomically replaces the installed directory (preserving the original `installedAt`, bumping `updatedAt`). Re-syncing a source then updating reflects upstream changes. MCP Gateway packs are rebuilt from the latest MCP provider discovery result.
-- **Uninstall** deletes the pack directory and removes it from the scope's `pack_order`. Because the directory is the unit of truth, uninstall removes exactly what install added — no orphans. If the pack contributed MCP servers, Bobbit reloads the affected MCP managers and unregisters removed external MCP tools.
+- **Uninstall** deletes the pack directory and removes it from the scope's `pack_order`. Because the directory is the unit of truth, uninstall removes exactly what install added. If the pack contributed MCP servers, Bobbit reloads the affected MCP managers and unregisters removed external MCP tools.
+
+A `localData` directory is the intentional exception to installation cleanup: it is created under
+the registered project root, not copied into the installed pack. Disable, uninstall, update, pack
+precedence changes, and sandbox cleanup remove the capability or mount but never delete that
+directory or its files. Reinstalling the same declaration reuses it; changing the declaration leaves
+the prior directory untouched. Operators or the extension must delete data explicitly. For the
+declaration, Host APIs, worktree behavior, and sandbox mapping, see [Pack Local Data](extension-host-authoring.md#project-local-data-localdata--schema-2).
+
+For sandboxed projects, changes to the active winning declarations trigger mount reconciliation.
+Affected long-lived containers are recreated only when their writable mount set is stale, and
+attached sessions follow the normal recovery/respawn path. The local-data directories remain on the
+host even if a remount fails, so an exposure failure cannot become data loss.
 
 **When the Update button appears (change detection).** The Update button is shown only when the source's latest **manifest version** differs from the installed `.pack-meta.yaml` version — a plain version-string comparison, not a commit-SHA or file diff. This is cheap, deterministic, and matches the semver the publisher advertises.
 
@@ -652,6 +664,7 @@ name: research-pack              # REQUIRED. /^[a-z0-9][a-z0-9-]*$/ — used as 
 description: >                   # REQUIRED. One-paragraph summary shown in the browse UI.
   Deep-research role, web tools, and a literature-review skill.
 version: 1.2.0                   # REQUIRED. Semver-ish string; shown in provenance.
+schema: 2                       # OPTIONAL. Required to activate schema-2 fields such as localData.
 author: jane@example.com         # OPTIONAL.
 homepage: https://...            # OPTIONAL.
 contents:                        # REQUIRED. roles/tools/skills required; each MAY be empty.
@@ -665,10 +678,16 @@ contents:                        # REQUIRED. roles/tools/skills required; each M
   pi-extensions: [demo]          #   OPTIONAL — pi-extensions/<name>/ or <name>.ts/.js/.mjs/.cjs (toggleable).
 routes:                          # OPTIONAL top-level block — Extension-Host pack routes.
   module: lib/routes.mjs         #   relative to pack.yaml, contained in the pack root.
-  names:  [bundle, publish]       #   exported route-name allowlist.
+  names:  [bundle, publish]      #   exported route-name allowlist.
+# schema: 2 only:
+# localData:                    # OPTIONAL — stable project-scoped extension directory.
+#   scope: project
+#   directory: .research-pack
+#   access: read-write
+#   preserveOnUninstall: true
 ```
 
-Validation rules: `name`, `description`, `version` must be non-empty; `name` must match the pattern (rejects path separators, `..`, leading dots); `contents` is required with the `roles`/`tools`/`skills` array keys present (each may be empty). `contents.tools` lists tool **group** directory names, while activation catalogues expand those groups to concrete tool names. `contents.entrypoints` is optional and lists the basenames of `entrypoints/<name>.yaml` files (the Extension-Host activation catalogue — see [authoring guide](extension-host-authoring.md#entrypoints--non-chat-launchers--deep-link-routes-hostuinavigate)). The optional top-level `routes:` block declares pack-level Extension-Host routes. Panels are **auto-discovered** from `panels/*.yaml` and are not listed here. `contents.mcp` and `contents.pi-extensions` are **rejected at schema 1** (the absent-or-`1` default) and **accepted at `schema: 2`**; schema-2 MCP basenames load pack-owned MCP contribution files from `mcp/<name>.yaml|yml|json` (see [Marketplace MCP](#marketplace-mcp)), and schema-2 pi-extension basenames resolve standalone pi entries from `pi-extensions/<name>/` or `pi-extensions/<name>.ts/.js/.mjs/.cjs` (see [Marketplace pi extensions](#marketplace-pi-extensions)). There is **no `stores` key** (Extension-Host stores are implicit, namespaced by the server-derived `packId`) and **no `permissions` key** (trusted pack code has ambient OS access — there is no permission system). Unknown top-level keys are ignored (forward-compat). A pack whose `pack.yaml` is missing or invalid is skipped with a warning, never fatal.
+Validation rules: `name`, `description`, `version` must be non-empty; `name` must match the pattern (rejects path separators, `..`, leading dots); `contents` is required with the `roles`/`tools`/`skills` array keys present (each may be empty). `contents.tools` lists tool **group** directory names, while activation catalogues expand those groups to concrete tool names. `contents.entrypoints` is optional and lists the basenames of `entrypoints/<name>.yaml` files (the Extension-Host activation catalogue — see [authoring guide](extension-host-authoring.md#entrypoints--non-chat-launchers--deep-link-routes-hostuinavigate)). The optional top-level `routes:` block declares pack-level Extension-Host routes. Panels are **auto-discovered** from `panels/*.yaml` and are not listed here. `contents.mcp`, `contents.pi-extensions`, and operational `localData` are schema-2 features; schema-2 MCP basenames load pack-owned MCP contribution files from `mcp/<name>.yaml|yml|json` (see [Marketplace MCP](#marketplace-mcp)), and schema-2 pi-extension basenames resolve standalone pi entries from `pi-extensions/<name>/` or `pi-extensions/<name>.ts/.js/.mjs/.cjs` (see [Marketplace pi extensions](#marketplace-pi-extensions)). `localData` uses a strict fixed declaration documented in [Pack Local Data](extension-host-authoring.md#project-local-data-localdata--schema-2). There is **no `stores` key** (Extension-Host stores are implicit, namespaced by the server-derived `packId`) and **no `permissions` key** (trusted pack code has ambient OS access — there is no permission system). Unknown top-level keys are ignored (forward-compat). A pack whose `pack.yaml` is missing or invalid is skipped with a warning, never fatal.
 
 ### `pack.yaml` schema 2 (Extension Platform)
 
@@ -696,9 +715,9 @@ dispatch PRs landed and have them load, validate, and toggle in the meantime.
 
 - **`schema?: number`** — a positive integer. Absent ⇒ **1** (every existing pack). Schema 1
   keeps verbatim v1 validation, including the `contents.mcp` rejection below. Other stray
-  schema-2 `contents` keys and top-level `provides`/`requires` are ignored, so v1 packs cannot
+  schema-2 `contents` keys and top-level `provides`/`requires`/`localData` are ignored, so v1 packs cannot
   load providers and their `pack-activation` catalogue remains the old shape.
-- **`schema: 2`** unlocks the six new `contents` keys and the `provides`/`requires` arrays.
+- **`schema: 2`** unlocks the six new `contents` keys, the `provides`/`requires` arrays, and `localData`.
 - **`schema: 3` or higher** is *not* fatal: the pack loads its **schema-2 subset** and one
   forward-compat warning is recorded (`pack.yaml: schema N is newer than supported (2)`).
   This keeps a newer pack installable on an older Bobbit rather than vanishing — the publisher
@@ -714,6 +733,15 @@ Two optional top-level arrays of **capability names** (each entry matches `/^[a-
 They are **metadata only** today (recorded on the parsed manifest, surfaced nowhere
 behaviourally yet) — the dependency/capability graph that consumes them belongs to a later
 goal. They are validated now so packs can declare them ahead of that work.
+
+#### Project local data
+
+Schema 2 also accepts the optional top-level `localData` declaration. It is not a `contents`
+entity or an independently toggleable catalogue row; it binds the active winning pack to one
+stable directory below the registered canonical project root. The fields are fixed to
+`scope: project`, `access: read-write`, and `preserveOnUninstall: true`, with a portable relative
+`directory`. This is why worktrees and polyrepo component roots cannot accidentally split a pack's
+data. See [Extension Host authoring — Pack Local Data](extension-host-authoring.md#project-local-data-localdata--schema-2) for validation, browser/server APIs, the multi-pack agent environment carrier, and sandbox behavior.
 
 #### Six new `contents` keys
 
@@ -742,6 +770,11 @@ version: 1.0.0
 schema: 2                     # opt into schema 2; absent ⇒ schema 1
 provides: [session-memory]    # capability names this pack offers (metadata only)
 requires: []                  # capability names it depends on (metadata only)
+localData:                    # optional stable project-scoped directory
+  scope: project
+  directory: .memory-pack
+  access: read-write
+  preserveOnUninstall: true
 contents:
   roles:    []
   tools:    []

--- a/market-packs/_fixtures/pack-local-data/entrypoints/viewer-route.yaml
+++ b/market-packs/_fixtures/pack-local-data/entrypoints/viewer-route.yaml
@@ -1,0 +1,6 @@
+id: pack-local-data.viewer-route
+kind: route
+routeId: pack-local-data
+target:
+  panelId: pack-local-data.viewer
+paramKeys: []

--- a/market-packs/_fixtures/pack-local-data/lib/panel.js
+++ b/market-packs/_fixtures/pack-local-data/lib/panel.js
@@ -1,0 +1,32 @@
+export default function createPanel({ html, renderHeader }) {
+	let result;
+	let error;
+	let loading;
+
+	return {
+		render(_params, host) {
+			if (!loading && !result && !error) {
+				loading = (async () => {
+					const browserDirectory = await host.localData.directory();
+					await host.callRoute("write", { body: { name: "host-marker.txt", content: "written-by-browser-route" } });
+					const snapshot = await host.callRoute("snapshot", {});
+					result = { browserDirectory, snapshot };
+				})().catch((cause) => {
+					error = cause instanceof Error ? cause.message : String(cause);
+				}).finally(() => host.requestRender?.());
+			}
+
+			const header = renderHeader
+				? renderHeader({ title: "Pack Local Data Fixture" })
+				: html`<header>Pack Local Data Fixture</header>`;
+			if (error) return html`${header}<pre data-testid="pack-local-data-error">${error}</pre>`;
+			if (!result) return html`${header}<div data-testid="pack-local-data-loading">Loading…</div>`;
+			return html`
+				${header}
+				<div data-testid="pack-local-data-browser-directory">${result.browserDirectory}</div>
+				<div data-testid="pack-local-data-route-directory">${result.snapshot.directory}</div>
+				<pre data-testid="pack-local-data-markers">${JSON.stringify(result.snapshot.markers)}</pre>
+			`;
+		},
+	};
+}

--- a/market-packs/_fixtures/pack-local-data/lib/routes.mjs
+++ b/market-packs/_fixtures/pack-local-data/lib/routes.mjs
@@ -1,0 +1,34 @@
+import fs from "node:fs";
+import path from "node:path";
+
+const MARKERS = ["ordinary-marker.txt", "pi-marker.txt", "host-marker.txt", "container-marker.txt"];
+
+function directory(ctx) {
+	if (!ctx.host?.capabilities?.has?.("localData") || !ctx.host.localData) {
+		throw new Error("host.localData capability is unavailable");
+	}
+	return ctx.host.localData.directory();
+}
+
+function readMarkers(root) {
+	return Object.fromEntries(MARKERS.map((name) => {
+		const file = path.join(root, name);
+		return [name, fs.existsSync(file) ? fs.readFileSync(file, "utf8") : null];
+	}));
+}
+
+export const routes = {
+	async snapshot(ctx) {
+		const root = directory(ctx);
+		return { directory: root, markers: readMarkers(root) };
+	},
+	async write(ctx, req) {
+		const root = directory(ctx);
+		const name = typeof req?.body?.name === "string" && MARKERS.includes(req.body.name)
+			? req.body.name
+			: "host-marker.txt";
+		const content = typeof req?.body?.content === "string" ? req.body.content : "written-by-route";
+		fs.writeFileSync(path.join(root, name), content, "utf8");
+		return { directory: root, name, content };
+	},
+};

--- a/market-packs/_fixtures/pack-local-data/pack.yaml
+++ b/market-packs/_fixtures/pack-local-data/pack.yaml
@@ -1,0 +1,24 @@
+name: pack-local-data
+schema: 2
+description: End-to-end fixture for project-scoped pack local data across browser, server, agent, and sandbox realms.
+version: 1.0.0
+defaultDisabled: true
+localData:
+  scope: project
+  directory: .pack-local-data-fixture
+  access: read-write
+  preserveOnUninstall: true
+contents:
+  roles: []
+  tools: []
+  skills: []
+  entrypoints: [viewer-route]
+  providers: []
+  hooks: []
+  mcp: []
+  pi-extensions: [marker]
+  runtimes: []
+  workflows: []
+routes:
+  module: lib/routes.mjs
+  names: [snapshot, write]

--- a/market-packs/_fixtures/pack-local-data/panels/viewer.yaml
+++ b/market-packs/_fixtures/pack-local-data/panels/viewer.yaml
@@ -1,0 +1,3 @@
+id: pack-local-data.viewer
+title: Pack Local Data Fixture
+entry: ../lib/panel.js

--- a/market-packs/_fixtures/pack-local-data/pi-extensions/marker/extension.ts
+++ b/market-packs/_fixtures/pack-local-data/pi-extensions/marker/extension.ts
@@ -1,0 +1,40 @@
+import fs from "node:fs";
+import path from "node:path";
+
+const PACK_ID = "pack-local-data";
+const ENV_NAME = "BOBBIT_PACK_LOCAL_DATA_JSON";
+
+type MarkerInput = { operation?: "read" | "write"; name?: string; content?: string };
+
+function directory(): string {
+	const raw = process.env[ENV_NAME];
+	if (!raw) throw new Error(`${ENV_NAME} is unavailable`);
+	const value = JSON.parse(raw)?.[PACK_ID];
+	if (typeof value !== "string" || !value) throw new Error(`No local-data binding for ${PACK_ID}`);
+	return value;
+}
+
+export default function activate(pi: any) {
+	pi.tool({
+		name: "pi_local_data_marker",
+		description: "Read or write a fixed marker in this pack's project-local data directory.",
+		inputSchema: {
+			type: "object",
+			properties: {
+				operation: { type: "string", enum: ["read", "write"] },
+				name: { type: "string", enum: ["pi-marker.txt", "container-marker.txt", "host-marker.txt", "ordinary-marker.txt"] },
+				content: { type: "string" },
+			},
+		},
+	}, (input: MarkerInput = {}) => {
+		const root = directory();
+		const name = input.name || "pi-marker.txt";
+		const file = path.join(root, name);
+		if (input.operation === "read") {
+			return { directory: root, name, content: fs.readFileSync(file, "utf8") };
+		}
+		const content = input.content || "written-by-pi";
+		fs.writeFileSync(file, content, "utf8");
+		return { directory: root, name, content };
+	});
+}

--- a/scripts/affected/impact-rules.mjs
+++ b/scripts/affected/impact-rules.mjs
@@ -1004,6 +1004,14 @@ export const UNRESOLVED_REPOSITORY_READ_AUDIT = Object.freeze([
 		]),
 	},
 	{
+		consumer: "tests2/integration/pack-local-data-fixture.test.ts",
+		allowReason: "isolated test-owned local-data marker files written through the fixture route and Pi tool",
+		reads: frozen([
+			{ expression: "path.join(directory, \"host-marker.txt\")", count: 1 },
+			{ expression: "path.join(directory, \"pi-marker.txt\")", count: 1 },
+		]),
+	},
+	{
 		consumer: "tests2/integration/sandbox-security.test.ts",
 		allowReason: "isolated integration gateway, project, or harness-owned output",
 		reads: frozen([

--- a/src/app/api.ts
+++ b/src/app/api.ts
@@ -3264,6 +3264,8 @@ export interface ToolInfo {
 	 *  the panel within the renderer's OWN pack, never a global panel-id search that
 	 *  would collide when another installed pack shares the panel id. */
 	packId?: string;
+	/** Present only when the winning contributing pack declares project local data. */
+	hasLocalData?: true;
 	grantPolicy?: string;
 	providerType?: "pi-extension" | string;
 	origin?: "marketplace-pi-extension" | "builtin" | "server" | "user" | "project" | string;
@@ -3361,6 +3363,8 @@ export interface PackEntrypointWire {
 export interface PackContributionsWire {
 	packId: string;
 	packName: string;
+	/** Present only when this active winning pack declares project local data. */
+	hasLocalData?: true;
 	panels: PackPanelWire[];
 	entrypoints: PackEntrypointWire[];
 	/** Pack-local channel names only; module/handler paths stay server-side. */

--- a/src/app/host-api.ts
+++ b/src/app/host-api.ts
@@ -126,8 +126,8 @@ export type SurfaceRef =
 	// server (the server derives the trusted packId from the `tool`) — it exists
 	// purely so `host.ui.openPanel({panelId})` resolves the panel WITHIN the
 	// renderer's pack (panel ids are pack-local). Absent for a built-in renderer.
-	| { kind: "tool"; tool: string; packId?: string }
-	| { kind: "pack"; packId: string; contributionKind: "panel" | "entrypoint" | "route"; contributionId: string };
+	| { kind: "tool"; tool: string; packId?: string; hasLocalData?: true }
+	| { kind: "pack"; packId: string; contributionKind: "panel" | "entrypoint" | "route"; contributionId: string; hasLocalData?: true };
 
 // Pack schema V1 §8.4: give pack PANELS a host API bound to the active session +
 // the panel's PACK-BOUND surface, so `panel.render(params, host)` can reach the
@@ -136,8 +136,14 @@ export type SurfaceRef =
 // contributionKind:"panel", contributionId:panelId}`. Registered from host-api
 // (which already imports pack-panels) so pack-panels stays free of a reverse
 // import cycle.
-setPanelHostFactory((sessionId, packId, panelId) =>
-	getHostApi(sessionId, undefined, { kind: "pack", packId, contributionKind: "panel", contributionId: panelId }),
+setPanelHostFactory((sessionId, packId, panelId, hasLocalData) =>
+	getHostApi(sessionId, undefined, {
+		kind: "pack",
+		packId,
+		contributionKind: "panel",
+		contributionId: panelId,
+		...(hasLocalData ? { hasLocalData: true } : {}),
+	}),
 );
 
 // Pack schema V1 §8.4: give pack LAUNCHER entrypoints (composer-slash /
@@ -151,8 +157,14 @@ setPanelHostFactory((sessionId, packId, panelId) =>
 // (`getEntrypoint`), so it must be a real entrypoint id (mirroring how the panel
 // factory threads the panelId). Registered from host-api (which already imports
 // pack-panels) so pack-panels stays free of a reverse cycle.
-setLauncherHostFactory((sessionId, packId, contributionId) =>
-	getHostApi(sessionId, undefined, { kind: "pack", packId, contributionKind: "entrypoint", contributionId }),
+setLauncherHostFactory((sessionId, packId, contributionId, hasLocalData) =>
+	getHostApi(sessionId, undefined, {
+		kind: "pack",
+		packId,
+		contributionKind: "entrypoint",
+		contributionId,
+		...(hasLocalData ? { hasLocalData: true } : {}),
+	}),
 );
 
 export function getHostApi(
@@ -232,6 +244,7 @@ export function getHostApi(
 		session: true,
 		ui: true,
 		store: true,
+		...(surface?.hasLocalData === true ? { localData: true } : {}),
 		channels: true,
 	};
 	const api = {
@@ -385,6 +398,22 @@ export function getHostApi(
 			// no-op (e.g. owning pack uninstalled).
 			navigate: (target) => navigateToTarget(target),
 		} as HostApi["ui"],
+		...(surface?.hasLocalData === true ? {
+			localData: {
+				directory: async (): Promise<string> => {
+					const resp = await scopedFetch((token) => ({
+						path: "/api/ext/local-data/directory",
+						init: { method: "POST", body: JSON.stringify({ sessionId, toolUseId, surfaceToken: token }) },
+					}));
+					if (!resp.ok) throw new Error(`localData.directory HTTP ${resp.status}`);
+					const data = (await resp.json()) as { directory?: unknown };
+					if (typeof data?.directory !== "string" || data.directory.length === 0) {
+						throw new Error("localData.directory: empty response");
+					}
+					return data.directory;
+				},
+			},
+		} : {}),
 		store: {
 			get: async (key: string) => (await storeOp("get", { key })) as never,
 			read: async <T = unknown>(key: string): Promise<StoreReadResult<T>> =>

--- a/src/app/pack-entrypoints.ts
+++ b/src/app/pack-entrypoints.ts
@@ -74,6 +74,8 @@ export interface ChannelPanelLaunchTarget {
 export interface LauncherEntrypoint {
 	id: string;
 	packId: string;
+	/** Present only when the winning contributing pack declares project local data. */
+	hasLocalData?: true;
 	kind: LauncherKind;
 	label: string;
 	icon?: EntrypointIconId;
@@ -86,6 +88,8 @@ export interface LauncherEntrypoint {
 export interface RouteEntrypoint {
 	id: string;
 	packId: string;
+	/** Present only when the winning contributing pack declares project local data. */
+	hasLocalData?: true;
 	kind: "route";
 	routeId: string;
 	target: PanelTarget;
@@ -119,6 +123,7 @@ export interface RegisteredLauncher {
 	icon?: EntrypointIconId;
 	target: PanelTarget | RouteTarget | SpawnLaunchTarget | ChannelPanelLaunchTarget;
 	projectId?: string;
+	hasLocalData: boolean;
 }
 
 /** Compound launcher key — entrypoint ids are only pack-unique, so a launcher is
@@ -233,6 +238,7 @@ export function registerPackEntrypoints(eps: ReadonlyArray<EntrypointInfo>, proj
 				...(ep.icon ? { icon: ep.icon } : {}),
 				target: ep.target,
 				projectId,
+				hasLocalData: ep.hasLocalData === true,
 			});
 		}
 	}
@@ -348,7 +354,7 @@ async function runChannelPanelLauncher(
 	onResult?: (r: LauncherDispatchResult) => void,
 	options?: LauncherDispatchOptions,
 ): Promise<void> {
-	const host = getLauncherHost(l.packId, l.id, options?.sessionId);
+	const host = getLauncherHost(l.packId, l.id, options?.sessionId, l.hasLocalData);
 	const launchId = `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
 	const launchParams = {
 		...(target.params ?? {}),
@@ -389,7 +395,7 @@ async function runSpawnLauncher(
 	if (inFlightSpawnLaunch.has(l.key)) return;      // ignore re-entrant click
 	inFlightSpawnLaunch.add(l.key);
 	try {
-		const host = getLauncherHost(l.packId, l.id, options?.sessionId);
+		const host = getLauncherHost(l.packId, l.id, options?.sessionId, l.hasLocalData);
 		if (!host?.capabilities?.callRoute) { onResult?.({ ok: false, error: `${l.label} is unavailable.` }); return; }
 		let res: SpawnRouteOutcome | undefined;
 		try {
@@ -488,7 +494,7 @@ export function entrypointInfosFromContributions(packs: ReadonlyArray<PackContri
 				const paramKeys = Array.isArray(e.paramKeys)
 					? (e.paramKeys.filter((k): k is string => typeof k === "string"))
 					: [];
-				out.push({ id, packId, kind: "route", routeId, target: { panelId, params: target?.params }, paramKeys });
+				out.push({ id, packId, kind: "route", routeId, target: { panelId, params: target?.params }, paramKeys, ...(p.hasLocalData === true ? { hasLocalData: true } : {}) });
 			} else if (kind === "composer-slash" || kind === "session-menu") {
 				const label = typeof e.label === "string" ? e.label : undefined;
 				// Pass the launcher target through UNCHANGED — a PanelTarget, a RouteTarget,
@@ -498,7 +504,7 @@ export function entrypointInfosFromContributions(packs: ReadonlyArray<PackContri
 				const target = e.target as PanelTarget | RouteTarget | SpawnLaunchTarget | ChannelPanelLaunchTarget | undefined;
 				if (!label || !target) continue;
 				const icon = isSupportedEntrypointIconId(e.icon) ? e.icon : undefined;
-				out.push({ id, packId, kind, label, ...(icon ? { icon } : {}), target });
+				out.push({ id, packId, kind, label, ...(icon ? { icon } : {}), target, ...(p.hasLocalData === true ? { hasLocalData: true } : {}) });
 			}
 		}
 	}

--- a/src/app/pack-panels.ts
+++ b/src/app/pack-panels.ts
@@ -78,9 +78,9 @@ export interface PackPanel {
  *  `pack-panels.ts` stays free of a `host-api.ts` import cycle (host-api already
  *  imports `openPackPanel`). When the factory is unset (e.g. unit fixtures that
  *  never load host-api) panels render with `host === undefined` exactly as before. */
-let panelHostFactory: ((sessionId: string | undefined, packId: string, panelId: string) => HostApi) | undefined;
+let panelHostFactory: ((sessionId: string | undefined, packId: string, panelId: string, hasLocalData: boolean) => HostApi) | undefined;
 export function setPanelHostFactory(
-	fn: (sessionId: string | undefined, packId: string, panelId: string) => HostApi,
+	fn: (sessionId: string | undefined, packId: string, panelId: string, hasLocalData: boolean) => HostApi,
 ): void {
 	panelHostFactory = fn;
 }
@@ -99,12 +99,12 @@ export function setPanelHostFactory(
  *  `pr-walkthrough.git-widget`) — the surface-token mint validates it against the
  *  pack's registered entrypoints (`getEntrypoint`), so it MUST be a real entrypoint
  *  id, mirroring how {@link panelHostFactory} threads the panelId. */
-let launcherHostFactory: ((sessionId: string | undefined, packId: string, contributionId: string) => HostApi) | undefined;
-export function setLauncherHostFactory(fn: (sessionId: string | undefined, packId: string, contributionId: string) => HostApi): void {
+let launcherHostFactory: ((sessionId: string | undefined, packId: string, contributionId: string, hasLocalData: boolean) => HostApi) | undefined;
+export function setLauncherHostFactory(fn: (sessionId: string | undefined, packId: string, contributionId: string, hasLocalData: boolean) => HostApi): void {
 	launcherHostFactory = fn;
 }
-export function getLauncherHost(packId: string, contributionId: string, sessionId?: string): HostApi | undefined {
-	return launcherHostFactory?.(sessionId ?? currentSessionIdForPanel(), packId, contributionId);
+export function getLauncherHost(packId: string, contributionId: string, sessionId: string | undefined, hasLocalData: boolean): HostApi | undefined {
+	return launcherHostFactory?.(sessionId ?? currentSessionIdForPanel(), packId, contributionId, hasLocalData);
 }
 
 /** The CANONICAL session-switch entrypoint (`connectToSession(sessionId, false)`
@@ -149,6 +149,8 @@ export interface PackPanelInfo {
 	instanceMode?: "singleton" | "parameterized";
 	/** Allowlisted param name used as the instanceKey for parameterized panels. */
 	instanceParam?: string;
+	/** Present only when the winning contributing pack declares project local data. */
+	hasLocalData?: true;
 }
 
 /** A registered panel: the owning `packId` (used to build the pack-addressed
@@ -165,6 +167,7 @@ export interface PackPanelInstanceIdentityInfo {
 interface RegisteredPanel extends PackPanelInstanceIdentityInfo {
 	title?: string;
 	projectId?: string;
+	hasLocalData: boolean;
 }
 
 /** `{packId, panelId}` key → registration. Reconciled from /api/ext/contributions
@@ -224,7 +227,7 @@ export function registerPackPanels(
 		if (!info?.packId || !info.panelId) continue;
 		const instanceMode = info.instanceMode === "parameterized" ? "parameterized" : "singleton";
 		const instanceParam = typeof info.instanceParam === "string" && info.instanceParam.trim() ? info.instanceParam.trim() : undefined;
-		next.set(panelKey(info.packId, info.panelId), { packId: info.packId, panelId: info.panelId, title: info.title, projectId, instanceMode, instanceParam });
+		next.set(panelKey(info.packId, info.panelId), { packId: info.packId, panelId: info.panelId, title: info.title, projectId, instanceMode, instanceParam, hasLocalData: info.hasLocalData === true });
 	}
 	// RECONCILE: compare prior registry to the fresh one.
 	for (const [key, prev] of panels) {
@@ -298,6 +301,7 @@ export function panelInfosFromContributions(packs: ReadonlyArray<PackContributio
 				title: typeof panel?.title === "string" ? panel.title : undefined,
 				instanceMode: raw.instanceMode === "parameterized" ? "parameterized" : raw.instanceMode === "singleton" ? "singleton" : undefined,
 				instanceParam: typeof raw.instanceParam === "string" ? raw.instanceParam : undefined,
+				...(p.hasLocalData === true ? { hasLocalData: true } : {}),
 			});
 		}
 	}
@@ -528,8 +532,9 @@ function removePackPanelTab(packId: string, panelId: string): void {
  */
 function panelInvocationContext(packId: string, panelId: string, params?: Record<string, unknown>, boundSessionId?: string) {
 	const sessionId = boundSessionId || currentSessionIdForPanel();
+	const hasLocalData = panels.get(panelKey(packId, panelId))?.hasLocalData === true;
 	const host = panelHostFactory
-		? panelHostFactory(sessionId, packId, panelId)
+		? panelHostFactory(sessionId, packId, panelId, hasLocalData)
 		: undefined;
 	const renderParams = sessionId ? { ...(params ?? {}), __sessionId: sessionId } : params;
 	return { host, renderParams };

--- a/src/app/pack-renderers.ts
+++ b/src/app/pack-renderers.ts
@@ -37,6 +37,8 @@ export interface PackRendererToolInfo {
 	 *  into the renderer's host so `host.ui.openPanel({panelId})` resolves the panel
 	 *  within the renderer's OWN pack (pack schema V1 — panel ids are pack-local). */
 	packId?: string;
+	/** Present only when the winning contributing pack declares project local data. */
+	hasLocalData?: true;
 }
 
 /** Names currently registered as pack renderers by {@link registerPackRenderers}.
@@ -50,12 +52,19 @@ let packRegistered = new Set<string>();
  *  must resolve within its OWN pack; {@link packIdForTool} supplies that packId to
  *  the surface ref the tool renderer binds (see Messages.ts / ToolGroup.ts). */
 let toolPackIds = new Map<string, string>();
+/** Tool names whose current winning pack declares project local data. */
+let localDataTools = new Set<string>();
 
 /** The structural `packId` that contributed `toolName` (a pack renderer tool), or
  *  `undefined` for a built-in / unknown tool. Used to bind the tool renderer's
  *  Host API to its own pack so `openPanel({panelId})` is pack-scoped. */
 export function packIdForTool(toolName: string): string | undefined {
 	return toolPackIds.get(toolName);
+}
+
+/** Whether the current winning pack renderer tool declares project local data. */
+export function packHasLocalDataForTool(toolName: string): boolean {
+	return localDataTools.has(toolName);
 }
 
 /**
@@ -77,10 +86,12 @@ export function registerPackRenderers(
 ): void {
 	const next = new Set<string>();
 	const nextPackIds = new Map<string, string>();
+	const nextLocalDataTools = new Set<string>();
 	for (const t of tools) {
 		if (t.rendererKind !== "pack") continue;
 		next.add(t.name);
 		if (typeof t.packId === "string" && t.packId) nextPackIds.set(t.name, t.packId);
+		if (t.hasLocalData === true) nextLocalDataTools.add(t.name);
 		const qs = projectId ? `?projectId=${encodeURIComponent(projectId)}` : "";
 		registerLazyToolRenderer(
 			t.name,
@@ -108,6 +119,7 @@ export function registerPackRenderers(
 	// Rebuild the tool→packId map from the fresh metadata (drops uninstalled tools'
 	// entries) so `packIdForTool` always reflects the current winning providers.
 	toolPackIds = nextPackIds;
+	localDataTools = nextLocalDataTools;
 }
 
 /** Sentinel: no reconcile has run yet. Distinct from `undefined` (reconciled

--- a/src/server/agent/docker-args.ts
+++ b/src/server/agent/docker-args.ts
@@ -100,10 +100,48 @@ export function e2eSandboxVolumeCreateArgs(projectId: string, runId = process.en
 	return projectSandboxVolumeCreateArgs(projectId, runId);
 }
 
+export const PACK_LOCAL_DATA_CONTAINER_ROOT = "/bobbit/local-data";
+
+/** One winning pack's canonical project-local data bind mount. */
+export interface PackLocalDataMountPlan {
+	packId: string;
+	hostDirectory: string;
+	containerDirectory: string;
+}
+
+/** Stable sandbox path for a pack's local data. Pack names are manifest-validated. */
+export function packLocalDataContainerDirectory(packId: string): string {
+	if (!/^[a-z0-9][a-z0-9-]*$/.test(packId)) {
+		throw new Error(`[docker-args] Invalid pack ID for local-data mount: ${JSON.stringify(packId)}`);
+	}
+	return `${PACK_LOCAL_DATA_CONTAINER_ROOT}/${encodeURIComponent(packId)}`;
+}
+
+function sortedPackLocalDataMountPlans(plans: readonly PackLocalDataMountPlan[]): PackLocalDataMountPlan[] {
+	const sorted = [...plans].sort((a, b) => a.packId.localeCompare(b.packId));
+	const seenPackIds = new Set<string>();
+	for (const plan of sorted) {
+		if (seenPackIds.has(plan.packId)) {
+			throw new Error(`[docker-args] Duplicate pack local-data mount for ${plan.packId}`);
+		}
+		seenPackIds.add(plan.packId);
+		if (!plan.hostDirectory || !path.isAbsolute(plan.hostDirectory)) {
+			throw new Error(`[docker-args] Pack local-data host directory must be absolute for ${plan.packId}`);
+		}
+		const expectedContainerDirectory = packLocalDataContainerDirectory(plan.packId);
+		if (plan.containerDirectory !== expectedContainerDirectory) {
+			throw new Error(`[docker-args] Pack local-data container directory must be ${expectedContainerDirectory}`);
+		}
+	}
+	return sorted;
+}
+
 export interface DockerRunConfig {
 	image: string;
 	/** Host path to mount as /workspace (used for bind-mount mode when projectId is not set). */
 	workspaceDir: string;
+	/** Canonical project-local directories mounted read-write for winning packs. */
+	packLocalDataMounts?: readonly PackLocalDataMountPlan[];
 
 	// ── Labels ───────────────────────────────────────────────────────────
 	/** Label value for the label prefix. */
@@ -243,6 +281,13 @@ export function buildDockerRunArgs(config: DockerRunConfig, commandRunner: Comma
 		// Legacy pool mode: bind-mount host directory as /workspace
 		args.push("-v", `${toDockerPath(workspaceDir)}:/workspace`);
 	}
+	// Pack local-data mounts are writable by contract. Sort by pack identity so
+	// equivalent winning contribution sets always produce byte-identical args.
+	// Omitting the capability (or resolving no declarations) adds no args.
+	for (const mount of sortedPackLocalDataMountPlans(config.packLocalDataMounts ?? [])) {
+		args.push("-v", `${toDockerPath(mount.hostDirectory)}:${mount.containerDirectory}`);
+	}
+
 	// pi-coding-agent is baked into the Docker image (avoids 20x slower
 	// bind-mount I/O on Docker Desktop Windows/macOS). No node_modules mount needed.
 	args.push("-v", `${toDockerPath(toolsDir)}:/tools:ro`);

--- a/src/server/agent/lifecycle-hub.ts
+++ b/src/server/agent/lifecycle-hub.ts
@@ -121,7 +121,7 @@ export class LifecycleHub {
 	private readonly trace: ContextTraceStore;
 	private readonly gatewayInfo: () => { baseUrl: string; token: string };
 	private readonly globalMaxTokens: number;
-	private readonly providerHostApi?: (opts: { sessionId: string; packId: string }) => ServerHostApi;
+	private readonly providerHostApi?: (opts: { sessionId: string; packId: string; projectId?: string }) => ServerHostApi;
 	private readonly goalMetadataResolver?: GoalMetadataResolver;
 	private readonly scopeContextResolver?: HookScopeContextResolver;
 
@@ -137,12 +137,10 @@ export class LifecycleHub {
 		goalMetadataResolver?: GoalMetadataResolver;
 		/** Best-effort project-safe scope resolver for ordinary lifecycle events. */
 		scopeContextResolver?: HookScopeContextResolver;
-		/** Factory for a LEAST-PRIVILEGE, provider-scoped server Host API (store-only:
-		 *  `capabilities.store === true`, `session`/`agents` false/unavailable). Built
-		 *  per provider invocation so a hook reaches its own pack's durable store
-		 *  (retain queue / diagnostics) via the SAME pack-scoped, parent-authorized
-		 *  path routes use. Omitted ⇒ provider hooks run without `ctx.host`. */
-		providerHostApi?: (opts: { sessionId: string; packId: string }) => ServerHostApi;
+		/** Factory for a least-privilege provider Host API. Store and any declared
+		 *  local-data binding are pack-scoped; session/agents stay unavailable.
+		 *  Omitted ⇒ provider hooks run without `ctx.host`. */
+		providerHostApi?: (opts: { sessionId: string; packId: string; projectId?: string }) => ServerHostApi;
 	}) {
 		this.registry = deps.registry;
 		this.moduleHost = deps.moduleHost;
@@ -204,7 +202,7 @@ export class LifecycleHub {
 			(p) => !disabled.has(p.id) && p.hooks.includes("goalProvisioned"),
 		);
 		for (const provider of providers) {
-			const providerHost = this.providerHostApi?.({ sessionId: `goal:${ctx.goalId}`, packId: packIdFromRoot(provider.packRoot) });
+			const providerHost = this.providerHostApi?.({ sessionId: `goal:${ctx.goalId}`, packId: packIdFromRoot(provider.packRoot), projectId: ctx.projectId });
 			const url = pathToFileURL(path.resolve(path.dirname(provider.sourceFile), provider.module)).href;
 			try {
 				await this.moduleHost.invoke({
@@ -262,11 +260,10 @@ export class LifecycleHub {
 				budget: { maxTokens: provider.budget.maxTokens },
 				gateway: this.gatewayInfo(),
 			};
-			// Provider-scoped, store-only host (least privilege). The LIVE object stays
-			// in the parent (module-host-worker strips it before serialization) and
-			// services the worker's proxied store calls — the durable retain queue /
-			// diagnostics path. packId is derived from the contribution's pack root.
-			const providerHost = this.providerHostApi?.({ sessionId: base.sessionId, packId: packIdFromRoot(provider.packRoot) });
+			// Provider-scoped least-privilege host. The LIVE object stays in the parent
+			// (module-host-worker strips it before serialization). packId is derived
+			// from the contribution's pack root; projectId comes from the bound session.
+			const providerHost = this.providerHostApi?.({ sessionId: base.sessionId, packId: packIdFromRoot(provider.packRoot), projectId: base.projectId });
 			const url = pathToFileURL(path.resolve(path.dirname(provider.sourceFile), provider.module)).href;
 			const t0 = performance.now();
 			let ms = 0;

--- a/src/server/agent/pack-contributions.ts
+++ b/src/server/agent/pack-contributions.ts
@@ -33,7 +33,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { parse } from "yaml";
-import type { PackManifest } from "./pack-types.js";
+import type { PackLocalDataDeclaration, PackManifest } from "./pack-types.js";
 import { isSafeRelativePath, parseEntrypoints } from "./tool-contributions.js";
 import type { EntrypointIconId } from "../../shared/entrypoint-icons.js";
 import { isSafeBasename, isValidPackName } from "./pack-manifest.js";
@@ -297,6 +297,8 @@ export interface PackContributions {
 	packId: string; // structural, from the pack root dir name
 	packName: string;
 	packRoot: string;
+	/** Present only when the winning schema-2 manifest declares local data. */
+	localData?: PackLocalDataDeclaration;
 	panels: PanelContribution[];
 	entrypoints: EntrypointContribution[];
 	providers: ProviderContribution[];
@@ -341,6 +343,7 @@ export function loadPackContributions(packRoot: string, manifest: PackManifest):
 		hooks: loadHooks(packRoot, manifest),
 		mcp: loadMcpContributions(packRoot, manifest),
 	};
+	if (manifest.localData) out.localData = manifest.localData;
 	const routes = loadRoutes(packRoot, manifest);
 	if (routes) out.routes = routes;
 	return out;

--- a/src/server/agent/pack-local-data-runtime.ts
+++ b/src/server/agent/pack-local-data-runtime.ts
@@ -1,0 +1,45 @@
+/**
+ * Agent-realm binding for project-scoped extension pack local data.
+ *
+ * The server-owned resolver derives project and pack identity. Agent/session
+ * callers only select the execution realm; cwd/worktree paths are deliberately
+ * absent from this contract.
+ */
+export const BOBBIT_PACK_LOCAL_DATA_ENV = "BOBBIT_PACK_LOCAL_DATA_JSON";
+
+export type PackLocalDataRealm = "host" | "sandbox";
+export type PackLocalDataBindings = Readonly<Record<string, string>>;
+
+export interface PackLocalDataBindingScope {
+	projectId: string;
+	realm: PackLocalDataRealm;
+}
+
+export type PackLocalDataBindingsResolver = (
+	scope: PackLocalDataBindingScope,
+) => PackLocalDataBindings | undefined;
+
+/**
+ * Resolve and deterministically serialize the exact pack-id-to-directory map.
+ * Empty maps omit the environment capability entirely.
+ */
+export function resolvePackLocalDataEnvironment(
+	resolver: PackLocalDataBindingsResolver | null | undefined,
+	projectId: string | undefined,
+	sandboxed: boolean,
+): Record<string, string> {
+	if (!resolver || !projectId) return {};
+	const bindings = resolver({ projectId, realm: sandboxed ? "sandbox" : "host" });
+	if (!bindings) return {};
+
+	const entries = Object.entries(bindings).sort(([left], [right]) => left < right ? -1 : left > right ? 1 : 0);
+	if (entries.length === 0) return {};
+	for (const [packId, directory] of entries) {
+		if (!packId || typeof directory !== "string" || directory.length === 0) {
+			throw new Error("Pack local-data resolver returned an invalid runtime binding");
+		}
+	}
+	return {
+		[BOBBIT_PACK_LOCAL_DATA_ENV]: JSON.stringify(Object.fromEntries(entries)),
+	};
+}

--- a/src/server/agent/pack-manifest.ts
+++ b/src/server/agent/pack-manifest.ts
@@ -10,7 +10,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { parse, stringify } from "yaml";
-import type { PackManifest, PackMeta, PackRoutesRef, PackScope } from "./pack-types.js";
+import type { PackLocalDataDeclaration, PackManifest, PackMeta, PackRoutesRef, PackScope } from "./pack-types.js";
 
 /** Route name guard — mirrors the per-pack route allowlist token shape. */
 const ROUTE_NAME_RE = /^[a-z0-9][a-z0-9_-]*$/;
@@ -64,6 +64,44 @@ function asStringArray(v: unknown): string[] | null {
 	return out;
 }
 
+const WINDOWS_RESERVED_LOCAL_DATA_NAMES = new Set([
+	"CON", "PRN", "AUX", "NUL", "CLOCK$", "CONIN$", "CONOUT$",
+	...Array.from({ length: 9 }, (_, index) => `COM${index + 1}`),
+	...Array.from({ length: 9 }, (_, index) => `LPT${index + 1}`),
+	...(["¹", "²", "³"] as const).flatMap(suffix => [`COM${suffix}`, `LPT${suffix}`]),
+]);
+
+/** Normalize one portable local-data directory declaration. The accepted form
+ * is already-trimmed, forward-slash-separated, and relative on every host. */
+export function normalizePackLocalDataDirectory(value: unknown): string | null {
+	if (typeof value !== "string" || value.length === 0 || value.trim() !== value) return null;
+	if (value.includes("\\") || value.includes(":")) return null;
+	if (path.posix.isAbsolute(value) || path.win32.isAbsolute(value) || /^[A-Za-z]:/.test(value)) return null;
+	if (/[<>"|?*\0-\x1f\x7f]/.test(value)) return null;
+
+	const components = value.split("/");
+	for (const component of components) {
+		if (component.length === 0 || component === "." || component === "..") return null;
+		if (/[. ]$/.test(component)) return null;
+		const deviceStem = component.split(".", 1)[0]?.toUpperCase();
+		if (deviceStem && WINDOWS_RESERVED_LOCAL_DATA_NAMES.has(deviceStem)) return null;
+	}
+	return components.join("/");
+}
+
+function parseLocalDataDeclaration(raw: unknown): PackLocalDataDeclaration | null {
+	if (!raw || typeof raw !== "object" || Array.isArray(raw)) return null;
+	const data = raw as Record<string, unknown>;
+	const directory = normalizePackLocalDataDirectory(data.directory);
+	if (
+		data.scope !== "project"
+		|| directory === null
+		|| data.access !== "read-write"
+		|| data.preserveOnUninstall !== true
+	) return null;
+	return { scope: "project", directory, access: "read-write", preserveOnUninstall: true };
+}
+
 /**
  * Validate a parsed object as a {@link PackManifest}. Returns the normalized
  * manifest, or `null` with a reason pushed onto `problems`.
@@ -113,6 +151,17 @@ export function validateManifest(
 	if (provides === null) return null;
 	const requires = schemaSupportsExtensionKeys ? parseCapabilities("requires") : undefined;
 	if (requires === null) return null;
+	let localData: PackLocalDataDeclaration | undefined;
+	if (schemaSupportsExtensionKeys && d.localData !== undefined) {
+		const parsed = parseLocalDataDeclaration(d.localData);
+		if (!parsed) {
+			return fail(
+				"pack.yaml: localData must declare scope=project, a portable relative directory, "
+				+ "access=read-write, and preserveOnUninstall=true",
+			);
+		}
+		localData = parsed;
+	}
 
 	const contents = d.contents;
 	if (!contents || typeof contents !== "object" || Array.isArray(contents)) {
@@ -192,6 +241,7 @@ export function validateManifest(
 	if (d.defaultDisabled === true) manifest.defaultDisabled = true;
 	if (provides !== undefined) manifest.provides = provides;
 	if (requires !== undefined) manifest.requires = requires;
+	if (localData !== undefined) manifest.localData = localData;
 	// NEW (pack-schema-v1 §1.2): optional top-level `routes: { module?, names? }`.
 	// Tolerant — a malformed routes block is dropped (no routes), never fatal.
 	const routes = parseRoutesRef(d.routes);

--- a/src/server/agent/pack-manifest.ts
+++ b/src/server/agent/pack-manifest.ts
@@ -71,6 +71,11 @@ const WINDOWS_RESERVED_LOCAL_DATA_NAMES = new Set([
 	...(["¹", "²", "³"] as const).flatMap(suffix => [`COM${suffix}`, `LPT${suffix}`]),
 ]);
 
+const MANAGED_MARKETPLACE_LOCAL_DATA_ROOTS = [
+	".bobbit/config/market-packs",
+	"config/market-packs",
+] as const;
+
 /** Normalize one portable local-data directory declaration. The accepted form
  * is already-trimmed, forward-slash-separated, and relative on every host. */
 export function normalizePackLocalDataDirectory(value: unknown): string | null {
@@ -86,7 +91,12 @@ export function normalizePackLocalDataDirectory(value: unknown): string | null {
 		const deviceStem = component.split(".", 1)[0]?.toUpperCase();
 		if (deviceStem && WINDOWS_RESERVED_LOCAL_DATA_NAMES.has(deviceStem)) return null;
 	}
-	return components.join("/");
+	const normalized = components.join("/");
+	const comparable = normalized.toLowerCase();
+	if (MANAGED_MARKETPLACE_LOCAL_DATA_ROOTS.some(root => comparable === root || comparable.startsWith(`${root}/`))) {
+		return null;
+	}
+	return normalized;
 }
 
 function parseLocalDataDeclaration(raw: unknown): PackLocalDataDeclaration | null {

--- a/src/server/agent/pack-types.ts
+++ b/src/server/agent/pack-types.ts
@@ -43,6 +43,14 @@ export interface PackRoutesRef {
 	names?: string[];
 }
 
+/** Stable project-scoped storage declaration for trusted extension code. */
+export interface PackLocalDataDeclaration {
+	scope: "project";
+	directory: string;
+	access: "read-write";
+	preserveOnUninstall: true;
+}
+
 /** Parsed `pack.yaml`. `contents` is REQUIRED with all v1 entity-list keys. */
 export interface PackManifest {
 	name: string;
@@ -64,6 +72,8 @@ export interface PackManifest {
 	provides?: string[];
 	/** Capability names this pack depends on (schema 2+ metadata). */
 	requires?: string[];
+	/** Optional schema-2 project-scoped extension data directory. */
+	localData?: PackLocalDataDeclaration;
 	/**
 	 * Authoritative advertised contents. v1 keys are REQUIRED but each MAY be
 	 * empty. Schema 2 adds optional pack-scoped catalogues; only `providers` has

--- a/src/server/agent/project-sandbox.ts
+++ b/src/server/agent/project-sandbox.ts
@@ -19,7 +19,16 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { cpuDiagnosticsEnabled, getCpuDiagnostics } from "./cpu-diagnostics.js";
-import { buildDockerRunArgs, projectSandboxVolumeCreateArgs, projectSandboxVolumeNames, SANDBOX_STATE_MOUNTS, validatedE2ERunId } from "./docker-args.js";
+import {
+	buildDockerRunArgs,
+	PACK_LOCAL_DATA_CONTAINER_ROOT,
+	packLocalDataContainerDirectory,
+	projectSandboxVolumeCreateArgs,
+	projectSandboxVolumeNames,
+	SANDBOX_STATE_MOUNTS,
+	validatedE2ERunId,
+	type PackLocalDataMountPlan,
+} from "./docker-args.js";
 import { activeAgentSessionsDir } from "./agent-session-path.js";
 import { globalAgentDir } from "../bobbit-dir.js";
 import { toDockerPath } from "./rpc-bridge.js";
@@ -67,6 +76,11 @@ export interface AgentDirMountStalenessResult {
 export interface StateDirMountExpectation {
 	stateDir: string;
 }
+
+/** Live project-aware resolver; callers must not snapshot winning pack mounts. */
+export type PackLocalDataMountPlanResolver = (
+	projectId: string,
+) => readonly PackLocalDataMountPlan[] | Promise<readonly PackLocalDataMountPlan[]>;
 
 export function getModelsJsonContentStaleness(hostContent: string, containerContent: string): AgentDirMountStalenessResult {
 	return hostContent === containerContent
@@ -180,6 +194,49 @@ export function getStateDirMountStaleness(
 			const mode = readOnly ? "read-only" : "writable";
 			return { stale: true, reason: `state mount ${destination} does not match the active ${mode} state directory` };
 		}
+	}
+	return { stale: false };
+}
+
+/**
+ * Compare the immutable Docker bind set with the current winning declarations.
+ * This is intentionally exact: missing, duplicate, read-only, retargeted, and
+ * stale-extra local-data mounts all require container recreation.
+ */
+export function getPackLocalDataMountStaleness(
+	mounts: DockerMountInfo[] | unknown,
+	expected: readonly PackLocalDataMountPlan[],
+): AgentDirMountStalenessResult {
+	if (!Array.isArray(mounts)) return { stale: true, reason: "container mount metadata is not an array" };
+
+	const actual = mounts.filter((mount) => {
+		const destination = normalizeContainerMountDestination(mount?.Destination);
+		return destination === PACK_LOCAL_DATA_CONTAINER_ROOT
+			|| destination.startsWith(`${PACK_LOCAL_DATA_CONTAINER_ROOT}/`);
+	});
+	const seenPackIds = new Set<string>();
+	for (const plan of expected) {
+		if (seenPackIds.has(plan.packId)) {
+			return { stale: true, reason: `duplicate expected pack local-data mount for ${plan.packId}` };
+		}
+		seenPackIds.add(plan.packId);
+		const destination = packLocalDataContainerDirectory(plan.packId);
+		if (plan.containerDirectory !== destination) {
+			return { stale: true, reason: `pack local-data destination for ${plan.packId} is not stable` };
+		}
+		const matches = actual.filter((mount) => normalizeContainerMountDestination(mount?.Destination) === destination);
+		if (matches.length === 0) return { stale: true, reason: `missing pack local-data mount ${destination}` };
+		if (matches.length !== 1) return { stale: true, reason: `duplicate pack local-data mount ${destination}` };
+		const match = matches[0];
+		if (!mountSourceMatches(match.Source, plan.hostDirectory)) {
+			return { stale: true, reason: `pack local-data mount ${destination} has a stale host source` };
+		}
+		if (match.RW !== true || isMountReadOnly(match)) {
+			return { stale: true, reason: `pack local-data mount ${destination} is not writable` };
+		}
+	}
+	if (actual.length !== expected.length) {
+		return { stale: true, reason: "container has stale extra pack local-data mounts" };
 	}
 	return { stale: false };
 }
@@ -323,6 +380,8 @@ export interface ProjectSandboxOptions {
 	 * container. See `docs/design/base-ref.md` §6.
 	 */
 	baseRefResolver?: () => string | undefined;
+	/** Re-resolved for reconnect checks, explicit refreshes, and every create. */
+	resolvePackLocalDataMounts?: PackLocalDataMountPlanResolver;
 }
 
 export interface ContainerState {
@@ -959,6 +1018,36 @@ export class ProjectSandbox {
 		}
 	}
 
+	/**
+	 * Apply changed winning pack local-data mounts to the immutable container.
+	 * Returns false without disruption when the live plan already matches.
+	 */
+	async refreshPackLocalDataMounts(): Promise<boolean> {
+		if (!this.options.resolvePackLocalDataMounts) return false;
+		return this._withContainerLifecycle(async () => {
+			if (this._status === "starting" && this._readyPromise) await this._readyPromise;
+			const oldContainerId = this.containerId;
+			if (!oldContainerId) return false;
+
+			const expected = await this._resolvePackLocalDataMounts();
+			if (!(await this._hasStalePackLocalDataMounts(oldContainerId, expected))) return false;
+
+			this._recovering = true;
+			this._status = "error";
+			this._emitHealthEvent({ type: "container-died", projectId: this.options.projectId, containerId: oldContainerId });
+			try {
+				await this._removeContainer(oldContainerId);
+				this.containerId = null;
+				await this.init();
+				this._emitHealthEvent({ type: "container-recovered", projectId: this.options.projectId, containerId: this.containerId! });
+				console.log(`[project-sandbox] Refreshed pack local-data mounts for project ${this.options.projectId}`);
+				return true;
+			} finally {
+				this._recovering = false;
+			}
+		});
+	}
+
 	/** Graceful shutdown: stop the container (don't remove — named volume persists). */
 	async shutdown(): Promise<void> {
 		this.stopHealthMonitor();
@@ -1042,6 +1131,14 @@ export class ProjectSandbox {
 			const staleStateMounts = await this._hasStaleStateDirMounts(existingId);
 			if (staleStateMounts) {
 				console.warn(`[project-sandbox] Container ${existingId.substring(0, 12)} has stale state mounts; recreating`);
+				await this._removeContainer(existingId);
+				await this._createContainer(e2eRunId);
+				await this._runInitSequence();
+				return;
+			}
+
+			if (this.options.resolvePackLocalDataMounts && await this._hasStalePackLocalDataMounts(existingId)) {
+				console.warn(`[project-sandbox] Container ${existingId.substring(0, 12)} has stale pack local-data mounts; recreating`);
 				await this._removeContainer(existingId);
 				await this._createContainer(e2eRunId);
 				await this._runInitSequence();
@@ -1165,6 +1262,9 @@ export class ProjectSandbox {
 		// replacement can repair a failed prior initialization without taking over
 		// an unproven pre-existing workspace volume.
 		const volumeEvidence = await this._createSandboxVolumes(e2eRunId);
+		const packLocalDataMounts = this.options.resolvePackLocalDataMounts
+			? await this._resolvePackLocalDataMounts()
+			: undefined;
 		const dockerArgs = buildDockerRunArgs({
 			image,
 			workspaceDir: "", // unused for /workspace — named volume instead
@@ -1186,6 +1286,7 @@ export class ProjectSandbox {
 			sandboxNetwork,
 			toolManager: this.options.toolManager,
 			extraReadonlyMounts: extraReadonlyMounts.length ? extraReadonlyMounts : undefined,
+			packLocalDataMounts,
 		}, this.commandRunner);
 
 		// Inject GITHUB_TOKEN for git push/PR inside container. Only the name goes
@@ -1512,6 +1613,36 @@ export class ProjectSandbox {
 		} catch (err: any) {
 			console.warn(`[project-sandbox] Could not inspect state mounts for container ${containerId.substring(0, 12)}; keeping existing container: ${err?.message || err}`);
 			return false;
+		}
+	}
+
+	private async _resolvePackLocalDataMounts(): Promise<readonly PackLocalDataMountPlan[]> {
+		return await this.options.resolvePackLocalDataMounts?.(this.options.projectId) ?? [];
+	}
+
+	private async _hasStalePackLocalDataMounts(
+		containerId: string,
+		expected: readonly PackLocalDataMountPlan[] | Promise<readonly PackLocalDataMountPlan[]> = this._resolvePackLocalDataMounts(),
+	): Promise<boolean> {
+		const resolvedExpected = await expected;
+		try {
+			const { stdout } = await this.execDocker([
+				"inspect", "--format", "{{json .Mounts}}", containerId,
+			], {
+				timeout: 5_000,
+				env: DOCKER_ENV,
+			});
+			const mounts = JSON.parse(stdout.trim() || "[]") as DockerMountInfo[];
+			const result = getPackLocalDataMountStaleness(mounts, resolvedExpected);
+			if (result.stale && result.reason) {
+				console.warn(`[project-sandbox] Container ${containerId.substring(0, 12)} ${result.reason}`);
+			}
+			return result.stale;
+		} catch (err: any) {
+			throw new Error(
+				`[project-sandbox] Could not inspect pack local-data mounts for container ${containerId.substring(0, 12)}: ${err?.message || err}`,
+				{ cause: err },
+			);
 		}
 	}
 

--- a/src/server/agent/rpc-bridge.ts
+++ b/src/server/agent/rpc-bridge.ts
@@ -15,6 +15,7 @@ import { THINKING_LEVELS, type ThinkingLevel } from "../../shared/thinking-level
 import { resolveBuiltinPacksDir } from "./builtin-packs.js";
 import { scopePaths } from "./pack-types.js";
 import { normalizeToolResultErrorEvent, normalizeToolResultErrorSnapshot } from "./tool-result-error-normalizer.js";
+import { BOBBIT_PACK_LOCAL_DATA_ENV } from "./pack-local-data-runtime.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 /** Builtin tools directory — dist/server/defaults/tools/ (read-only, shipped with Bobbit). */
@@ -286,6 +287,12 @@ export function registerRpcBridgeFactory(factory: RpcBridgeFactory | null): void
  * and emit exactly one leading `--no-approve` and `--no-context-files` that no
  * caller can override.
  */
+/** Build the explicit docker-exec forwarding args for the non-secret pack binding. */
+export function packLocalDataDockerExecArgs(env?: Readonly<Record<string, string>>): string[] {
+	const value = env?.[BOBBIT_PACK_LOCAL_DATA_ENV];
+	return value ? ["-e", `${BOBBIT_PACK_LOCAL_DATA_ENV}=${value}`] : [];
+}
+
 /**
  * Resolve the gateway credentials to inject into a direct (non-sandbox) child's
  * env: BOBBIT_TOKEN + BOBBIT_GATEWAY_URL.
@@ -981,6 +988,7 @@ export class RpcBridge {
 		if (this.options.env?.BOBBIT_GOAL_ID) {
 			execArgs.push("-e", `BOBBIT_GOAL_ID=${this.options.env.BOBBIT_GOAL_ID}`);
 		}
+		execArgs.push(...packLocalDataDockerExecArgs(this.options.env));
 		if (this.options.gatewayToken) {
 			execArgs.push("-e", `BOBBIT_TOKEN=${this.options.gatewayToken}`);
 		}

--- a/src/server/agent/sandbox-manager.ts
+++ b/src/server/agent/sandbox-manager.ts
@@ -225,6 +225,27 @@ export class SandboxManager {
 		}
 	}
 
+	/**
+	 * Reconcile immutable pack local-data binds for one project or every tracked
+	 * project. Each ProjectSandbox serializes comparison/recreation with health
+	 * recovery and emits the normal recovery event only when its live plan differs.
+	 */
+	async refreshPackLocalDataMounts(projectId?: string): Promise<void> {
+		const sandboxes = projectId
+			? [this.sandboxes.get(projectId)].filter((sandbox): sandbox is ProjectSandbox => sandbox !== undefined)
+			: [...this.sandboxes.values()];
+		const results = await Promise.allSettled(sandboxes.map((sandbox) => sandbox.refreshPackLocalDataMounts()));
+		const failures = results.flatMap((result, index) => result.status === "rejected"
+			? [{ projectId: sandboxes[index].getStatus().projectId, reason: result.reason }]
+			: []);
+		if (failures.length > 0) {
+			throw new AggregateError(
+				failures.map((failure) => failure.reason),
+				`Failed to refresh pack local-data mounts for project(s): ${failures.map((failure) => failure.projectId).join(", ")}`,
+			);
+		}
+	}
+
 	/** Get stats for all sandboxes. */
 	getStats(): SandboxManagerStats {
 		const containers: ContainerState[] = [];

--- a/src/server/agent/session-manager.ts
+++ b/src/server/agent/session-manager.ts
@@ -184,6 +184,10 @@ import {
 	normalizeSandboxCwdOffset,
 	relativeSandboxCwdOffset,
 } from "./session-setup.js";
+import {
+	resolvePackLocalDataEnvironment,
+	type PackLocalDataBindingsResolver,
+} from "./pack-local-data-runtime.js";
 
 
 function isSandboxContainerPath(cwd?: string): boolean {
@@ -3257,6 +3261,7 @@ export class SessionManager {
 	private scopedMcpManagers: Map<string, McpManager> = new Map();
 	private marketplaceMcpResolver: MarketplaceMcpResolver | null = null;
 	private marketplacePiExtensionResolver: MarketplacePiExtensionResolver | null = null;
+	private packLocalDataBindingsResolver: PackLocalDataBindingsResolver | null = null;
 	private piExtensionRuntimeDiagnostics = new Map<string, PiExtensionDiagnostic>();
 	private worktreePools: Map<string, WorktreePool> = new Map();
 	private worktreePoolInitializations = new Map<string, Promise<void>>();
@@ -4534,6 +4539,7 @@ export class SessionManager {
 			toolManager: this.toolManager ?? null,
 			mcpManager: this.getMcpManagerForContext(projectId, cwd),
 			marketplacePiExtensionResolver: this.marketplacePiExtensionResolver,
+			packLocalDataBindingsResolver: this.packLocalDataBindingsResolver,
 			goalManager: resolvedGoalManager,
 			taskManager: resolvedTaskManager,
 			projectConfigStore: resolvedProjectConfigStore,
@@ -5277,6 +5283,11 @@ export class SessionManager {
 		this.marketplacePiExtensionResolver = resolver ?? null;
 	}
 
+	/** Late-bound by server composition after the winning pack registry exists. */
+	setPackLocalDataBindingsResolver(resolver: PackLocalDataBindingsResolver | null | undefined): void {
+		this.packLocalDataBindingsResolver = resolver ?? null;
+	}
+
 	resolveMarketplacePiExtensionContributions(projectId?: string, cwd?: string): ReturnType<MarketplacePiExtensionResolver> {
 		return this.overlayPiExtensionRuntimeDiagnostics(this.marketplacePiExtensionResolver?.({ projectId, cwd }) ?? []);
 	}
@@ -5574,6 +5585,7 @@ export class SessionManager {
 		projectId?: string,
 		effectiveGoalId?: string,
 		grantedTools?: string[],
+		sandboxed = false,
 	): { args: string[]; env: Record<string, string>; runtimeExtensions: RuntimePiExtensionInfo[] } {
 		// Goal-metadata disabled tools (bobbit.disabledTools). Resolved from the
 		// session's EFFECTIVE goal (goalId ?? teamGoalId, threaded by the caller)
@@ -5651,7 +5663,16 @@ export class SessionManager {
 			args.push("--extension", aigwDnsGuardPath);
 		}
 
-		return { args, env: activation.env, runtimeExtensions: piExtensionActivation.runtimeExtensions };
+		const packLocalDataEnv = resolvePackLocalDataEnvironment(
+			this.packLocalDataBindingsResolver,
+			projectId,
+			sandboxed,
+		);
+		return {
+			args,
+			env: { ...activation.env, ...packLocalDataEnv },
+			runtimeExtensions: piExtensionActivation.runtimeExtensions,
+		};
 	}
 
 	private messageAuthorDependencies(
@@ -11263,7 +11284,7 @@ export class SessionManager {
 			(hasExplicitAllowlist || effectiveAllowed.length > 0) ? restoredFiltered : undefined;
 		const restoredAllowedNames = restoredAllowedTools?.map(e => e.name);
 		await this.ensureMcpManagerForContext(ps.projectId, ps.cwd);
-		const restoredActivation = this.buildToolActivationArgs(ps.id, restoredAllowedTools, restoredRole, ps.cwd, ps.projectId, ps.goalId ?? ps.teamGoalId, overrideGrantedTools);
+		const restoredActivation = this.buildToolActivationArgs(ps.id, restoredAllowedTools, restoredRole, ps.cwd, ps.projectId, ps.goalId ?? ps.teamGoalId, overrideGrantedTools, restoredSandboxed);
 		bridgeOptions.args = [...restoredActivation.args, ...(bridgeOptions.args || [])];
 		bridgeOptions.piExtensions = [...(bridgeOptions.piExtensions ?? []), ...restoredActivation.runtimeExtensions];
 		bridgeOptions.env = { ...(bridgeOptions.env || {}), ...restoredActivation.env };
@@ -14541,7 +14562,7 @@ export class SessionManager {
 		// `respawnAllowed` is `[]` (NO tools) when a role allowlist was fully removed by
 		// `bobbit.disabledTools`, and `undefined` only for a genuinely unrestricted session.
 		await this.ensureMcpManagerForContext(replacementSession.projectId, replacementSession.cwd);
-		const respawnActivation = this.buildToolActivationArgs(id, respawnAllowed, fullRole, replacementSession.cwd, replacementSession.projectId, respawnEffectiveGoalId, session.sessionOnlyGrantedTools);
+		const respawnActivation = this.buildToolActivationArgs(id, respawnAllowed, fullRole, replacementSession.cwd, replacementSession.projectId, respawnEffectiveGoalId, session.sessionOnlyGrantedTools, replacementSession.sandboxed === true);
 		bridgeOptions.args = [...respawnActivation.args, ...(bridgeOptions.args || [])];
 		bridgeOptions.piExtensions = [...(bridgeOptions.piExtensions ?? []), ...respawnActivation.runtimeExtensions];
 		bridgeOptions.env = { ...(bridgeOptions.env || {}), ...respawnActivation.env };
@@ -17349,7 +17370,7 @@ export class SessionManager {
 				? effective
 				: (effective.length > 0 ? effective : undefined);
 			await this.ensureMcpManagerForContext(session.projectId, session.cwd);
-			const forceActivation = this.buildToolActivationArgs(id, forceAbortAllowed, role, session.cwd, session.projectId, session.goalId ?? session.teamGoalId, session.sessionOnlyGrantedTools);
+			const forceActivation = this.buildToolActivationArgs(id, forceAbortAllowed, role, session.cwd, session.projectId, session.goalId ?? session.teamGoalId, session.sessionOnlyGrantedTools, session.sandboxed === true);
 			bridgeOptions.args = [...forceActivation.args, ...(bridgeOptions.args || [])];
 			bridgeOptions.piExtensions = [...(bridgeOptions.piExtensions ?? []), ...forceActivation.runtimeExtensions];
 			bridgeOptions.env = { ...(bridgeOptions.env || {}), ...forceActivation.env };

--- a/src/server/agent/session-setup.ts
+++ b/src/server/agent/session-setup.ts
@@ -56,6 +56,7 @@ import type { PromptParts, NestingContext } from "./system-prompt.js";
 import type { PrStatusStore } from "./pr-status-store.js";
 import type { LifecycleHub } from "./lifecycle-hub.js";
 import type { ContextBlock } from "./context-blocks.js";
+import { BOBBIT_PACK_LOCAL_DATA_ENV, resolvePackLocalDataEnvironment, type PackLocalDataBindingsResolver } from "./pack-local-data-runtime.js";
 
 import type { ConfigCascade } from "./config-cascade.js";
 import { getAssistantDef, assistantRoleForType } from "./assistant-registry.js";
@@ -422,6 +423,8 @@ export interface PipelineContext {
 	toolManager: ToolManager | null;
 	mcpManager: McpManager | null;
 	marketplacePiExtensionResolver?: MarketplacePiExtensionResolver | null;
+	/** Server-bound project/pack resolver. It never receives cwd or worktree paths. */
+	packLocalDataBindingsResolver?: PackLocalDataBindingsResolver | null;
 	goalManager: GoalManager;
 	taskManager: TaskManager;
 	projectConfigStore: import("./project-config-store.js").ProjectConfigStore | null;
@@ -1063,10 +1066,19 @@ function _resolveToolActivation(plan: SessionSetupPlan, ctx: PipelineContext): v
 
 	const activation = computeToolActivationArgs(plan.effectiveAllowedTools, ctx.toolManager ?? undefined, plan.cwd, mcpExtPaths, disabledTools, toolScope);
 	const piExtensionActivation = resolveMarketplacePiExtensionActivation(ctx.marketplacePiExtensionResolver, plan.projectId, plan.cwd);
+	const packLocalDataEnv = resolvePackLocalDataEnvironment(
+		ctx.packLocalDataBindingsResolver,
+		plan.projectId,
+		plan.sandboxed === true,
+	);
 
 	plan.bridgeOptions.args = prependToolResultErrorBridge([...activation.args, ...piExtensionActivation.args, ...(plan.bridgeOptions.args || [])]);
 	plan.bridgeOptions.piExtensions = [...(plan.bridgeOptions.piExtensions ?? []), ...piExtensionActivation.runtimeExtensions];
-	plan.bridgeOptions.env = { ...(plan.bridgeOptions.env || {}), ...activation.env };
+	// Once the server binding is installed this is a reserved, server-derived
+	// value. An empty winning declaration set means the variable is absent rather
+	// than falling back to a caller-provided path map.
+	if (ctx.packLocalDataBindingsResolver) delete plan.bridgeOptions.env?.[BOBBIT_PACK_LOCAL_DATA_ENV];
+	plan.bridgeOptions.env = { ...(plan.bridgeOptions.env || {}), ...activation.env, ...packLocalDataEnv };
 
 	// Generate and add the tool_call guard extension if any tools have 'ask' or 'never' policy.
 	const guardPath = ctx.toolManager ? writeToolGuardExtension(

--- a/src/server/extension-host/module-host-bootstrap.ts
+++ b/src/server/extension-host/module-host-bootstrap.ts
@@ -155,7 +155,9 @@ interface SerializableCtx {
 	sessionArchived?: boolean;
 	hostVersion?: number;
 	hostContractVersion?: number;
-	capabilities: { callRoute: boolean; session: boolean; store: boolean; agents: boolean };
+	/** Plain, parent-resolved binding. No resolver or live host object crosses here. */
+	localDataDirectory?: string;
+	capabilities: { callRoute: boolean; session: boolean; store: boolean; agents: boolean; localData?: boolean };
 }
 
 interface ChannelSerializableCtx {
@@ -468,8 +470,12 @@ function buildHostProxy(ctx: SerializableCtx): unknown {
 			session: flags.session,
 			store: flags.store,
 			agents: flags.agents,
+			...(flags.localData === true ? { localData: true as const } : {}),
 			has: (name: string) => (flags as Record<string, boolean>)[name] === true,
 		},
+		...(flags.localData === true && typeof ctx.localDataDirectory === "string"
+			? { localData: { directory: (): string => ctx.localDataDirectory! } }
+			: {}),
 		store: {
 			get: (key: string) => callHost(["store", "get"], [key]),
 			// Durable reads preserve absent/present/error across the worker boundary;

--- a/src/server/extension-host/module-host-worker.ts
+++ b/src/server/extension-host/module-host-worker.ts
@@ -186,6 +186,18 @@ export class ModuleHost {
 		const limit = timeoutMs ?? this.defaultTimeoutMs;
 		const host = (req.ctx as { host?: unknown } | undefined)?.host;
 		const capSrc = (host as { capabilities?: Record<string, unknown> } | undefined)?.capabilities;
+		// Pack local data is already resolved and identity-bound by the parent host.
+		// Read it synchronously here so only one plain string crosses the worker
+		// boundary; no resolver, caller path, or function is serialized.
+		const localDataDirectory = capSrc?.localData === true
+			? (host as { localData?: { directory?: () => unknown } } | undefined)?.localData?.directory?.()
+			: undefined;
+		const serializedLocalData = typeof localDataDirectory === "string" && localDataDirectory.length > 0
+			? { localDataDirectory }
+			: {};
+		const serializedLocalDataCapability = typeof localDataDirectory === "string" && localDataDirectory.length > 0
+			? { localData: true as const }
+			: {};
 		const providerCtx = req.ctx as unknown as Record<string, unknown>;
 		// The LIVE host stays in the PARENT (it services proxied store calls); it is a
 		// function-bearing object that cannot cross the MessagePort, so strip it from
@@ -205,7 +217,9 @@ export class ModuleHost {
 					session: capSrc?.session === true,
 					store: capSrc?.store === true,
 					agents: capSrc?.agents === true,
+					...serializedLocalDataCapability,
 				},
+				...serializedLocalData,
 			}
 			: {
 				sessionId: req.ctx?.sessionId,
@@ -223,7 +237,9 @@ export class ModuleHost {
 					session: capSrc?.session === true,
 					store: capSrc?.store === true,
 					agents: capSrc?.agents === true,
+					...serializedLocalDataCapability,
 				},
+				...serializedLocalData,
 			};
 
 		const worker = new Worker(this.bootstrapUrl(), {

--- a/src/server/extension-host/pack-local-data.ts
+++ b/src/server/extension-host/pack-local-data.ts
@@ -219,19 +219,31 @@ export class PackLocalDataResolver {
 	}
 }
 
-/** Native lexical spelling plus its canonical spelling when the path exists. */
+/** Native lexical spelling plus the spelling obtained by canonicalizing the
+ * nearest existing ancestor. Appending the missing suffix is essential when a
+ * managed root sits below a symlinked Headquarters/project directory but its
+ * final `config/market-packs` components have not been created yet. */
 function absolutePathVariants(value: string): string[] {
 	const absolute = path.resolve(value);
 	const variants = [absolute];
-	try {
-		const real = fs.realpathSync(absolute);
-		if (!sameNativePath(absolute, real)) variants.push(real);
-	} catch (cause: any) {
-		if (cause?.code !== "ENOENT" && cause?.code !== "ENOTDIR") {
-			throw new PackLocalDataError("filesystem_error", "Could not canonicalize a managed Marketplace path", { cause });
+	const suffix: string[] = [];
+	let cursor = absolute;
+
+	while (true) {
+		try {
+			const real = path.resolve(fs.realpathSync(cursor), ...suffix);
+			if (!sameNativePath(absolute, real)) variants.push(real);
+			return variants;
+		} catch (cause: any) {
+			if (cause?.code !== "ENOENT" && cause?.code !== "ENOTDIR") {
+				throw new PackLocalDataError("filesystem_error", "Could not canonicalize a managed Marketplace path", { cause });
+			}
+			const parent = path.dirname(cursor);
+			if (parent === cursor) return variants;
+			suffix.unshift(path.basename(cursor));
+			cursor = parent;
 		}
 	}
-	return variants;
 }
 
 function isEqualOrDescendant(root: string, candidate: string): boolean {

--- a/src/server/extension-host/pack-local-data.ts
+++ b/src/server/extension-host/pack-local-data.ts
@@ -22,6 +22,9 @@ export interface PackLocalDataContributionRegistry {
 	list(projectId: string | undefined): PackContributions[];
 }
 
+/** Live view of every Marketplace directory whose children uninstall may remove. */
+export type ManagedMarketplaceRootsProvider = () => readonly string[];
+
 export type PackLocalDataErrorCode =
 	| "project_not_found"
 	| "pack_not_active"
@@ -67,6 +70,7 @@ export class PackLocalDataResolver {
 	constructor(
 		private readonly projects: PackLocalDataProjectRegistry,
 		private readonly contributions: PackLocalDataContributionRegistry,
+		private readonly managedMarketplaceRoots: ManagedMarketplaceRootsProvider = () => [],
 	) {}
 
 	resolveHostDirectory(projectId: string, packId: string): string {
@@ -129,6 +133,14 @@ export class PackLocalDataResolver {
 			throw new PackLocalDataError("invalid_project_root", "Registered project root is unavailable", { cause });
 		}
 
+		// Marketplace uninstall recursively removes an installed pack directory. A
+		// registered project may be an ancestor of Headquarters, the user's home,
+		// or another registered project, so the manifest-only relative-prefix guard
+		// cannot see every managed pack tree. Reject the fully resolved candidate
+		// against the live roots before creating even its first component.
+		const candidate = path.resolve(rootReal, ...normalized.split("/"));
+		this.assertOutsideManagedMarketplaceRoots(candidate);
+
 		let current = rootReal;
 		for (const component of normalized.split("/")) {
 			const candidate = path.join(current, component);
@@ -171,6 +183,32 @@ export class PackLocalDataResolver {
 		return current;
 	}
 
+	private assertOutsideManagedMarketplaceRoots(candidate: string): void {
+		let managedRoots: readonly string[];
+		try {
+			managedRoots = this.managedMarketplaceRoots();
+		} catch (cause) {
+			throw new PackLocalDataError("filesystem_error", "Could not enumerate managed Marketplace roots", { cause });
+		}
+
+		const candidateVariants = absolutePathVariants(candidate);
+		for (const managedRoot of managedRoots) {
+			let rootVariants: string[];
+			try {
+				rootVariants = absolutePathVariants(managedRoot);
+			} catch (cause) {
+				if (cause instanceof PackLocalDataError) throw cause;
+				throw new PackLocalDataError("filesystem_error", "Could not inspect a managed Marketplace root", { cause });
+			}
+			if (rootVariants.some(root => candidateVariants.some(variant => isEqualOrDescendant(root, variant)))) {
+				throw new PackLocalDataError(
+					"unsafe_path",
+					"Pack local-data directory overlaps a Bobbit-managed Marketplace root",
+				);
+			}
+		}
+	}
+
 	private lstat(candidate: string): fs.Stats | undefined {
 		try {
 			return fs.lstatSync(candidate);
@@ -179,6 +217,38 @@ export class PackLocalDataResolver {
 			throw new PackLocalDataError("filesystem_error", "Could not inspect pack local-data directory", { cause });
 		}
 	}
+}
+
+/** Native lexical spelling plus its canonical spelling when the path exists. */
+function absolutePathVariants(value: string): string[] {
+	const absolute = path.resolve(value);
+	const variants = [absolute];
+	try {
+		const real = fs.realpathSync(absolute);
+		if (!sameNativePath(absolute, real)) variants.push(real);
+	} catch (cause: any) {
+		if (cause?.code !== "ENOENT" && cause?.code !== "ENOTDIR") {
+			throw new PackLocalDataError("filesystem_error", "Could not canonicalize a managed Marketplace path", { cause });
+		}
+	}
+	return variants;
+}
+
+function isEqualOrDescendant(root: string, candidate: string): boolean {
+	const rootKey = nativePathKey(root);
+	const candidateKey = nativePathKey(candidate);
+	if (candidateKey === rootKey) return true;
+	const prefix = rootKey.endsWith(path.sep) ? rootKey : `${rootKey}${path.sep}`;
+	return candidateKey.startsWith(prefix);
+}
+
+function nativePathKey(value: string): string {
+	const normalized = path.normalize(path.resolve(value));
+	return process.platform === "win32" ? normalized.toLowerCase() : normalized;
+}
+
+function sameNativePath(left: string, right: string): boolean {
+	return nativePathKey(left) === nativePathKey(right);
 }
 
 function sameWindowsPath(left: string, right: string): boolean {

--- a/src/server/extension-host/pack-local-data.ts
+++ b/src/server/extension-host/pack-local-data.ts
@@ -1,0 +1,186 @@
+import fs from "node:fs";
+import path from "node:path";
+import { normalizePackLocalDataDirectory } from "../agent/pack-manifest.js";
+import type { PackContributions } from "../agent/pack-contributions.js";
+import type { PackLocalDataDeclaration } from "../agent/pack-types.js";
+import { isPackPathWithinRoot } from "./path-guard.js";
+
+export const PACK_LOCAL_DATA_CONTAINER_ROOT = "/bobbit/local-data";
+
+export interface PackLocalDataMount {
+	packId: string;
+	hostDirectory: string;
+	containerDirectory: string;
+}
+
+export interface PackLocalDataProjectRegistry {
+	get(projectId: string): { rootPath: string } | undefined;
+}
+
+export interface PackLocalDataContributionRegistry {
+	getPack(projectId: string | undefined, packId: string): PackContributions | undefined;
+	list(projectId: string | undefined): PackContributions[];
+}
+
+export type PackLocalDataErrorCode =
+	| "project_not_found"
+	| "pack_not_active"
+	| "local_data_undeclared"
+	| "invalid_declaration"
+	| "invalid_project_root"
+	| "unsafe_path"
+	| "path_not_directory"
+	| "path_is_link"
+	| "filesystem_error";
+
+/** A location-binding failure. Adapters decide how to project it to their realm. */
+export class PackLocalDataError extends Error {
+	constructor(
+		public readonly code: PackLocalDataErrorCode,
+		message: string,
+		options?: ErrorOptions,
+	) {
+		super(message, options);
+		this.name = "PackLocalDataError";
+	}
+}
+
+/** Stable sandbox projection. Pack identity is encoded as one path component. */
+export function packLocalDataContainerDirectory(packId: string): string {
+	if (!packId) throw new PackLocalDataError("pack_not_active", "Pack identity is required");
+	let encoded: string;
+	try {
+		encoded = encodeURIComponent(packId).replace(/[.!'()*]/g, character =>
+			`%${character.charCodeAt(0).toString(16).toUpperCase()}`,
+		);
+	} catch (cause) {
+		throw new PackLocalDataError("pack_not_active", "Pack identity cannot be encoded", { cause });
+	}
+	return path.posix.join(PACK_LOCAL_DATA_CONTAINER_ROOT, encoded);
+}
+
+/**
+ * Stateless resolver for an active winning pack's project-local data binding.
+ * It never infers project identity from cwd/worktrees and never caches paths.
+ */
+export class PackLocalDataResolver {
+	constructor(
+		private readonly projects: PackLocalDataProjectRegistry,
+		private readonly contributions: PackLocalDataContributionRegistry,
+	) {}
+
+	resolveHostDirectory(projectId: string, packId: string): string {
+		const project = this.projects.get(projectId);
+		if (!project) {
+			throw new PackLocalDataError("project_not_found", `Unknown project: ${projectId}`);
+		}
+		const pack = this.contributions.getPack(projectId, packId);
+		if (!pack) {
+			throw new PackLocalDataError("pack_not_active", `Pack is not active: ${packId}`);
+		}
+		if (!pack.localData) {
+			throw new PackLocalDataError("local_data_undeclared", `Pack does not declare local data: ${packId}`);
+		}
+		return this.materialize(project.rootPath, pack.localData);
+	}
+
+	resolveContainerDirectory(packId: string): string {
+		return packLocalDataContainerDirectory(packId);
+	}
+
+	/** Resolve all active declarations to deterministic writable mount plans. */
+	resolveMounts(projectId: string): PackLocalDataMount[] {
+		const project = this.projects.get(projectId);
+		if (!project) {
+			throw new PackLocalDataError("project_not_found", `Unknown project: ${projectId}`);
+		}
+		return this.contributions.list(projectId)
+			.filter((pack): pack is typeof pack & { localData: PackLocalDataDeclaration } => pack.localData !== undefined)
+			.map(pack => ({
+				packId: pack.packId,
+				hostDirectory: this.materialize(project.rootPath, pack.localData),
+				containerDirectory: packLocalDataContainerDirectory(pack.packId),
+			}))
+			.sort((a, b) => a.packId.localeCompare(b.packId));
+	}
+
+	private materialize(projectRoot: string, declaration: PackLocalDataDeclaration): string {
+		const normalized = normalizePackLocalDataDirectory(declaration.directory);
+		if (
+			declaration.scope !== "project"
+			|| normalized === null
+			|| declaration.access !== "read-write"
+			|| declaration.preserveOnUninstall !== true
+		) {
+			throw new PackLocalDataError("invalid_declaration", "Pack local-data declaration is invalid");
+		}
+		if (!path.isAbsolute(projectRoot)) {
+			throw new PackLocalDataError("invalid_project_root", "Registered project root is not absolute");
+		}
+
+		let rootReal: string;
+		try {
+			rootReal = fs.realpathSync(projectRoot);
+			if (!fs.lstatSync(rootReal).isDirectory()) {
+				throw new PackLocalDataError("invalid_project_root", "Registered project root is not a directory");
+			}
+		} catch (cause) {
+			if (cause instanceof PackLocalDataError) throw cause;
+			throw new PackLocalDataError("invalid_project_root", "Registered project root is unavailable", { cause });
+		}
+
+		let current = rootReal;
+		for (const component of normalized.split("/")) {
+			const candidate = path.join(current, component);
+			let stat = this.lstat(candidate);
+			if (!stat) {
+				try {
+					fs.mkdirSync(candidate);
+				} catch (cause: any) {
+					// Concurrent resolvers may have created the same component.
+					if (cause?.code !== "EEXIST") {
+						throw new PackLocalDataError("filesystem_error", "Could not create pack local-data directory", { cause });
+					}
+				}
+				stat = this.lstat(candidate);
+			}
+			if (!stat) {
+				throw new PackLocalDataError("filesystem_error", "Pack local-data directory disappeared during creation");
+			}
+			if (stat.isSymbolicLink()) {
+				throw new PackLocalDataError("path_is_link", "Pack local-data path contains a symbolic link or junction");
+			}
+			if (!stat.isDirectory()) {
+				throw new PackLocalDataError("path_not_directory", "Pack local-data path contains a non-directory component");
+			}
+
+			let candidateReal: string;
+			try {
+				candidateReal = fs.realpathSync(candidate);
+			} catch (cause) {
+				throw new PackLocalDataError("filesystem_error", "Could not canonicalize pack local-data directory", { cause });
+			}
+			if (process.platform === "win32" && !sameWindowsPath(candidate, candidateReal)) {
+				throw new PackLocalDataError("path_is_link", "Pack local-data path contains a reparse-point redirect");
+			}
+			if (!isPackPathWithinRoot(rootReal, candidateReal)) {
+				throw new PackLocalDataError("unsafe_path", "Pack local-data directory escapes the registered project root");
+			}
+			current = candidateReal;
+		}
+		return current;
+	}
+
+	private lstat(candidate: string): fs.Stats | undefined {
+		try {
+			return fs.lstatSync(candidate);
+		} catch (cause: any) {
+			if (cause?.code === "ENOENT") return undefined;
+			throw new PackLocalDataError("filesystem_error", "Could not inspect pack local-data directory", { cause });
+		}
+	}
+}
+
+function sameWindowsPath(left: string, right: string): boolean {
+	return path.win32.normalize(left).toLowerCase() === path.win32.normalize(right).toLowerCase();
+}

--- a/src/server/extension-host/server-host-api.ts
+++ b/src/server/extension-host/server-host-api.ts
@@ -30,6 +30,11 @@ import { transcriptToHostMessages, transcriptToToolCall, buildTranscriptEnvelope
 // instance through CreateServerHostApiOptions.orchestrationCore (an A seam).
 import type { DismissResult, OrchestrationCore } from "../agent/orchestration-core.js";
 
+export interface ServerHostLocalDataApi {
+	/** Return the pre-resolved project-scoped directory bound to this pack. */
+	directory(): string;
+}
+
 export interface ServerHostStoreApi {
 	get<T = unknown>(key: string): Promise<T | null>;
 	read<T = unknown>(key: string): Promise<StoreReadResult<T>>;
@@ -124,6 +129,8 @@ export interface ServerHostCapabilities {
 	/** Ambient child-agent orchestration (sub-goal C). True once `host.agents` is
 	 *  wired to the injected OrchestrationCore. */
 	readonly agents: boolean;
+	/** Project-scoped pack local data. Absent unless a directory is bound. */
+	readonly localData?: boolean;
 	/** Convenience: feature-detect by name; returns the flag, or false for unknown names. */
 	has(name: string): boolean;
 }
@@ -146,6 +153,8 @@ export interface ServerHostApi {
 	readonly session: ServerHostSessionApi;
 	/** Ambient child-agent orchestration (sub-goal C) — own host.agents children only. */
 	readonly agents: ServerHostAgentsApi;
+	/** Project-scoped pack data, present only for packs that declare the capability. */
+	readonly localData?: ServerHostLocalDataApi;
 }
 
 export interface CreateServerHostApiOptions {
@@ -163,6 +172,9 @@ export interface CreateServerHostApiOptions {
 	/** Slice B1 — the process-singleton pack store. When present, `ctx.host.store`
 	 *  delegates to it scoped to the closure `packId`. */
 	packStore?: PackStore;
+	/** Pre-resolved project-scoped directory for this pack. The caller derives this
+	 *  from the bound project + winning pack; extension code never supplies a path. */
+	localDataDirectory?: string;
 	/** Host-owned notification fired AFTER a successful `host.store.put`, with the
 	 *  written key. The gateway uses it to drop activation-derived caches when a
 	 *  pack persists provider config (key `provider-config:*`), so a dormant
@@ -193,8 +205,9 @@ export interface CreateServerHostApiOptions {
 	 *  silently delegating. A provider host is built with `{ store: true }` so the
 	 *  worker tier gets `capabilities.store === true` while `session`/`agents` stay
 	 *  false AND unavailable. Omitted ⇒ the full implemented capability set
-	 *  (store/session/agents all true) — the existing route/action host behaviour. */
-	capabilityMask?: { store?: boolean; session?: boolean; agents?: boolean };
+	 *  (store/session/agents all true, plus localData when bound) — the existing
+	 *  route/action host behaviour. */
+	capabilityMask?: { store?: boolean; session?: boolean; agents?: boolean; localData?: boolean };
 }
 
 /**
@@ -234,9 +247,16 @@ export function createServerHostApi(opts: CreateServerHostApiOptions): ServerHos
 	// namespaces are additionally replaced with throwing stubs below so a denied
 	// capability is unavailable, not merely flagged false.
 	const mask = opts.capabilityMask;
-	const flags = mask
-		? { session: mask.session === true, store: mask.store === true, agents: mask.agents === true }
-		: { session: true, store: true, agents: true };
+	const localDataDirectory = typeof opts.localDataDirectory === "string" && opts.localDataDirectory.length > 0
+		? opts.localDataDirectory
+		: undefined;
+	const localDataEnabled = localDataDirectory !== undefined && (!mask || mask.localData === true);
+	const flags = {
+		...(mask
+			? { session: mask.session === true, store: mask.store === true, agents: mask.agents === true }
+			: { session: true, store: true, agents: true }),
+		...(localDataEnabled ? { localData: true as const } : {}),
+	};
 	const capabilities: ServerHostCapabilities = {
 		...flags,
 		has: (name: string) => (flags as Record<string, boolean>)[name] === true,
@@ -382,6 +402,9 @@ export function createServerHostApi(opts: CreateServerHostApiOptions): ServerHos
 		store: flags.store ? store : denyNamespace("store", store),
 		session: flags.session ? session : denyNamespace("session", session),
 		agents: flags.agents ? agents : denyNamespace("agents", agents),
+		...(localDataEnabled
+			? { localData: { directory: (): string => localDataDirectory } }
+			: {}),
 	};
 }
 

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -2836,6 +2836,10 @@ export function createGateway(config: GatewayConfig, deps?: GatewayDeps) {
 		}
 		for (const scope of ["server", "global-user", "project"] as const) {
 			for (const e of marketPackProvider.marketEntries(scope, effectiveProjectId)) {
+				const activation = e.manifest
+					? packActivationStore(scope, effectiveProjectId)?.getPackActivation(scope, e.manifest.name)
+					: undefined;
+				if (!isPackEffectivelyEnabled(e.manifest, activation)) continue;
 				const key = path.resolve(e.path);
 				if (seen.has(key)) continue;
 				seen.add(key);

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -90,7 +90,7 @@ import { resolvePackIdentityForTool } from "./extension-host/pack-identity.js";
 import { mintSurfaceToken, resolveSurfaceIdentity } from "./extension-host/surface-binding.js";
 import type { StorePutOptions } from "../shared/extension-host/host-api.js";
 import { PackContributionRegistry, type ProviderConfigOverrideReadResult } from "./extension-host/pack-contribution-registry.js";
-import { loadPackContributions, providerConfigStoreKey, PROVIDER_CONFIG_KEY_PREFIX } from "./agent/pack-contributions.js";
+import { loadPackContributions, packIdFromRoot, providerConfigStoreKey, PROVIDER_CONFIG_KEY_PREFIX } from "./agent/pack-contributions.js";
 import { loadPiExtensionContributions, loadPiExtensionContributionsWithDiscoverySync } from "./agent/pi-extension-contributions.js";
 import { LifecycleHub, type HookCtx } from "./agent/lifecycle-hub.js";
 import { resolveConfiguredComponent, resolveHookScopeContext } from "./agent/hook-scope-context.js";
@@ -2902,6 +2902,10 @@ export function createGateway(config: GatewayConfig, deps?: GatewayDeps) {
 		for (const entry of marketPackEntriesForProject(projectId)) {
 			if (!entry.manifest || (entry.manifest.schema ?? 1) < 2 || (entry.manifest.contents.piExtensions ?? []).length === 0) continue;
 			const manifest = entry.manifest;
+			const packId = packIdFromRoot(entry.path);
+			const winningPack = packContributionRegistry.getPack(projectId, packId);
+			if ((manifest.localData !== undefined || winningPack?.localData !== undefined)
+				&& (!winningPack || path.resolve(winningPack.packRoot) !== path.resolve(entry.path))) continue;
 			const store = packActivationStore(entry.scope, projectId);
 			const disabled = new Set(store?.getPackActivation(entry.scope as PackOrderScope, manifest.name).piExtensions ?? []);
 			const origin = {
@@ -2959,7 +2963,6 @@ export function createGateway(config: GatewayConfig, deps?: GatewayDeps) {
 		return contributions;
 	};
 	sessionManager.setMarketplaceMcpResolver(marketplaceMcpResolver);
-	sessionManager.setMarketplacePiExtensionResolver(marketplacePiExtensionResolver);
 	packContributionRegistry = new PackContributionRegistry(
 		marketPackEntriesForProject,
 		(scope, projectId, packName) => packActivationStore(scope as PackScope, projectId)?.getPackActivation(scope as PackOrderScope, packName).entrypoints ?? [],
@@ -2990,6 +2993,9 @@ export function createGateway(config: GatewayConfig, deps?: GatewayDeps) {
 		},
 		(scope, projectId, packName) => packActivationStore(scope as PackScope, projectId)?.getPackActivation(scope as PackOrderScope, packName).hooks ?? [],
 	);
+	// Pi winner filtering consults the contribution registry, so bind the resolver
+	// only after the registry is initialized.
+	sessionManager.setMarketplacePiExtensionResolver(marketplacePiExtensionResolver);
 	const packLocalDataResolver = new PackLocalDataResolver(
 		projectRegistry,
 		packContributionRegistry,

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -702,7 +702,7 @@ import { MarketplaceInstaller, MarketplaceError, readPackEntityDescriptions, typ
 import type { MarketplaceMcpResolver, McpReloadResult, McpToolRouteSnapshot, ResolvedMcpContribution } from "./mcp/mcp-manager.js";
 import type { MarketplacePiExtensionResolver, ResolvedPiExtensionContribution, PiExtensionDiagnostic } from "./agent/session-setup.js";
 import { scopeMarketPackEntries, invalidateMarketPackScanCache } from "./agent/pack-list.js";
-import { buildConflictsFor, type ConflictWire, type PackScope, type PackEntry } from "./agent/pack-types.js";
+import { buildConflictsFor, scopePaths, type ConflictWire, type PackScope, type PackEntry } from "./agent/pack-types.js";
 import { isSafeBasename } from "./agent/pack-manifest.js";
 import { gatewayMcpActivationContributionId, gatewayMcpRuntimeKey } from "./agent/mcp-gateway-runtime-identity.js";
 
@@ -2990,7 +2990,15 @@ export function createGateway(config: GatewayConfig, deps?: GatewayDeps) {
 		},
 		(scope, projectId, packName) => packActivationStore(scope as PackScope, projectId)?.getPackActivation(scope as PackOrderScope, packName).hooks ?? [],
 	);
-	const packLocalDataResolver = new PackLocalDataResolver(projectRegistry, packContributionRegistry);
+	const packLocalDataResolver = new PackLocalDataResolver(
+		projectRegistry,
+		packContributionRegistry,
+		() => [
+			scopePaths("server", headquartersDir()).marketPacksRoot,
+			scopePaths("global-user", os.homedir()).marketPacksRoot,
+			...projectRegistry.list().map(project => scopePaths("project", project.rootPath).marketPacksRoot),
+		],
+	);
 	const resolveDeclaredPackLocalData = (projectId: string | undefined, packId: string): string | undefined => {
 		if (!projectId || !packId || !packContributionRegistry.getPack(projectId, packId)?.localData) return undefined;
 		return packLocalDataResolver.resolveHostDirectory(projectId, packId);

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -10100,6 +10100,10 @@ async function handleApiRoute(
 			json({ error: surf.error }, surf.status);
 			return;
 		}
+		// `surf.tool` comes only from an HMAC-validated, session-bound token whose
+		// winning contribution was re-resolved above. Its absence intentionally selects
+		// the installed+active+own-session contract for pack-bound surfaces.
+		// codeql[js/user-controlled-bypass] Signed surface kind selects one of two complete authorization contracts.
 		const guard = surf.tool !== undefined
 			? authorizeScopedRequest({
 				tool: surf.tool,

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -84,6 +84,7 @@ import { ModuleHost } from "./extension-host/module-host-worker.js";
 import { authorizeActionRequest, authorizeScopedRequest, transcriptHasToolUse, type ActionGuardSession } from "./extension-host/action-guard.js";
 import { getPackStore, withStoreTimeout, PackStoreTimeoutError, PackStoreQuotaError } from "./extension-host/pack-store.js";
 import { createServerHostApi } from "./extension-host/server-host-api.js";
+import { PackLocalDataError, PackLocalDataResolver } from "./extension-host/pack-local-data.js";
 import { transcriptToHostMessages, transcriptToToolCall, buildTranscriptEnvelope } from "./extension-host/contract-adapter.js";
 import { resolvePackIdentityForTool } from "./extension-host/pack-identity.js";
 import { mintSurfaceToken, resolveSurfaceIdentity } from "./extension-host/surface-binding.js";
@@ -2989,6 +2990,19 @@ export function createGateway(config: GatewayConfig, deps?: GatewayDeps) {
 		},
 		(scope, projectId, packName) => packActivationStore(scope as PackScope, projectId)?.getPackActivation(scope as PackOrderScope, packName).hooks ?? [],
 	);
+	const packLocalDataResolver = new PackLocalDataResolver(projectRegistry, packContributionRegistry);
+	const resolveDeclaredPackLocalData = (projectId: string | undefined, packId: string): string | undefined => {
+		if (!projectId || !packId || !packContributionRegistry.getPack(projectId, packId)?.localData) return undefined;
+		return packLocalDataResolver.resolveHostDirectory(projectId, packId);
+	};
+	sessionManager.setPackLocalDataBindingsResolver(({ projectId, realm }) => {
+		const mounts = packLocalDataResolver.resolveMounts(projectId);
+		if (mounts.length === 0) return undefined;
+		return Object.fromEntries(mounts.map((mount) => [
+			mount.packId,
+			realm === "sandbox" ? mount.containerDirectory : mount.hostDirectory,
+		]));
+	});
 	sessionManager.lifecycleHub = new LifecycleHub({
 		registry: packContributionRegistry,
 		moduleHost,
@@ -3011,16 +3025,24 @@ export function createGateway(config: GatewayConfig, deps?: GatewayDeps) {
 		// only coordinates owned by the dispatched session and never falls back to
 		// another project by goal id.
 		scopeContextResolver: (input) => resolveHookScopeContext(projectContextManager, input),
-		// Least-privilege, store-only host for provider hooks (capabilities.store ===
-		// true; session/agents denied) — gives a provider its own pack-scoped durable
-		// store via the same parent-authorized path routes use.
-		providerHostApi: ({ sessionId, packId }) => createServerHostApi({
-			sessionId,
-			packId,
-			contributionId: "",
-			packStore: getPackStore(),
-			capabilityMask: { store: true, session: false, agents: false },
-		}),
+		// Least-privilege provider host: durable store plus the provider pack's
+		// declared local-data binding; session/agents remain denied.
+		providerHostApi: ({ sessionId, packId, projectId }) => {
+			const localDataDirectory = resolveDeclaredPackLocalData(projectId, packId);
+			return createServerHostApi({
+				sessionId,
+				packId,
+				contributionId: "",
+				packStore: getPackStore(),
+				...(localDataDirectory ? { localDataDirectory } : {}),
+				capabilityMask: {
+					store: true,
+					session: false,
+					agents: false,
+					...(localDataDirectory ? { localData: true } : {}),
+				},
+			});
+		},
 		gatewayInfo: () => {
 			try {
 				const baseUrl = publishedGatewayUrl || process.env.BOBBIT_GATEWAY_URL || fs.readFileSync(path.join(bobbitStateDir(), "gateway-url"), "utf-8").trim();
@@ -3916,7 +3938,7 @@ export function createGateway(config: GatewayConfig, deps?: GatewayDeps) {
 			// Enable via BOBBIT_TIMING_LOG=1 to print "[timing] METHOD path ms" for each API call.
 			const _timingEnabled = process.env.BOBBIT_TIMING_LOG === "1";
 			const _timingStart = _timingEnabled ? performance.now() : 0;
-			await handleApiRoute(url, req, res, sessionManager, config, colorStore, prStatusStore, teamManager, orchestrationCore, roleManager, toolManager, projectContextManager, bgProcessManager, staffManager, verificationHarness, preferencesStore, projectConfigStore, groupPolicyStore, broadcastToGoal, broadcastToAll, broadcastToUi, sandboxManager, projectRegistry, configCascade, sandboxScope, sandboxTokenStore, reviewAnnotationStore, broadcastToSession, roleStore, inboxManager, marketplaceSourceStore, marketplaceInstaller, cookieStore, actionDispatcher, routeDispatcher, routeRegistry, packContributionRegistry, extensionChannelServices, gatewayDeps.fetchImpl, gatewayDeps.commandRunner, gatewayDeps.fsImpl, gatewayDeps.clock, withPreviewSessionOperation, reviewPayloadOperations, oauthCancellationRetryState, remoteStateRoutes);
+			await handleApiRoute(url, req, res, sessionManager, config, colorStore, prStatusStore, teamManager, orchestrationCore, roleManager, toolManager, projectContextManager, bgProcessManager, staffManager, verificationHarness, preferencesStore, projectConfigStore, groupPolicyStore, broadcastToGoal, broadcastToAll, broadcastToUi, sandboxManager, projectRegistry, configCascade, sandboxScope, sandboxTokenStore, reviewAnnotationStore, broadcastToSession, roleStore, inboxManager, marketplaceSourceStore, marketplaceInstaller, cookieStore, actionDispatcher, routeDispatcher, routeRegistry, packContributionRegistry, packLocalDataResolver, extensionChannelServices, gatewayDeps.fetchImpl, gatewayDeps.commandRunner, gatewayDeps.fsImpl, gatewayDeps.clock, withPreviewSessionOperation, reviewPayloadOperations, oauthCancellationRetryState, remoteStateRoutes);
 			if (_timingEnabled) {
 				const dur = performance.now() - _timingStart;
 				if (dur >= 100) console.log(`[timing] ${req.method} ${url.pathname}${url.search} ${dur.toFixed(1)}ms`);
@@ -4694,6 +4716,9 @@ export function createGateway(config: GatewayConfig, deps?: GatewayDeps) {
 					// reads the current project-config-store value rather than a snapshot taken at
 					// sandbox bootstrap. Same shape as the worktree-pool baseRefResolver.
 					baseRefResolver: () => cfg.get("base_ref"),
+					// Docker mounts are immutable, so every reconnect/recovery/create reads
+					// the current winning declarations rather than retaining a boot snapshot.
+					resolvePackLocalDataMounts: (resolvedProjectId) => packLocalDataResolver.resolveMounts(resolvedProjectId),
 				};
 			};
 			sandboxManager = new SandboxManager({ bootstrap: sandboxBootstrap, commandRunner: gatewayDeps.commandRunner, clock: gatewayDeps.clock, worktreeSetupRuntime });
@@ -5259,6 +5284,7 @@ async function handleApiRoute(
 	routeDispatcherArg?: RouteDispatcher,
 	routeRegistryArg?: RouteRegistry,
 	packContributionRegistryArg?: PackContributionRegistry,
+	packLocalDataResolverArg?: PackLocalDataResolver,
 	extensionChannelServices?: ExtensionChannelServices,
 	fetchImpl: typeof fetch = fetch,
 	commandRunner: CommandRunner = realCommandRunner,
@@ -5281,6 +5307,13 @@ async function handleApiRoute(
 	// pack-schema-v1 §5.2: the project-scoped pack-contribution registry (panels /
 	// entrypoints / routes), always wired by the sole caller.
 	const packContributionRegistry = packContributionRegistryArg!;
+	const packLocalDataResolver = packLocalDataResolverArg!;
+	const packDeclaresLocalData = (projectId: string | undefined, packId: string): boolean =>
+		!!projectId && !!packId && packContributionRegistry.getPack(projectId, packId)?.localData !== undefined;
+	const resolveDeclaredPackLocalData = (projectId: string | undefined, packId: string): string | undefined => {
+		if (!projectId || !packDeclaresLocalData(projectId, packId)) return undefined;
+		return packLocalDataResolver.resolveHostDirectory(projectId, packId);
+	};
 	/** Serialize a cascade-resolved item with origin/overrides + market-pack tags (design §5.2). */
 	const withOrigin = (r: { item: Record<string, unknown>; origin: unknown; overrides?: unknown; originPackId?: string | null; originPackName?: string | null }): Record<string, unknown> => ({
 		...r.item,
@@ -5359,6 +5392,36 @@ async function handleApiRoute(
 		const result = await sessionManager.reloadMcpAfterMarketplaceMutation(scope, projectId);
 		refreshMcpExternalTools();
 		return result;
+	};
+	type PackLocalDataDeclarationSnapshot = Map<string, string>;
+	const snapshotPackLocalDataDeclarations = (scope: InstallScope, projectId?: string): PackLocalDataDeclarationSnapshot => {
+		const projectIds = scope === "project" && projectId
+			? [projectId]
+			: [...new Set((sandboxManager?.getStats().containers ?? []).map((container) => container.projectId))];
+		return new Map(projectIds.map((id) => [
+			id,
+			JSON.stringify(packContributionRegistry.list(id)
+				.filter((pack) => pack.localData !== undefined)
+				.map((pack) => ({ packId: pack.packId, localData: pack.localData }))
+				.sort((left, right) => left.packId.localeCompare(right.packId))),
+		]));
+	};
+	const refreshPackLocalDataAfterMarketplaceMutation = async (
+		scope: InstallScope,
+		projectId: string | undefined,
+		before: PackLocalDataDeclarationSnapshot,
+	): Promise<void> => {
+		const after = snapshotPackLocalDataDeclarations(scope, projectId);
+		const changedProjectIds = [...new Set([...before.keys(), ...after.keys()])]
+			.filter((id) => before.get(id) !== after.get(id));
+		if (changedProjectIds.length === 0) return;
+		try {
+			await Promise.all(changedProjectIds.map((id) => sandboxManager?.refreshPackLocalDataMounts(id)));
+		} catch (err) {
+			// The pack mutation is already durable. Keep its data intact and report the
+			// recoverable exposure mismatch without pretending the old container changed.
+			console.warn("[pack-local-data] sandbox mount refresh failed after marketplace mutation:", err);
+		}
 	};
 	// Host-owned activation-cache invalidation: a pack persisting provider config
 	// (key `provider-config:*`) must drop the activation-filtered provider index so
@@ -9483,7 +9546,10 @@ async function handleApiRoute(
 			const out = withOrigin(r as any);
 			if (r.originPackId && toolPackTm) {
 				const packId = resolvePackIdentityForTool(toolPackTm, r.item.name).packId;
-				if (packId) out.packId = packId;
+				if (packId) {
+					out.packId = packId;
+					if (packDeclaresLocalData(effectiveConfigProjectId, packId)) out.hasLocalData = true;
+				}
 			}
 			return out;
 		});
@@ -9532,7 +9598,15 @@ async function handleApiRoute(
 				// pack-schema-v1: mirror the LIST endpoint's structural packId so the
 				// tools edit page keeps the same own-pack identity for a market-pack tool.
 				const packId = cascadeEntry.originPackId ? resolvePackIdentityForTool(tm, name).packId : "";
-				const detail: Record<string, unknown> = { ...tool, origin: withMeta.origin, ...(withMeta.overrides ? { overrides: withMeta.overrides } : {}), originPackId: withMeta.originPackId, originPackName: withMeta.originPackName, ...(packId ? { packId } : {}) };
+				const detail: Record<string, unknown> = {
+					...tool,
+					origin: withMeta.origin,
+					...(withMeta.overrides ? { overrides: withMeta.overrides } : {}),
+					originPackId: withMeta.originPackId,
+					originPackName: withMeta.originPackName,
+					...(packId ? { packId } : {}),
+					...(packDeclaresLocalData(effectiveConfigProjectId, packId) ? { hasLocalData: true } : {}),
+				};
 				if (piTool) appendPiExtensionToolRows([detail], [piTool]);
 				attachToolDiagnostics([detail], toolDiagnostics);
 				json(detail);
@@ -9709,6 +9783,7 @@ async function handleApiRoute(
 		const packs = packContributionRegistry.list(contribScope.effectiveProjectId).map((p) => ({
 			packId: p.packId,
 			packName: p.packName,
+			...(p.localData !== undefined ? { hasLocalData: true } : {}),
 			panels: p.panels.map((panel) => {
 				const out: Record<string, unknown> = { id: panel.id };
 				if (panel.title !== undefined) out.title = panel.title;
@@ -9825,12 +9900,14 @@ async function handleApiRoute(
 			const jsonl = await sessionFileRead(fsCtx, ps.agentSessionFile, sandboxManager);
 			return projectOwnTranscriptJsonl(guard.sessionId, jsonl);
 		};
+		const actionLocalDataDirectory = resolveDeclaredPackLocalData(actionSessionProjectId, ident.packId);
 		const host = createServerHostApi({
 			sessionId: guard.sessionId,
 			toolUseId,
 			packId: ident.packId,
 			contributionId: ident.contributionId,
 			packStore: getPackStore(),
+			...(actionLocalDataDirectory ? { localDataDirectory: actionLocalDataDirectory } : {}),
 			readOwnTranscript,
 			// Sub-goal A seam — sub-goal C consumes this to back `host.agents`.
 			orchestrationCore,
@@ -9974,6 +10051,67 @@ async function handleApiRoute(
 		}
 		console.log(`[ext-channel-grant] channel=${result.channelName} packId=${result.packId} session=${result.sessionId} outcome=ok`);
 		json({ openGrant: result.openGrant });
+		return;
+	}
+
+	// POST /api/ext/local-data/directory — resolve the calling surface's winning
+	// pack against the authenticated session's canonical project. The request has
+	// no project, pack, or path input; all three coordinates are server-derived.
+	if (url.pathname === "/api/ext/local-data/directory" && req.method === "POST") {
+		const body = (await readBody(req)) ?? {};
+		const headerSessionId = req.headers["x-bobbit-session-id"] as string | string[] | undefined;
+		const headerSid = Array.isArray(headerSessionId) ? headerSessionId[0] : headerSessionId;
+		const sessionProjectId = headerSid
+			? (sessionManager.getSession(headerSid)?.projectId
+				?? sessionManager.getPersistedSession(headerSid)?.projectId)
+			: undefined;
+		const sessionToolManager = resolveActionToolManager(
+			toolManager,
+			sessionProjectId ? projectContextManager.getOrCreate(sessionProjectId)?.toolManager : undefined,
+		);
+		const resolveSession = (id: string): ActionGuardSession | undefined => {
+			const live = sessionManager.getSession(id);
+			if (live) return { allowedTools: live.allowedTools };
+			const persisted = sessionManager.getPersistedSession(id);
+			return persisted ? { allowedTools: persisted.allowedTools } : undefined;
+		};
+		const surf = resolveSurfaceIdentity({
+			token: (body as { surfaceToken?: unknown }).surfaceToken,
+			headerSessionId: headerSid,
+			resolver: sessionToolManager,
+			contributions: packContributionRegistry,
+			projectId: sessionProjectId,
+		});
+		if (!surf.ok) {
+			json({ error: surf.error }, surf.status);
+			return;
+		}
+		const guard = surf.tool !== undefined
+			? authorizeScopedRequest({
+				tool: surf.tool,
+				headerSessionId,
+				bodySessionId: (body as { sessionId?: unknown }).sessionId,
+				resolveSession,
+			})
+			: packBoundScopedGuard(headerSid, (body as { sessionId?: unknown }).sessionId, resolveSession);
+		if (!guard.ok) {
+			json({ error: guard.error }, guard.status);
+			return;
+		}
+		if (!sessionProjectId) {
+			json({ error: "pack local data is unavailable", code: "project_not_found" }, 404);
+			return;
+		}
+		try {
+			json({ directory: packLocalDataResolver.resolveHostDirectory(sessionProjectId, surf.packId) });
+		} catch (err) {
+			if (err instanceof PackLocalDataError) {
+				const status = err.code === "local_data_undeclared" || err.code === "pack_not_active" || err.code === "project_not_found" ? 404 : 409;
+				json({ error: "pack local data is unavailable", code: err.code }, status);
+				return;
+			}
+			throw err;
+		}
 		return;
 	}
 
@@ -10245,12 +10383,14 @@ async function handleApiRoute(
 			const jsonl = await sessionFileRead(fsCtx, ps.agentSessionFile, sandboxManager);
 			return projectOwnTranscriptJsonl(guard.sessionId, jsonl);
 		};
+		const routeLocalDataDirectory = resolveDeclaredPackLocalData(routeSessionProjectId, ident.packId);
 		const host = createServerHostApi({
 			sessionId: guard.sessionId,
 			toolUseId,
 			packId: ident.packId,
 			contributionId: ident.contributionId,
 			packStore: getPackStore(),
+			...(routeLocalDataDirectory ? { localDataDirectory: routeLocalDataDirectory } : {}),
 			readOwnTranscript,
 			// Sub-goal A seam — sub-goal C consumes this to back `host.agents`.
 			orchestrationCore,
@@ -10889,8 +11029,10 @@ async function handleApiRoute(
 			try {
 				const targetScope = st.target.scope;
 				const targetProjectId = targetScope === "project" ? normalizeConfigProjectId(body?.projectId) : undefined;
+				const localDataBefore = snapshotPackLocalDataDeclarations(targetScope, targetProjectId);
 				const installed = await installer.installMarketplacePack({ sourceId: body.sourceId, dirName, scope: targetScope, projectBase: st.target.projectBase, packOrderStore: st.target.store });
 				invalidateResolverCaches();
+				await refreshPackLocalDataAfterMarketplaceMutation(targetScope, targetProjectId, localDataBefore);
 				const mcpReload = installed.manifest.contents.mcp?.length ? await reloadMcpAfterMarketplaceMutation(targetScope, targetProjectId) : undefined;
 				json({ installed, ...(mcpReload ? { mcpReload } : {}) }, 201);
 			} catch (err) { handleMarketErr(err); }
@@ -10914,10 +11056,12 @@ async function handleApiRoute(
 			try {
 				const targetScope = st.target.scope;
 				const targetProjectId = targetScope === "project" ? normalizeConfigProjectId(body?.projectId) : undefined;
+				const localDataBefore = snapshotPackLocalDataDeclarations(targetScope, targetProjectId);
 				const prior = installer.listInstalled([{ scope: targetScope, projectBase: st.target.projectBase }]).find((p) => p.scope === targetScope && p.packName === body.packName);
 				const hadMcp = (prior?.manifest.contents.mcp?.length ?? 0) > 0;
 				const installed = await installer.updateMarketplacePack({ packName: body.packName, scope: targetScope, projectBase: st.target.projectBase, packOrderStore: st.target.store });
 				invalidateResolverCaches();
+				await refreshPackLocalDataAfterMarketplaceMutation(targetScope, targetProjectId, localDataBefore);
 				const hasMcp = (installed.manifest.contents.mcp?.length ?? 0) > 0;
 				const mcpReload = hadMcp || hasMcp ? await reloadMcpAfterMarketplaceMutation(targetScope, targetProjectId) : undefined;
 				json({ installed, ...(mcpReload ? { mcpReload } : {}) });
@@ -10942,9 +11086,11 @@ async function handleApiRoute(
 			try {
 				const targetScope = st.target.scope;
 				const targetProjectId = targetScope === "project" ? normalizeConfigProjectId(body?.projectId) : undefined;
+				const localDataBefore = snapshotPackLocalDataDeclarations(targetScope, targetProjectId);
 				const prior = installer.listInstalled([{ scope: targetScope, projectBase: st.target.projectBase }]).find((p) => p.scope === targetScope && p.packName === body.packName);
 				installer.uninstallPack({ packName: body.packName, scope: targetScope, projectBase: st.target.projectBase, packOrderStore: st.target.store });
 				invalidateResolverCaches();
+				await refreshPackLocalDataAfterMarketplaceMutation(targetScope, targetProjectId, localDataBefore);
 				if (prior?.manifest.contents.mcp?.length) await reloadMcpAfterMarketplaceMutation(targetScope, targetProjectId);
 				res.writeHead(204); res.end();
 			} catch (err) { handleMarketErr(err, 404); }
@@ -11003,8 +11149,10 @@ async function handleApiRoute(
 			const filtered = (body.order as string[]).filter((n) => installedSet.has(n));
 			const missing = installedNames.filter((n) => !filtered.includes(n));
 			const normalized = [...missing, ...filtered];
+			const localDataBefore = snapshotPackLocalDataDeclarations(targetScope, targetProjectId);
 			st.target.store.setPackOrder(targetScope, normalized);
 			invalidateResolverCaches();
+			await refreshPackLocalDataAfterMarketplaceMutation(targetScope, targetProjectId, localDataBefore);
 			const hasMcp = installer.listInstalled([{ scope: targetScope, projectBase: st.target.projectBase }]).some((p) => p.scope === targetScope && (p.manifest.contents.mcp?.length ?? 0) > 0);
 			const mcpReload = hasMcp ? await reloadMcpAfterMarketplaceMutation(targetScope, targetProjectId) : undefined;
 			json({ scope: targetScope, order: normalized, ...(mcpReload ? { mcpReload } : {}) });
@@ -11319,8 +11467,10 @@ async function handleApiRoute(
 			};
 			const before = beforeActivation.mcp ?? [];
 			const beforeOps = beforeActivation.mcpOperations ?? {};
+			const localDataBefore = snapshotPackLocalDataDeclarations(targetScope, targetProjectId);
 			cfgStore.setPackActivation(targetScope as PackOrderScope, packName, normalized);
 			invalidateResolverCaches();
+			await refreshPackLocalDataAfterMarketplaceMutation(targetScope, targetProjectId, localDataBefore);
 			const mcpChanged = JSON.stringify([...before].sort()) !== JSON.stringify([...normalized.mcp].sort()) || JSON.stringify(beforeOps) !== JSON.stringify(normalized.mcpOperations ?? {});
 			const mcpReload = mcpChanged ? await reloadMcpAfterMarketplaceMutation(targetScope, targetProjectId) : undefined;
 			const refreshedCatalogue = mcpChanged ? buildActivationCatalogue(targetScope, st.target.projectBase, st.target.store, packName, targetProjectId) ?? catalogue : catalogue;

--- a/src/shared/extension-host/host-api.ts
+++ b/src/shared/extension-host/host-api.ts
@@ -117,6 +117,9 @@ export interface HostApi {
 	/** UI surface capabilities. PHASE 2 (frozen, not implemented). */
 	readonly ui: HostUiApi;
 
+	/** Stable project-scoped directory, present only when the contributing pack declares it. */
+	readonly localData?: HostLocalDataApi;
+
 	/** Ownership-scoped persistence. PHASE 2 (frozen, not implemented). */
 	readonly store: HostStoreApi;
 
@@ -144,6 +147,8 @@ export interface HostCapabilities {
 	readonly ui: boolean;
 	/** Phase-2 — ownership-scoped persistence. False on a Phase-1 host. */
 	readonly store: boolean;
+	/** Project-scoped pack local data. False/absent until the host wires the binding. */
+	readonly localData?: boolean;
 	/** Long-lived pack-scoped framed channels. False/absent until the host wires the bridge. */
 	readonly channels?: boolean;
 	/** Convenience: feature-detect by name; returns the flag, or false for unknown names. */
@@ -160,6 +165,12 @@ export interface HostRouteInit {
 	body?: unknown;
 	/** Typed query params appended to the route. */
 	query?: Record<string, string | number | boolean>;
+}
+
+/** Project-scoped directory bound to the current pack surface by the host. */
+export interface HostLocalDataApi {
+	/** Return the host-realm absolute path without accepting caller-supplied identity or path input. */
+	directory(): Promise<string>;
 }
 
 /** PHASE 2 — frozen, not implemented. Read/post the current session's transcript.

--- a/src/ui/components/Messages.ts
+++ b/src/ui/components/Messages.ts
@@ -17,7 +17,7 @@ import { i18n } from "../utils/i18n.js";
 import { fetchToolContentByToolCall } from "../utils/fetch-tool-content.js";
 import { state as appState, renderApp } from "../../app/state.js";
 import { getHostApi } from "../../app/host-api.js";
-import { packIdForTool } from "../../app/pack-renderers.js";
+import { packHasLocalDataForTool, packIdForTool } from "../../app/pack-renderers.js";
 import "./ThinkingBlock.js";
 import "./LiveTimer.js";
 import "./ToolGroup.js";
@@ -889,7 +889,12 @@ export class ToolMessage extends LitElement {
 				goalId: goalIdCtx,
 				getAskResponseAnswers,
 				packTool: toolName,
-				host: getHostApi(sessionIdCtx, this.toolCall.id, { kind: "tool", tool: toolName, packId: packIdForTool(toolName) }),
+				host: getHostApi(sessionIdCtx, this.toolCall.id, {
+					kind: "tool",
+					tool: toolName,
+					packId: packIdForTool(toolName),
+					...(packHasLocalDataForTool(toolName) ? { hasLocalData: true } : {}),
+				}),
 			},
 		);
 

--- a/src/ui/components/ToolGroup.ts
+++ b/src/ui/components/ToolGroup.ts
@@ -16,7 +16,7 @@ import { renderTool } from "../tools/index.js";
 import { isSkippedToolResult, TOOL_RENDERER_LOADED_EVENT, TOOL_RENDER_REQUESTED_EVENT } from "../tools/renderer-registry.js";
 import { state as appState } from "../../app/state.js";
 import { getHostApi } from "../../app/host-api.js";
-import { packIdForTool } from "../../app/pack-renderers.js";
+import { packHasLocalDataForTool, packIdForTool } from "../../app/pack-renderers.js";
 
 /** Icon lookup by tool name — mirrors individual renderers */
 const TOOL_ICONS: Record<string, any> = {
@@ -179,7 +179,12 @@ export class ToolGroup extends LitElement {
 									toolCallInput: (tc as any).input,
 									sessionId: sessionIdCtx,
 									packTool: tc.name,
-									host: getHostApi(sessionIdCtx, tc.id, { kind: "tool", tool: tc.name, packId: packIdForTool(tc.name) }),
+									host: getHostApi(sessionIdCtx, tc.id, {
+										kind: "tool",
+										tool: tc.name,
+										packId: packIdForTool(tc.name),
+										...(packHasLocalDataForTool(tc.name) ? { hasLocalData: true } : {}),
+									}),
 								});
 								if (renderResult.isCustom) {
 									return renderResult.content;

--- a/tests/e2e/in-process-harness.ts
+++ b/tests/e2e/in-process-harness.ts
@@ -138,13 +138,16 @@ async function restoreHarnessDefaultProject(info: GatewayInfo): Promise<void> {
  *   import { test, expect } from "./in-process-harness.js";
  *   // e2e-setup helpers automatically target this worker's gateway
  */
-export const test = base.extend<{ restoreDefaultProject: void }, { enableWorktreePool: boolean; gateway: GatewayInfo }>({
+export const test = base.extend<{ restoreDefaultProject: void }, { enableWorktreePool: boolean; serveUi: boolean; gateway: GatewayInfo }>({
 	// Worker-scoped option. Default false (pool pre-fill skipped for CPU).
 	// Opt in with `test.use({ enableWorktreePool: true })` in specs that
 	// actually exercise the pool endpoints.
 	enableWorktreePool: [false, { scope: "worker", option: true }],
+	// Most in-process specs are API-only. A combined realm test may opt into the
+	// already-built UI without paying for a second spawned gateway.
+	serveUi: [false, { scope: "worker", option: true }],
 
-	gateway: [async ({ enableWorktreePool }, use, workerInfo) => {
+	gateway: [async ({ enableWorktreePool, serveUi }, use, workerInfo) => {
 		mkdirSync(E2E_TEMP_ROOT, { recursive: true });
 		// Every worker gets an owned child of the coordinator's canonical run root.
 		let bobbitDir = createRunChild(`e2e-inproc-${process.pid}-${workerInfo.workerIndex}`);
@@ -293,6 +296,7 @@ export const test = base.extend<{ restoreDefaultProject: void }, { enableWorktre
 			defaultCwd: bobbitDir,
 			forceAuth: true,
 			agentCliPath: MOCK_AGENT,
+			...(serveUi ? { staticDir: resolve(PROJECT_ROOT, "dist", "ui") } : {}),
 		});
 
 		const port = await gw.start();

--- a/tests/e2e/in-process-mock-bridge.mjs
+++ b/tests/e2e/in-process-mock-bridge.mjs
@@ -153,7 +153,25 @@ async function loadMockPiExtensions(args = [], env = {}, extensionCache = shared
 		},
 		tool(...registrationArgs) {
 			const parsed = parseToolRegistration(registrationArgs);
-			if (parsed) tools.set(parsed.name, parsed);
+			if (parsed) {
+				const handler = parsed.handler;
+				parsed.handler = (...handlerArgs) => {
+					// A real Pi extension runs in the agent child process and reads its
+					// session environment directly. This in-process bridge must scope the
+					// local-data binding while a synchronous fixture handler executes.
+					const key = "BOBBIT_PACK_LOCAL_DATA_JSON";
+					const previous = process.env[key];
+					try {
+						if (env[key] === undefined) delete process.env[key];
+						else process.env[key] = env[key];
+						return handler(...handlerArgs);
+					} finally {
+						if (previous === undefined) delete process.env[key];
+						else process.env[key] = previous;
+					}
+				};
+				tools.set(parsed.name, parsed);
+			}
 			return parsed;
 		},
 		registerTool(...registrationArgs) {

--- a/tests/e2e/pack-local-data-runtime.spec.ts
+++ b/tests/e2e/pack-local-data-runtime.spec.ts
@@ -14,10 +14,118 @@ import {
 const PACK = "pack-local-data";
 const PI_TOOL = "pi_local_data_marker";
 const SOURCE = fileURLToPath(new URL("../../market-packs/_fixtures", import.meta.url));
+const WINNER_PACK = "pi-local-data-same-id";
+const LEGACY_PACK = "pi-legacy-same-id";
 
 let sourceId: string | undefined;
+const fixtureSourceIds = new Set<string>();
+const fixtureSourceRoots: string[] = [];
+const fixtureInstalls: Array<{ packName: string; scope: "server" | "project"; projectId?: string }> = [];
 const sessionIds: string[] = [];
 let sandboxConfigured = false;
+
+interface FixturePackOptions {
+	packName: string;
+	dirName: string;
+	piExtension: string;
+	toolName: string;
+	marker: string;
+	localDataDirectory?: string;
+}
+
+function createPiPackSource(parent: string, options: FixturePackOptions): string {
+	const sourceRoot = fs.mkdtempSync(path.join(parent, "pi-winner-source-"));
+	fixtureSourceRoots.push(sourceRoot);
+	const extensionRoot = path.join(sourceRoot, options.dirName, "pi-extensions", options.piExtension);
+	fs.mkdirSync(extensionRoot, { recursive: true });
+	const localData = options.localDataDirectory
+		? `localData:\n  scope: project\n  directory: ${options.localDataDirectory}\n  access: read-write\n  preserveOnUninstall: true\n`
+		: "";
+	fs.writeFileSync(path.join(sourceRoot, options.dirName, "pack.yaml"), `name: ${options.packName}
+schema: 2
+description: Same-ID Pi winner regression fixture.
+version: 1.0.0
+defaultDisabled: true
+${localData}contents:
+  roles: []
+  tools: []
+  skills: []
+  entrypoints: []
+  providers: []
+  hooks: []
+  mcp: []
+  pi-extensions: [${options.piExtension}]
+  runtimes: []
+  workflows: []
+`, "utf8");
+	const bindingBody = options.localDataDirectory
+		? `const raw = process.env.BOBBIT_PACK_LOCAL_DATA_JSON;
+		if (!raw) throw new Error("missing Pack Local Data environment");
+		const bindings = JSON.parse(raw);
+		const directory = bindings[${JSON.stringify(options.packName)}];
+		if (typeof directory !== "string" || !directory) throw new Error("missing same-ID Pack Local Data binding");
+		return { marker: ${JSON.stringify(options.marker)}, directory, bindingKeys: Object.keys(bindings).sort() };`
+		: `return { marker: ${JSON.stringify(options.marker)} };`;
+	fs.writeFileSync(path.join(extensionRoot, "extension.ts"), `export default function activate(pi: any) {
+	pi.tool({
+		name: ${JSON.stringify(options.toolName)},
+		description: "Reports which same-ID Pi extension was activated.",
+		inputSchema: { type: "object", properties: {} },
+	}, () => {
+		${bindingBody}
+	});
+}
+`, "utf8");
+	return sourceRoot;
+}
+
+async function addFixtureSource(sourceRoot: string): Promise<string> {
+	const response = await apiFetch("/api/marketplace/sources", {
+		method: "POST",
+		body: JSON.stringify({ url: sourceRoot }),
+	});
+	const text = await response.text();
+	expect(response.status, text).toBe(201);
+	const id = JSON.parse(text).source.id;
+	fixtureSourceIds.add(id);
+	return id;
+}
+
+async function installFixturePack(
+	sourceRoot: string,
+	dirName: string,
+	packName: string,
+	scope: "server" | "project",
+	projectId?: string,
+): Promise<void> {
+	const fixtureSourceId = await addFixtureSource(sourceRoot);
+	const install = await apiFetch("/api/marketplace/install", {
+		method: "POST",
+		body: JSON.stringify({ sourceId: fixtureSourceId, dirName, scope, ...(projectId ? { projectId } : {}) }),
+	});
+	const installText = await install.text();
+	expect(install.status, installText).toBe(201);
+	fixtureInstalls.push({ packName, scope, projectId });
+	const enable = await apiFetch("/api/marketplace/pack-activation", {
+		method: "PUT",
+		body: JSON.stringify({ scope, packName, ...(projectId ? { projectId } : {}), disabled: { enabled: true } }),
+	});
+	const enableText = await enable.text();
+	expect(enable.status, enableText).toBe(200);
+}
+
+function extensionArgs(gateway: any, sessionId: string): string[] {
+	const args: string[] = gateway.sessionManager.getSession(sessionId)?.rpcClient?.options?.args ?? [];
+	const extensions: string[] = [];
+	for (let index = 0; index < args.length; index++) {
+		if (args[index] === "--extension" && typeof args[index + 1] === "string") extensions.push(args[++index]);
+	}
+	return extensions.map(extension => extension.replace(/\\/g, "/"));
+}
+
+function runtimeEnvironment(gateway: any, sessionId: string): Record<string, string> {
+	return gateway.sessionManager.getSession(sessionId)?.rpcClient?.options?.env ?? {};
+}
 
 async function installAndEnable(projectId?: string): Promise<void> {
 	const source = await apiFetch("/api/marketplace/sources", {
@@ -70,17 +178,17 @@ async function waitForPiTool(): Promise<void> {
 	}, { timeout: 15_000, message: `${PI_TOOL} should be discovered before session creation` }).toBe(true);
 }
 
-async function runPiTool(sessionId: string, input: Record<string, unknown>): Promise<any> {
+async function runPiTool(sessionId: string, input: Record<string, unknown>, toolName = PI_TOOL): Promise<any> {
 	const connection = await connectWs(sessionId);
 	try {
 		const cursor = connection.messageCount();
-		connection.send({ type: "prompt", text: `PI_EXTENSION_TOOL:${PI_TOOL}::${JSON.stringify(input)}` });
+		connection.send({ type: "prompt", text: `PI_EXTENSION_TOOL:${toolName}::${JSON.stringify(input)}` });
 		const result = await connection.waitForFrom(
 			cursor,
 			message => message.type === "event"
 				&& message.data?.type === "message_end"
 				&& message.data?.message?.role === "toolResult"
-				&& message.data?.message?.toolName === PI_TOOL,
+				&& message.data?.message?.toolName === toolName,
 			20_000,
 		);
 		await connection.waitForFrom(cursor, agentEndPredicate(), 20_000).catch(() => {});
@@ -127,13 +235,28 @@ test.afterEach(async () => {
 		if (project) await apiFetch(`/api/projects/${project.id}/config`, { method: "PUT", body: JSON.stringify({ sandbox: "none" }) }).catch(() => {});
 		sandboxConfigured = false;
 	}
+	for (const fixture of fixtureInstalls.splice(0).reverse()) {
+		await apiFetch("/api/marketplace/installed", {
+			method: "DELETE",
+			body: JSON.stringify({ scope: fixture.scope, packName: fixture.packName, ...(fixture.projectId ? { projectId: fixture.projectId } : {}) }),
+		}).catch(() => {});
+	}
 	await uninstall().catch(() => {});
 	if (sourceId) {
 		await apiFetch(`/api/marketplace/sources/${encodeURIComponent(sourceId)}`, { method: "DELETE" }).catch(() => {});
 		sourceId = undefined;
 	}
+	for (const id of fixtureSourceIds) {
+		await apiFetch(`/api/marketplace/sources/${encodeURIComponent(id)}`, { method: "DELETE" }).catch(() => {});
+	}
+	fixtureSourceIds.clear();
+	for (const root of fixtureSourceRoots.splice(0)) fs.rmSync(root, { recursive: true, force: true });
 	const project = await defaultProject().catch(() => undefined);
-	if (project) fs.rmSync(path.join(project.rootPath, ".pack-local-data-fixture"), { recursive: true, force: true });
+	if (project) {
+		for (const directory of [".pack-local-data-fixture", ".pi-winner-project", ".pi-winner-server"]) {
+			fs.rmSync(path.join(project.rootPath, directory), { recursive: true, force: true });
+		}
+	}
 });
 
 test("ordinary and Pi runtime access share the canonical project directory and preserve it", async ({ gateway }) => {
@@ -165,6 +288,108 @@ test("ordinary and Pi runtime access share the canonical project directory and p
 	await expect.poll(() => packIsContributed(), { timeout: 15_000 }).toBe(false);
 	expect(fs.readFileSync(path.join(expectedDirectory, "pi-marker.txt"), "utf8")).toBe("written-by-pi-host");
 	expect(fs.readFileSync(path.join(expectedDirectory, "ordinary-marker.txt"), "utf8")).toBe("E2E_WRITE_TEST\n");
+});
+
+test("same-ID Pi activation follows the local-data winner and falls back after project disable and uninstall", async ({ gateway }) => {
+	const project = await defaultProject();
+	const serverSource = createPiPackSource(gateway.bobbitDir, {
+		packName: WINNER_PACK,
+		dirName: "server-same-id",
+		piExtension: "server-winner",
+		toolName: "pi_same_id_server_marker",
+		marker: "server",
+		localDataDirectory: ".pi-winner-server",
+	});
+	const projectSource = createPiPackSource(gateway.bobbitDir, {
+		packName: WINNER_PACK,
+		dirName: "project-same-id",
+		piExtension: "project-winner",
+		toolName: "pi_same_id_project_marker",
+		marker: "project",
+		localDataDirectory: ".pi-winner-project",
+	});
+	await installFixturePack(serverSource, "server-same-id", WINNER_PACK, "server");
+	await installFixturePack(projectSource, "project-same-id", WINNER_PACK, "project", project.id);
+
+	const projectSession = await createSession({ projectId: project.id });
+	sessionIds.push(projectSession);
+	const projectExtensions = extensionArgs(gateway, projectSession);
+	expect(projectExtensions.some(extension => extension.endsWith("/pi-extensions/project-winner/extension.ts"))).toBe(true);
+	expect(projectExtensions.some(extension => extension.endsWith("/pi-extensions/server-winner/extension.ts")), "the shadowed server extension must not receive the project winner's binding").toBe(false);
+	const projectDirectory = fs.realpathSync(path.join(project.rootPath, ".pi-winner-project"));
+	expect(JSON.parse(runtimeEnvironment(gateway, projectSession).BOBBIT_PACK_LOCAL_DATA_JSON)).toEqual({
+		[WINNER_PACK]: projectDirectory,
+	});
+	expect(await runPiTool(projectSession, {}, "pi_same_id_project_marker")).toEqual({
+		marker: "project",
+		directory: projectDirectory,
+		bindingKeys: [WINNER_PACK],
+	});
+
+	const disable = await apiFetch("/api/marketplace/pack-activation", {
+		method: "PUT",
+		body: JSON.stringify({ scope: "project", projectId: project.id, packName: WINNER_PACK, disabled: { enabled: false } }),
+	});
+	const disableText = await disable.text();
+	expect(disable.status, disableText).toBe(200);
+
+	const disabledFallbackSession = await createSession({ projectId: project.id });
+	sessionIds.push(disabledFallbackSession);
+	const disabledFallbackExtensions = extensionArgs(gateway, disabledFallbackSession);
+	expect(disabledFallbackExtensions.some(extension => extension.endsWith("/pi-extensions/server-winner/extension.ts"))).toBe(true);
+	expect(disabledFallbackExtensions.some(extension => extension.endsWith("/pi-extensions/project-winner/extension.ts"))).toBe(false);
+	const serverDirectory = fs.realpathSync(path.join(project.rootPath, ".pi-winner-server"));
+	expect(JSON.parse(runtimeEnvironment(gateway, disabledFallbackSession).BOBBIT_PACK_LOCAL_DATA_JSON)).toEqual({
+		[WINNER_PACK]: serverDirectory,
+	});
+	expect(await runPiTool(disabledFallbackSession, {}, "pi_same_id_server_marker")).toEqual({
+		marker: "server",
+		directory: serverDirectory,
+		bindingKeys: [WINNER_PACK],
+	});
+
+	const removed = await apiFetch("/api/marketplace/installed", {
+		method: "DELETE",
+		body: JSON.stringify({ scope: "project", projectId: project.id, packName: WINNER_PACK }),
+	});
+	expect(removed.status).toBe(204);
+	const uninstalledFallbackSession = await createSession({ projectId: project.id });
+	sessionIds.push(uninstalledFallbackSession);
+	const uninstalledFallbackExtensions = extensionArgs(gateway, uninstalledFallbackSession);
+	expect(uninstalledFallbackExtensions.some(extension => extension.endsWith("/pi-extensions/server-winner/extension.ts"))).toBe(true);
+	expect(uninstalledFallbackExtensions.some(extension => extension.endsWith("/pi-extensions/project-winner/extension.ts"))).toBe(false);
+	expect(JSON.parse(runtimeEnvironment(gateway, uninstalledFallbackSession).BOBBIT_PACK_LOCAL_DATA_JSON)).toEqual({
+		[WINNER_PACK]: serverDirectory,
+	});
+});
+
+test("same-ID Pi packs without local data preserve legacy multiple-entry activation", async ({ gateway }) => {
+	const project = await defaultProject();
+	const serverSource = createPiPackSource(gateway.bobbitDir, {
+		packName: LEGACY_PACK,
+		dirName: "legacy-server-same-id",
+		piExtension: "legacy-server",
+		toolName: "pi_legacy_same_id_server",
+		marker: "legacy-server",
+	});
+	const projectSource = createPiPackSource(gateway.bobbitDir, {
+		packName: LEGACY_PACK,
+		dirName: "legacy-project-same-id",
+		piExtension: "legacy-project",
+		toolName: "pi_legacy_same_id_project",
+		marker: "legacy-project",
+	});
+	await installFixturePack(serverSource, "legacy-server-same-id", LEGACY_PACK, "server");
+	await installFixturePack(projectSource, "legacy-project-same-id", LEGACY_PACK, "project", project.id);
+
+	const sessionId = await createSession({ projectId: project.id });
+	sessionIds.push(sessionId);
+	const extensions = extensionArgs(gateway, sessionId);
+	expect(extensions.some(extension => extension.endsWith("/pi-extensions/legacy-server/extension.ts"))).toBe(true);
+	expect(extensions.some(extension => extension.endsWith("/pi-extensions/legacy-project/extension.ts"))).toBe(true);
+	expect(runtimeEnvironment(gateway, sessionId).BOBBIT_PACK_LOCAL_DATA_JSON).toBeUndefined();
+	expect(await runPiTool(sessionId, {}, "pi_legacy_same_id_server")).toEqual({ marker: "legacy-server" });
+	expect(await runPiTool(sessionId, {}, "pi_legacy_same_id_project")).toEqual({ marker: "legacy-project" });
 });
 
 test("sandbox mount is writable in both directions at the stable pack path", async ({ gateway }) => {

--- a/tests/e2e/pack-local-data-runtime.spec.ts
+++ b/tests/e2e/pack-local-data-runtime.spec.ts
@@ -127,7 +127,7 @@ function runtimeEnvironment(gateway: any, sessionId: string): Record<string, str
 	return gateway.sessionManager.getSession(sessionId)?.rpcClient?.options?.env ?? {};
 }
 
-async function installAndEnable(projectId?: string): Promise<void> {
+async function installFixture(projectId?: string): Promise<void> {
 	const source = await apiFetch("/api/marketplace/sources", {
 		method: "POST",
 		body: JSON.stringify({ url: SOURCE }),
@@ -149,18 +149,26 @@ async function installAndEnable(projectId?: string): Promise<void> {
 	});
 	const installText = await install.text();
 	expect(install.status, installText).toBe(201);
+}
 
-	const enable = await apiFetch("/api/marketplace/pack-activation", {
+async function setFixtureActivation(disabled: Record<string, unknown>, projectId?: string): Promise<any> {
+	const response = await apiFetch("/api/marketplace/pack-activation", {
 		method: "PUT",
 		body: JSON.stringify({
 			scope: projectId ? "project" : "server",
 			packName: PACK,
 			...(projectId ? { projectId } : {}),
-			disabled: { enabled: true },
+			disabled,
 		}),
 	});
-	const enableText = await enable.text();
-	expect(enable.status, enableText).toBe(200);
+	const text = await response.text();
+	expect(response.status, text).toBe(200);
+	return JSON.parse(text);
+}
+
+async function installAndEnable(projectId?: string): Promise<void> {
+	await installFixture(projectId);
+	await setFixtureActivation({ enabled: true }, projectId);
 }
 
 async function uninstall(projectId?: string): Promise<Response> {
@@ -170,12 +178,21 @@ async function uninstall(projectId?: string): Promise<Response> {
 	});
 }
 
+async function piToolIsListed(): Promise<boolean> {
+	const response = await apiFetch("/api/tools");
+	expect(response.status).toBe(200);
+	return ((await response.json()).tools ?? []).some((tool: any) => tool.name === PI_TOOL);
+}
+
 async function waitForPiTool(): Promise<void> {
-	await expect.poll(async () => {
-		const response = await apiFetch("/api/tools");
-		expect(response.status).toBe(200);
-		return ((await response.json()).tools ?? []).some((tool: any) => tool.name === PI_TOOL);
-	}, { timeout: 15_000, message: `${PI_TOOL} should be discovered before session creation` }).toBe(true);
+	await expect.poll(piToolIsListed, {
+		timeout: 15_000,
+		message: `${PI_TOOL} should be discovered before session creation`,
+	}).toBe(true);
+}
+
+function hasFixturePiExtension(gateway: any, sessionId: string): boolean {
+	return extensionArgs(gateway, sessionId).some(extension => extension.endsWith("/pack-local-data/pi-extensions/marker/extension.ts"));
 }
 
 async function runPiTool(sessionId: string, input: Record<string, unknown>, toolName = PI_TOOL): Promise<any> {
@@ -241,6 +258,7 @@ test.afterEach(async () => {
 			body: JSON.stringify({ scope: fixture.scope, packName: fixture.packName, ...(fixture.projectId ? { projectId: fixture.projectId } : {}) }),
 		}).catch(() => {});
 	}
+	if (sourceId) await setFixtureActivation({}).catch(() => {});
 	await uninstall().catch(() => {});
 	if (sourceId) {
 		await apiFetch(`/api/marketplace/sources/${encodeURIComponent(sourceId)}`, { method: "DELETE" }).catch(() => {});
@@ -257,6 +275,62 @@ test.afterEach(async () => {
 			fs.rmSync(path.join(project.rootPath, directory), { recursive: true, force: true });
 		}
 	}
+});
+
+test("default-disabled installed local data stays inert until enabled and preserves data after the override is cleared", async ({ gateway }) => {
+	const project = await defaultProject();
+	const declaredDirectory = path.join(project.rootPath, ".pack-local-data-fixture");
+	fs.rmSync(declaredDirectory, { recursive: true, force: true });
+
+	await installFixture();
+
+	const installedResponse = await apiFetch(`/api/marketplace/installed?projectId=${encodeURIComponent(project.id)}`);
+	expect(installedResponse.status).toBe(200);
+	const installedRows = (await installedResponse.json()).installed ?? [];
+	const rawInstalledRow = installedRows.find((row: any) => row.packName === PACK && row.scope === "server" && row.builtin !== true);
+	expect(rawInstalledRow, "default-disabled installed packs must remain visible in the raw Marketplace listing").toBeTruthy();
+	expect(rawInstalledRow.manifest.defaultDisabled).toBe(true);
+
+	expect(await packIsContributed()).toBe(false);
+	expect(await piToolIsListed()).toBe(false);
+	const disabledSession = await createSession({ projectId: project.id });
+	sessionIds.push(disabledSession);
+	expect(runtimeEnvironment(gateway, disabledSession).BOBBIT_PACK_LOCAL_DATA_JSON).toBeUndefined();
+	expect(hasFixturePiExtension(gateway, disabledSession)).toBe(false);
+	expect(fs.existsSync(declaredDirectory), "default-OFF session activation must not materialize local data").toBe(false);
+
+	const enabled = await setFixtureActivation({ enabled: true });
+	expect(enabled.disabled.enabled).toBe(true);
+	await expect.poll(() => packIsContributed(), { timeout: 15_000 }).toBe(true);
+	await waitForPiTool();
+
+	const enabledSession = await createSession({ projectId: project.id });
+	sessionIds.push(enabledSession);
+	const expectedDirectory = fs.realpathSync(declaredDirectory);
+	expect(JSON.parse(runtimeEnvironment(gateway, enabledSession).BOBBIT_PACK_LOCAL_DATA_JSON)).toEqual({
+		[PACK]: expectedDirectory,
+	});
+	expect(hasFixturePiExtension(gateway, enabledSession)).toBe(true);
+	const markerPath = path.join(expectedDirectory, "default-disabled-marker.txt");
+	const markerContent = "default-disabled lifecycle marker: π\n";
+	const writeResult = await runPiTool(enabledSession, {
+		operation: "write",
+		name: path.basename(markerPath),
+		content: markerContent,
+	});
+	expect(writeResult).toMatchObject({ directory: expectedDirectory, content: markerContent });
+	const markerBytes = fs.readFileSync(markerPath);
+
+	const cleared = await setFixtureActivation({});
+	expect(cleared.disabled.enabled).toBeUndefined();
+	await expect.poll(() => packIsContributed(), { timeout: 15_000 }).toBe(false);
+	await expect.poll(piToolIsListed, { timeout: 15_000 }).toBe(false);
+
+	const freshDisabledSession = await createSession({ projectId: project.id });
+	sessionIds.push(freshDisabledSession);
+	expect(runtimeEnvironment(gateway, freshDisabledSession).BOBBIT_PACK_LOCAL_DATA_JSON).toBeUndefined();
+	expect(hasFixturePiExtension(gateway, freshDisabledSession)).toBe(false);
+	expect(fs.readFileSync(markerPath)).toEqual(markerBytes);
 });
 
 test("ordinary and Pi runtime access share the canonical project directory and preserve it", async ({ gateway }) => {

--- a/tests/e2e/pack-local-data-runtime.spec.ts
+++ b/tests/e2e/pack-local-data-runtime.spec.ts
@@ -10,7 +10,6 @@ import {
 	defaultProject,
 	deleteSession,
 } from "./e2e-setup.js";
-import { openApp } from "./ui/ui-helpers.js";
 
 const PACK = "pack-local-data";
 const PI_TOOL = "pi_local_data_marker";
@@ -119,17 +118,6 @@ async function packIsContributed(projectId?: string): Promise<boolean> {
 	return ((await response.json()).packs ?? []).some((pack: any) => pack.packId === PACK);
 }
 
-async function selectSessionAndOpenPanel(page: any, sessionId: string): Promise<void> {
-	await page.evaluate((id: string) => { window.location.hash = `#/session/${id}`; }, sessionId);
-	await expect.poll(
-		() => page.evaluate(() => (window as any).__bobbitState?.selectedSessionId ?? (window as any).bobbitState?.selectedSessionId),
-		{ timeout: 15_000 },
-	).toBe(sessionId);
-	await page.evaluate(() => { window.location.hash = "#/ext/pack-local-data"; });
-	await page.getByRole("button", { name: "Open Pack Local Data Fixture" }).click();
-}
-
-test.use({ serveUi: true });
 test.describe.configure({ mode: "serial" });
 
 test.afterEach(async () => {
@@ -148,7 +136,7 @@ test.afterEach(async () => {
 	if (project) fs.rmSync(path.join(project.rootPath, ".pack-local-data-fixture"), { recursive: true, force: true });
 });
 
-test("browser, server route, Pi tool, and ordinary filesystem access share the canonical project directory and preserve it", async ({ page, gateway }) => {
+test("ordinary and Pi runtime access share the canonical project directory and preserve it", async ({ gateway }) => {
 	const project = await defaultProject();
 	const componentCwd = path.join(project.rootPath, "components", "web");
 	fs.mkdirSync(componentCwd, { recursive: true });
@@ -172,25 +160,11 @@ test("browser, server route, Pi tool, and ordinary filesystem access share the c
 	expect(piResult).toMatchObject({ directory: expectedDirectory, name: "pi-marker.txt", content: "written-by-pi-host" });
 	expect(fs.readFileSync(path.join(expectedDirectory, "pi-marker.txt"), "utf8")).toBe("written-by-pi-host");
 
-	await openApp(page);
-	await selectSessionAndOpenPanel(page, sessionId);
-	await expect(page.locator('[data-testid="pack-local-data-browser-directory"]')).toHaveText(expectedDirectory, { timeout: 20_000 });
-	await expect(page.locator('[data-testid="pack-local-data-route-directory"]')).toHaveText(expectedDirectory);
-	await expect(page.locator('[data-testid="pack-local-data-markers"]')).toContainText('"ordinary-marker.txt":"E2E_WRITE_TEST\\n"');
-	await expect(page.locator('[data-testid="pack-local-data-markers"]')).toContainText('"pi-marker.txt":"written-by-pi-host"');
-	await expect(page.locator('[data-testid="pack-local-data-markers"]')).toContainText('"host-marker.txt":"written-by-browser-route"');
-
-	await page.reload();
-	await expect(page.locator("body[data-shortcuts-ready='1']")).toBeVisible({ timeout: 20_000 });
-	await selectSessionAndOpenPanel(page, sessionId);
-	await expect(page.locator('[data-testid="pack-local-data-browser-directory"]')).toHaveText(expectedDirectory, { timeout: 20_000 });
-
 	const removed = await uninstall();
 	expect(removed.status).toBe(204);
 	await expect.poll(() => packIsContributed(), { timeout: 15_000 }).toBe(false);
 	expect(fs.readFileSync(path.join(expectedDirectory, "pi-marker.txt"), "utf8")).toBe("written-by-pi-host");
 	expect(fs.readFileSync(path.join(expectedDirectory, "ordinary-marker.txt"), "utf8")).toBe("E2E_WRITE_TEST\n");
-	expect(fs.readFileSync(path.join(expectedDirectory, "host-marker.txt"), "utf8")).toBe("written-by-browser-route");
 });
 
 test("sandbox mount is writable in both directions at the stable pack path", async ({ gateway }) => {

--- a/tests/e2e/pack-local-data-runtime.spec.ts
+++ b/tests/e2e/pack-local-data-runtime.spec.ts
@@ -455,10 +455,11 @@ test("sandbox mount is writable in both directions at the stable pack path", asy
 	await installAndEnable();
 	await waitForPiTool();
 
-	const docker = await import("node:child_process").then(({ spawnSync }) => ({
+	const { spawnSync } = await import("node:child_process");
+	const docker = {
 		info: spawnSync("docker", ["info"], { stdio: "ignore" }),
 		image: spawnSync("docker", ["image", "inspect", "bobbit-agent"], { stdio: "ignore" }),
-	}));
+	};
 	test.skip(docker.info.status !== 0 || docker.image.status !== 0, "Docker and the bobbit-agent image are required for the writable bind-mount round trip");
 
 	const setSandbox = await apiFetch(`/api/projects/${project.id}/config`, {
@@ -485,6 +486,28 @@ test("sandbox mount is writable in both directions at the stable pack path", asy
 	fs.writeFileSync(path.join(expectedHostDirectory, "host-marker.txt"), "written-on-host", "utf8");
 	const containerRead = await runPiTool(sessionId, { operation: "read", name: "host-marker.txt" });
 	expect(containerRead).toMatchObject({ directory: expectedContainerDirectory, content: "written-on-host" });
+	const markerBytes = fs.readFileSync(path.join(expectedHostDirectory, "container-marker.txt"));
+
+	await setFixtureActivation({});
+	await expect.poll(() => packIsContributed(), { timeout: 15_000 }).toBe(false);
+	await expect.poll(piToolIsListed, { timeout: 15_000 }).toBe(false);
+
+	const disabledSession = await createSession({ projectId: project.id });
+	sessionIds.push(disabledSession);
+	expect(runtimeEnvironment(gateway, disabledSession).BOBBIT_PACK_LOCAL_DATA_JSON).toBeUndefined();
+	expect(hasFixturePiExtension(gateway, disabledSession)).toBe(false);
+	expect(fs.readFileSync(path.join(expectedHostDirectory, "container-marker.txt"))).toEqual(markerBytes);
+
+	const poolResponse = await apiFetch("/api/sandbox-pool");
+	expect(poolResponse.status).toBe(200);
+	const containerId = ((await poolResponse.json()).containers ?? [])
+		.find((container: any) => container.projectId === project.id)?.containerId;
+	expect(containerId, "the refreshed project sandbox must remain tracked").toBeTruthy();
+	const inspect = spawnSync("docker", ["inspect", containerId], { encoding: "utf8" });
+	expect(inspect.status, inspect.stderr).toBe(0);
+	const mounts = JSON.parse(inspect.stdout)[0]?.Mounts ?? [];
+	expect(mounts.some((mount: any) => mount.Destination === expectedContainerDirectory),
+		"clearing the default-disabled override must remove the stale local-data bind").toBe(false);
 
 	const restoreConfig = await apiFetch(`/api/projects/${project.id}/config`, {
 		method: "PUT",

--- a/tests/e2e/pack-local-data-runtime.spec.ts
+++ b/tests/e2e/pack-local-data-runtime.spec.ts
@@ -290,7 +290,7 @@ test("ordinary and Pi runtime access share the canonical project directory and p
 	expect(fs.readFileSync(path.join(expectedDirectory, "ordinary-marker.txt"), "utf8")).toBe("E2E_WRITE_TEST\n");
 });
 
-test("same-ID Pi activation follows the local-data winner and falls back after project disable and uninstall", async ({ gateway }) => {
+test("same-ID Pi activation follows the local-data winner and falls back after project uninstall", async ({ gateway }) => {
 	const project = await defaultProject();
 	const serverSource = createPiPackSource(gateway.bobbitDir, {
 		packName: WINNER_PACK,
@@ -326,40 +326,24 @@ test("same-ID Pi activation follows the local-data winner and falls back after p
 		bindingKeys: [WINNER_PACK],
 	});
 
-	const disable = await apiFetch("/api/marketplace/pack-activation", {
-		method: "PUT",
-		body: JSON.stringify({ scope: "project", projectId: project.id, packName: WINNER_PACK, disabled: { enabled: false } }),
-	});
-	const disableText = await disable.text();
-	expect(disable.status, disableText).toBe(200);
-
-	const disabledFallbackSession = await createSession({ projectId: project.id });
-	sessionIds.push(disabledFallbackSession);
-	const disabledFallbackExtensions = extensionArgs(gateway, disabledFallbackSession);
-	expect(disabledFallbackExtensions.some(extension => extension.endsWith("/pi-extensions/server-winner/extension.ts"))).toBe(true);
-	expect(disabledFallbackExtensions.some(extension => extension.endsWith("/pi-extensions/project-winner/extension.ts"))).toBe(false);
-	const serverDirectory = fs.realpathSync(path.join(project.rootPath, ".pi-winner-server"));
-	expect(JSON.parse(runtimeEnvironment(gateway, disabledFallbackSession).BOBBIT_PACK_LOCAL_DATA_JSON)).toEqual({
-		[WINNER_PACK]: serverDirectory,
-	});
-	expect(await runPiTool(disabledFallbackSession, {}, "pi_same_id_server_marker")).toEqual({
-		marker: "server",
-		directory: serverDirectory,
-		bindingKeys: [WINNER_PACK],
-	});
-
 	const removed = await apiFetch("/api/marketplace/installed", {
 		method: "DELETE",
 		body: JSON.stringify({ scope: "project", projectId: project.id, packName: WINNER_PACK }),
 	});
 	expect(removed.status).toBe(204);
-	const uninstalledFallbackSession = await createSession({ projectId: project.id });
-	sessionIds.push(uninstalledFallbackSession);
-	const uninstalledFallbackExtensions = extensionArgs(gateway, uninstalledFallbackSession);
-	expect(uninstalledFallbackExtensions.some(extension => extension.endsWith("/pi-extensions/server-winner/extension.ts"))).toBe(true);
-	expect(uninstalledFallbackExtensions.some(extension => extension.endsWith("/pi-extensions/project-winner/extension.ts"))).toBe(false);
-	expect(JSON.parse(runtimeEnvironment(gateway, uninstalledFallbackSession).BOBBIT_PACK_LOCAL_DATA_JSON)).toEqual({
+	const fallbackSession = await createSession({ projectId: project.id });
+	sessionIds.push(fallbackSession);
+	const fallbackExtensions = extensionArgs(gateway, fallbackSession);
+	expect(fallbackExtensions.some(extension => extension.endsWith("/pi-extensions/server-winner/extension.ts"))).toBe(true);
+	expect(fallbackExtensions.some(extension => extension.endsWith("/pi-extensions/project-winner/extension.ts"))).toBe(false);
+	const serverDirectory = fs.realpathSync(path.join(project.rootPath, ".pi-winner-server"));
+	expect(JSON.parse(runtimeEnvironment(gateway, fallbackSession).BOBBIT_PACK_LOCAL_DATA_JSON)).toEqual({
 		[WINNER_PACK]: serverDirectory,
+	});
+	expect(await runPiTool(fallbackSession, {}, "pi_same_id_server_marker")).toEqual({
+		marker: "server",
+		directory: serverDirectory,
+		bindingKeys: [WINNER_PACK],
 	});
 });
 

--- a/tests/e2e/pack-local-data.spec.ts
+++ b/tests/e2e/pack-local-data.spec.ts
@@ -1,0 +1,238 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { test, expect } from "./in-process-harness.js";
+import {
+	agentEndPredicate,
+	apiFetch,
+	connectWs,
+	createSession,
+	defaultProject,
+	deleteSession,
+} from "./e2e-setup.js";
+import { openApp } from "./ui/ui-helpers.js";
+
+const PACK = "pack-local-data";
+const PI_TOOL = "pi_local_data_marker";
+const SOURCE = fileURLToPath(new URL("../../market-packs/_fixtures", import.meta.url));
+
+let sourceId: string | undefined;
+const sessionIds: string[] = [];
+let sandboxConfigured = false;
+
+async function installAndEnable(projectId?: string): Promise<void> {
+	const source = await apiFetch("/api/marketplace/sources", {
+		method: "POST",
+		body: JSON.stringify({ url: SOURCE }),
+	});
+	const sourceText = await source.text();
+	if (source.status === 409) {
+		const existing = await apiFetch("/api/marketplace/sources");
+		expect(existing.status).toBe(200);
+		sourceId = ((await existing.json()).sources ?? []).find((item: any) => item.url === SOURCE)?.id;
+		expect(sourceId, sourceText).toBeTruthy();
+	} else {
+		expect(source.status, sourceText).toBe(201);
+		sourceId = JSON.parse(sourceText).source.id;
+	}
+
+	const install = await apiFetch("/api/marketplace/install", {
+		method: "POST",
+		body: JSON.stringify({ sourceId, dirName: PACK, scope: projectId ? "project" : "server", ...(projectId ? { projectId } : {}) }),
+	});
+	const installText = await install.text();
+	expect(install.status, installText).toBe(201);
+
+	const enable = await apiFetch("/api/marketplace/pack-activation", {
+		method: "PUT",
+		body: JSON.stringify({
+			scope: projectId ? "project" : "server",
+			packName: PACK,
+			...(projectId ? { projectId } : {}),
+			disabled: { enabled: true },
+		}),
+	});
+	const enableText = await enable.text();
+	expect(enable.status, enableText).toBe(200);
+}
+
+async function uninstall(projectId?: string): Promise<Response> {
+	return apiFetch("/api/marketplace/installed", {
+		method: "DELETE",
+		body: JSON.stringify({ scope: projectId ? "project" : "server", packName: PACK, ...(projectId ? { projectId } : {}) }),
+	});
+}
+
+async function waitForPiTool(): Promise<void> {
+	await expect.poll(async () => {
+		const response = await apiFetch("/api/tools");
+		expect(response.status).toBe(200);
+		return ((await response.json()).tools ?? []).some((tool: any) => tool.name === PI_TOOL);
+	}, { timeout: 15_000, message: `${PI_TOOL} should be discovered before session creation` }).toBe(true);
+}
+
+async function runPiTool(sessionId: string, input: Record<string, unknown>): Promise<any> {
+	const connection = await connectWs(sessionId);
+	try {
+		const cursor = connection.messageCount();
+		connection.send({ type: "prompt", text: `PI_EXTENSION_TOOL:${PI_TOOL}::${JSON.stringify(input)}` });
+		const result = await connection.waitForFrom(
+			cursor,
+			message => message.type === "event"
+				&& message.data?.type === "message_end"
+				&& message.data?.message?.role === "toolResult"
+				&& message.data?.message?.toolName === PI_TOOL,
+			20_000,
+		);
+		await connection.waitForFrom(cursor, agentEndPredicate(), 20_000).catch(() => {});
+		expect(result.data.message.isError, JSON.stringify(result.data.message.content)).toBe(false);
+		return JSON.parse(result.data.message.content[0].text);
+	} finally {
+		connection.close();
+	}
+}
+
+async function runOrdinaryWrite(sessionId: string, file: string): Promise<void> {
+	const connection = await connectWs(sessionId);
+	try {
+		const cursor = connection.messageCount();
+		connection.send({ type: "prompt", text: `please use the write tool at ${file}` });
+		const result = await connection.waitForFrom(
+			cursor,
+			message => message.type === "event"
+				&& message.data?.type === "message_end"
+				&& message.data?.message?.role === "toolResult"
+				&& message.data?.message?.toolName === "Write",
+			20_000,
+		);
+		expect(result.data.message.isError).toBe(false);
+		await connection.waitForFrom(cursor, agentEndPredicate(), 20_000).catch(() => {});
+	} finally {
+		connection.close();
+	}
+}
+
+async function packIsContributed(projectId?: string): Promise<boolean> {
+	const suffix = projectId ? `?projectId=${encodeURIComponent(projectId)}` : "";
+	const response = await apiFetch(`/api/ext/contributions${suffix}`);
+	expect(response.status).toBe(200);
+	return ((await response.json()).packs ?? []).some((pack: any) => pack.packId === PACK);
+}
+
+async function selectSessionAndOpenPanel(page: any, sessionId: string): Promise<void> {
+	await page.evaluate((id: string) => { window.location.hash = `#/session/${id}`; }, sessionId);
+	await expect.poll(
+		() => page.evaluate(() => (window as any).__bobbitState?.selectedSessionId ?? (window as any).bobbitState?.selectedSessionId),
+		{ timeout: 15_000 },
+	).toBe(sessionId);
+	await page.evaluate(() => { window.location.hash = "#/ext/pack-local-data"; });
+	await page.getByRole("button", { name: "Open Pack Local Data Fixture" }).click();
+}
+
+test.use({ serveUi: true });
+test.describe.configure({ mode: "serial" });
+
+test.afterEach(async () => {
+	for (const sessionId of sessionIds.splice(0)) await deleteSession(sessionId).catch(() => {});
+	if (sandboxConfigured) {
+		const project = await defaultProject().catch(() => undefined);
+		if (project) await apiFetch(`/api/projects/${project.id}/config`, { method: "PUT", body: JSON.stringify({ sandbox: "none" }) }).catch(() => {});
+		sandboxConfigured = false;
+	}
+	await uninstall().catch(() => {});
+	if (sourceId) {
+		await apiFetch(`/api/marketplace/sources/${encodeURIComponent(sourceId)}`, { method: "DELETE" }).catch(() => {});
+		sourceId = undefined;
+	}
+	const project = await defaultProject().catch(() => undefined);
+	if (project) fs.rmSync(path.join(project.rootPath, ".pack-local-data-fixture"), { recursive: true, force: true });
+});
+
+test("browser, server route, Pi tool, and ordinary filesystem access share the canonical project directory and preserve it", async ({ page, gateway }) => {
+	const project = await defaultProject();
+	const componentCwd = path.join(project.rootPath, "components", "web");
+	fs.mkdirSync(componentCwd, { recursive: true });
+	await installAndEnable();
+	expect(await packIsContributed()).toBe(true);
+	await waitForPiTool();
+
+	const sessionId = await createSession({ projectId: project.id, cwd: componentCwd });
+	sessionIds.push(sessionId);
+	const declaredDirectory = path.join(project.rootPath, ".pack-local-data-fixture");
+	expect(fs.existsSync(declaredDirectory), "Pack Local Data activation must materialize the canonical project directory").toBe(true);
+	const expectedDirectory = fs.realpathSync(declaredDirectory);
+	const runtimeEnvironment = gateway.sessionManager.getSession(sessionId)?.rpcClient?.options?.env ?? {};
+	expect(runtimeEnvironment.BOBBIT_PACK_LOCAL_DATA_JSON, "ordinary sessions must receive the pack-local-data runtime binding").toBeTruthy();
+	expect(JSON.parse(runtimeEnvironment.BOBBIT_PACK_LOCAL_DATA_JSON)).toEqual({ [PACK]: expectedDirectory });
+
+	await runOrdinaryWrite(sessionId, path.join(expectedDirectory, "ordinary-marker.txt"));
+	expect(fs.readFileSync(path.join(expectedDirectory, "ordinary-marker.txt"), "utf8")).toBe("E2E_WRITE_TEST\n");
+
+	const piResult = await runPiTool(sessionId, { operation: "write", name: "pi-marker.txt", content: "written-by-pi-host" });
+	expect(piResult).toMatchObject({ directory: expectedDirectory, name: "pi-marker.txt", content: "written-by-pi-host" });
+	expect(fs.readFileSync(path.join(expectedDirectory, "pi-marker.txt"), "utf8")).toBe("written-by-pi-host");
+
+	await openApp(page);
+	await selectSessionAndOpenPanel(page, sessionId);
+	await expect(page.locator('[data-testid="pack-local-data-browser-directory"]')).toHaveText(expectedDirectory, { timeout: 20_000 });
+	await expect(page.locator('[data-testid="pack-local-data-route-directory"]')).toHaveText(expectedDirectory);
+	await expect(page.locator('[data-testid="pack-local-data-markers"]')).toContainText('"ordinary-marker.txt":"E2E_WRITE_TEST\\n"');
+	await expect(page.locator('[data-testid="pack-local-data-markers"]')).toContainText('"pi-marker.txt":"written-by-pi-host"');
+	await expect(page.locator('[data-testid="pack-local-data-markers"]')).toContainText('"host-marker.txt":"written-by-browser-route"');
+
+	await page.reload();
+	await expect(page.locator("body[data-shortcuts-ready='1']")).toBeVisible({ timeout: 20_000 });
+	await selectSessionAndOpenPanel(page, sessionId);
+	await expect(page.locator('[data-testid="pack-local-data-browser-directory"]')).toHaveText(expectedDirectory, { timeout: 20_000 });
+
+	const removed = await uninstall();
+	expect(removed.status).toBe(204);
+	await expect.poll(() => packIsContributed(), { timeout: 15_000 }).toBe(false);
+	expect(fs.readFileSync(path.join(expectedDirectory, "pi-marker.txt"), "utf8")).toBe("written-by-pi-host");
+	expect(fs.readFileSync(path.join(expectedDirectory, "ordinary-marker.txt"), "utf8")).toBe("E2E_WRITE_TEST\n");
+	expect(fs.readFileSync(path.join(expectedDirectory, "host-marker.txt"), "utf8")).toBe("written-by-browser-route");
+});
+
+test("sandbox mount is writable in both directions at the stable pack path", async ({ gateway }) => {
+	const project = await defaultProject();
+	await installAndEnable();
+	await waitForPiTool();
+
+	const docker = await import("node:child_process").then(({ spawnSync }) => ({
+		info: spawnSync("docker", ["info"], { stdio: "ignore" }),
+		image: spawnSync("docker", ["image", "inspect", "bobbit-agent"], { stdio: "ignore" }),
+	}));
+	test.skip(docker.info.status !== 0 || docker.image.status !== 0, "Docker and the bobbit-agent image are required for the writable bind-mount round trip");
+
+	const setSandbox = await apiFetch(`/api/projects/${project.id}/config`, {
+		method: "PUT",
+		body: JSON.stringify({ sandbox: "docker" }),
+	});
+	const configText = await setSandbox.text();
+	expect(setSandbox.status, configText).toBe(200);
+	sandboxConfigured = true;
+
+	const sessionId = await createSession({ projectId: project.id });
+	sessionIds.push(sessionId);
+	const declaredHostDirectory = path.join(project.rootPath, ".pack-local-data-fixture");
+	expect(fs.existsSync(declaredHostDirectory), "sandbox activation must materialize the host directory before mounting it").toBe(true);
+	const expectedHostDirectory = fs.realpathSync(declaredHostDirectory);
+	const expectedContainerDirectory = "/bobbit/local-data/pack-local-data";
+	const runtimeEnvironment = gateway.sessionManager.getSession(sessionId)?.rpcClient?.options?.env ?? {};
+	expect(JSON.parse(runtimeEnvironment.BOBBIT_PACK_LOCAL_DATA_JSON)).toEqual({ [PACK]: expectedContainerDirectory });
+
+	const containerWrite = await runPiTool(sessionId, { operation: "write", name: "container-marker.txt", content: "written-in-container" });
+	expect(containerWrite.directory).toBe(expectedContainerDirectory);
+	expect(fs.readFileSync(path.join(expectedHostDirectory, "container-marker.txt"), "utf8")).toBe("written-in-container");
+
+	fs.writeFileSync(path.join(expectedHostDirectory, "host-marker.txt"), "written-on-host", "utf8");
+	const containerRead = await runPiTool(sessionId, { operation: "read", name: "host-marker.txt" });
+	expect(containerRead).toMatchObject({ directory: expectedContainerDirectory, content: "written-on-host" });
+
+	const restoreConfig = await apiFetch(`/api/projects/${project.id}/config`, {
+		method: "PUT",
+		body: JSON.stringify({ sandbox: "none" }),
+	});
+	expect(restoreConfig.status).toBe(200);
+	sandboxConfigured = false;
+});

--- a/tests2/browser/e2e/pack-local-data.spec.ts
+++ b/tests2/browser/e2e/pack-local-data.spec.ts
@@ -1,0 +1,119 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import type { Page } from "@playwright/test";
+import {
+	apiFetch,
+	createSession,
+	defaultProject,
+	deleteSession,
+	expect,
+	navigateToHash,
+	openApp,
+	test,
+} from "../_helpers/journey-fixture.js";
+
+const PACK = "pack-local-data";
+const SOURCE = fileURLToPath(new URL("../../../market-packs/_fixtures", import.meta.url));
+
+let sourceId: string | undefined;
+let sessionId: string | undefined;
+
+async function installAndEnable(): Promise<void> {
+	const source = await apiFetch("/api/marketplace/sources", {
+		method: "POST",
+		body: JSON.stringify({ url: SOURCE }),
+	});
+	const sourceText = await source.text();
+	if (source.status === 409) {
+		const existing = await apiFetch("/api/marketplace/sources");
+		expect(existing.status).toBe(200);
+		sourceId = ((await existing.json()).sources ?? []).find((item: any) => item.url === SOURCE)?.id;
+		expect(sourceId, sourceText).toBeTruthy();
+	} else {
+		expect(source.status, sourceText).toBe(201);
+		sourceId = JSON.parse(sourceText).source.id;
+	}
+
+	const install = await apiFetch("/api/marketplace/install", {
+		method: "POST",
+		body: JSON.stringify({ sourceId, dirName: PACK, scope: "server" }),
+	});
+	const installText = await install.text();
+	expect(install.status, installText).toBe(201);
+
+	const enable = await apiFetch("/api/marketplace/pack-activation", {
+		method: "PUT",
+		body: JSON.stringify({ scope: "server", packName: PACK, disabled: { enabled: true } }),
+	});
+	const enableText = await enable.text();
+	expect(enable.status, enableText).toBe(200);
+}
+
+async function uninstall(): Promise<Response> {
+	return apiFetch("/api/marketplace/installed", {
+		method: "DELETE",
+		body: JSON.stringify({ scope: "server", packName: PACK }),
+	});
+}
+
+async function packIsContributed(): Promise<boolean> {
+	const response = await apiFetch("/api/ext/contributions");
+	expect(response.status).toBe(200);
+	return ((await response.json()).packs ?? []).some((pack: any) => pack.packId === PACK);
+}
+
+async function selectSessionAndOpenPanel(page: Page, id: string): Promise<void> {
+	await navigateToHash(page, `#/session/${id}`);
+	await expect.poll(
+		() => page.evaluate(() => (window as any).__bobbitState?.selectedSessionId ?? (window as any).bobbitState?.selectedSessionId),
+		{ timeout: 15_000 },
+	).toBe(id);
+	await navigateToHash(page, "#/ext/pack-local-data");
+	await page.getByRole("button", { name: "Open Pack Local Data Fixture" }).click();
+}
+
+test.describe.configure({ mode: "serial" });
+
+test.afterEach(async () => {
+	if (sessionId) await deleteSession(sessionId).catch(() => {});
+	sessionId = undefined;
+	await uninstall().catch(() => {});
+	if (sourceId) {
+		await apiFetch(`/api/marketplace/sources/${encodeURIComponent(sourceId)}`, { method: "DELETE" }).catch(() => {});
+		sourceId = undefined;
+	}
+	const project = await defaultProject().catch(() => undefined);
+	if (project) fs.rmSync(path.join(project.rootPath, ".pack-local-data-fixture"), { recursive: true, force: true });
+});
+
+test("installed pack panel resolves browser and route local data, survives reload, and preserves data on uninstall", async ({ page }) => {
+	const project = await defaultProject();
+	await installAndEnable();
+	await expect.poll(() => packIsContributed(), { timeout: 15_000 }).toBe(true);
+
+	sessionId = await createSession({ projectId: project.id });
+	const declaredDirectory = path.join(project.rootPath, ".pack-local-data-fixture");
+	await expect.poll(() => fs.existsSync(declaredDirectory), {
+		timeout: 15_000,
+		message: "Pack Local Data activation should materialize the project directory",
+	}).toBe(true);
+	const expectedDirectory = fs.realpathSync(declaredDirectory);
+
+	await openApp(page);
+	await selectSessionAndOpenPanel(page, sessionId);
+	await expect(page.locator('[data-testid="pack-local-data-browser-directory"]')).toHaveText(expectedDirectory, { timeout: 20_000 });
+	await expect(page.locator('[data-testid="pack-local-data-route-directory"]')).toHaveText(expectedDirectory);
+	await expect(page.locator('[data-testid="pack-local-data-markers"]')).toContainText('"host-marker.txt":"written-by-browser-route"');
+
+	await page.reload();
+	await expect(page.locator("body[data-shortcuts-ready='1']")).toBeVisible({ timeout: 20_000 });
+	await selectSessionAndOpenPanel(page, sessionId);
+	await expect(page.locator('[data-testid="pack-local-data-browser-directory"]')).toHaveText(expectedDirectory, { timeout: 20_000 });
+	await expect(page.locator('[data-testid="pack-local-data-route-directory"]')).toHaveText(expectedDirectory);
+
+	const removed = await uninstall();
+	expect(removed.status).toBe(204);
+	await expect.poll(() => packIsContributed(), { timeout: 15_000 }).toBe(false);
+	expect(fs.readFileSync(path.join(expectedDirectory, "host-marker.txt"), "utf8")).toBe("written-by-browser-route");
+});

--- a/tests2/core/docker-args.test.ts
+++ b/tests2/core/docker-args.test.ts
@@ -11,7 +11,7 @@ import assert from "node:assert";
 import fs from "node:fs";
 import path from "node:path";
 import type { CommandRunner } from "../../src/server/gateway-deps.ts";
-import { buildDockerRunArgs, e2eSandboxVolumeCreateArgs, projectSandboxVolumeNames } from "../../src/server/agent/docker-args.js";
+import { buildDockerRunArgs, e2eSandboxVolumeCreateArgs, packLocalDataContainerDirectory, projectSandboxVolumeNames } from "../../src/server/agent/docker-args.js";
 import { ProjectSandbox, _resetDockerLimitsCache } from "../../src/server/agent/project-sandbox.js";
 import { prepareSanitizedSandboxCloneSource, resolveSandboxCloneSource } from "../../src/server/agent/sandbox-clone-source.js";
 import { toDockerPath } from "../../src/server/agent/rpc-bridge.js";
@@ -126,6 +126,36 @@ describe("buildDockerRunArgs", () => {
 		assert.ok(
 			args.includes(`bobbit-worktrees-${projectId}:/workspace-wt`),
 			"should mount worktrees named volume",
+		);
+	});
+
+	it("mounts pack local-data directories read-write in stable pack order", () => {
+		const alphaHost = path.join(fixtureDir("local-data"), "alpha");
+		const zetaHost = path.join(fixtureDir("local-data"), "zeta");
+		const args = buildDockerRunArgs({
+			image: "test",
+			workspaceDir: "/tmp/test",
+			packLocalDataMounts: [
+				{ packId: "zeta-pack", hostDirectory: zetaHost, containerDirectory: packLocalDataContainerDirectory("zeta-pack") },
+				{ packId: "alpha-pack", hostDirectory: alphaHost, containerDirectory: packLocalDataContainerDirectory("alpha-pack") },
+			],
+		}, NOOP_COMMAND_RUNNER);
+		const mounts = args.filter((_arg, index) => args[index - 1] === "-v");
+		const alpha = `${toDockerPath(alphaHost)}:/bobbit/local-data/alpha-pack`;
+		const zeta = `${toDockerPath(zetaHost)}:/bobbit/local-data/zeta-pack`;
+
+		assert.ok(mounts.includes(alpha));
+		assert.ok(mounts.includes(zeta));
+		assert.ok(mounts.indexOf(alpha) < mounts.indexOf(zeta), "local-data binds must be sorted by pack ID");
+		assert.ok(!mounts.find((entry) => entry === alpha)?.endsWith(":ro"));
+		assert.ok(!mounts.find((entry) => entry === zeta)?.endsWith(":ro"));
+	});
+
+	it("preserves Docker args exactly when the local-data mount set is empty", () => {
+		const config = { image: "test", workspaceDir: "/tmp/test" };
+		assert.deepEqual(
+			buildDockerRunArgs({ ...config, packLocalDataMounts: [] }, NOOP_COMMAND_RUNNER),
+			buildDockerRunArgs(config, NOOP_COMMAND_RUNNER),
 		);
 	});
 

--- a/tests2/core/extension-host-module-isolation.test.ts
+++ b/tests2/core/extension-host-module-isolation.test.ts
@@ -45,6 +45,7 @@ import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { ModuleHost, type InvokeRequest } from "../../src/server/extension-host/module-host-worker.ts";
 import { ActionError, type ActionHandlerCtx } from "../../src/server/extension-host/action-dispatcher.ts";
+import { createServerHostApi } from "../../src/server/extension-host/server-host-api.ts";
 import { makeTmpDir } from "../../tests/helpers/tmp.ts";
 
 let tmp: string;
@@ -106,9 +107,51 @@ describe.concurrent("ModuleHost — confined execution (happy path + identity)",
 	it("runs a handler in a worker and returns its (structured-cloned) result", async () => {
 		const mh = new ModuleHost({ timeoutMs: 10_000 });
 		try {
-			const url = writeModule(`export const actions = { run: async (ctx, arg) => ({ ok: true, echo: arg, tool: ctx.tool, sid: ctx.sessionId }) };`);
+			const url = writeModule(`export const actions = { run: async (ctx, arg) => ({ ok: true, echo: arg, tool: ctx.tool, sid: ctx.sessionId, hasLocalData: Object.hasOwn(ctx.host, "localData"), hasLocalDataCapability: Object.hasOwn(ctx.host.capabilities, "localData") }) };`);
 			const result = await mh.invoke(req(url, "run", bareCtx(), { n: 7 }));
-			assert.deepEqual(result, { ok: true, echo: { n: 7 }, tool: "demo_tool", sid: "sess-1" });
+			assert.deepEqual(result, { ok: true, echo: { n: 7 }, tool: "demo_tool", sid: "sess-1", hasLocalData: false, hasLocalDataCapability: false });
+		} finally {
+			mh.dispose();
+		}
+	});
+
+	it("copies a declared local-data binding into the worker as a synchronous local namespace", async () => {
+		const mh = new ModuleHost({ timeoutMs: 10_000 });
+		try {
+			const directory = path.join(tmp, ".performance-optimisation");
+			const host = createServerHostApi({
+				sessionId: "sess-1",
+				packId: "performance-optimisation",
+				contributionId: "tools/performance",
+				localDataDirectory: directory,
+			});
+			let parentDirectoryReads = 0;
+			const countedHost = {
+				...host,
+				localData: { directory: () => { parentDirectoryReads++; return host.localData!.directory(); } },
+			};
+			const ctx: ActionHandlerCtx = { ...bareCtx(), host: countedHost };
+			const url = writeModule(
+				`const readBinding = (ctx) => ({` +
+				` value: ctx.host.localData.directory(),` +
+				` isPromise: typeof ctx.host.localData.directory()?.then === "function",` +
+				` hasCapability: ctx.host.capabilities.has("localData"),` +
+				` capability: ctx.host.capabilities.localData` +
+				` });` +
+				` export const actions = { directory: readBinding };` +
+				` export default { provider: readBinding };`,
+			);
+			const expected = {
+				value: directory,
+				isPromise: false,
+				hasCapability: true,
+				capability: true,
+			};
+
+			assert.deepEqual(await mh.invoke(req(url, "directory", ctx)), expected);
+			const providerRequest: InvokeRequest = { ...req(url, "provider", ctx), exportKind: "providers" };
+			assert.deepEqual(await mh.invoke(providerRequest), expected);
+			assert.equal(parentDirectoryReads, 2, "each worker receives one serialized string rather than proxying directory() calls");
 		} finally {
 			mh.dispose();
 		}

--- a/tests2/core/extension-host-server-host-api.test.ts
+++ b/tests2/core/extension-host-server-host-api.test.ts
@@ -62,6 +62,53 @@ describe("createServerHostApi — durable v1 (no gateway passthrough)", () => {
 	});
 });
 
+describe("createServerHostApi — project-scoped pack local data", () => {
+	it("exposes the exact pre-resolved directory synchronously when bound", () => {
+		const directory = path.join(os.tmpdir(), "project", ".performance-optimisation");
+		const host = createServerHostApi({
+			sessionId: "s",
+			packId: "performance-optimisation",
+			contributionId: "tools/performance",
+			localDataDirectory: directory,
+		});
+
+		assert.equal(host.capabilities.localData, true);
+		assert.equal(host.capabilities.has("localData"), true);
+		assert.equal(host.localData?.directory(), directory);
+		assert.equal(host.localData?.directory(), directory, "the stable binding is reused without caller input");
+	});
+
+	it("adds no namespace or capability property when no directory is bound", () => {
+		const host = createServerHostApi({ sessionId: "s", packId: "plain-pack", contributionId: "g/t" });
+		assert.equal(Object.hasOwn(host, "localData"), false);
+		assert.equal(Object.hasOwn(host.capabilities, "localData"), false);
+		assert.equal(host.capabilities.has("localData"), false);
+	});
+
+	it("honours a least-privilege mask for the declared binding", () => {
+		const directory = path.join(os.tmpdir(), ".p");
+		const denied = createServerHostApi({
+			sessionId: "s",
+			packId: "p",
+			contributionId: "providers/p",
+			localDataDirectory: directory,
+			capabilityMask: { store: true },
+		});
+		assert.equal(Object.hasOwn(denied, "localData"), false);
+		assert.equal(denied.capabilities.has("localData"), false);
+
+		const allowed = createServerHostApi({
+			sessionId: "s",
+			packId: "p",
+			contributionId: "providers/p",
+			localDataDirectory: directory,
+			capabilityMask: { store: true, localData: true },
+		});
+		assert.equal(allowed.localData?.directory(), directory);
+		assert.equal(allowed.capabilities.has("localData"), true);
+	});
+});
+
 describe("createServerHostApi — Fix B: NO server-side session.postMessage", () => {
 	it("the server host session API does NOT expose postMessage (driving the agent is client-only)", () => {
 		const host = createServerHostApi({ sessionId: "s", toolUseId: "tu", packId: "p", contributionId: "g/t" });

--- a/tests2/core/marketplace-install.test.ts
+++ b/tests2/core/marketplace-install.test.ts
@@ -464,6 +464,33 @@ describe("#7 install / uninstall / update", () => {
 		}
 	});
 
+	it("rejects project installs whose local data overlaps the managed pack tree", () => {
+		w(path.join(repo, "qa-pack", "pack.yaml"),
+			"name: qa-pack\nschema: 2\ndescription: qa tools\nversion: 1.0.0\n"
+			+ "localData:\n  scope: project\n  directory: .bobbit/config/market-packs/qa-pack/data\n"
+			+ "  access: read-write\n  preserveOnUninstall: true\n"
+			+ "contents:\n  roles: []\n  tools: [qa]\n  skills: []\n");
+		const sourceMarker = path.join(repo, "qa-pack", "source-marker.txt");
+		w(sourceMarker, "must remain");
+		const projectBase = path.join(root, "project");
+		const projectPackOrder = new ProjectConfigStore(path.join(projectBase, ".bobbit", "config"));
+
+		assert.throws(
+			() => inst.installPack({
+				sourceId: sourceId(),
+				dirName: "qa-pack",
+				scope: "project",
+				projectBase,
+				packOrderStore: projectPackOrder,
+			}),
+			(e: any) => e instanceof MarketplaceError && e.code === "invalid_pack",
+		);
+		const { marketPacksRoot } = scopePaths("project", projectBase);
+		assert.equal(fs.existsSync(path.join(marketPacksRoot, "qa-pack")), false);
+		assert.deepEqual(projectPackOrder.getPackOrder("project"), []);
+		assert.equal(fs.readFileSync(sourceMarker, "utf8"), "must remain");
+	});
+
 	it("uninstall deletes exactly the added dir and cleans pack_order", () => {
 		inst.installPack({ sourceId: sourceId(), dirName: "research-pack", scope: "server", packOrderStore: packOrder });
 		inst.installPack({ sourceId: sourceId(), dirName: "qa-pack", scope: "server", packOrderStore: packOrder });

--- a/tests2/core/pack-local-data.test.ts
+++ b/tests2/core/pack-local-data.test.ts
@@ -325,6 +325,28 @@ describe("PackLocalDataResolver", () => {
 			},
 		);
 
+		it("canonicalizes a POSIX symlink or Windows junction before an absent managed-root suffix", () => {
+			const root = fixtureRoot();
+			const canonicalHeadquarters = path.join(root, "canonical-headquarters");
+			const linkedHeadquarters = path.join(root, "linked-headquarters");
+			fs.mkdirSync(canonicalHeadquarters);
+			fs.symlinkSync(
+				canonicalHeadquarters,
+				linkedHeadquarters,
+				process.platform === "win32" ? "junction" : "dir",
+			);
+			const managedRoot = path.join(linkedHeadquarters, "config", "market-packs");
+			const candidate = path.join(canonicalHeadquarters, "config", "market-packs", "performance");
+			const resolver = resolverFor(root, [
+				contribution("performance", relativeDeclaration(root, candidate)),
+			], () => [managedRoot]);
+
+			expect(fs.existsSync(path.join(canonicalHeadquarters, "config"))).toBe(false);
+			expect(() => resolver.resolveHostDirectory("project-1", "performance"))
+				.toThrowError(expect.objectContaining({ code: "unsafe_path" }));
+			expect(fs.existsSync(path.join(canonicalHeadquarters, "config"))).toBe(false);
+		});
+
 		it("allows a nearby non-overlapping directory", () => {
 			const root = fixtureRoot();
 			const managedRoot = path.join(root, "simulated-headquarters", "config", "market-packs");

--- a/tests2/core/pack-local-data.test.ts
+++ b/tests2/core/pack-local-data.test.ts
@@ -63,14 +63,26 @@ function fixtureRoot(): string {
 	return root;
 }
 
-function resolverFor(projectRoot: string, packs: PackContributions[]): PackLocalDataResolver {
+function resolverFor(
+	projectRoot: string,
+	packs: PackContributions[],
+	managedMarketplaceRoots: () => readonly string[] = () => [],
+): PackLocalDataResolver {
 	return new PackLocalDataResolver(
 		{ get: id => id === "project-1" ? ({ id, rootPath: projectRoot } as never) : undefined },
 		{
 			getPack: (projectId, packId) => projectId === "project-1" ? packs.find(pack => pack.packId === packId) : undefined,
 			list: projectId => projectId === "project-1" ? packs : [],
 		},
+		managedMarketplaceRoots,
 	);
+}
+
+function relativeDeclaration(projectRoot: string, target: string): PackLocalDataDeclaration {
+	return {
+		...declaration,
+		directory: path.relative(projectRoot, target).split(path.sep).join("/"),
+	};
 }
 
 describe("pack local-data manifest declaration", () => {
@@ -246,6 +258,124 @@ describe("PackLocalDataResolver", () => {
 			},
 		]);
 		expect(fs.existsSync(path.join(root, "undeclared"))).toBe(false);
+	});
+
+	describe("managed Marketplace overlap guard", () => {
+		it("rejects a parent project's candidate equal to or below Headquarters config/market-packs", () => {
+			const root = fixtureRoot();
+			const managedRoot = path.join(root, "simulated-headquarters", "config", "market-packs");
+			const descendant = path.join(managedRoot, "performance", "cache");
+			fs.mkdirSync(managedRoot, { recursive: true });
+			const resolver = resolverFor(root, [
+				contribution("equal", relativeDeclaration(root, managedRoot)),
+				contribution("descendant", relativeDeclaration(root, descendant)),
+			], () => [managedRoot]);
+
+			for (const packId of ["equal", "descendant"]) {
+				expect(() => resolver.resolveHostDirectory("project-1", packId))
+					.toThrowError(expect.objectContaining({ code: "unsafe_path" }));
+			}
+			expect(fs.existsSync(descendant)).toBe(false);
+		});
+
+		it("rejects global-user and another registered child project's managed roots", () => {
+			const parentRoot = fixtureRoot();
+			const registeredProjects = new Map([
+				["project-1", parentRoot],
+				["child-project", path.join(parentRoot, "registered-child")],
+			]);
+			const globalUserRoot = path.join(parentRoot, "simulated-global-user");
+			const globalMarketplaceRoot = path.join(globalUserRoot, ".bobbit", "config", "market-packs");
+			const childMarketplaceRoot = path.join(
+				registeredProjects.get("child-project")!,
+				".bobbit", "config", "market-packs",
+			);
+			const resolver = resolverFor(parentRoot, [
+				contribution("global", relativeDeclaration(parentRoot, path.join(globalMarketplaceRoot, "global-pack"))),
+				contribution("child", relativeDeclaration(parentRoot, path.join(childMarketplaceRoot, "child-pack"))),
+			], () => [
+				globalMarketplaceRoot,
+				...Array.from(registeredProjects.values(), projectRoot =>
+					path.join(projectRoot, ".bobbit", "config", "market-packs")),
+			]);
+
+			for (const packId of ["global", "child"]) {
+				expect(() => resolver.resolveHostDirectory("project-1", packId))
+					.toThrowError(expect.objectContaining({ code: "unsafe_path" }));
+			}
+			expect(fs.existsSync(globalUserRoot)).toBe(false);
+			expect(fs.existsSync(registeredProjects.get("child-project")!)).toBe(false);
+		});
+
+		it.each(["resolveHostDirectory", "resolveMounts"] as const)(
+			"%s rejects an absent managed root before creating its first component",
+			api => {
+				const root = fixtureRoot();
+				const firstComponent = path.join(root, "future-headquarters");
+				const managedRoot = path.join(firstComponent, "config", "market-packs");
+				const resolver = resolverFor(root, [
+					contribution("performance", relativeDeclaration(root, path.join(managedRoot, "performance"))),
+				], () => [managedRoot]);
+
+				const resolve = api === "resolveHostDirectory"
+					? () => resolver.resolveHostDirectory("project-1", "performance")
+					: () => resolver.resolveMounts("project-1");
+				expect(resolve).toThrowError(expect.objectContaining({ code: "unsafe_path" }));
+				expect(fs.existsSync(firstComponent)).toBe(false);
+			},
+		);
+
+		it("allows a nearby non-overlapping directory", () => {
+			const root = fixtureRoot();
+			const managedRoot = path.join(root, "simulated-headquarters", "config", "market-packs");
+			const nearby = path.join(root, "simulated-headquarters", "config", "market-packs-data", "cache");
+			const resolver = resolverFor(root, [
+				contribution("performance", relativeDeclaration(root, nearby)),
+			], () => [managedRoot]);
+
+			expect(resolver.resolveHostDirectory("project-1", "performance")).toBe(nearby);
+			expect(fs.statSync(nearby).isDirectory()).toBe(true);
+		});
+
+		it("normalizes path spellings and applies deterministic Windows case folding", () => {
+			const root = fixtureRoot();
+			const candidate = path.join(root, "Headquarters", "config", "market-packs", "cache");
+			const managedRoot = [
+				root,
+				"headquarters",
+				"config",
+				"ignored",
+				"..",
+				"market-packs",
+			].join(path.sep);
+			vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+			const resolver = resolverFor(root, [
+				contribution("performance", relativeDeclaration(root, candidate)),
+			], () => [managedRoot]);
+
+			expect(() => resolver.resolveHostDirectory("project-1", "performance"))
+				.toThrowError(expect.objectContaining({ code: "unsafe_path" }));
+			expect(fs.existsSync(path.join(root, "Headquarters"))).toBe(false);
+		});
+
+		it("reads the managed-roots provider on every resolution", () => {
+			const root = fixtureRoot();
+			const lateManagedRoot = path.join(root, "late-project", ".bobbit", "config", "market-packs");
+			let managedRoots: readonly string[] = [];
+			const provider = vi.fn(() => managedRoots);
+			const resolver = resolverFor(root, [
+				contribution("ordinary", { ...declaration, directory: "ordinary-data" }),
+				contribution("late", relativeDeclaration(root, path.join(lateManagedRoot, "late-pack"))),
+			], provider);
+
+			expect(resolver.resolveHostDirectory("project-1", "ordinary"))
+				.toBe(path.join(root, "ordinary-data"));
+			managedRoots = [lateManagedRoot];
+			expect(() => resolver.resolveHostDirectory("project-1", "late"))
+				.toThrowError(expect.objectContaining({ code: "unsafe_path" }));
+			expect(provider).toHaveBeenCalledTimes(2);
+			expect(fs.existsSync(path.join(root, "late-project"))).toBe(false);
+		});
 	});
 
 	it("fails closed for unknown projects, inactive packs, and undeclared packs", () => {

--- a/tests2/core/pack-local-data.test.ts
+++ b/tests2/core/pack-local-data.test.ts
@@ -104,6 +104,35 @@ describe("pack local-data manifest declaration", () => {
 		expect(problems.join("; ")).toMatch(/localData/);
 	});
 
+	it.each([
+		".bobbit/config/market-packs",
+		".bobbit/config/market-packs/performance",
+		"config/market-packs",
+		"config/market-packs/performance/cache",
+		".BOBBIT/CONFIG/MARKET-PACKS/Performance",
+		"Config/Market-Packs/performance",
+	])("rejects Bobbit-managed marketplace directory %j", directory => {
+		expect(validateManifest({
+			...baseManifest,
+			schema: 2,
+			localData: { ...declaration, directory },
+		})).toBeNull();
+	});
+
+	it.each([
+		".performance-optimisation",
+		".bobbit/config/market-pack",
+		".bobbit/config/market-packs-data",
+		"config/market-pack",
+		"data/config/market-packs/performance",
+	])("accepts external or near-miss directory %j", directory => {
+		expect(validateManifest({
+			...baseManifest,
+			schema: 2,
+			localData: { ...declaration, directory },
+		})?.localData?.directory).toBe(directory);
+	});
+
 	it("requires every fixed lifecycle/access field", () => {
 		for (const localData of [
 			{ ...declaration, scope: "user" },

--- a/tests2/core/pack-local-data.test.ts
+++ b/tests2/core/pack-local-data.test.ts
@@ -1,0 +1,238 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { loadPackContributions, type PackContributions } from "../../src/server/agent/pack-contributions.js";
+import { validateManifest } from "../../src/server/agent/pack-manifest.js";
+import type { PackEntry, PackLocalDataDeclaration, PackManifest } from "../../src/server/agent/pack-types.js";
+import { PackContributionRegistry } from "../../src/server/extension-host/pack-contribution-registry.js";
+import {
+	PACK_LOCAL_DATA_CONTAINER_ROOT,
+	PackLocalDataError,
+	PackLocalDataResolver,
+} from "../../src/server/extension-host/pack-local-data.js";
+
+const fixtures: string[] = [];
+
+afterEach(() => {
+	vi.restoreAllMocks();
+	for (const fixture of fixtures.splice(0)) fs.rmSync(fixture, { recursive: true, force: true });
+});
+
+const baseManifest = {
+	name: "performance",
+	description: "Performance tools",
+	version: "1.0.0",
+	contents: { roles: [], tools: [], skills: [] },
+};
+
+const declaration: PackLocalDataDeclaration = {
+	scope: "project",
+	directory: ".performance-optimisation/cache",
+	access: "read-write",
+	preserveOnUninstall: true,
+};
+
+function manifest(localData?: PackLocalDataDeclaration): PackManifest {
+	return {
+		...baseManifest,
+		schema: 2,
+		contents: { ...baseManifest.contents, entrypoints: [] },
+		...(localData ? { localData } : {}),
+	};
+}
+
+function contribution(packId: string, localData?: PackLocalDataDeclaration): PackContributions {
+	return {
+		packId,
+		packName: packId,
+		packRoot: path.join("packs", packId),
+		panels: [],
+		entrypoints: [],
+		providers: [],
+		channels: [],
+		hooks: [],
+		mcp: [],
+		...(localData ? { localData } : {}),
+	};
+}
+
+function fixtureRoot(): string {
+	const root = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "pack-local-data-")));
+	fixtures.push(root);
+	return root;
+}
+
+function resolverFor(projectRoot: string, packs: PackContributions[]): PackLocalDataResolver {
+	return new PackLocalDataResolver(
+		{ get: id => id === "project-1" ? ({ id, rootPath: projectRoot } as never) : undefined },
+		{
+			getPack: (projectId, packId) => projectId === "project-1" ? packs.find(pack => pack.packId === packId) : undefined,
+			list: projectId => projectId === "project-1" ? packs : [],
+		},
+	);
+}
+
+describe("pack local-data manifest declaration", () => {
+	it("accepts and normalizes the fixed schema-2 declaration", () => {
+		const parsed = validateManifest({ ...baseManifest, schema: 2, localData: declaration });
+		expect(parsed?.localData).toEqual(declaration);
+	});
+
+	it("preserves the no-declaration and schema-1 object shape", () => {
+		const schema2 = validateManifest({ ...baseManifest, schema: 2 })!;
+		expect(Object.hasOwn(schema2, "localData")).toBe(false);
+		const schema1 = validateManifest({
+			...baseManifest,
+			localData: { ...declaration, directory: "../ignored-for-schema-1" },
+		})!;
+		expect(Object.hasOwn(schema1, "localData")).toBe(false);
+	});
+
+	it.each([
+		"", " spaced", "spaced ", "/absolute", "//server/share", "C:\\absolute",
+		"C:drive-relative", "\\\\server\\share", "with\\backslash", ".", "..",
+		"a/./b", "a/../b", "a//b", "CON", "con.txt", "nested/COM1.log", "COM¹",
+		"trailing.", "trailing ", "ads:name", "question?mark", "with\0nul",
+	])("rejects non-portable directory %j", directory => {
+		const problems: string[] = [];
+		expect(validateManifest({
+			...baseManifest,
+			schema: 2,
+			localData: { ...declaration, directory },
+		}, problems)).toBeNull();
+		expect(problems.join("; ")).toMatch(/localData/);
+	});
+
+	it("requires every fixed lifecycle/access field", () => {
+		for (const localData of [
+			{ ...declaration, scope: "user" },
+			{ ...declaration, access: "read-only" },
+			{ ...declaration, preserveOnUninstall: false },
+			{ directory: declaration.directory },
+		]) {
+			expect(validateManifest({ ...baseManifest, schema: 2, localData })).toBeNull();
+		}
+	});
+
+	it("copies only declared local data into contribution objects", () => {
+		const root = path.join(fixtureRoot(), "market-packs", "performance");
+		fs.mkdirSync(root, { recursive: true });
+		const without = loadPackContributions(root, manifest());
+		expect(Object.hasOwn(without, "localData")).toBe(false);
+		expect(loadPackContributions(root, manifest(declaration)).localData).toEqual(declaration);
+	});
+
+	it("exposes only the winning pack declaration through the contribution registry", () => {
+		const fixture = fixtureRoot();
+		const lowerRoot = path.join(fixture, "global", "market-packs", "performance");
+		const winnerRoot = path.join(fixture, "project", "market-packs", "performance");
+		fs.mkdirSync(lowerRoot, { recursive: true });
+		fs.mkdirSync(winnerRoot, { recursive: true });
+		const lower = manifest({ ...declaration, directory: "global-data" });
+		const winner = manifest({ ...declaration, directory: "project-data" });
+		const entry = (packPath: string, scope: PackEntry["scope"], packManifest: PackManifest): PackEntry => ({
+			id: `market:${scope}:performance`, kind: "market", scope, path: packPath,
+			readOnly: false, manifest: packManifest, layout: "defaults-tree",
+		});
+		const registry = new PackContributionRegistry(() => [
+			entry(lowerRoot, "global-user", lower),
+			entry(winnerRoot, "project", winner),
+		]);
+		expect(registry.getPack("project-1", "performance")?.localData?.directory).toBe("project-data");
+	});
+});
+
+describe("PackLocalDataResolver", () => {
+	it("materializes below the registered canonical project root, independent of worktrees", () => {
+		const root = fixtureRoot();
+		const resolver = resolverFor(root, [contribution("performance", declaration)]);
+		const expected = path.join(root, ".performance-optimisation", "cache");
+
+		expect(resolver.resolveHostDirectory("project-1", "performance")).toBe(expected);
+		expect(fs.statSync(expected).isDirectory()).toBe(true);
+		// The API has no cwd/worktree coordinate: repeated realm adapters resolve the same root binding.
+		expect(resolver.resolveHostDirectory("project-1", "performance")).toBe(expected);
+	});
+
+	it("uses the registered polyrepo container root rather than a component root", () => {
+		const root = fixtureRoot();
+		fs.mkdirSync(path.join(root, "components", "web"), { recursive: true });
+		const resolver = resolverFor(root, [contribution("performance", declaration)]);
+		expect(resolver.resolveHostDirectory("project-1", "performance"))
+			.toBe(path.join(root, ".performance-optimisation", "cache"));
+	});
+
+	it("rejects links and non-directory components even when they remain in-root", () => {
+		const root = fixtureRoot();
+		const real = path.join(root, "real-data");
+		const link = path.join(root, "linked-data");
+		fs.mkdirSync(real);
+		let linked = false;
+		try {
+			fs.symlinkSync(real, link, process.platform === "win32" ? "junction" : "dir");
+			linked = true;
+		} catch (error: any) {
+			if (!["EPERM", "EACCES", "ENOSYS", "ENOTSUP"].includes(error?.code)) throw error;
+			fs.mkdirSync(link);
+		}
+		const linkedDeclaration = { ...declaration, directory: "linked-data/child" };
+		const resolver = resolverFor(root, [contribution("performance", linkedDeclaration)]);
+		if (!linked) {
+			const realLstat = fs.lstatSync.bind(fs);
+			vi.spyOn(fs, "lstatSync").mockImplementation(((candidate: fs.PathLike) => {
+				const stat = realLstat(candidate);
+				return path.resolve(String(candidate)) === path.resolve(link)
+					? ({ ...stat, isSymbolicLink: () => true } as fs.Stats)
+					: stat;
+			}) as typeof fs.lstatSync);
+		}
+		expect(() => resolver.resolveHostDirectory("project-1", "performance"))
+			.toThrowError(expect.objectContaining({ code: "path_is_link" }));
+
+		const file = path.join(root, "file-component");
+		fs.writeFileSync(file, "not a directory");
+		const fileResolver = resolverFor(root, [contribution("file-pack", { ...declaration, directory: "file-component/child" })]);
+		expect(() => fileResolver.resolveHostDirectory("project-1", "file-pack"))
+			.toThrowError(expect.objectContaining({ code: "path_not_directory" }));
+	});
+
+	it("returns sorted host/container mount plans and performs no work for undeclared packs", () => {
+		const root = fixtureRoot();
+		const resolver = resolverFor(root, [
+			contribution("z-pack", { ...declaration, directory: "z-data" }),
+			contribution("undeclared"),
+			contribution("a/pack", { ...declaration, directory: "a-data" }),
+		]);
+		expect(resolver.resolveMounts("project-1")).toEqual([
+			{
+				packId: "a/pack",
+				hostDirectory: path.join(root, "a-data"),
+				containerDirectory: `${PACK_LOCAL_DATA_CONTAINER_ROOT}/a%2Fpack`,
+			},
+			{
+				packId: "z-pack",
+				hostDirectory: path.join(root, "z-data"),
+				containerDirectory: `${PACK_LOCAL_DATA_CONTAINER_ROOT}/z-pack`,
+			},
+		]);
+		expect(fs.existsSync(path.join(root, "undeclared"))).toBe(false);
+	});
+
+	it("fails closed for unknown projects, inactive packs, and undeclared packs", () => {
+		const root = fixtureRoot();
+		const resolver = resolverFor(root, [contribution("bare")]);
+		const assertCode = (run: () => unknown, code: PackLocalDataError["code"]) => {
+			try {
+				run();
+				throw new Error("expected PackLocalDataError");
+			} catch (error) {
+				expect(error).toBeInstanceOf(PackLocalDataError);
+				expect((error as PackLocalDataError).code).toBe(code);
+			}
+		};
+		assertCode(() => resolver.resolveHostDirectory("missing", "bare"), "project_not_found");
+		assertCode(() => resolver.resolveHostDirectory("project-1", "missing"), "pack_not_active");
+		assertCode(() => resolver.resolveHostDirectory("project-1", "bare"), "local_data_undeclared");
+	});
+});

--- a/tests2/core/project-sandbox-agent-dir-mounts.test.ts
+++ b/tests2/core/project-sandbox-agent-dir-mounts.test.ts
@@ -5,7 +5,8 @@
 import { describe, it } from "vitest";
 import assert from "node:assert/strict";
 import path from "node:path";
-import { ProjectSandbox, getAgentDirMountStaleness, getModelsJsonContentStaleness, getStateDirMountStaleness } from "../../src/server/agent/project-sandbox.js";
+import { ProjectSandbox, getAgentDirMountStaleness, getModelsJsonContentStaleness, getPackLocalDataMountStaleness, getStateDirMountStaleness } from "../../src/server/agent/project-sandbox.js";
+import { packLocalDataContainerDirectory, type PackLocalDataMountPlan } from "../../src/server/agent/docker-args.js";
 import { SandboxManager } from "../../src/server/agent/sandbox-manager.js";
 
 type Call = string | [string, string];
@@ -14,12 +15,13 @@ function mount(source: string, destination: string, rw = true, mode = ""): { Sou
 	return { Source: source, Destination: destination, RW: rw, Mode: mode };
 }
 
-function makeSandbox(): ProjectSandbox {
+function makeSandbox(resolvePackLocalDataMounts?: () => readonly PackLocalDataMountPlan[]): ProjectSandbox {
 	return new ProjectSandbox({
 		projectId: "stale-agent-dir-mounts",
 		projectDir: path.join(process.cwd(), "tmp-project"),
 		repoUrl: "https://example.test/repo.git",
 		image: "bobbit-test-image:latest",
+		resolvePackLocalDataMounts,
 	});
 }
 
@@ -220,6 +222,103 @@ describe("SandboxManager atomic model refresh", () => {
 
 		await assert.rejects(manager.refreshAgentModelMounts(), /broken/);
 		assert.deepEqual(calls.sort(), ["broken", "healthy"]);
+	});
+});
+
+describe("ProjectSandbox pack local-data mounts", () => {
+	const hostDirectory = path.resolve("/project/.performance-optimisation");
+	const plan: PackLocalDataMountPlan = {
+		packId: "performance-optimisation",
+		hostDirectory,
+		containerDirectory: packLocalDataContainerDirectory("performance-optimisation"),
+	};
+
+	it("requires the exact host source, stable destination, writable mode, and no stale extras", () => {
+		assert.equal(getPackLocalDataMountStaleness([
+			mount(hostDirectory, plan.containerDirectory),
+		], [plan]).stale, false);
+
+		const staleSource = getPackLocalDataMountStaleness([
+			mount(path.resolve("/project/.old-performance"), plan.containerDirectory),
+		], [plan]);
+		assert.equal(staleSource.stale, true);
+		assert.match(staleSource.reason ?? "", /stale host source/);
+
+		const readOnly = getPackLocalDataMountStaleness([
+			mount(hostDirectory, plan.containerDirectory, false, "ro"),
+		], [plan]);
+		assert.equal(readOnly.stale, true);
+		assert.match(readOnly.reason ?? "", /not writable/);
+
+		const staleExtra = getPackLocalDataMountStaleness([
+			mount(hostDirectory, plan.containerDirectory),
+			mount(path.resolve("/project/.removed-pack"), "/bobbit/local-data/removed-pack"),
+		], [plan]);
+		assert.equal(staleExtra.stale, true);
+		assert.match(staleExtra.reason ?? "", /stale extra/);
+
+		assert.equal(getPackLocalDataMountStaleness([
+			mount(hostDirectory, plan.containerDirectory),
+		], []).stale, true, "disabling a pack must remove its stale bind on recreation");
+	});
+
+	it("recreates a restored container before reconnecting when local-data binds differ", async () => {
+		const sandbox = makeSandbox(() => [plan]);
+		const calls: Call[] = [];
+		(sandbox as any)._findContainerByLabel = async () => "old-container-id";
+		(sandbox as any)._hasStaleAgentDirMounts = async () => false;
+		(sandbox as any)._hasStaleStateDirMounts = async () => false;
+		(sandbox as any)._hasStalePackLocalDataMounts = async () => true;
+		(sandbox as any)._isContainerImageStale = async () => { throw new Error("must not inspect image after stale local-data mounts"); };
+		(sandbox as any)._isContainerRunning = async () => { throw new Error("must not reconnect stale local-data mounts"); };
+		(sandbox as any)._removeContainer = async (containerId: string) => { calls.push(["remove", containerId]); };
+		(sandbox as any)._createContainer = async () => { calls.push("create"); (sandbox as any).containerId = "new-container-id"; };
+		(sandbox as any)._runInitSequence = async () => { calls.push("init"); };
+
+		await (sandbox as any)._initContainer();
+
+		assert.deepEqual(calls, [["remove", "old-container-id"], "create", "init"]);
+	});
+
+	it("re-resolves live plans and emits recovery events only when mounts changed", async () => {
+		let current = [plan];
+		const sandbox = makeSandbox(() => current);
+		const calls: Call[] = [];
+		const events: string[] = [];
+		(sandbox as any).containerId = "container-0";
+		(sandbox as any)._status = "ready";
+		(sandbox as any)._hasStalePackLocalDataMounts = async (_containerId: string, expected: readonly PackLocalDataMountPlan[]) => expected[0]?.hostDirectory !== hostDirectory;
+		(sandbox as any)._removeContainer = async (containerId: string) => { calls.push(["remove", containerId]); };
+		(sandbox as any)._initContainer = async () => { calls.push("create"); (sandbox as any).containerId = "container-1"; };
+		sandbox.onHealthEvent((event) => events.push(`${event.type}:${event.containerId}`));
+
+		assert.equal(await sandbox.refreshPackLocalDataMounts(), false);
+		assert.deepEqual(calls, []);
+		assert.deepEqual(events, []);
+
+		current = [{ ...plan, hostDirectory: path.resolve("/project/.performance-v2") }];
+		assert.equal(await sandbox.refreshPackLocalDataMounts(), true);
+		assert.deepEqual(calls, [["remove", "container-0"], "create"]);
+		assert.deepEqual(events, ["container-died:container-0", "container-recovered:container-1"]);
+	});
+});
+
+describe("SandboxManager pack local-data refresh", () => {
+	it("targets one project or all tracked projects and aggregates failures", async () => {
+		const manager = new SandboxManager();
+		const calls: string[] = [];
+		(manager as any).sandboxes = new Map([
+			["alpha", { getStatus: () => ({ projectId: "alpha" }), refreshPackLocalDataMounts: async () => { calls.push("alpha"); } }],
+			["beta", { getStatus: () => ({ projectId: "beta" }), refreshPackLocalDataMounts: async () => { calls.push("beta"); } }],
+		]);
+
+		await manager.refreshPackLocalDataMounts("alpha");
+		assert.deepEqual(calls, ["alpha"]);
+		await manager.refreshPackLocalDataMounts();
+		assert.deepEqual(calls.sort(), ["alpha", "alpha", "beta"]);
+
+		(manager as any).sandboxes.get("beta").refreshPackLocalDataMounts = async () => { throw new Error("remount failed"); };
+		await assert.rejects(manager.refreshPackLocalDataMounts(), /beta/);
 	});
 });
 

--- a/tests2/core/session-manager-pi-extension-args.test.ts
+++ b/tests2/core/session-manager-pi-extension-args.test.ts
@@ -8,7 +8,9 @@ import path from "node:path";
 
 import { EventBuffer } from "../../src/server/agent/event-buffer.ts";
 import { SessionManager } from "../../src/server/agent/session-manager.ts";
-import { resolveMarketplacePiExtensionActivation, type ResolvedPiExtensionContribution } from "../../src/server/agent/session-setup.ts";
+import { resolveMarketplacePiExtensionActivation, resolveToolActivation, type ResolvedPiExtensionContribution } from "../../src/server/agent/session-setup.ts";
+import { BOBBIT_PACK_LOCAL_DATA_ENV } from "../../src/server/agent/pack-local-data-runtime.ts";
+import { packLocalDataDockerExecArgs } from "../../src/server/agent/rpc-bridge.ts";
 import type { ScopedToolContext } from "../../src/server/agent/tool-manager.ts";
 import { pinAgentDirForTest, resetAgentDirForTest } from "../../tests/helpers/agent-dir.js";
 import { installMemoryFs } from "./helpers/memory-fs-spies.js";
@@ -85,6 +87,82 @@ describe("marketplace pi extension activation args", () => {
 		assert.deepEqual(extensionPaths(result.args), [a, b]);
 		assert.deepEqual(result.tools.map((t) => t.name), ["enabled_tool", "discovery_failed_tool"]);
 		assert.equal(result.diagnostics.length, 4);
+	});
+
+	it("binds exact multi-pack local-data directories in initial agent/Pi activation", () => {
+		const tmp = fixtureRoot("local-data-initial");
+		const calls: unknown[] = [];
+		const plan: any = {
+			id: "session-local-data",
+			mode: "normal",
+			cwd: tmp,
+			projectId: "project-1",
+			sandboxed: false,
+			bridgeOptions: { args: [], env: {} },
+		};
+		resolveToolActivation(plan, {
+			toolManager: null,
+			mcpManager: null,
+			groupPolicyStore: null,
+			lifecycleHub: undefined,
+			marketplacePiExtensionResolver: null,
+			packLocalDataBindingsResolver: (scope: { projectId: string; realm: "host" | "sandbox" }) => {
+				calls.push(scope);
+				return {
+					"z-pack": path.join(tmp, ".z-data"),
+					"pack:with:exact-id": path.join(tmp, ".exact-data"),
+				};
+			},
+		} as any);
+
+		assert.deepEqual(calls, [{ projectId: "project-1", realm: "host" }]);
+		assert.deepEqual(JSON.parse(plan.bridgeOptions.env[BOBBIT_PACK_LOCAL_DATA_ENV]), {
+			"pack:with:exact-id": path.join(tmp, ".exact-data"),
+			"z-pack": path.join(tmp, ".z-data"),
+		});
+	});
+
+	it("recomputes host/sandbox bindings through the restore, respawn, and staff activation helper", () => {
+		const tmp = fixtureRoot("local-data-restore");
+		const calls: unknown[] = [];
+		const manager: any = new SessionManager();
+		manager.setPackLocalDataBindingsResolver((scope: { projectId: string; realm: "host" | "sandbox" }) => {
+			calls.push(scope);
+			return scope.realm === "sandbox"
+				? { perf: "/bobbit/local-data/perf" }
+				: { perf: path.join(tmp, ".performance-optimisation") };
+		});
+
+		// buildToolActivationArgs is the shared restore/role-respawn/force-abort
+		// funnel. Staff restore uses it unchanged; identity comes from projectId,
+		// never staff cwd or a worktree path.
+		const host = manager.buildToolActivationArgs("staff-session", undefined, undefined, path.join(tmp, "staff-wt"), "project-1");
+		const sandbox = manager.buildToolActivationArgs("team-session", undefined, undefined, "/workspace-wt/team", "project-1", undefined, undefined, true);
+
+		assert.deepEqual(calls, [
+			{ projectId: "project-1", realm: "host" },
+			{ projectId: "project-1", realm: "sandbox" },
+		]);
+		assert.deepEqual(JSON.parse(host.env[BOBBIT_PACK_LOCAL_DATA_ENV]), {
+			perf: path.join(tmp, ".performance-optimisation"),
+		});
+		assert.deepEqual(JSON.parse(sandbox.env[BOBBIT_PACK_LOCAL_DATA_ENV]), {
+			perf: "/bobbit/local-data/perf",
+		});
+	});
+
+	it("omits empty bindings and forwards populated JSON through docker exec", () => {
+		const manager: any = new SessionManager();
+		manager.setPackLocalDataBindingsResolver(() => ({}));
+		const empty = manager.buildToolActivationArgs("session-empty", undefined, undefined, "/workspace", "project-1", undefined, undefined, true);
+		assert.equal(empty.env[BOBBIT_PACK_LOCAL_DATA_ENV], undefined);
+		assert.deepEqual(packLocalDataDockerExecArgs(empty.env), []);
+
+		const json = JSON.stringify({ perf: "/bobbit/local-data/perf" });
+		assert.deepEqual(packLocalDataDockerExecArgs({ [BOBBIT_PACK_LOCAL_DATA_ENV]: json }), [
+			"-e",
+			`${BOBBIT_PACK_LOCAL_DATA_ENV}=${json}`,
+		]);
 	});
 
 	it("threads marketplace pi extension args through SessionManager restore/respawn helper after Bobbit activation args", () => {

--- a/tests2/dom/client-host-api.test.ts
+++ b/tests2/dom/client-host-api.test.ts
@@ -39,8 +39,12 @@ function caps() {
 		session: h.capabilities.session,
 		ui: h.capabilities.ui,
 		store: h.capabilities.store,
+		localData: h.capabilities.localData,
+		hasLocalDataMember: Object.prototype.hasOwnProperty.call(h, "localData"),
+		localDataDirectory: h.localData ? typeof h.localData.directory : "missing",
 		hasInvokeAction: h.capabilities.has("invokeAction"),
 		hasCallRoute: h.capabilities.has("callRoute"),
+		hasLocalData: h.capabilities.has("localData"),
 		hasUnknown: h.capabilities.has("nope"),
 		hasGatewayMember: (h as unknown as Record<string, unknown>).gateway !== undefined,
 	};
@@ -104,6 +108,45 @@ async function clientStoreRead() {
 	} finally {
 		window.fetch = originalFetch;
 		unregisterSurfaceTokenMinter("sess-read");
+	}
+}
+
+async function clientLocalDataDirectory() {
+	const originalFetch = window.fetch;
+	const expectedDirectory = "C:\\canonical project\\.performance-optimisation";
+	let request: { path?: string; method?: string; body?: Record<string, unknown> } = {};
+	registerSurfaceTokenMinter("sess-local-data", async () => "local-data-surface-token");
+	window.fetch = (async (input: any, init?: any) => {
+		const path = String(input);
+		if (path.includes("/api/ext/local-data/directory")) {
+			request = {
+				path: new URL(path, window.location.href).pathname,
+				method: init?.method,
+				body: JSON.parse(String(init?.body ?? "{}")),
+			};
+			return new Response(JSON.stringify({ directory: expectedDirectory }), {
+				status: 200, headers: { "content-type": "application/json" },
+			});
+		}
+		return new Response("not found", { status: 404 });
+	}) as any;
+	try {
+		const h = getHostApi("sess-local-data", "tu-local-data", {
+			kind: "pack",
+			packId: "performance",
+			contributionKind: "panel",
+			contributionId: "dashboard",
+			hasLocalData: true,
+		});
+		return {
+			directory: await h.localData!.directory(),
+			hasLocalData: h.capabilities.has("localData"),
+			hasLocalDataMember: Object.prototype.hasOwnProperty.call(h, "localData"),
+			request,
+		};
+	} finally {
+		window.fetch = originalFetch;
+		unregisterSurfaceTokenMinter("sess-local-data");
 	}
 }
 
@@ -321,7 +364,11 @@ describe("getHostApi — durable v1 capabilities (extension-host §3)", () => {
 		expect(c.session).toBe(true);
 		expect(c.ui).toBe(true);
 		expect(c.store).toBe(true);
+		expect(c.localData).toBeUndefined();
+		expect(c.hasLocalDataMember).toBe(false);
+		expect(c.localDataDirectory).toBe("missing");
 		expect(c.hasCallRoute).toBe(true);
+		expect(c.hasLocalData).toBe(false);
 		expect(c.hasUnknown).toBe(false);
 		expect(c.hasGatewayMember).toBe(false);
 	});
@@ -336,6 +383,23 @@ describe("getHostApi — durable v1 capabilities (extension-host §3)", () => {
 			request: {
 				path: "/api/ext/store/read",
 				body: { sessionId: "sess-read", surfaceToken: "surface-read-token", key: "retain-queue" },
+			},
+		});
+	});
+
+	it("returns the unrestricted local-data path through only the bound surface identity", async () => {
+		await expect(clientLocalDataDirectory()).resolves.toEqual({
+			directory: "C:\\canonical project\\.performance-optimisation",
+			hasLocalData: true,
+			hasLocalDataMember: true,
+			request: {
+				path: "/api/ext/local-data/directory",
+				method: "POST",
+				body: {
+					sessionId: "sess-local-data",
+					toolUseId: "tu-local-data",
+					surfaceToken: "local-data-surface-token",
+				},
 			},
 		});
 	});

--- a/tests2/dom/pack-renderers-reconcile.test.ts
+++ b/tests2/dom/pack-renderers-reconcile.test.ts
@@ -12,7 +12,7 @@ __syncBeforeAll(() => __syncCE());
 // Module-level reconcile dedupe state persists across tests in a fork (the
 // legacy suite got a fresh page per test), so each test uses UNIQUE project ids.
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { registerPackRenderers, reconcilePackRenderersForProject } from "../../src/app/pack-renderers.js";
+import { packHasLocalDataForTool, registerPackRenderers, reconcilePackRenderersForProject } from "../../src/app/pack-renderers.js";
 import { getToolRenderer } from "../../src/ui/tools/renderer-registry.js";
 
 let fetchCalls: string[];
@@ -51,6 +51,17 @@ const triggerLoad = (name: string) => { getToolRenderer(name); };
 const flush = async () => { await new Promise((r) => setTimeout(r, 30)); };
 
 describe("reconcilePackRenderersForProject (extension-host §4a/§4c)", () => {
+	it("projects local-data capability only for the current declared winning pack renderer", () => {
+		registerPackRenderers([{ name: "local_data_tool", rendererKind: "pack", packId: "declared", hasLocalData: true }]);
+		expect(packHasLocalDataForTool("local_data_tool")).toBe(true);
+
+		registerPackRenderers([{ name: "local_data_tool", rendererKind: "pack", packId: "undeclared" }]);
+		expect(packHasLocalDataForTool("local_data_tool")).toBe(false);
+
+		registerPackRenderers([]);
+		expect(packHasLocalDataForTool("local_data_tool")).toBe(false);
+	});
+
 	it("re-drives registration scoped to the active session's project; dedupes unchanged; swaps the loader on project change", async () => {
 		clearCalls();
 		await reconcile("A1");

--- a/tests2/integration/pack-local-data-fixture.test.ts
+++ b/tests2/integration/pack-local-data-fixture.test.ts
@@ -1,0 +1,107 @@
+import { afterEach, describe, expect, it } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { guardProcessEnv } from "../core/helpers/env-guard.js";
+import { enableTsWorkerResolver } from "../core/helpers/enable-ts-worker.js";
+import { loadPackContributions } from "../../src/server/agent/pack-contributions.js";
+import { parseManifest } from "../../src/server/agent/pack-manifest.js";
+import { PackLocalDataResolver } from "../../src/server/extension-host/pack-local-data.js";
+import { createServerHostApi } from "../../src/server/extension-host/server-host-api.js";
+import { ModuleHost } from "../../src/server/extension-host/module-host-worker.js";
+import activateMarker from "../../market-packs/_fixtures/pack-local-data/pi-extensions/marker/extension.js";
+
+guardProcessEnv();
+enableTsWorkerResolver();
+
+const PACK_ID = "pack-local-data";
+const PACK_ROOT = fileURLToPath(new URL("../../market-packs/_fixtures/pack-local-data", import.meta.url));
+const ROUTES = path.join(PACK_ROOT, "lib", "routes.mjs");
+const tempRoots: string[] = [];
+const originalBinding = process.env.BOBBIT_PACK_LOCAL_DATA_JSON;
+
+afterEach(() => {
+	if (originalBinding === undefined) delete process.env.BOBBIT_PACK_LOCAL_DATA_JSON;
+	else process.env.BOBBIT_PACK_LOCAL_DATA_JSON = originalBinding;
+	for (const root of tempRoots.splice(0)) fs.rmSync(root, { recursive: true, force: true });
+});
+
+describe("pack local-data fixture realm parity", () => {
+	it("shares one canonical directory across resolver, confined server route, Pi tool, and ordinary filesystem access", async () => {
+		const projectRoot = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "pack-local-data-integration-")));
+		tempRoots.push(projectRoot);
+		const componentCwd = path.join(projectRoot, "components", "web");
+		fs.mkdirSync(componentCwd, { recursive: true });
+
+		const problems: string[] = [];
+		const manifest = parseManifest(fs.readFileSync(path.join(PACK_ROOT, "pack.yaml"), "utf8"), problems);
+		expect(problems).toEqual([]);
+		expect(manifest?.localData?.directory).toBe(".pack-local-data-fixture");
+		const contribution = loadPackContributions(PACK_ROOT, manifest!);
+		let active = true;
+		const resolver = new PackLocalDataResolver(
+			{ get: id => id === "project-fixture" ? ({ id, rootPath: projectRoot } as never) : undefined },
+			{
+				getPack: (_projectId, packId) => active && packId === PACK_ID ? contribution : undefined,
+				list: () => active ? [contribution] : [],
+			},
+		);
+		const directory = resolver.resolveHostDirectory("project-fixture", PACK_ID);
+		expect(directory).toBe(path.join(projectRoot, ".pack-local-data-fixture"));
+		expect(directory.startsWith(componentCwd)).toBe(false);
+
+		const host = createServerHostApi({
+			sessionId: "session-fixture",
+			packId: PACK_ID,
+			contributionId: "pack-local-data/snapshot",
+			localDataDirectory: directory,
+			capabilityMask: { localData: true },
+		});
+		const moduleHost = new ModuleHost({ timeoutMs: 10_000 });
+		try {
+			const written = await moduleHost.invoke({
+				url: pathToFileURL(ROUTES).href,
+				packRoot: PACK_ROOT,
+				epoch: 0,
+				exportKind: "routes",
+				member: "write",
+				ctx: { host, sessionId: "session-fixture", toolUseId: "", tool: "route:write", workingDir: componentCwd },
+				arg: { body: { name: "host-marker.txt", content: "written-through-route" } },
+			});
+			expect(written).toEqual({ directory, name: "host-marker.txt", content: "written-through-route" });
+
+			fs.writeFileSync(path.join(directory, "ordinary-marker.txt"), "written-directly", "utf8");
+			process.env.BOBBIT_PACK_LOCAL_DATA_JSON = JSON.stringify({ [PACK_ID]: directory });
+			let markerHandler: ((input: any) => Promise<any>) | undefined;
+			activateMarker({ tool: (_definition: unknown, handler: (input: any) => Promise<any>) => { markerHandler = handler; } });
+			const piResult = await markerHandler!({ operation: "write", name: "pi-marker.txt", content: "written-through-pi" });
+			expect(piResult).toEqual({ directory, name: "pi-marker.txt", content: "written-through-pi" });
+
+			const snapshot = await moduleHost.invoke({
+				url: pathToFileURL(ROUTES).href,
+				packRoot: PACK_ROOT,
+				epoch: 0,
+				exportKind: "routes",
+				member: "snapshot",
+				ctx: { host, sessionId: "session-fixture", toolUseId: "", tool: "route:snapshot", workingDir: componentCwd },
+				arg: {},
+			});
+			expect(snapshot).toMatchObject({
+				directory,
+				markers: {
+					"host-marker.txt": "written-through-route",
+					"ordinary-marker.txt": "written-directly",
+					"pi-marker.txt": "written-through-pi",
+				},
+			});
+
+			active = false;
+			expect(() => resolver.resolveHostDirectory("project-fixture", PACK_ID)).toThrow(/not active/);
+			expect(fs.readFileSync(path.join(directory, "host-marker.txt"), "utf8")).toBe("written-through-route");
+			expect(fs.readFileSync(path.join(directory, "pi-marker.txt"), "utf8")).toBe("written-through-pi");
+		} finally {
+			moduleHost.dispose();
+		}
+	});
+});

--- a/tests2/tests-map.json
+++ b/tests2/tests-map.json
@@ -4,22 +4,40 @@
   "note": "Re-run `node scripts/testing-v2/gen-inventory.mjs` after census changes. Classification overrides live in this generator; execution ownership is derived by test-map-execution.mjs.",
   "censusTotal": 1142,
   "buckets": {
-    "daily": 68,
+    "daily": 67,
     "v2-browser": 216,
     "v2-core": 512,
     "v2-dom": 144,
-    "v2-integration": 202
+    "v2-integration": 203
   },
   "methods": {
-    "adapter": 275,
+    "adapter": 276,
     "codemod": 512,
     "legacy-pending": 153,
     "port": 2,
-    "relocate": 53,
+    "relocate": 52,
     "rewrite": 145,
     "vitest-e2e": 2
   },
   "v2Native": [
+    {
+      "path": "tests2/core/pack-local-data.test.ts",
+      "reason": "Core coverage for schema-2 localData validation, canonical project-root materialization, worktree/polyrepo independence, link and non-directory rejection, stable sandbox projection, and no-declaration compatibility.",
+      "execution": {
+        "runner": "vitest",
+        "tier": "unit",
+        "project": "core"
+      }
+    },
+    {
+      "path": "tests2/integration/pack-local-data-fixture.test.ts",
+      "reason": "Integration coverage proving the reusable fixture shares one canonical directory across a confined server route, Pi-extension tool, ordinary filesystem access, nested component cwd, and disabled-pack preservation.",
+      "execution": {
+        "runner": "vitest",
+        "tier": "unit",
+        "project": "integration"
+      }
+    },
     {
       "path": "tests2/core/github-trusted-host-resolver.test.ts",
       "reason": "Core security and caching coverage for token-free gh-config GitHub host discovery, environment stripping, normalization, failure fallback, and single-flight refreshes.",
@@ -18418,6 +18436,13 @@
       "method": "relocate",
       "replacement": [],
       "rationale": "Opt-in real Pi/real-model context-pressure smoke for exact-once steer and follow-up delivery through automatic compaction; manual/daily only, with explicit credentials, no provider fallback, and bounded request/token/cost/time guards."
+    },
+    {
+      "file": "tests/e2e/pack-local-data.spec.ts",
+      "bucket": "v2-integration",
+      "method": "adapter",
+      "replacement": [],
+      "rationale": "API/integration E2E against a real gateway — gateway-per-worker integration tier."
     }
   ]
 }

--- a/tests2/tests-map.json
+++ b/tests2/tests-map.json
@@ -39,6 +39,15 @@
       }
     },
     {
+      "path": "tests2/browser/e2e/pack-local-data.spec.ts",
+      "reason": "Chromium journey proving an installed and enabled pack panel receives host.localData, shares its canonical project directory with a server route, survives reload, and preserves route-written data through uninstall and cleanup.",
+      "execution": {
+        "runner": "playwright",
+        "tier": "browser",
+        "project": "browser"
+      }
+    },
+    {
       "path": "tests2/core/github-trusted-host-resolver.test.ts",
       "reason": "Core security and caching coverage for token-free gh-config GitHub host discovery, environment stripping, normalization, failure fallback, and single-flight refreshes.",
       "execution": {
@@ -18438,11 +18447,11 @@
       "rationale": "Opt-in real Pi/real-model context-pressure smoke for exact-once steer and follow-up delivery through automatic compaction; manual/daily only, with explicit credentials, no provider fallback, and bounded request/token/cost/time guards."
     },
     {
-      "file": "tests/e2e/pack-local-data.spec.ts",
+      "file": "tests/e2e/pack-local-data-runtime.spec.ts",
       "bucket": "v2-integration",
       "method": "adapter",
       "replacement": [],
-      "rationale": "API/integration E2E against a real gateway — gateway-per-worker integration tier."
+      "rationale": "Real gateway/runtime adapter for canonical host and ordinary/Pi agent bindings, lifecycle preservation, and the conditional real-Docker bidirectional mount round trip; browser ownership lives in tests2/browser/e2e/pack-local-data.spec.ts."
     }
   ]
 }


### PR DESCRIPTION
## Summary
- add validated project-scoped local data declarations for schema-2 extension packs
- expose winning, effectively enabled pack bindings to browser/server hosts, agents, Pi tools, restored sessions, and writable sandboxes
- reject escaping, linked, and Bobbit-managed Marketplace locations before materialization
- remove exposure and mounts on disable while preserving extension-owned files through disable/uninstall
- document lifecycle, activation, worktree, polyrepo, precedence, and sandbox behavior
- add focused core, DOM, integration, browser, runtime, and conditional Docker coverage

## Validation
- implementation workflow passed build, type-check, unit, browser, E2E, conformance, integrated, security, and QA verification
- documentation coverage review passed
- managed-root resolver matrix: 52 tests passed
- focused activation/contribution/local-data suites: 112 tests passed
- same-ID Pi precedence/fallback and default-disabled lifecycle E2E passed
- Docker round-trip skips when Docker or the `bobbit-agent` image is unavailable
- narrow CodeQL annotation documents the HMAC-validated trusted surface-kind authorization branch

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)
