### PR TITLE
Add unified host hooks

### DIFF
--- a/defaults/tools/bobbit/extension.ts
+++ b/defaults/tools/bobbit/extension.ts
@@ -628,6 +628,10 @@ export default function (pi: ExtensionAPI) {
 	let baseUrl: string;
 	const envToken = process.env.BOBBIT_TOKEN;
 	const envUrl = process.env.BOBBIT_GATEWAY_URL;
+	// Bind gateway requests to this exact host-issued session when available.
+	// Causation controls remain server-owned and are derived from this identity;
+	// no caller-provided root, depth, or correlation headers are forwarded.
+	const sessionSecret = process.env.BOBBIT_SESSION_SECRET;
 	if (envToken && envUrl) {
 		token = envToken;
 		baseUrl = envUrl.replace(/\/+$/, "");
@@ -650,7 +654,11 @@ export default function (pi: ExtensionAPI) {
 	async function api(method: string, urlPath: string, body?: unknown): Promise<unknown> {
 		const resp = await fetch(`${baseUrl}${urlPath}`, {
 			method,
-			headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
+			headers: {
+				Authorization: `Bearer ${token}`,
+				"Content-Type": "application/json",
+				...(sessionSecret ? { "X-Bobbit-Session-Secret": sessionSecret } : {}),
+			},
 			body: body !== undefined ? JSON.stringify(body) : undefined,
 		});
 		const text = await resp.text();

--- a/defaults/tools/inbox/extension.ts
+++ b/defaults/tools/inbox/extension.ts
@@ -18,10 +18,12 @@ import { homedir } from "node:os";
 export default function (pi: ExtensionAPI) {
 	// ── Config ────────────────────────────────────────────────────────
 	const sessionId = process.env.BOBBIT_SESSION_ID;
+	const sessionSecret = process.env.BOBBIT_SESSION_SECRET;
 	const staffId = process.env.BOBBIT_STAFF_ID;
-	if (!sessionId || !staffId) {
+	if (!sessionId || !sessionSecret || !staffId) {
 		return;
 	}
+	const exactSessionSecret = sessionSecret;
 
 	let token: string;
 	let baseUrl: string;
@@ -49,7 +51,11 @@ export default function (pi: ExtensionAPI) {
 	async function api(method: string, urlPath: string, body?: unknown): Promise<unknown> {
 		const resp = await fetch(`${baseUrl}${urlPath}`, {
 			method,
-			headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
+			headers: {
+				Authorization: `Bearer ${token}`,
+				"Content-Type": "application/json",
+				"X-Bobbit-Session-Secret": exactSessionSecret,
+			},
 			body: body !== undefined ? JSON.stringify(body) : undefined,
 		});
 		const text = await resp.text();

--- a/defaults/tools/tasks/extension.ts
+++ b/defaults/tools/tasks/extension.ts
@@ -16,6 +16,7 @@ import { homedir } from "node:os";
 export default function (pi: ExtensionAPI) {
 	// ── Config ────────────────────────────────────────────────────────
 	const sessionId = process.env.BOBBIT_SESSION_ID;
+	const sessionSecret = process.env.BOBBIT_SESSION_SECRET;
 	const goalId = process.env.BOBBIT_GOAL_ID;
 	if (!sessionId || !goalId) {
 		return;
@@ -47,7 +48,11 @@ export default function (pi: ExtensionAPI) {
 	async function api(method: string, urlPath: string, body?: unknown): Promise<unknown> {
 		const resp = await fetch(`${baseUrl}${urlPath}`, {
 			method,
-			headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
+			headers: {
+				Authorization: `Bearer ${token}`,
+				...(sessionSecret ? { "X-Bobbit-Session-Secret": sessionSecret } : {}),
+				"Content-Type": "application/json",
+			},
 			body: body !== undefined ? JSON.stringify(body) : undefined,
 		});
 		const text = await resp.text();

--- a/docs/design/unified-host-hooks.md
+++ b/docs/design/unified-host-hooks.md
@@ -318,20 +318,27 @@ One dispatch deadline prevents `number of extensions × timeout` latency. Cancel
 
 ### 3.3 Tool lifecycle order
 
-Compose the current generated permission guard and tool wrapper seams (`generateToolGuardExtension`, `generateToolResultErrorBridgeExtension`) rather than observing Pi's `tool_execution_end` after persistence. Permission checks remain first:
+Compose the generated permission guard and tool wrapper seams (`generateToolGuardExtension`, `generateToolResultErrorBridgeExtension`) with the current Pi writer's lifecycle stream. Pi emits `tool_execution_start` before its `tool_call` permission listeners; Bobbit treats that early event only as provenance. Permission remains the first policy decision, and no public start fact exists until permission and `beforeToolCall` both admit the call:
 
 ```text
-role/tool permission guard
+current Pi writer emits tool_execution_start
+-> session event owner accepts it at a cursor
+-> role/tool permission guard
+-> exact one-use before callback claim
 -> beforeToolCall router
+-> admitted settlement publishes toolCallStarted
 -> approved or host-schema-valid mutated handler invocation
--> handler completes
--> protected afterToolResult router/policy gate
--> approved/replaced/constant synthetic result returned to Pi
--> Pi persists and publishes the corresponding tool-result message_end
+-> handler completes or throws
+-> bridge attempts the exact admitted-call after callback claim
+-> protected afterToolResult router/policy or host-owned transport fallback
+-> approved/replaced/original-error/constant synthetic result returned to Pi
+-> matching current-writer tool_execution_end classifies safe outcome
+-> Pi publishes the corresponding post-policy tool-result message_end
+-> session event owner accepts messageAppended at its cursor
 -> toolCallCompleted notification
 ```
 
-Add a bounded per-session `ToolCallLifecycleTracker` inside `SessionManager` (or its event adapter), keyed by `toolCallId`, holding only tool name, monotonic start time, turn index, and safe terminal outcome. `tool_execution_start` is recorded only after admission. `tool_execution_end` may classify safe outcome but cannot publish completion. The matching accepted, non-replay `message_end` for the tool result is the publication fence. Clear entries on completion, process replacement, turn terminal, archive, and shutdown; cap the map to prevent leaks.
+The bounded per-session tracker is keyed by `toolCallId` and retains only tool name, session generation, accepted start cursor, monotonic start time, turn index, phase/lease, cancellation, and safe terminal outcome. The exact-session secret authenticates callback transport but cannot create lifecycle provenance. A process-local opaque claim is minted only for the matching current writer, generation, tool ID/name, cursor, and phase, then consumed once. A before callback may wait briefly for stdout/event-buffer arrival ordering; no event means no claim. Forged, duplicate, mismatched, terminal, and stale-generation callbacks invoke no interceptor and publish no fact. `tool_execution_end` classifies outcome but cannot publish completion; the accepted non-replay tool-result `message_end` remains the completion fence. Clear provenance on completion, writer/process replacement, turn terminal, archive, and shutdown; bound both tracker and waiters to prevent leaks.
 
 ## 4. Notification dispatcher
 
@@ -372,6 +379,8 @@ export default {
 
 `ctx` contains only server-derived project/pack identity, effective config, cancellation, and granted Host APIs. The frozen canonical event is the only argument. Return values are ignored. The dispatcher rechecks winning pack, activation, disabled ref, and grants before invocation and ignores late settlement after invalidation. Each handler has its declared timeout capped by the catalogue. Errors/timeouts are isolated and recorded by code and attribution only. A handler cannot block the source operation because dispatch begins after publication and runs on a per-project ordered async queue.
 
+A session-scoped handler's granted `host.session` and `host.agents` operations additionally revalidate the source session's current host-owned project before work and after asynchronous settlement. A project move withholds an in-flight read/result, rejects later operations, and best-effort dismisses a child whose spawn raced revocation. The handler itself can continue to its bounded deadline, but it cannot exercise the captured old-project session authority.
+
 Queues preserve publication order within one project; projects may run concurrently. Queue capacity is bounded. On overflow, module deliveries are dropped with a diagnostic and modules recover by reading authoritative snapshots; no unbounded memory or replay journal is introduced.
 
 ## 5. Authoritative publication map
@@ -386,8 +395,8 @@ A publisher must build an allowlisted payload from captured before/after scalars
 | `turnStarted` | `SessionManager.handleAgentLifecycle()` first canonical current-writer `agent_start`, after persisted `wasStreaming`/`streamingStartedAt` update and streaming status transition. Add/use the session's turn index; duplicate start/replay does not republish. | `turn/<sessionId>:<turnIndex>`, revision `turnIndex` |
 | `turnCompleted` | Sole final `agent_end` path after `willRetry !== true`, terminal identity dedupe, `turnTerminalHandled` test/set, outcome classification, persisted streaming marker clear, completed-turn increment, and idle/error status publication. Retry attempts, duplicate terminal frames, restore replay, and late frames cannot reach publication. Error and abort use explicit outcomes. | `turn/<sessionId>:<turnIndex>`, revision completed turn index |
 | `messageAppended` | Normal non-restoring `subscribeToEvents`/`message_end` path after `prepareVisibleAgentEvent` and `emitSessionEvent` accept the event into `EventBuffer`. Use the accepted buffer seq/cursor and stable message identity. Do not publish client remapping, snapshots, partial streaming, or restore replay. | `message/<messageId>`, revision accepted event cursor |
-| `toolCallStarted` | Pi `tool_execution_start` only after permission plus `beforeToolCall` admission, recorded in the bounded tracker. | `toolCall/<toolCallId>`, revision tool-call identity/start cursor |
-| `toolCallCompleted` | Matching non-replay tool-result `message_end` after handler -> protected `afterToolResult` -> final approved/synthetic result -> Pi persistence/publication. Join only safe tracker metadata; never emit at `tool_execution_end`. | `toolCall/<toolCallId>`, revision result message cursor |
+| `toolCallStarted` | Current-writer Pi `tool_execution_start` after EventBuffer acceptance gives the matching callback an opaque one-use claim. Publish only after the permission guard and claimed `beforeToolCall` settle as admitted; blocked, forged, duplicate, mismatched, or stale claims emit nothing. | `toolCall/<toolCallId>`, revision accepted start-event cursor |
+| `toolCallCompleted` | Matching non-replay tool-result `message_end` after handler, claimed/fallback protected `afterToolResult`, final approved/replaced/original-error/synthetic result, and matching current-writer `tool_execution_end`. Join only safe tracker metadata; never emit completion at `tool_execution_end`. | `toolCall/<toolCallId>`, revision accepted result-message cursor |
 
 The existing `isRetryableAgentEnd`, `turnTerminalHandled`, and `assistantTerminalIdentities` fences remain the single turn-terminal suppression mechanism. A new parallel dedupe owner is prohibited.
 
@@ -465,17 +474,17 @@ Add bounded protocol frames in `src/server/ws/protocol.ts`:
 
 The stream epoch/sequence is transport metadata, not semantic envelope state. It is ephemeral per authenticated connection/scope and is not a durable event cursor.
 
-Tag each authenticated UI socket in `ws/handler.ts` with its server-resolved session and persisted/live project binding. A dedicated `HostNotificationSocketRouter` sends:
+Tag each authenticated UI socket in `ws/handler.ts` with its server-resolved session and persisted/live project binding. Before every delta and refresh, the dedicated `HostNotificationSocketRouter` re-resolves current host-owned session authority and sends:
 
 - a session notification only to sockets bound to that exact session;
-- a project notification only to sockets whose server-tagged project exactly equals the envelope project;
+- a project notification only to sockets whose current server-tagged project exactly equals the envelope project;
 - nothing to `__viewer__`, unbound, projectless, foreign-project, or future system-scope sockets.
 
-Do not use `broadcastToProject`: it intentionally includes unscoped viewers and is unsuitable as this security boundary. Client filtering is defense-in-depth only. Surface-token validation proves that a mounted contributed panel belongs to the bound session/pack, but project isolation remains server-owned.
+A detected session project move suppresses the discovering frame, rebinds the socket, and fences old- and new-project deltas behind one project refresh-required frame. Missing or conflicting live/persisted authority unbinds the socket rather than selecting a partition. Do not use `broadcastToProject`: it intentionally includes unscoped viewers and is unsuitable as this security boundary. Client filtering is defense-in-depth only. Surface-token validation proves that a mounted contributed panel belongs to the bound session/pack, but project isolation remains server-owned.
 
 Add `src/app/host-notification-bus.ts`, fed by `RemoteAgent`'s canonical frame handler. It deduplicates bounded recent envelope IDs, verifies monotonically contiguous sequence within the current epoch, routes by name, and generation-fences handlers. The client never accepts a project ID from extension code.
 
-Initial mount, socket re-auth/reconnect, epoch change, explicit refresh-required frame, or sequence gap calls `onRefreshRequired` once through a short coalescer. Mounted panels reread their authoritative REST/Host projection; they do not reconstruct state from missed deltas. Event bursts may debounce/coalesce refreshes because correctness comes from the snapshot. Reload repeats snapshot-first initialization, then resumes live observation. No historical notification replay endpoint is added.
+Initial mount, a session project move, socket re-auth/reconnect, epoch change, explicit refresh-required frame, or sequence gap calls `onRefreshRequired` once through a short coalescer. Mounted panels reread their authoritative REST/Host projection; after a move this means the destination project's snapshot. They do not reconstruct state from missed deltas. Event bursts may debounce/coalesce refreshes because correctness comes from the snapshot. Reload repeats snapshot-first initialization, then resumes live observation. No historical notification replay endpoint is added.
 
 ## 7. Notification-based staff triggers
 
@@ -572,6 +581,8 @@ The shared catalogue and payload projectors enforce these invariants:
 - no provider error text, host exception message, stack trace, or worker output;
 - no cwd, worktree, repository, absolute path, or mutable store/session object;
 - no arbitrary consumer-supplied project/session/pack identity;
+- the per-session secret authenticates Pi callback transport only; current-writer generation, accepted cursor, tool identity, and phase establish one-use tool lifecycle provenance;
+- provenance-invalid callbacks invoke no hook, publish no browser/module fact, and create no matching staff intent or wake;
 - public error fields are closed enums such as `timeout`, `denied`, `handler_error`, not messages;
 - filter fields are catalogue allowlists over bounded scalars only.
 

--- a/docs/design/unified-host-hooks.md
+++ b/docs/design/unified-host-hooks.md
@@ -1,0 +1,732 @@
+# Unified Host Hooks
+
+**Status:** implementation design  
+**Decision:** use a shared TypeBox catalogue, an operation-specific interceptor router, and one post-commit notification dispatcher. Persist only staff delivery intents; do not add a durable global notification journal.
+
+## 1. Scope and decisions
+
+Bobbit exposes two hook kinds with deliberately different control flow:
+
+- An **interceptor** participates in one operation before Bobbit commits its result. Bobbit awaits it, validates its typed result, and alone decides what was applied.
+- A **notification** describes an immutable fact after Bobbit has committed or published the authoritative change. Consumers cannot delay, alter, compensate, or roll it back.
+
+The minimum composition is:
+
+```text
+operation boundary
+  -> HostInterceptorRouter (typed, awaited, operation-specific folding)
+     -> existing PackContributionRegistry + ModuleHost worker path
+     -> legacy LifecycleHub/provider adapter where compatibility requires it
+  -> Bobbit applies/persists/publishes the authoritative result
+  -> HostNotificationDispatcher.publish(...)
+     -> exact-project/session browser fanout (live)
+     -> observational hook queue (live)
+     -> NotificationDeliveryStore staff intents (durable)
+     -> bounded diagnostics
+```
+
+`LifecycleHub` remains the compatibility owner for legacy context-block providers. It does not own domain facts, WebSocket routing, or staff durability. Existing `providers/*.yaml`, inert legacy `hooks/*.yaml`, `goal_created`/`goal_archived` staff triggers, and `host.session.subscribe("status" | "message" | "tool_result", ...)` continue unchanged during migration.
+
+The following are explicit decisions:
+
+1. `toolCallCompleted` remains **session-scoped**. The goal's illustrative notification-trigger example with `scope: "project"` is contradictory and is rejected by validation. A staff member in the same project may subscribe to the session-scoped fact because the dispatcher derives and verifies `projectId`; this does not promote the fact to project scope.
+2. Browser and observational-module delivery is live and best-effort. Reconnects and sequence gaps cause authoritative refresh, not event replay.
+3. Staff delivery uses a small durable subscriber outbox. There is no durable global notification journal and no exactly-once claim.
+4. Current `hooks/*.yaml` declarations remain inert. Runtime execution requires the new explicit `kind`; old `mode: observe|decide` is not silently activated.
+5. `afterTurn` and `goalProvisioned` remain compatibility-only provider hooks. New consumers observe `turnCompleted`; `goalProvisioned` retains its existing specialized path.
+6. Ordinary project imports remain committed if `projectImported` fails. The hook is an awaited post-import initialization boundary, not an authority to rewrite or undo the imported project.
+7. Administrative/system scope is reserved but not exposed to ordinary packs.
+
+## 2. One shared runtime/type catalogue
+
+Add `src/shared/extension-host/host-hooks.ts`. It is the only source of notification names, payloads, schemas, filter fields, interceptor request/results, and catalogue metadata. It uses the installed `@sinclair/typebox` package (`Type`, `Static`) and `Value.Check`; it does not maintain parallel hand-written TypeScript and runtime maps.
+
+### 2.1 Public types and helpers
+
+The shared module exports these shapes:
+
+```ts
+export type HostHookScope = "session" | "project";
+export type HostConsumerKind = "browser" | "module" | "staff" | "diagnostic";
+
+export interface HostNotification<
+  N extends HostNotificationName = HostNotificationName,
+> {
+  readonly id: string;
+  readonly scope: HostNotificationScope<N>;
+  readonly name: N;
+  readonly payloadVersion: number;
+  readonly occurredAt: number;
+  readonly projectId: string;
+  readonly sessionId?: string;
+  readonly aggregate: Readonly<{
+    kind: HostNotificationAggregateKind<N>;
+    id: string;
+    revision?: string | number;
+  }>;
+  readonly correlationId?: string;
+  readonly causationId?: string;
+  readonly payload: Readonly<HostNotificationPayload<N>>;
+}
+
+export type HostNotificationName = keyof typeof HOST_NOTIFICATION_CATALOGUE;
+export type SessionNotificationName = /* catalogue entries with session scope */;
+export type ProjectNotificationName = /* catalogue entries with project scope */;
+export type HostNotificationPayload<N extends HostNotificationName> =
+  Static<(typeof HOST_NOTIFICATION_CATALOGUE)[N]["payloadSchema"]>;
+
+export function validateNotificationPayload<N extends HostNotificationName>(
+  name: N,
+  value: unknown,
+): value is HostNotificationPayload<N>;
+
+export function validateNotificationFilter(
+  scope: HostHookScope,
+  name: HostNotificationName,
+  value: unknown,
+): { ok: true; filter: Readonly<Record<string, string | number | boolean>> }
+   | { ok: false; code: "UNKNOWN_NOTIFICATION" | "INELIGIBLE_CONSUMER" |
+       "UNKNOWN_FILTER_FIELD" | "INVALID_FILTER_VALUE" | "FILTER_TOO_LARGE" };
+```
+
+Schemas are strict (`additionalProperties: false`) and bounded. Shared constructors reject non-finite numbers, oversized strings/arrays/objects, and unknown keys. `HostNotificationDispatcher`, not extensions, constructs IDs, timestamps, scope, project/session bindings, aggregate data, and correlation fields. It deep-freezes the validated projection before fanout.
+
+Each `HostNotificationDefinition` contains:
+
+```ts
+interface HostNotificationDefinition<
+  N extends string,
+  S extends HostHookScope,
+  P extends TSchema,
+> {
+  readonly name: N;
+  readonly scope: S;
+  readonly payloadVersion: 1;
+  readonly payloadSchema: P;
+  readonly boundary: string;
+  readonly aggregateKind: string;
+  readonly revisionSource: string;
+  readonly filterFields: Readonly<Record<string, TSchema>>;
+  readonly consumers: ReadonlySet<HostConsumerKind>;
+  readonly privacy: "public-metadata" | "project-metadata";
+  readonly delivery: Readonly<{
+    browser: "live" | "none";
+    module: "live" | "none";
+    staff: "durable-intent" | "none";
+  }>;
+}
+```
+
+Definitions are keyed by canonical name. Names are globally unique in this first catalogue, and scope remains part of each definition. Tests additionally reject duplicate `(scope,name)` pairs. A later administrative catalogue must use a distinct gated scope and cannot be inferred from a missing project binding.
+
+### 2.2 Notification payloads
+
+All fields below are maxima-bounded scalar metadata. `changedFields`/`changedKeys` are allowlisted, sorted, deduplicated string arrays with a small catalogue-owned maximum.
+
+| Scope/name | Bounded payload | Filterable fields |
+|---|---|---|
+| session `statusChanged` | `{previousStatus,status,statusVersion}` | `status` |
+| session `turnStarted` | `{turnIndex,source}` | `source` |
+| session `turnCompleted` | `{turnIndex,outcome,durationMs,hadToolCalls}` where outcome is `succeeded|errored|aborted` | `outcome`, `hadToolCalls` |
+| session `messageAppended` | `{messageId,cursor,role,blockKinds}`; no content | `role` |
+| session `toolCallStarted` | `{toolCallId,toolName,turnIndex}` | `toolName` |
+| session `toolCallCompleted` | `{toolCallId,toolName,status,durationMs,errorStatus?}` | `toolName`, `status`, `errorStatus` |
+| project `sessionCreated` | `{sessionId,kind,goalId?}` | `kind` |
+| project `sessionArchived` | `{sessionId,reason}` | `reason` |
+| project `sessionForked` | `{sourceSessionId,sessionId,cutEntryId?,forkMode}` | `forkMode` |
+| project `sessionStatusChanged` | `{sessionId,previousStatus,status,statusVersion}` | `status` |
+| project `staffCreated` | `{staffId,state,sessionId?}` | `state` |
+| project `staffConfigChanged` | `{staffId,changedFields}` | none in v1 |
+| project `staffRetired` | `{staffId}` | none |
+| project `staffSessionChanged` | `{staffId,previousSessionId?,sessionId?}` | none |
+| project `goalCreated` | `{goalId,parentGoalId?,state}` | `state` |
+| project `goalUpdated` | `{goalId,state,changedFields}` | `state` |
+| project `goalCompleted` | `{goalId,parentGoalId?}` | none |
+| project `goalArchived` | `{goalId}` | none |
+| project `taskCreated` | `{taskId,goalId,type,state,parentTaskId?}` | `type`, `state` |
+| project `taskUpdated` | `{taskId,goalId,state,changedFields}` | `state` |
+| project `taskStateChanged` | `{taskId,goalId,previousState,state}` | `previousState`, `state` |
+| project `gateStatusChanged` | `{gateId,goalId,previousStatus,status}` | `status` |
+| project `pullRequestStatusChanged` | `{goalId,number?,state,reviewDecision?,mergeability?}` | `state`, `reviewDecision`, `mergeability` |
+| project `settingsChanged` | `{target,changedKeys}` | `target` |
+
+`toolCallCompleted` is not accepted with project scope. In particular, the valid form of the illustrative trigger is:
+
+```json
+{
+  "type": "notification",
+  "notification": { "scope": "session", "name": "toolCallCompleted" },
+  "filter": { "toolName": "example_tool", "status": "succeeded" }
+}
+```
+
+The host still requires `notification.projectId === staff.projectId`, so a project staff subscriber cannot receive another project's session fact.
+
+### 2.3 Interceptor definitions
+
+The same module exports `HOST_INTERCEPTOR_CATALOGUE`, conditional request/result types, and strict validators:
+
+```ts
+export type HostInterceptorName = keyof typeof HOST_INTERCEPTOR_CATALOGUE;
+export type HostInterceptorRequest<N extends HostInterceptorName> =
+  Static<(typeof HOST_INTERCEPTOR_CATALOGUE)[N]["requestSchema"]>;
+export type HostInterceptorResult<N extends HostInterceptorName> =
+  Static<(typeof HOST_INTERCEPTOR_CATALOGUE)[N]["resultSchema"]>;
+
+export function validateInterceptorRequest<N extends HostInterceptorName>(
+  name: N, value: unknown,
+): value is HostInterceptorRequest<N>;
+export function validateInterceptorResult<N extends HostInterceptorName>(
+  name: N, value: unknown,
+): value is HostInterceptorResult<N>;
+```
+
+Every definition owns `requestSchema`, `resultSchema`, `defaultTimeoutMs`, `maxTimeoutMs`, dispatch-wide deadline, allowed failure policies, required grants, audit projector, and cancellation behavior. Requests and results are copied, size-bounded, validated, and frozen at the host boundary.
+
+| Name | Request/result and application | Default failure policy |
+|---|---|---|
+| `sessionSetup` | bounded session/scope projection -> `{context: ContextContribution[]}`; host validates, fences provenance, and applies existing budgets | fail open; omit timed-out/invalid contribution |
+| `beforePrompt` | bounded prompt metadata and capped text already available to trusted legacy providers -> `{context: ContextContribution[]}`; it contributes hidden context and does not rewrite the raw user message | fail open; a timeout cannot block a turn |
+| `beforeToolCall` | `{toolCallId,toolName,args}` with capped structured args -> `allow | block(reasonCode) | replaceArgs(args)`; host validates replacement against the tool schema before sequential application | fail open for ordinary contributions; protected policy may declare `failClosed` |
+| `afterToolResult` | trusted worker receives a capped structured result -> `allow | replaceResult(result) | syntheticError(code)`; only the host returns/persists the final result | protected contributions default fail closed with a constant synthetic error |
+| `beforeCompact` | bounded about-to-be-lost span/summary -> `{context?: ContextContribution[], flush?: "complete"}` | fail open; compaction proceeds on timeout/error |
+| `sessionShutdown` | identifiers and bounded reason -> `{flush?: "complete"}` | non-fatal; teardown proceeds at deadline |
+| `projectImported` | committed project/component identifiers -> `{initialised?: true}` | non-fatal; import remains committed |
+
+New explicit contributions use these definition-level timing caps (a smaller declared timeout wins):
+
+| Interceptor | Default per contribution | Maximum per contribution | Whole dispatch deadline |
+|---|---:|---:|---:|
+| `sessionSetup` | 1,500 ms | 3,000 ms | 5,000 ms |
+| `beforePrompt` | 500 ms | 1,000 ms | 1,500 ms |
+| `beforeToolCall` | 750 ms | 1,500 ms | 2,000 ms |
+| `afterToolResult` | 750 ms | 1,500 ms | 2,000 ms |
+| `beforeCompact` | 1,500 ms | 3,000 ms | 5,000 ms |
+| `sessionShutdown` | 1,000 ms | 2,000 ms | 3,000 ms |
+| `projectImported` | 2,000 ms | 5,000 ms | 8,000 ms |
+
+Legacy provider budgets continue to be read from `ProviderContribution.budget`; the compatibility adapter is one ordered router participant and preserves `LifecycleHub`'s validation/budget semantics. The outer operation deadline still cancels late worker work and prevents a legacy timeout from extending the host operation indefinitely.
+
+`projectImported` is wired at the project-create/import owner in `src/server/server.ts`: after `projectRegistry.register`, `ProjectContextManager.getOrCreate`, component/workflow/base-ref publication, optional worktree-pool initialization, and `wireGoalManagerResolvers` have completed, but before the 201 response. Its request contains only the new project ID and configured component coordinates. Failure is recorded after the durable registration/config boundary; it neither removes the project nor changes the response to failure.
+
+Raw tool args/results exist only in the interceptor's trusted worker request. They are excluded from audit rows, diagnostics, notifications, staff rows, and browser frames. The host records whether a proposal was `received`, `valid`, and `applied`; extension code cannot assert application.
+
+## 3. Contribution normalization and execution
+
+### 3.1 Additive manifest syntax
+
+Extend `src/server/agent/pack-contributions.ts::HookContribution` with an explicit discriminated runtime form while retaining its current inert legacy form:
+
+```yaml
+# hooks/policy-tools.yaml
+id: policy.tools
+module: ../lib/hooks.mjs
+kind: interceptor
+interceptors: [beforeToolCall, afterToolResult]
+failurePolicy: failClosed
+capabilities: [store]
+budget: { timeoutMs: 1500 }
+activation: { requiresConfig: [enabled] }
+```
+
+```yaml
+# hooks/audit-goals.yaml
+id: audit.goals
+module: ../lib/hooks.mjs
+kind: notification
+notifications:
+  - { scope: project, name: goalUpdated }
+  - { scope: project, name: goalCompleted }
+capabilities: [store]
+budget: { timeoutMs: 1500 }
+activation: { requiresConfig: [enabled] }
+```
+
+`loadHooks()` continues parsing old `{events,mode}` declarations as `LegacyInertHookContribution`. They remain listable through `PackContributionRegistry.listHooks()` but are never imported or invoked. This preserves the documented inert contract and avoids executing placeholder modules. New declarations are validated against the shared catalogue at load time.
+
+Add a pure normalizer in `src/server/extension-host/host-hook-contributions.ts`:
+
+```ts
+export type RuntimeHookContribution =
+  | NormalizedInterceptorContribution
+  | NormalizedNotificationContribution
+  | NormalizedLegacyProviderContribution;
+
+export function normalizeHookContributions(
+  registry: Pick<PackContributionRegistry, "list" | "listHooks" | "listProviders">,
+  projectId: string | undefined,
+): readonly RuntimeHookContribution[];
+```
+
+Legacy providers normalize only for supported compatibility interceptor names and retain `LifecycleHub` application semantics. `afterTurn` and `goalProvisioned` do not become new interceptor definitions. New explicit hook declarations invoke `exportKind: "hooks"`; update `ModuleHost.invoke`, `InvokeRequest`, and `module-host-bootstrap.ts::handleInvoke` to resolve `default.<canonicalName>` exactly as provider members are resolved today.
+
+Order is deterministic:
+
+1. active winning packs in existing `PackContributionRegistry.list(projectId)` low-to-high precedence order;
+2. within a pack, legacy provider contributions first for compatibility, then explicit hook files in manifest/list order;
+3. within a declaration, names in declaration order.
+
+No free-form numeric priority is introduced. Each normalized row carries the server-derived `packId`, declaration/list identity, source path, effective config, budget, capability grant mask, and activation epoch. Pack-root containment and worker isolation remain in `ModuleHost`.
+
+### 3.2 Interceptor router
+
+Add `src/server/extension-host/host-interceptor-router.ts`:
+
+```ts
+export interface HostInterceptorContext {
+  readonly projectId?: string;
+  readonly sessionId?: string;
+  readonly goalId?: string;
+  readonly cwd: string;
+  readonly correlationId?: string;
+  readonly signal: AbortSignal;
+}
+
+export interface HostInterceptorDispatchResult<N extends HostInterceptorName> {
+  readonly value: HostInterceptorRequest<N>;
+  readonly decisions: readonly HostInterceptorAuditDecision[];
+}
+
+export class HostInterceptorRouter {
+  dispatch<N extends HostInterceptorName>(
+    name: N,
+    input: HostInterceptorRequest<N>,
+    context: HostInterceptorContext,
+  ): Promise<HostInterceptorDispatchResult<N>>;
+}
+```
+
+The router composes `PackContributionRegistry`, `ModuleHost`, `createServerHostApi`, and `LifecycleHub`; it does not replace their activation, containment, worker, provider budgeting, or tracing code.
+
+Dispatch algorithm:
+
+1. Validate and bound the host-owned request before extension selection.
+2. Resolve active contributions from the project-scoped winning-pack registry. Capture each declaration identity and activation epoch.
+3. Create one host-owned absolute dispatch deadline. For each sequential contribution, invoke with `min(remaining dispatch time, declared timeout, catalogue maxTimeoutMs)`.
+4. Merge the operation signal, deadline cancellation, registry invalidation/disable cancellation, session termination, and staff/pack retirement as applicable. `ModuleHost.invoke` accepts the resulting `AbortSignal` and terminates/ignores the worker invocation on abort.
+5. Immediately before invocation, re-resolve the winning pack/declaration and capability grant. Skip it if disabled, replaced, unconfigured, or ungranted.
+6. Invoke through the existing worker and parent-authorized least-privilege Host API. Context identity is server-derived.
+7. Validate the result using the operation's TypeBox schema. Malformed results never reach application.
+8. Immediately before application, repeat the winner, activation epoch, disabled-ref, and capability-grant check. Discard a late result whose authority changed while it ran.
+9. Apply valid mutations sequentially. `beforeToolCall` replacements are also validated against the registered tool's input schema; `afterToolResult` replacements are checked against its bounded result contract.
+10. Apply the definition/contribution failure policy. A protected fail-closed timeout/error yields a constant host synthetic denial/error, never the extension exception.
+11. Append a bounded audit/trace row containing time, hook, project/session, pack/contribution identity, duration, outcome code, timeout/cancel flags, and host `applied` decision. Never record request/result bodies, provider error text, stack, paths, prompt text, args, or tool-result data.
+
+One dispatch deadline prevents `number of extensions × timeout` latency. Cancellation cannot retract an already applied earlier result, but it prevents later invocation and late application.
+
+`LifecycleHub.dispatch()` remains available and its tests remain valid. For `sessionSetup`, `beforePrompt`, `beforeCompact`, and `sessionShutdown`, a legacy adapter calls the hub's existing provider loop and folds its validated/budgeted blocks into the router result. Do not move `validateBlock`, `applyBudgets`, `ContextTraceStore`, `goalMetadataResolver`, or `scopeContextResolver` into a second implementation. `hasProviderBridgeHooks()` and generated provider bridge paths continue to work during phased adoption.
+
+### 3.3 Tool lifecycle order
+
+Compose the current generated permission guard and tool wrapper seams (`generateToolGuardExtension`, `generateToolResultErrorBridgeExtension`) rather than observing Pi's `tool_execution_end` after persistence. Permission checks remain first:
+
+```text
+role/tool permission guard
+-> beforeToolCall router
+-> approved or host-schema-valid mutated handler invocation
+-> handler completes
+-> protected afterToolResult router/policy gate
+-> approved/replaced/constant synthetic result returned to Pi
+-> Pi persists and publishes the corresponding tool-result message_end
+-> toolCallCompleted notification
+```
+
+Add a bounded per-session `ToolCallLifecycleTracker` inside `SessionManager` (or its event adapter), keyed by `toolCallId`, holding only tool name, monotonic start time, turn index, and safe terminal outcome. `tool_execution_start` is recorded only after admission. `tool_execution_end` may classify safe outcome but cannot publish completion. The matching accepted, non-replay `message_end` for the tool result is the publication fence. Clear entries on completion, process replacement, turn terminal, archive, and shutdown; cap the map to prevent leaks.
+
+## 4. Notification dispatcher
+
+Add `src/server/extension-host/host-notification-dispatcher.ts`:
+
+```ts
+export interface HostNotificationPublication<N extends HostNotificationName> {
+  readonly projectId: string;
+  readonly sessionId?: HostNotificationScope<N> extends "session" ? string : string | undefined;
+  readonly aggregateId: string;
+  readonly aggregateRevision?: string | number;
+  readonly correlationId?: string;
+  readonly causationId?: string;
+  readonly payload: HostNotificationPayload<N>;
+}
+
+export class HostNotificationDispatcher {
+  publish<N extends HostNotificationName>(
+    name: N,
+    publication: HostNotificationPublication<N>,
+  ): HostNotification<N> | undefined;
+}
+```
+
+`publish` validates the catalogue definition, scope prerequisites, payload, project/session ownership, and aggregate revision; creates a UUID, timestamp, and exact canonical envelope; deep-freezes it; and places that same envelope onto bounded browser, module, and staff-intent queues. It performs no socket send, worker invocation, or disk write inline, and the source never awaits consumer work. Since the originating state is already authoritative, any fanout failure is isolated, emits only a bounded diagnostic code, and never throws back into, delays completion of, or compensates the mutation. A queue-overflow/fanout failure is reported by code and the envelope is dropped for that consumer according to its documented delivery class.
+
+Wire one dispatcher through `ProjectContext`/`ProjectContextManager` using the existing late-wiring pattern used by `setGoalTriggerDispatcher`, while session lifecycle owners receive a narrow publisher callback. There is no process-global event emitter and no client-originated publisher.
+
+### 4.1 Observational module handlers
+
+For each envelope, resolve active `kind: notification` contributions using `PackContributionRegistry.listHooks(envelope.projectId)`. Filter by exact catalogue scope/name and eligible consumer kind. Invoke in the same deterministic order through `ModuleHost` with:
+
+```ts
+export default {
+  async goalUpdated(ctx: NotificationHookContext, event: HostNotification<"goalUpdated">): Promise<void> {}
+}
+```
+
+`ctx` contains only server-derived project/pack identity, effective config, cancellation, and granted Host APIs. The frozen canonical event is the only argument. Return values are ignored. The dispatcher rechecks winning pack, activation, disabled ref, and grants before invocation and ignores late settlement after invalidation. Each handler has its declared timeout capped by the catalogue. Errors/timeouts are isolated and recorded by code and attribution only. A handler cannot block the source operation because dispatch begins after publication and runs on a per-project ordered async queue.
+
+Queues preserve publication order within one project; projects may run concurrently. Queue capacity is bounded. On overflow, module deliveries are dropped with a diagnostic and modules recover by reading authoritative snapshots; no unbounded memory or replay journal is introduced.
+
+## 5. Authoritative publication map
+
+A publisher must build an allowlisted payload from captured before/after scalars, never spread a store object. “After commit” below means after the owner's fail-loud persistence/publication barrier. Where an existing callback currently precedes that barrier or a save swallows errors, the implementation must add a strict owner method/callback and publish only from it. Legacy cache invalidation may remain independent.
+
+### 5.1 Session facts
+
+| Notification | Exact owner and boundary | Aggregate/revision |
+|---|---|---|
+| `statusChanged` | Extend `src/server/agent/session-status.ts::broadcastStatus` with an optional session-owned observer. Publish after `session.status` changes, `statusVersion` increments, and the authoritative legacy frame is queued. Do not publish heartbeats/resync echoes or unchanged status. | `session/<sessionId>`, revision `statusVersion` |
+| `turnStarted` | `SessionManager.handleAgentLifecycle()` first canonical current-writer `agent_start`, after persisted `wasStreaming`/`streamingStartedAt` update and streaming status transition. Add/use the session's turn index; duplicate start/replay does not republish. | `turn/<sessionId>:<turnIndex>`, revision `turnIndex` |
+| `turnCompleted` | Sole final `agent_end` path after `willRetry !== true`, terminal identity dedupe, `turnTerminalHandled` test/set, outcome classification, persisted streaming marker clear, completed-turn increment, and idle/error status publication. Retry attempts, duplicate terminal frames, restore replay, and late frames cannot reach publication. Error and abort use explicit outcomes. | `turn/<sessionId>:<turnIndex>`, revision completed turn index |
+| `messageAppended` | Normal non-restoring `subscribeToEvents`/`message_end` path after `prepareVisibleAgentEvent` and `emitSessionEvent` accept the event into `EventBuffer`. Use the accepted buffer seq/cursor and stable message identity. Do not publish client remapping, snapshots, partial streaming, or restore replay. | `message/<messageId>`, revision accepted event cursor |
+| `toolCallStarted` | Pi `tool_execution_start` only after permission plus `beforeToolCall` admission, recorded in the bounded tracker. | `toolCall/<toolCallId>`, revision tool-call identity/start cursor |
+| `toolCallCompleted` | Matching non-replay tool-result `message_end` after handler -> protected `afterToolResult` -> final approved/synthetic result -> Pi persistence/publication. Join only safe tracker metadata; never emit at `tool_execution_end`. | `toolCall/<toolCallId>`, revision result message cursor |
+
+The existing `isRetryableAgentEnd`, `turnTerminalHandled`, and `assistantTerminalIdentities` fences remain the single turn-terminal suppression mechanism. A new parallel dedupe owner is prohibited.
+
+`statusChanged` also causes one project `sessionStatusChanged` envelope from the same observer and same `statusVersion`; it is not inferred from WebSocket frames.
+
+### 5.2 Project facts
+
+| Notification | Exact owner and boundary | Aggregate/revision source |
+|---|---|---|
+| `sessionCreated` | `SessionManager.notifySessionCreated()` after `persistOnce`/`SessionStore` strict initial publication. If the current listener can run before flush, move the listener fence rather than publishing at the route. | `session/<id>`, persisted session `updatedAt` or initial store revision |
+| `sessionArchived` | A single helper used by live `_terminateSessionOwned` and dormant `archiveWithCascade`, immediately after `SessionStore.archiveAsync()` succeeds. Repeat archive/purge emits nothing. This closes the dormant path's current termination-listener gap. | `session/<id>`, persisted `archivedAt` |
+| `sessionForked` | Successful history-fork branch in `server.ts`, after destination `createSession` and transcript/proposal/sidecar materialization all succeed, immediately before the success response. Failed compensation emits nothing. | destination `session/<id>`, destination persisted revision |
+| `sessionStatusChanged` | Same post-transition observer as session `statusChanged`, published once with exact project binding. | `session/<id>`, `statusVersion` |
+| `staffCreated` | `StaffManager.createStaff()` after staff record persistence, permanent-session metadata, and `currentSessionId` are durably accepted. Do not publish its provisional early `StaffStore.put`. | `staff/<id>`, persisted `updatedAt` |
+| `staffConfigChanged` | Public `StaffManager.updateStaff()` after a fail-loud store commit and a pre/post clone diff. Allowlisted author-controlled fields only; exclude `lastWakeAt`, trigger cursors, outbox state, and migration repairs. | `staff/<id>`, persisted `updatedAt` |
+| `staffRetired` | Exact non-retired -> `state:"retired"` durable transition. Cleanup failure cannot retract it. Hard deletion without a retirement transition is not this fact. | `staff/<id>`, persisted `updatedAt`/retirement revision |
+| `staffSessionChanged` | Centralize all successful `currentSessionId` writes/clears (create, migration, recovery, replacement) in `StaffManager.commitCurrentSession()`, then publish after fail-loud persistence. | `staff/<id>`, persisted `updatedAt` |
+| `goalCreated` | New-ID branch in `GoalStore`, after strict persistence/publication. Keep `onIndexUpdate` and legacy `onGoalCreated` independent; move/add a post-publication notification callback rather than repurposing either. | `goal/<id>`, durable `updatedAt` |
+| `goalUpdated` | `GoalStore.update/updateStrict` after successful publication of an actual allowlisted change. Capture pre/post scalars; specialized terminal facts may accompany but do not replace a general changed-field fact. | `goal/<id>`, durable `updatedAt` |
+| `goalCompleted` | Exact previous state != `complete` -> `state:"complete"` through `GoalManager.updateGoal`/`GoalStore.updateStrict`, after strict durable publication. Route direct completion sites such as team completion and child completion through this helper. Consumer failure is non-fatal. | `goal/<id>`, stable persisted completion `updatedAt` |
+| `goalArchived` | False -> true only, after `GoalStore.archiveStrict()` succeeds. It is distinct from and may follow `goalCompleted`; duplicate archive emits nothing. | `goal/<id>`, persisted archive `updatedAt` |
+| `taskCreated` | `TaskManager.createTask()` after `TaskStore.put` strict/fail-loud publication. | `task/<id>`, durable `updatedAt` |
+| `taskUpdated` | `TaskManager.updateTask`/`assignTask` after each changed task is published, including an auto-updated parent. Emit allowlisted non-state changed fields; no-op writes emit nothing. | `task/<id>`, durable `updatedAt` |
+| `taskStateChanged` | Every real previous -> next state transition through `updateTask`, `assignTask`, `completeTask`, or `transitionTask`, after the affected task is published. An automatic parent transition is a separate task fact. | `task/<id>`, durable `updatedAt` |
+| `gateStatusChanged` | Centralize old/new summary comparison in `GateStore` across `updateGateStatus`, `bypassGate`, verification completion, and strict reset/reconcile. Publish after the relevant persistence fence and only if summary status differs. `recordSignal` and current `broadcastGateStatusChanged`/`onStatusChange` alone are not authority. | `gate/<goalId>:<gateId>`, persisted status-change revision; add this small per-gate revision to GateStore because reset has no stable signal ID |
+| `pullRequestStatusChanged` | `PrStatusStore.set()` after changing it to atomic, fail-loud persistence; compare only the bounded public status projection and suppress no-ops. Existing `pr_status_changed` remains a cache-bust adapter. | `pullRequest/<goalId>`, provider `updatedAt` when present, otherwise SHA-256 of canonical safe projection |
+| `settingsChanged` | `ProjectConfigStore.mutate()` after its temp-file rename commits canonical bytes. Diff pre/post target/key identifiers. Project contexts only; global preferences belong to reserved system scope. | `settings/<projectId>`, SHA-256 of committed canonical project-config bytes |
+
+For entities whose existing `updatedAt` is the revision, mutation helpers must ensure a real transition receives a new monotonic millisecond value (`max(Date.now(), previous + 1)`) before strict persistence. This avoids same-millisecond completion/update collisions without introducing durable revision stores. Gate status is the one exception requiring a tiny persisted per-gate revision because resets may remove the signal that would otherwise identify the state.
+
+## 6. Browser API, routing, gaps, and refresh
+
+### 6.1 Additive Host API
+
+Update `src/shared/extension-host/host-api.ts`:
+
+```ts
+export interface HostNotificationSubscriptionApi<N extends HostNotificationName> {
+  subscribe<E extends N>(
+    name: E,
+    handler: (event: HostNotification<E>) => void,
+  ): () => void;
+  onRefreshRequired(handler: () => void): () => void;
+}
+
+export interface HostSessionApi {
+  // existing members unchanged
+  readonly notifications: HostNotificationSubscriptionApi<SessionNotificationName>;
+}
+
+export interface HostProjectApi {
+  readonly notifications: HostNotificationSubscriptionApi<ProjectNotificationName>;
+}
+
+export interface HostApi {
+  // existing members unchanged
+  readonly project: HostProjectApi;
+}
+```
+
+Add feature flags for session/project notifications and bump `HOST_CONTRACT_VERSION` additively; do not bump `HOST_API_VERSION`. `getHostApi` binds session ID and project authority from the already trusted host/surface construction. Pack code never supplies either ID. An unbound host returns inert subscriptions. Every unsubscribe closure has a local active/generation flag, is idempotent, and fences already queued stale callbacks.
+
+Keep `HostSessionApi.subscribe` and `src/app/session-event-bus.ts` byte-compatible. That legacy API deliberately exposes richer `HostMessage`/`ToolCallRecord` shapes from existing raw session frames. Rebuilding it from privacy-bounded notifications would either break consumers or leak bodies, so it remains a separately documented compatibility adapter.
+
+### 6.2 WebSocket routing
+
+Add bounded protocol frames in `src/server/ws/protocol.ts`:
+
+```ts
+{ type: "host_notification"; notification: HostNotification;
+  stream: { epoch: string; sequence: number } }
+{ type: "host_notifications_refresh_required";
+  scope: "session" | "project"; epoch: string; sequence: number }
+```
+
+The stream epoch/sequence is transport metadata, not semantic envelope state. It is ephemeral per authenticated connection/scope and is not a durable event cursor.
+
+Tag each authenticated UI socket in `ws/handler.ts` with its server-resolved session and persisted/live project binding. A dedicated `HostNotificationSocketRouter` sends:
+
+- a session notification only to sockets bound to that exact session;
+- a project notification only to sockets whose server-tagged project exactly equals the envelope project;
+- nothing to `__viewer__`, unbound, projectless, foreign-project, or future system-scope sockets.
+
+Do not use `broadcastToProject`: it intentionally includes unscoped viewers and is unsuitable as this security boundary. Client filtering is defense-in-depth only. Surface-token validation proves that a mounted contributed panel belongs to the bound session/pack, but project isolation remains server-owned.
+
+Add `src/app/host-notification-bus.ts`, fed by `RemoteAgent`'s canonical frame handler. It deduplicates bounded recent envelope IDs, verifies monotonically contiguous sequence within the current epoch, routes by name, and generation-fences handlers. The client never accepts a project ID from extension code.
+
+Initial mount, socket re-auth/reconnect, epoch change, explicit refresh-required frame, or sequence gap calls `onRefreshRequired` once through a short coalescer. Mounted panels reread their authoritative REST/Host projection; they do not reconstruct state from missed deltas. Event bursts may debounce/coalesce refreshes because correctness comes from the snapshot. Reload repeats snapshot-first initialization, then resumes live observation. No historical notification replay endpoint is added.
+
+## 7. Notification-based staff triggers
+
+### 7.1 Trigger contract and validation
+
+Extend `src/server/agent/staff-store.ts` additively:
+
+```ts
+export interface NotificationTriggerSelector<N extends HostNotificationName = HostNotificationName> {
+  scope: HostNotificationScope<N>;
+  name: N;
+}
+
+export type StaffTrigger = LegacyStaffTrigger | {
+  id: string;
+  type: "notification";
+  notification: NotificationTriggerSelector;
+  filter: Readonly<Record<string, string | number | boolean>>;
+  enabled: boolean;
+  prompt?: string;
+  lastFired?: number;
+};
+```
+
+Preserve `schedule`, `git`, `manual`, `goal_created`, and `goal_archived` types and their current UI/API semantics. `StaffManager.validateTriggers()` resolves the shared catalogue, requires staff eligibility, rejects the contradictory project-scoped `toolCallCompleted`, and validates flat exact-AND filter keys and scalar values against definition-owned schemas. V1 has no regex, JSONPath, expressions, payload bodies, or arbitrary nested keys.
+
+Legacy `GoalTriggerDispatcher` remains active during migration. Do not route legacy `goal_created`/`goal_archived` definitions into notification triggers automatically; that would double wake staff. A later explicit migration can rewrite stored triggers and then disable the compatibility callback under its own goal.
+
+### 7.2 Small durable delivery outbox
+
+Add `src/server/agent/notification-delivery-store.ts` and `notification-staff-dispatcher.ts`. The outbox is per project and stores subscriber delivery state, not canonical notification history.
+
+A row is keyed by deterministic `deliveryId = sha256(staffId + "|" + triggerId + "|" + notification.id)` and contains only:
+
+```ts
+interface NotificationDeliveryRow {
+  deliveryId: string;
+  notificationId: string;
+  projectId: string;
+  staffId: string;
+  triggerId: string;
+  subscriberVersion: string; // hash of enabled selector/filter/prompt config
+  name: HostNotificationName;
+  aggregateKind: string;
+  aggregateId: string;
+  aggregateRevision?: string | number;
+  safeContext: Record<string, string | number | boolean>; // allowlisted render fields
+  state: "pending" | "leased" | "accepted" | "cancelled" | "failed";
+  attempt: number;
+  nextAttemptAt: number;
+  leaseUntil?: number;
+  rootCorrelationId: string;
+  causationDepth: number;
+  createdAt: number;
+  updatedAt: number;
+  diagnosticCode?: string;
+}
+```
+
+The bounded staff-intent queue asynchronously matches active, enabled project staff triggers and upserts pending rows without holding up the source operation. The unique delivery ID coalesces concurrent duplicate fanout. It is intentionally possible for the source mutation to commit and the subsequent queueing/outbox insert to be lost or fail catastrophically; the source still succeeds and the dispatcher records a bounded diagnostic when possible. This is the unavoidable consequence of notifications being non-blocking/non-transactional/non-rollback. The design does not misrepresent that window as exactly-once notification capture.
+
+A project worker/reconciler:
+
+1. scans pending and expired leased rows at boot and after staff/trigger activation changes;
+2. claims a bounded lease and creates an abort controller;
+3. rechecks exact project match, staff existence/active state, trigger enabled state, selector/filter equality, `subscriberVersion`, causation limit, and retirement/disable cancellation;
+4. renders a fixed host-owned title/context from `safeContext`; it never serializes a full envelope or source aggregate;
+5. calls additive `InboxManager.enqueueWithId(deliveryId, ...)`, backed by fail-loud `InboxStore.putStrict`, so inbox acceptance is idempotent;
+6. marks `accepted` only after the inbox write durably succeeds or proves that the identical deterministic entry already exists;
+7. lets existing `InboxNudger` own session wake-up. Inbox acceptance, not agent execution/completion, is notification delivery success.
+
+If the gateway crashes after inbox commit and before outbox acceptance, boot retry uses the same inbox ID, observes/overwrites only an identical entry, then marks the row accepted without a duplicate. Late retries use compare-and-set state/lease generation and cannot move `accepted`, `cancelled`, or permanent `failed` back to pending.
+
+Retry only classified transient storage/unavailable errors with capped exponential backoff, bounded attempts, and a final deadline. Invalid trigger/filter/project data is permanent failure. Paused, retired, deleted, or disabled staff/trigger rows are cancelled; cancellation aborts a leased attempt and a final live recheck precedes inbox acceptance. Accepted inbox work is not rolled back by later retirement.
+
+Correlation/loop protection uses a root correlation ID and bounded causation depth propagated in internal inbox metadata, not prompt text. Permit at most one delivery for `(rootCorrelationId, staffId, triggerId)` and cap depth. A notification caused by that staff wake cannot recursively redeliver to the same subscriber/root chain. Unknown/missing causation starts a new root; extensions cannot forge it because the host constructs envelopes.
+
+Guarantees are therefore:
+
+- source commit precedes notification publication;
+- browser/module observation is ordered live per connection/project queue and best-effort;
+- a successfully inserted staff intent is restart-recoverable; staff intent queueing/insertion never delays the source operation;
+- durable inbox acceptance is idempotent and effectively once per delivery identity;
+- attempt semantics are at least once, never exactly once;
+- source commit cannot be rolled back by any consumer or outbox failure;
+- intermediate notification facts lost in the commit-to-outbox crash window are not reconstructed; authoritative state remains queryable.
+
+## 8. Security and privacy bounds
+
+The shared catalogue and payload projectors enforce these invariants:
+
+- no raw prompt/user/assistant/message text or content blocks;
+- no tool arguments/input, tool result/output/body, or synthetic result text;
+- no setting values, provider keys, sandbox tokens, secrets, credentials, headers, or gateway tokens;
+- no provider error text, host exception message, stack trace, or worker output;
+- no cwd, worktree, repository, absolute path, or mutable store/session object;
+- no arbitrary consumer-supplied project/session/pack identity;
+- public error fields are closed enums such as `timeout`, `denied`, `handler_error`, not messages;
+- filter fields are catalogue allowlists over bounded scalars only.
+
+Builders accept explicit safe scalars or pre-projected snapshots, not domain objects. Tests recursively inject forbidden sentinel keys/values and prove they cannot serialize. Browser routing uses exact server-derived bindings. Module Host APIs remain pack- and grant-scoped. Staff matching requires the envelope's project and staff's project to match even for session-scoped facts.
+
+Diagnostics record only timestamp, hook/notification, project/session aggregate identity, pack/contribution/subscriber attribution, duration, outcome code, timeout/cancel/retry counts, and revision. They never include payload bodies or arbitrary exception strings.
+
+## 9. Compatibility and migration
+
+1. Add shared catalogue and normalization without activating old declarations.
+2. Keep `LifecycleHub`, provider YAML, provider bridge generator, `afterTurn`, and `goalProvisioned` behavior unchanged. Route compatible new operation entry points through the interceptor router only when the corresponding explicit contribution exists.
+3. Add explicit `kind` hook contributions as opt-in. Unsupported names fail installation/load validation; legacy inert names stay inert with bounded diagnostics.
+4. Keep legacy session event bus and `host.session.subscribe` unchanged. Add notification namespaces and feature flags alongside it.
+5. Add canonical publishers independently of existing legacy WS cache-bust/status frames; remove neither in this goal.
+6. Add notification staff triggers without rewriting stored legacy triggers. Keep `GoalTriggerDispatcher`, polling `TriggerEngine`, and manual triggers unchanged.
+7. Only after strict publisher tests pass should individual packs adopt the API; pack adoption belongs to separate goals.
+8. Bump `HOST_CONTRACT_VERSION` for the additive contracts, not `HOST_API_VERSION`.
+
+## 10. Implementation partitions and files
+
+Each partition is independently reviewable and keeps state ownership narrow.
+
+### A. Catalogue and contribution runtime
+
+- Add `src/shared/extension-host/host-hooks.ts`.
+- Add `src/server/extension-host/host-hook-contributions.ts`.
+- Modify `src/server/agent/pack-contributions.ts` (`HookContribution`, `loadHooks`, strict explicit-kind parsing; retain legacy inert parsing).
+- Modify `src/server/extension-host/pack-contribution-registry.ts` to activation/config/grant-filter explicit runtime hooks while keeping `listHooks` compatibility.
+- Modify `module-host-worker.ts` and `module-host-bootstrap.ts` with `exportKind:"hooks"` and cancellation.
+
+### B. Interceptors
+
+- Add `src/server/extension-host/host-interceptor-router.ts` and bounded audit types.
+- Keep `src/server/agent/lifecycle-hub.ts` as the legacy provider adapter/facade; do not make it publish facts.
+- Compose existing `provider-bridge-extension.ts`, `tool-guard-extension.ts`, and `tool-result-error-bridge-extension.ts` seams.
+- Wire setup/prompt/compact/shutdown/import and tool operation owners only.
+
+### C. Dispatcher, transport, and browser API
+
+- Add `src/server/extension-host/host-notification-dispatcher.ts` and a dedicated socket router.
+- Add `src/app/host-notification-bus.ts`.
+- Modify `ws/protocol.ts`, `ws/handler.ts`, `remote-agent.ts`, and `host-api.ts`.
+- Wire through `project-context.ts`/`project-context-manager.ts` using existing late wiring.
+
+### D. Authoritative publishers
+
+- Session: `session-status.ts`, `session-manager.ts`, and the history-fork success route in `server.ts`.
+- Project domains: `goal-store.ts`/`goal-manager.ts`, `task-store.ts`/`task-manager.ts`, `gate-store.ts`/gate status adapter, `staff-store.ts`/`staff-manager.ts`, `pr-status-store.ts`, and `project-config-store.ts`.
+- Add only the strict callbacks/revisions required by the boundary table. Preserve search, legacy broadcast, and goal-trigger callbacks independently.
+
+### E. Staff durability
+
+- Add `notification-delivery-store.ts` and `notification-staff-dispatcher.ts`.
+- Extend `staff-store.ts`, `staff-manager.ts`, and staff request/UI validation additively.
+- Add `InboxManager.enqueueWithId`/`InboxStore.putStrict`; reuse `InboxNudger`.
+- Leave `goal-trigger-dispatcher.ts` and `staff-trigger-engine.ts` compatibility semantics intact.
+
+### F. Documentation and fixtures
+
+Update `docs/extension-host-authoring.md`, `docs/lifecycle-hub.md`, staff trigger/inbox documentation, Host API contract/version reference, WebSocket reference, REST/project snapshot refresh guidance, and marketplace fixture documentation. Register every new Test Suite v2 file in `tests2/tests-map.json`; add no legacy-suite tests.
+
+## 11. Protecting tests and acceptance checks
+
+Reuse and extend existing seams rather than replace their tests:
+
+- Contributions/activation: `tests2/core/pack-contributions.test.ts`, `pack-providers-loader.test.ts`.
+- Worker isolation/capabilities: `extension-host-module-isolation.test.ts`, `extension-host-module-memory-isolation.test.ts`, `extension-host-no-capability-sandbox-residual.test.ts`, `extension-host-server-host-api.test.ts`.
+- Legacy providers/router composition: `lifecycle-hub.test.ts`, `provider-bridge-extension.test.ts`, `session-manager-respawn-provider-bridge.test.ts`.
+- Tool wrappers: `tool-guard-extension.test.ts`, `tool-result-error-bridge-extension.test.ts`, `pi-tool-lifecycle-contract.test.ts`.
+- Turn suppression/status: `pi-rpc-agent-end-retry.test.ts`, `session-manager-direct-prompt-lifecycle.test.ts`, `session-manager-force-abort-grace.test.ts`, `orphan-tool-result-recovery.test.ts`, `session-manager-status.test.ts`.
+- Host binding/legacy adapter: `extension-host-session-event-bus.test.ts`, `extension-host-surface-binding.test.ts`, `extension-host-surface-token.test.ts`.
+- Domain durability: `goal-store-sqlite.test.ts`, `goal-task-store-lifecycle.test.ts`, `task-state-machine.test.ts`, `task-generation.test.ts`, `gate-store-logic.test.ts`, `gate-store-sqlite.test.ts`, `project-config-store-durability*.test.ts`, and `tests2/integration/history-fork-api.test.ts`.
+- Staff compatibility: `staff-trigger-engine.test.ts`, `goal-trigger-dispatcher.test.ts`, `tests2/integration/staff-goal-triggers.test.ts`, `inbox-manager.test.ts`, and `inbox-store.test.ts`.
+
+Required new v2 coverage:
+
+### Core
+
+- catalogue name/(scope,name) uniqueness, TypeBox payload/request/result/filter validation, version and aggregate revision extraction;
+- bounded size/extra-key rejection and forbidden privacy sentinel fuzzing;
+- contribution normalization, old declarations inert, provider compatibility, deterministic pack/manifest order;
+- absolute deadlines, cancellation, pre-invoke and pre-apply activation/grant rechecks, every interceptor result/failure policy, and bounded audit output;
+- post-commit callback ordering for every boundary in §5 and no notification on strict persistence failure;
+- exact project/session routing and absent/unbound authority;
+- turn retry/duplicate/late/restore suppression and explicit error/abort completion;
+- tool permission -> interceptor -> handler -> result policy -> persisted message -> completion order;
+- revisions, no-op suppression, fork lineage, goal complete/archive distinction, settings no-values, and payload immutability.
+
+### DOM/Host API
+
+- typed session/project name restriction, server-derived binding, inert unbound host;
+- idempotent unsubscribe, remount/generation stale-callback isolation, recent-ID dedupe;
+- ordered stream, reconnect/epoch/sequence gap refresh, initial snapshot refresh, burst coalescing;
+- unchanged legacy `host.session.subscribe` behavior.
+
+### Integration
+
+- fixture installed explicit interceptor and notification handlers through real registry/worker infrastructure;
+- precedence, activation/config/grants, timeout, cancellation, malformed result, protected failure isolation, and exact project context;
+- staff filter validation/matching, concurrent duplicate coalescing, transient retry, retirement/disable cancellation, late retry fence, causation loop limit, deterministic inbox acceptance, and restart reconciliation;
+- unchanged schedule/git/manual/goal trigger suites.
+
+### Browser and E2E
+
+- fixture marketplace panel subscribes to session and project facts, observes live changes, refreshes from an authoritative snapshot after reconnect/gap/reload, unsubscribes cleanly, and receives no second-project facts;
+- E2E real WS project routing excludes foreign/unbound/viewer sockets;
+- gateway restart between staff inbox commit and outbox acceptance reconciles without a duplicate;
+- real final-turn and protected tool-result boundaries prove ordering that lower tiers cannot.
+
+Acceptance commands:
+
+```bash
+npm run check
+npm run test:unit
+npm run test:browser
+npm run test:e2e
+```
+
+Acceptance is complete only when every catalogue entry has exactly one tested authoritative publisher, public payload privacy tests pass, cross-project attempts are silent, existing provider/panel/staff compatibility tests remain green, and all new files are registered in `tests2/tests-map.json`.
+
+## 12. Defect-surface comparison: selected outbox vs rejected full journal
+
+The alternative durable-global-journal design adds a notification database, stream heads, retention, aggregate reconciliation, catch-up scheduling, and journal-to-consumer cursors before it can deliver the same user-visible behavior. It improves recovery of a subset of post-commit facts but cannot make the source-store commit and journal insert atomic without either coupling every domain transaction to the journal or allowing notification infrastructure to fail/roll back the source. It therefore still has a commit-to-journal crash window while adding substantial state.
+
+| Surface | Selected: live dispatcher + staff outbox | Rejected: durable global journal | Consequence |
+|---|---|---|---|
+| Durable state owners | One per-project staff delivery store; existing inbox remains wake authority | Notification journal, stream-head table, staff-delivery table, retention/quarantine state, reconciler cursors, plus inbox | Selected adds only state required for the one durable consumer. |
+| Canonical notification storage | None; envelope exists for live fanout and safe fields are copied only into matching staff rows | Every envelope and aggregate revision persisted | Journal enlarges privacy/retention/migration surface for events browsers/modules do not replay. |
+| Ordering state | Ephemeral per-connection sequence and per-project module queue | Durable publication sequence, stream heads, per-consumer cursors/leases | Selected provides required live ordering/gap refresh without pretending to be event sourcing. |
+| Crash before event persistence | Source remains committed; rare missed live fact/outbox diagnostic; consumers refresh state | Same unless every domain transaction shares journal transaction; reconciler can only infer current/terminal state | Journal cannot reconstruct unknowable intermediate facts, so its stronger guarantee is partial. |
+| Crash after staff intent | Pending/expired lease reconciles; deterministic inbox ID closes ACK window | Journal delivery row reconciles similarly | Both meet staff restart needs; global notification rows add no benefit to this path. |
+| Browser reconnect | Snapshot refresh, no replay | Design still requires snapshot refresh because deltas may be sensitive/incomplete and client state may be stale | Durable journal is unused for the required browser correctness model. |
+| Module restart | Best-effort observation; module reads snapshots | Could replay, but activation/grant/config may differ and replay semantics require durable per-handler cursors | Goal asks observational asynchronous handlers, not historical processors. Replay adds semantic ambiguity. |
+| Project isolation | Server-bound live router + project-owned outbox | Same plus journal query authorization and partition correctness | Journal adds another cross-project read boundary. |
+| Schema migration | Shared catalogue and compact staff-row schema | Catalogue plus persisted envelope versions, migrations, compatibility readers, quarantine | Full journal makes every payload version a storage migration concern. |
+| Retention/deletion | Terminal outbox rows can be compacted after bounded audit TTL | Must coordinate journal TTL with all consumer cursors, unresolved deliveries, project deletion, privacy policy | More cleanup branches and stuck-row modes. |
+| Corruption handling | Quarantine/fail one staff row/store; browser/modules unaffected | Journal corruption can block fanout order, replay, staff scanning, and stream heads | Larger blast radius. |
+| Backpressure | Bounded live queues may drop and force refresh; outbox is durable only for staff | Durable journal queue can grow without bound unless retention/cursors are correct | Selected failure behavior matches consumer guarantees explicitly. |
+| Source coupling | Narrow post-commit callback | Post-commit append at every source plus reconciliation readers for every aggregate | Journal creates a second representation of domain history. |
+| Aggregate revisions | Only catalogue-required revision sources; one small gate revision addition | Durable revisions/cursors must be added consistently to all aggregates for reconciliation | Full journal forces more new state and forgotten-writer risk. |
+| APIs | Two notification namespaces, explicit hook kind, internal staff rows | Same plus journal read/replay/admin/maintenance APIs even if initially hidden | Hidden operational APIs still require security/testing. |
+| Testing | Boundaries, live gaps/refresh, module isolation, staff crash window | All selected tests plus migrations, journal atomicity, replay order, cursor leases, TTL, compaction, quarantine, reconciliation | Materially larger verification matrix with no acceptance gain. |
+| Operational claims | Honest live best-effort + durable staff intent/idempotent acceptance | Tempts exactly-once/event-log claims that cross-store transactions cannot satisfy | Selected contract is smaller and accurate. |
+
+Unavoidable selected additions are limited to:
+
+- one shared TypeBox catalogue;
+- one interceptor result-folding router;
+- one post-commit live dispatcher and bounded module queue;
+- one exact-bound WebSocket route and ephemeral gap counter;
+- allowlist payload builders;
+- one bounded tool-call correlation map;
+- one durable staff delivery outbox/worker;
+- one persisted gate status revision where current state has no stable revision;
+- additive scoped Host APIs and explicit contribution discriminator.
+
+The selected design intentionally does **not** add a global notification database, replay API, event-sourced projection, arbitrary filter language, client-owned project selector, wildcard/system subscription, second worker runtime, second pack registry, or exactly-once execution claim. These omissions are part of the design, not deferred implementation shortcuts.

--- a/docs/design/unified-host-hooks.md
+++ b/docs/design/unified-host-hooks.md
@@ -1,6 +1,6 @@
 # Unified Host Hooks
 
-**Status:** implementation design  
+**Status:** implementation design
 **Decision:** use a shared TypeBox catalogue, an operation-specific interceptor router, and one post-commit notification dispatcher. Persist only matching staff delivery intents, including each intent's original bounded canonical notification; do not add a durable global notification journal.
 
 ## 1. Scope and decisions

--- a/docs/design/unified-host-hooks.md
+++ b/docs/design/unified-host-hooks.md
@@ -1,7 +1,7 @@
 # Unified Host Hooks
 
 **Status:** implementation design  
-**Decision:** use a shared TypeBox catalogue, an operation-specific interceptor router, and one post-commit notification dispatcher. Persist only staff delivery intents; do not add a durable global notification journal.
+**Decision:** use a shared TypeBox catalogue, an operation-specific interceptor router, and one post-commit notification dispatcher. Persist only matching staff delivery intents, including each intent's original bounded canonical notification; do not add a durable global notification journal.
 
 ## 1. Scope and decisions
 
@@ -209,7 +209,7 @@ Legacy provider budgets continue to be read from `ProviderContribution.budget`; 
 
 `projectImported` is wired at the project-create/import owner in `src/server/server.ts`: after `projectRegistry.register`, `ProjectContextManager.getOrCreate`, component/workflow/base-ref publication, optional worktree-pool initialization, and `wireGoalManagerResolvers` have completed, but before the 201 response. Its request contains only the new project ID and configured component coordinates. Failure is recorded after the durable registration/config boundary; it neither removes the project nor changes the response to failure.
 
-Raw tool args/results exist only in the interceptor's trusted worker request. They are excluded from audit rows, diagnostics, notifications, staff rows, and browser frames. The host records whether a proposal was `received`, `valid`, and `applied`; extension code cannot assert application.
+Raw tool args/results exist only in the interceptor's trusted worker request. They are excluded from audit rows, diagnostics, canonical notifications (including the bounded notification persisted in matching staff rows), and browser frames. The host records whether a proposal was `received`, `valid`, and `applied`; extension code cannot assert application.
 
 ## 3. Contribution normalization and execution
 
@@ -506,62 +506,61 @@ Legacy `GoalTriggerDispatcher` remains active during migration. Do not route leg
 
 ### 7.2 Small durable delivery outbox
 
-Add `src/server/agent/notification-delivery-store.ts` and `notification-staff-dispatcher.ts`. The outbox is per project and stores subscriber delivery state, not canonical notification history.
+Add `src/server/agent/notification-delivery-store.ts` and `notification-staff-dispatcher.ts`. The outbox is per project and stores only matching subscriber delivery state plus the original already-bounded canonical notification needed by that subscriber. It is not a global notification history, replay source, or raw aggregate store.
 
-A row is keyed by deterministic `deliveryId = sha256(staffId + "|" + triggerId + "|" + notification.id)` and contains only:
+A row is keyed by deterministic `deliveryId = sha256(staffId + "|" + triggerId + "|" + notification.id)`:
 
 ```ts
 interface NotificationDeliveryRow {
   deliveryId: string;
-  notificationId: string;
-  projectId: string;
+  projectId: string; // partition key; must equal notification.projectId
   staffId: string;
   triggerId: string;
   subscriberVersion: string; // hash of enabled selector/filter/prompt config
-  name: HostNotificationName;
-  aggregateKind: string;
-  aggregateId: string;
-  aggregateRevision?: string | number;
-  safeContext: Record<string, string | number | boolean>; // allowlisted render fields
+  notification: HostNotification; // complete validated, bounded catalogue projection
+  safeContext?: Record<string, string | number | boolean>; // display-only derivative
   state: "pending" | "leased" | "accepted" | "cancelled" | "failed";
   attempt: number;
   nextAttemptAt: number;
   leaseUntil?: number;
-  rootCorrelationId: string;
-  causationDepth: number;
+  rootCorrelationId: string; // internal loop-control state
+  causationDepth: number; // internal loop-control state
   createdAt: number;
   updatedAt: number;
   diagnosticCode?: string;
 }
 ```
 
-The bounded staff-intent queue asynchronously matches active, enabled project staff triggers and upserts pending rows without holding up the source operation. The unique delivery ID coalesces concurrent duplicate fanout. It is intentionally possible for the source mutation to commit and the subsequent queueing/outbox insert to be lost or fail catastrophically; the source still succeeds and the dispatcher records a bounded diagnostic when possible. This is the unavoidable consequence of notifications being non-blocking/non-transactional/non-rollback. The design does not misrepresent that window as exactly-once notification capture.
+`notification` preserves, losslessly, `id`, `scope`, `name`, `payloadVersion`, `occurredAt`, `projectId`, optional `sessionId`, aggregate kind/ID/revision, optional correlation/causation IDs, and the definition-validated payload. Persisting those fields as individual columns plus a typed payload blob is viable but rejected because it adds omission and schema-migration risk without reducing authority or delivery state. A `safeContext`-only row is invalid because it would give staff a different semantic contract. `safeContext`, when present, is derived from allowlisted fields solely for a host-owned display title; filtering, retry, inbox input, and staff behavior never depend on it.
+
+The bounded staff-intent queue asynchronously matches active, enabled project staff triggers and upserts pending rows without holding up the source operation. Before insertion it verifies the definition, supported `payloadVersion`, complete envelope and payload schema, size limits, and exact `notification.projectId === row.projectId === staff.projectId`; it stores no mutable source object. The unique delivery ID coalesces concurrent duplicate fanout. It is intentionally possible for the source mutation to commit and the subsequent queueing/outbox insert to be lost or fail catastrophically; the source still succeeds and the dispatcher records a bounded diagnostic when possible. This non-transactional window is not described as exactly-once capture.
 
 A project worker/reconciler:
 
 1. scans pending and expired leased rows at boot and after staff/trigger activation changes;
 2. claims a bounded lease and creates an abort controller;
-3. rechecks exact project match, staff existence/active state, trigger enabled state, selector/filter equality, `subscriberVersion`, causation limit, and retirement/disable cancellation;
-4. renders a fixed host-owned title/context from `safeContext`; it never serializes a full envelope or source aggregate;
-5. calls additive `InboxManager.enqueueWithId(deliveryId, ...)`, backed by fail-loud `InboxStore.putStrict`, so inbox acceptance is idempotent;
-6. marks `accepted` only after the inbox write durably succeeds or proves that the identical deterministic entry already exists;
+3. revalidates the persisted notification against its catalogue definition, supported schema version, size bounds, and project partition, then deep-freezes that exact stored event;
+4. rechecks staff existence/active state, trigger enabled state, selector and catalogue-owned filter match against that event, `subscriberVersion`, causation limit, and retirement/disable cancellation;
+5. creates only optional display text from `safeContext`, then calls additive `InboxManager.enqueueWithId(deliveryId, ...)` with the exact immutable notification in host-owned inbox/wake metadata and exposed as the staff notification input—never as prompt text;
+6. relies on fail-loud `InboxStore.putStrict` so acceptance is idempotent, and marks `accepted` only after the inbox write durably succeeds or proves that the identical deterministic entry with byte-equivalent semantic notification fields already exists;
 7. lets existing `InboxNudger` own session wake-up. Inbox acceptance, not agent execution/completion, is notification delivery success.
 
-If the gateway crashes after inbox commit and before outbox acceptance, boot retry uses the same inbox ID, observes/overwrites only an identical entry, then marks the row accepted without a duplicate. Late retries use compare-and-set state/lease generation and cannot move `accepted`, `cancelled`, or permanent `failed` back to pending.
+Restart retry reads and delivers the persisted original notification verbatim; it never reprojects a current mutable aggregate. If the gateway crashes after inbox commit and before outbox acceptance, boot retry uses the same inbox ID and identical notification metadata, then marks the row accepted without a duplicate. Late retries use compare-and-set state/lease generation and cannot move `accepted`, `cancelled`, or permanent `failed` back to pending. Unsupported versions, invalid schemas/sizes, partition mismatch, or changed trigger identity fail closed for that row with bounded diagnostics; they do not reach staff.
 
-Retry only classified transient storage/unavailable errors with capped exponential backoff, bounded attempts, and a final deadline. Invalid trigger/filter/project data is permanent failure. Paused, retired, deleted, or disabled staff/trigger rows are cancelled; cancellation aborts a leased attempt and a final live recheck precedes inbox acceptance. Accepted inbox work is not rolled back by later retirement.
+Retry only classified transient storage/unavailable errors with capped exponential backoff, bounded attempts, and a final deadline. Invalid trigger/filter/project data is permanent failure. Paused, retired, deleted, or disabled staff/trigger rows are cancelled; cancellation aborts a leased attempt and a final live recheck precedes inbox acceptance. Accepted inbox work is not rolled back by later retirement. The notification input and metadata path is available only to `type:"notification"` triggers; legacy schedule/git/manual/goal triggers cannot access or accidentally consume it.
 
-Correlation/loop protection uses a root correlation ID and bounded causation depth propagated in internal inbox metadata, not prompt text. Permit at most one delivery for `(rootCorrelationId, staffId, triggerId)` and cap depth. A notification caused by that staff wake cannot recursively redeliver to the same subscriber/root chain. Unknown/missing causation starts a new root; extensions cannot forge it because the host constructs envelopes.
+Correlation/loop protection uses separate internal `rootCorrelationId`/`causationDepth` delivery controls while preserving the canonical envelope's correlation and causation fields unchanged. Internal controls travel in host-owned inbox metadata, never prompt text. Permit at most one delivery for `(rootCorrelationId, staffId, triggerId)` and cap depth. A notification caused by that staff wake cannot recursively redeliver to the same subscriber/root chain. Unknown/missing causation starts a new host-owned root; extensions cannot forge it because the host constructs envelopes.
 
 Guarantees are therefore:
 
-- source commit precedes notification publication;
+- source commit precedes non-blocking notification publication;
+- browser, observational modules, and notification-triggered staff receive the same immutable canonical name/envelope/payload contract within their permitted scope;
 - browser/module observation is ordered live per connection/project queue and best-effort;
-- a successfully inserted staff intent is restart-recoverable; staff intent queueing/insertion never delays the source operation;
+- a successfully inserted staff intent retains the original canonical event and is restart-recoverable; queueing/insertion never delays or rolls back the source;
 - durable inbox acceptance is idempotent and effectively once per delivery identity;
-- attempt semantics are at least once, never exactly once;
-- source commit cannot be rolled back by any consumer or outbox failure;
-- intermediate notification facts lost in the commit-to-outbox crash window are not reconstructed; authoritative state remains queryable.
+- delivery attempts are at least once; staff execution is never exactly once;
+- intermediate facts lost in the source-commit-to-outbox window are not reconstructed from mutable state; authoritative state remains queryable;
+- no global journal, historical replay, or legacy-trigger access is introduced.
 
 ## 8. Security and privacy bounds
 
@@ -576,7 +575,7 @@ The shared catalogue and payload projectors enforce these invariants:
 - public error fields are closed enums such as `timeout`, `denied`, `handler_error`, not messages;
 - filter fields are catalogue allowlists over bounded scalars only.
 
-Builders accept explicit safe scalars or pre-projected snapshots, not domain objects. Tests recursively inject forbidden sentinel keys/values and prove they cannot serialize. Browser routing uses exact server-derived bindings. Module Host APIs remain pack- and grant-scoped. Staff matching requires the envelope's project and staff's project to match even for session-scoped facts.
+Builders accept explicit safe scalars or pre-projected snapshots, not domain objects. The staff outbox persists the complete canonical event only after that projection has passed catalogue schema/version/size validation; the worker revalidates and deep-freezes it before delivery. The same bounded event may appear only in matching project-partitioned notification rows and host-owned inbox/wake metadata, never prompt text, a global journal, or legacy-trigger input. Tests recursively inject forbidden sentinel keys/values and prove they cannot serialize in the envelope, persisted row, or inbox metadata. Browser routing uses exact server-derived bindings. Module Host APIs remain pack- and grant-scoped. Staff matching requires the envelope's project and staff's project to match even for session-scoped facts.
 
 Diagnostics record only timestamp, hook/notification, project/session aggregate identity, pack/contribution/subscriber attribution, duration, outcome code, timeout/cancel/retry counts, and revision. They never include payload bodies or arbitrary exception strings.
 
@@ -593,9 +592,11 @@ Diagnostics record only timestamp, hook/notification, project/session aggregate 
 
 ## 10. Implementation partitions and files
 
-Each partition is independently reviewable and keeps state ownership narrow.
+Each partition is independently reviewable and keeps state ownership narrow. Section 12.1 ties every new runtime state owner/API below to a selected component flow, rejected alternative, failure behavior, exact files, and focused tests; §12.2 separately decides durable global-journal versus subscriber-outbox storage.
 
 ### A. Catalogue and contribution runtime
+
+Decision coverage: the pure shared catalogue and contribution-normalization APIs serve all four §12.1 decisions; hook resolution/worker/grant changes are owned by the interceptor-execution and observational-fanout rows, not a new registry or worker runtime.
 
 - Add `src/shared/extension-host/host-hooks.ts`.
 - Add `src/server/extension-host/host-hook-contributions.ts`.
@@ -605,6 +606,8 @@ Each partition is independently reviewable and keeps state ownership narrow.
 
 ### B. Interceptors
 
+Decision coverage: §12.1 **Interceptor execution** owns the new coordinator and its ephemeral per-dispatch deadline/fold state.
+
 - Add `src/server/extension-host/host-interceptor-router.ts` and bounded audit types.
 - Keep `src/server/agent/lifecycle-hub.ts` as the legacy provider adapter/facade; do not make it publish facts.
 - Compose existing `provider-bridge-extension.ts`, `tool-guard-extension.ts`, and `tool-result-error-bridge-extension.ts` seams.
@@ -612,18 +615,24 @@ Each partition is independently reviewable and keeps state ownership narrow.
 
 ### C. Dispatcher, transport, and browser API
 
-- Add `src/server/extension-host/host-notification-dispatcher.ts` and a dedicated socket router.
+Decision coverage: §12.1 **Post-commit fanout/routing** owns the dispatcher, exact socket route, and bounded server queues; **Browser notification delivery** owns the additive scoped Host APIs and the single generation-fenced client bus.
+
+- Add `src/server/extension-host/host-notification-dispatcher.ts` and `host-notification-socket-router.ts`.
 - Add `src/app/host-notification-bus.ts`.
 - Modify `ws/protocol.ts`, `ws/handler.ts`, `remote-agent.ts`, and `host-api.ts`.
 - Wire through `project-context.ts`/`project-context-manager.ts` using existing late wiring.
 
 ### D. Authoritative publishers
 
+Decision coverage: §12.1 **Post-commit fanout/routing** limits domain owners to narrow post-authority callbacks and allowlisted payload builders; owners gain no fanout queues or transport API.
+
 - Session: `session-status.ts`, `session-manager.ts`, and the history-fork success route in `server.ts`.
 - Project domains: `goal-store.ts`/`goal-manager.ts`, `task-store.ts`/`task-manager.ts`, `gate-store.ts`/gate status adapter, `staff-store.ts`/`staff-manager.ts`, `pr-status-store.ts`, and `project-config-store.ts`.
 - Add only the strict callbacks/revisions required by the boundary table. Preserve search, legacy broadcast, and goal-trigger callbacks independently.
 
 ### E. Staff durability
+
+Decision coverage: §12.1 **Notification staff delivery** owns the sole new durable subscriber store/lease worker and the additive idempotent inbox metadata/API; §12.2 rejects broader durable event state.
 
 - Add `notification-delivery-store.ts` and `notification-staff-dispatcher.ts`.
 - Extend `staff-store.ts`, `staff-manager.ts`, and staff request/UI validation additively.
@@ -635,6 +644,8 @@ Each partition is independently reviewable and keeps state ownership narrow.
 Update `docs/extension-host-authoring.md`, `docs/lifecycle-hub.md`, staff trigger/inbox documentation, Host API contract/version reference, WebSocket reference, REST/project snapshot refresh guidance, and marketplace fixture documentation. Register every new Test Suite v2 file in `tests2/tests-map.json`; add no legacy-suite tests.
 
 ## 11. Protecting tests and acceptance checks
+
+Section 12.1 maps each component decision to exact protecting tests and focused new test files. The aggregate matrix below covers catalogue and authoritative-domain behavior shared across those component seams; §12.2 lists only the additional tests a rejected global journal would require.
 
 Reuse and extend existing seams rather than replace their tests:
 
@@ -673,7 +684,9 @@ Required new v2 coverage:
 - fixture installed explicit interceptor and notification handlers through real registry/worker infrastructure;
 - precedence, activation/config/grants, timeout, cancellation, malformed result, protected failure isolation, and exact project context;
 - staff filter validation/matching, concurrent duplicate coalescing, transient retry, retirement/disable cancellation, late retry fence, causation loop limit, deterministic inbox acceptance, and restart reconciliation;
-- unchanged schedule/git/manual/goal trigger suites.
+- a session `toolCallCompleted` and a project notification each deliver to matching staff with byte-equivalent semantic envelope fields to the dispatcher's canonical event; restart between intent persistence and acceptance preserves `id`, `scope`, `name`, `payloadVersion`, payload, aggregate revision, and correlation/causation fields;
+- forbidden privacy sentinels cannot serialize in the persisted delivery row or host-owned inbox/wake metadata, and `safeContext` cannot become semantic notification input;
+- unchanged schedule/git/manual/goal trigger suites remain unable to access notification metadata.
 
 ### Browser and E2E
 
@@ -693,28 +706,41 @@ npm run test:e2e
 
 Acceptance is complete only when every catalogue entry has exactly one tested authoritative publisher, public payload privacy tests pass, cross-project attempts are silent, existing provider/panel/staff compatibility tests remain green, and all new files are registered in `tests2/tests-map.json`.
 
-## 12. Defect-surface comparison: selected outbox vs rejected full journal
+## 12. Comparative design and defect surface
 
-The alternative durable-global-journal design adds a notification database, stream heads, retention, aggregate reconciliation, catch-up scheduling, and journal-to-consumer cursors before it can deliver the same user-visible behavior. It improves recovery of a subset of post-commit facts but cannot make the source-store commit and journal insert atomic without either coupling every domain transaction to the journal or allowing notification infrastructure to fail/roll back the source. It therefore still has a commit-to-journal crash window while adding substantial state.
+### 12.1 Component-level comparative decisions
+
+These decisions justify the non-trivial cross-layer additions independently. Each selected path composes current authority owners and gives its new state an explicit failure contract; the durable-storage choice remains separate in §12.2.
+
+| Decision | Selected data/control flow, new state, and failure behavior | Materially different rejected approach and defect-surface rationale | Exact implementation files and protecting/focused tests |
+|---|---|---|---|
+| Interceptor execution | `HostInterceptorRouter` validates a typed request, obtains deterministic contributions from `PackContributionRegistry`, invokes them sequentially through `ModuleHost`, folds typed mutations/decisions, and rechecks activation/epoch/grants before invocation and application. `LifecycleHub.dispatch()` remains one legacy-provider adapter and retains context validation/budget/application semantics. The router owns only ephemeral per-dispatch deadline, current folded value, and bounded decision rows—no durable state. Timeout/invalid/revoked work follows the definition's fail-open or protected fail-closed result without late application. | Generalize `LifecycleHub` into the executor for all seven operations. That would add tool mutation, result replacement, import/flush, and differing failure-policy branches to the legacy context-block owner, blur byte-compatible provider behavior, and still require worker/grant resolution. The selected coordinator exists specifically for typed sequential mutation and pre-apply authority checks rather than speculative reuse. | Production: `src/server/extension-host/host-interceptor-router.ts`, `host-hook-contributions.ts`, `module-host-worker.ts`, `module-host-bootstrap.ts`; `src/server/agent/lifecycle-hub.ts`, `pack-contributions.ts`; existing `tests2/core/lifecycle-hub.test.ts`, `provider-bridge-extension.test.ts`, `pack-contributions.test.ts`, `extension-host-module-isolation.test.ts`, `extension-host-module-memory-isolation.test.ts`, `extension-host-no-capability-sandbox-residual.test.ts`, `extension-host-server-host-api.test.ts`; focused `tests2/core/host-interceptor-router.test.ts`. |
+| Browser notification delivery | `HostNotificationSocketRouter` sends canonical frames only to exact server-bound sockets; `RemoteAgent` feeds one bounded `host-notification-bus.ts`; scoped `host-api.ts` subscriptions consume it. `session-event-bus.ts` remains the rich byte-compatible legacy adapter. New client state is one generation-fenced bounded recent-ID set plus epoch/sequence state per mounted host; on mount/reconnect/gap/overflow it coalesces refresh and discards delta reconstruction. | Extend `session-event-bus.ts` or synthesize canonical/project facts from existing raw session frames. Those frames lack an exact project-scoped routing model and include rich message/tool bodies; reuse would couple the public privacy contract to raw transport, invite client filtering, and endanger legacy compatibility. | Production: `src/server/ws/protocol.ts`, `handler.ts`, `src/server/extension-host/host-notification-socket-router.ts`, `src/app/remote-agent.ts`, `host-api.ts`, `host-notification-bus.ts`, `session-event-bus.ts`, `src/shared/extension-host/host-api.ts`; existing `tests2/core/extension-host-session-event-bus.test.ts`, `extension-host-surface-binding.test.ts`, `tests2/integration/extension-host-surface-token.test.ts`; focused `tests2/dom/extension-host-notification-bus.test.ts` and browser reconnect/gap/isolation journey. |
+| Notification staff delivery | After canonical publication, `notification-staff-dispatcher.ts` matches catalogue selectors/filters and persists a per-project `NotificationDeliveryStore` row containing subscriber lease/identity state and the complete original bounded event. Its worker revalidates/freezes that event and calls `InboxManager.enqueueWithId`; `InboxStore.putStrict` is durable acceptance and `InboxNudger` remains wake owner. This is the sole new durable consumer state. Queue/insert failure never affects the source; transient leased rows retry, invalid/foreign/version-mismatched rows fail closed, and deterministic IDs close the inbox-ACK window. Legacy `GoalTriggerDispatcher`/`TriggerEngine` remain unchanged. | Add selector/filter/causation/lease logic to the legacy goal dispatcher/trigger engine. It mixes non-migrated legacy semantics with canonical notifications, still requires durable identity and the original event for restart, and risks double wakes. A `safeContext`-only row violates the shared contract; individually columnizing the envelope is viable but has greater omission/migration risk; a global journal is disproportionate (§12.2). | Production: `src/server/agent/notification-delivery-store.ts`, `notification-staff-dispatcher.ts`, `staff-store.ts`, `staff-manager.ts`, `inbox-manager.ts`, `inbox-store.ts`, with unchanged `goal-trigger-dispatcher.ts`, `staff-trigger-engine.ts`; existing `tests2/core/staff-trigger-engine.test.ts`, `goal-trigger-dispatcher.test.ts`, `inbox-manager.test.ts`, `inbox-store.test.ts`, `tests2/integration/staff-goal-triggers.test.ts`; focused `tests2/integration/notification-staff-dispatcher.test.ts`, `tests/e2e/notification-staff-restart.spec.ts`. |
+| Post-commit fanout/routing | Narrow callbacks from §5 authority owners submit allowlisted scalars after their strict commit/publication fence. One `HostNotificationDispatcher` validates, constructs, and freezes the envelope, then enqueues exact socket, ordered module, matching staff, and bounded diagnostic fanout. It owns bounded live queues only—no durable global event state—and never awaits consumer I/O in the source operation. Queue/send/handler failures are isolated and coded; browser gaps refresh, module delivery may drop, and only matched staff intents become durable. | Let every domain owner send browser/module/staff facts through existing broadcast helpers. That duplicates envelope construction, schema, privacy, ordering, and failure branches at every mutation; tempts unsafe `broadcastToProject`; and prevents one canonical post-commit contract from being tested. | Production: `src/server/extension-host/host-notification-dispatcher.ts`, `host-notification-socket-router.ts`, `src/server/agent/project-context.ts`, `project-context-manager.ts`, and every §5 domain owner file; focused `tests2/core/host-notification-dispatcher.test.ts`, `tests2/integration/host-notification-routing.test.ts`, privacy/post-commit boundary cases in §11, and `tests/e2e/host-notification-routing.spec.ts`. |
+
+### 12.2 Durable storage decision: selected subscriber outbox vs rejected full journal
+
+The component choices above do not imply durable global publication state. The alternative durable-global-journal design adds a notification database, stream heads, retention, aggregate reconciliation, catch-up scheduling, and journal-to-consumer cursors before it can deliver the same user-visible behavior. It improves recovery of a subset of post-commit facts but cannot make the source-store commit and journal insert atomic without either coupling every domain transaction to the journal or allowing notification infrastructure to fail/roll back the source. It therefore still has a commit-to-journal crash window while adding substantial state.
 
 | Surface | Selected: live dispatcher + staff outbox | Rejected: durable global journal | Consequence |
 |---|---|---|---|
-| Durable state owners | One per-project staff delivery store; existing inbox remains wake authority | Notification journal, stream-head table, staff-delivery table, retention/quarantine state, reconciler cursors, plus inbox | Selected adds only state required for the one durable consumer. |
-| Canonical notification storage | None; envelope exists for live fanout and safe fields are copied only into matching staff rows | Every envelope and aggregate revision persisted | Journal enlarges privacy/retention/migration surface for events browsers/modules do not replay. |
+| Durable state owners | One per-project staff delivery store; each matching row holds subscriber state and its original bounded canonical event; existing inbox remains wake authority | Notification journal, stream-head table, staff-delivery table, retention/quarantine state, reconciler cursors, plus inbox | Selected adds only state required for the one durable consumer. |
+| Canonical notification storage | Only a matching staff intent persists its complete validated event until bounded terminal-row compaction; unmatched/browser/module events are not history | Every emitted envelope and aggregate revision is persisted independently of a subscriber | The selected row is necessary to give asynchronous/restarted staff the shared contract. A journal enlarges privacy/retention/migration surface for events no consumer replays. |
 | Ordering state | Ephemeral per-connection sequence and per-project module queue | Durable publication sequence, stream heads, per-consumer cursors/leases | Selected provides required live ordering/gap refresh without pretending to be event sourcing. |
 | Crash before event persistence | Source remains committed; rare missed live fact/outbox diagnostic; consumers refresh state | Same unless every domain transaction shares journal transaction; reconciler can only infer current/terminal state | Journal cannot reconstruct unknowable intermediate facts, so its stronger guarantee is partial. |
 | Crash after staff intent | Pending/expired lease reconciles; deterministic inbox ID closes ACK window | Journal delivery row reconciles similarly | Both meet staff restart needs; global notification rows add no benefit to this path. |
 | Browser reconnect | Snapshot refresh, no replay | Design still requires snapshot refresh because deltas may be sensitive/incomplete and client state may be stale | Durable journal is unused for the required browser correctness model. |
 | Module restart | Best-effort observation; module reads snapshots | Could replay, but activation/grant/config may differ and replay semantics require durable per-handler cursors | Goal asks observational asynchronous handlers, not historical processors. Replay adds semantic ambiguity. |
 | Project isolation | Server-bound live router + project-owned outbox | Same plus journal query authorization and partition correctness | Journal adds another cross-project read boundary. |
-| Schema migration | Shared catalogue and compact staff-row schema | Catalogue plus persisted envelope versions, migrations, compatibility readers, quarantine | Full journal makes every payload version a storage migration concern. |
+| Schema/version handling | Shared catalogue plus version-aware validation of bounded events in matching staff rows; invalid/unsupported rows fail closed or quarantine per-row | Catalogue plus migrations, compatibility readers, and quarantine for every emitted journal event and every consumer cursor | Staff needs bounded version handling either way; a full journal makes all payload versions and historical events a storage migration concern. |
 | Retention/deletion | Terminal outbox rows can be compacted after bounded audit TTL | Must coordinate journal TTL with all consumer cursors, unresolved deliveries, project deletion, privacy policy | More cleanup branches and stuck-row modes. |
 | Corruption handling | Quarantine/fail one staff row/store; browser/modules unaffected | Journal corruption can block fanout order, replay, staff scanning, and stream heads | Larger blast radius. |
 | Backpressure | Bounded live queues may drop and force refresh; outbox is durable only for staff | Durable journal queue can grow without bound unless retention/cursors are correct | Selected failure behavior matches consumer guarantees explicitly. |
 | Source coupling | Narrow post-commit callback | Post-commit append at every source plus reconciliation readers for every aggregate | Journal creates a second representation of domain history. |
 | Aggregate revisions | Only catalogue-required revision sources; one small gate revision addition | Durable revisions/cursors must be added consistently to all aggregates for reconciliation | Full journal forces more new state and forgotten-writer risk. |
 | APIs | Two notification namespaces, explicit hook kind, internal staff rows | Same plus journal read/replay/admin/maintenance APIs even if initially hidden | Hidden operational APIs still require security/testing. |
-| Testing | Boundaries, live gaps/refresh, module isolation, staff crash window | All selected tests plus migrations, journal atomicity, replay order, cursor leases, TTL, compaction, quarantine, reconciliation | Materially larger verification matrix with no acceptance gain. |
+| Testing | Boundaries, live gaps/refresh, module isolation, byte-equivalent staff event/inbox metadata, privacy sentinels, and staff crash window | All selected tests plus global migrations, journal atomicity, replay order, cursor leases, TTL, compaction, quarantine, reconciliation | Materially larger verification matrix with no acceptance gain. |
 | Operational claims | Honest live best-effort + durable staff intent/idempotent acceptance | Tempts exactly-once/event-log claims that cross-store transactions cannot satisfy | Selected contract is smaller and accurate. |
 
 Unavoidable selected additions are limited to:

--- a/docs/extension-host-authoring.md
+++ b/docs/extension-host-authoring.md
@@ -123,12 +123,13 @@ auto-discovered from `panels/*.yaml`).
 name: artifacts
 description: "Search tool + artifact viewer."
 version: 1.0.0
+schema: 2                                # required for channels and lifecycle hooks
 contents:
   roles:       []
   tools:       [artifact_demo]          # tools/<group> dir names
   skills:      []
   channels:    []                       # channels/<name>.yaml basenames; schema 2
-  hooks:       [turn-audit]             # hooks/<name>.yaml basenames; schema 2, metadata only
+  hooks:       [turn-audit]             # hooks/<name>.yaml basenames; explicit kind makes it runtime-eligible
   entrypoints: [artifacts-deeplink]     # entrypoints/<name>.yaml basenames; toggleable
 routes:                                 # optional top-level block
   module: lib/routes.mjs                # relative to pack.yaml; contained in pack root
@@ -145,8 +146,8 @@ Rules:
   channel names within a pack are rejected.
 - **`contents.hooks: string[]`** — schema-2 lifecycle-hook basenames under
   `hooks/<name>.yaml` (with `.yml` accepted as a fallback). An unlisted file is never
-  read. See [Lifecycle hooks](#lifecycle-hooks-hooksnameyaml--schema-2) for the declaration
-  contract and explicit runtime opt-in.
+  read. See [Unified Extension Host hooks](host-hooks.md#authoring-runtime-hook-contributions)
+  for the declaration contract and explicit runtime opt-in.
 - **`contents.panels` does not exist** — panels are auto-discovered from `panels/*.yaml`. They
   are support surfaces, not activation points, so there is nothing to list or toggle.
 - **`routes: { module?, names? }`** (optional, top-level) — when present, the pack contributes
@@ -1451,10 +1452,14 @@ Full behavior, diagnostics, Docker remapping, and trust details: [Marketplace pi
 
 ### Lifecycle hooks (`hooks/<name>.yaml`) — schema 2
 
-A hook declaration becomes executable only with an explicit `kind`:
+A hook declaration becomes runtime-eligible only with an explicit `kind`:
 
 - `kind: interceptor` participates before Bobbit commits an operation and returns a typed proposal;
 - `kind: notification` observes a canonical fact after Bobbit commits it.
+
+A kind does not invoke the hook by itself. The declaration executes only when it is listed in
+`contents.hooks`, currently active, selected for the canonical boundary, and authorized by live
+grant checks. Installation and indexing alone never call a handler.
 
 Copyable YAML and module examples, the canonical catalogues, failure policies, delivery guarantees,
 and privacy rules live in [Unified Extension Host hooks](host-hooks.md). Keep that page open while

--- a/docs/extension-host-authoring.md
+++ b/docs/extension-host-authoring.md
@@ -3,7 +3,7 @@
 This guide walks through making a **marketplace pack** that contributes Extension Host
 surfaces — a chat-block **renderer**, an interactive **server action handler**, side
 **panels**, long-lived **channels**, pack-owned **routes**, non-chat **entrypoints**, implicit
-pack-scoped **stores**, and **session** access. By the end you will understand every
+pack-scoped **stores**, **session** access, and lifecycle **hooks**. By the end you will understand every
 contribution point, *where each one is declared on disk*, and the one mediated **Host API**
 they all flow through — with no privileged escape hatch.
 
@@ -29,7 +29,7 @@ This guide is the practical how-to.
 - [docs/design/extension-host.md](design/extension-host.md) — the contribution-point model, two-host architecture, the frozen Host API, the security guard sequence, the adapter layer, and the isolation model. The *why* and the contract. (Its per-tool schema examples predate V1 — read them through [pack-schema-v1-rationalisation.md](design/pack-schema-v1-rationalisation.md).)
 - [docs/design/extension-channels-host-channels.md](design/extension-channels-host-channels.md) and [docs/design/extension-channels-terminal-ux.md](design/extension-channels-terminal-ux.md) — the design record for generic channels and the first-party terminal pack.
 
-**Status:** renderers, actions, panels, channels, routes, entrypoints, implicit stores, session access, and worker isolation are all **implemented**. `HOST_API_VERSION` is `1`; `HOST_CONTRACT_VERSION` is `4`; `host.capabilities` reports all flags `true` on a current host.
+**Status:** renderers, actions, panels, channels, routes, entrypoints, implicit stores, session access, unified lifecycle hooks, and worker isolation are all **implemented**. `HOST_API_VERSION` is `1`; `HOST_CONTRACT_VERSION` is `5`. Feature-detect individual optional capabilities such as `sessionNotifications` and `projectNotifications` through `host.capabilities`.
 
 The renderer+action working example lives at `tests/fixtures/market-sources/retry-demo-src/retry-demo/`; the full pack-scoped surface set is exercised by `market-packs/artifacts/` (a tool + panel + deep-link pack), `market-packs/pr-walkthrough/` (a first-party tool + role + panel + route + entrypoint pack), `market-packs/terminal/` (the first-party xterm terminal over `host.channels`), and no-tools fixture packs such as `tests/fixtures/market-sources/no-tools-pack-src/no-tools-pack/`.
 
@@ -45,7 +45,7 @@ The renderer+action working example lives at `tests/fixtures/market-sources/retr
 | **Entrypoints** | `entrypoints/<ep>.yaml` (listed in `contents`) | Browser (launchers + deep-link routes) | `host.ui.navigate` / `openPanel` |
 | **Pack store** | *implicit* — no declaration | Gateway | `host.store.{get,read,put,list,delete,deletePrefix,stats}` (pack-namespaced; `read` returns a tri-state durable-read outcome, while `get` is legacy and lossy) |
 | **Providers** *(schema 2; all hooks wired via the Lifecycle Hub)* | `providers/<id>.yaml` (listed in `contents.providers`) | Server (Lifecycle Hub, worker tier) | default-export hook object — see [docs/lifecycle-hub.md](lifecycle-hub.md) |
-| **Hook metadata** *(schema 2; inert)* | `hooks/<name>.yaml` (listed in `contents.hooks`) | Registry metadata only | Does not load the module or create a runtime surface |
+| **Lifecycle hooks** *(schema 2)* | `hooks/<name>.yaml` (listed in `contents.hooks`) | Gateway worker tier | Explicit `kind: interceptor` participates before authority; `kind: notification` observes canonical committed facts. Kindless legacy declarations remain inert. See [Unified Host hooks](host-hooks.md). |
 | **Standalone pi extensions** *(schema 2; not Extension Host surfaces)* | `pi-extensions/<id>/` or `pi-extensions/<id>.ts/.js/.mjs/.cjs` (listed in `contents.pi-extensions`) | Agent runtime via pi `--extension` | Plain pi extension API — see [Marketplace pi extensions](marketplace.md#marketplace-pi-extensions) |
 
 Plus the cross-cutting `host.session.*` (transcript reads, agent-driving posts, live events)
@@ -98,7 +98,7 @@ A pack is a directory with a `pack.yaml` plus an entity payload. The full V1 lay
   channels/<name>.yaml            # pack-scoped long-lived channel handlers (listed in contents.channels)
   entrypoints/<ep>.yaml           # pack-scoped launcher/deep-link definitions, one file each
   providers/<id>.yaml             # schema-2 provider contributions (listed in contents.providers; dispatched via the Lifecycle Hub)
-  hooks/<name>.yaml               # schema-2 inert hook metadata (listed in contents.hooks)
+  hooks/<name>.yaml               # schema-2 runtime hooks with explicit kind; kindless legacy metadata is inert
   pi-extensions/<id>/             # schema-2 standalone pi extensions (listed in contents.pi-extensions)
   pi-extensions/<id>.ts           # or a single .ts/.js/.mjs/.cjs entry module
   lib/                            # shared implementation modules, NOT entities
@@ -143,10 +143,10 @@ Rules:
 - **`contents.channels: string[]`** — schema-2 channel contribution basenames under
   `channels/<name>.yaml`. A channel file not listed here is not loaded, and duplicate
   channel names within a pack are rejected.
-- **`contents.hooks: string[]`** — schema-2 hook metadata basenames under
+- **`contents.hooks: string[]`** — schema-2 lifecycle-hook basenames under
   `hooks/<name>.yaml` (with `.yml` accepted as a fallback). An unlisted file is never
-  read. See [Hook metadata](#hook-metadata-hooksnameyaml--schema-2-inert) for the strict
-  declaration contract and its intentionally non-runtime boundary.
+  read. See [Lifecycle hooks](#lifecycle-hooks-hooksnameyaml--schema-2) for the declaration
+  contract and explicit runtime opt-in.
 - **`contents.panels` does not exist** — panels are auto-discovered from `panels/*.yaml`. They
   are support surfaces, not activation points, so there is nothing to list or toggle.
 - **`routes: { module?, names? }`** (optional, top-level) — when present, the pack contributes
@@ -1449,87 +1449,31 @@ Author-facing rules:
 
 Full behavior, diagnostics, Docker remapping, and trust details: [Marketplace pi extensions](marketplace.md#marketplace-pi-extensions).
 
-### Hook metadata (`hooks/<name>.yaml`) — schema 2; inert
+### Lifecycle hooks (`hooks/<name>.yaml`) — schema 2
 
-**Status:** a `schema: 2` pack can declare hook **metadata** in the same pack-contribution
-registry used by panels, entrypoints, providers, and channels. This is an indexing seam for a
-future runtime contract, not a hook runtime: it lets tooling inspect a stable declaration without
-making the declaration operational. Schema-1 packs, and schema-2 packs with no `contents.hooks`,
-produce an empty hook list and otherwise keep their existing behavior.
+A hook declaration becomes executable only with an explicit `kind`:
 
-Declare each file by basename in `pack.yaml`; only listed files are considered:
+- `kind: interceptor` participates before Bobbit commits an operation and returns a typed proposal;
+- `kind: notification` observes a canonical fact after Bobbit commits it.
 
-```yaml
-# pack.yaml
-schema: 2
-contents:
-  roles: []
-  tools: []
-  skills: []
-  hooks: [turn-audit]
-```
+Copyable YAML and module examples, the canonical catalogues, failure policies, delivery guarantees,
+and privacy rules live in [Unified Extension Host hooks](host-hooks.md). Keep that page open while
+authoring; `src/shared/extension-host/host-hooks.ts` is the final runtime/type source of truth.
 
-```yaml
-# hooks/turn-audit.yaml
-id: audit.turn
-module: ../lib/audit-turn.mjs
-# One or more distinct events from the supported set.
-events: [beforePrompt, afterTurn]
-mode: observe
-# Required; an empty list is also valid.
-capabilities: [store, session]
-budget:
-  maxTokens: 1200
-  timeoutMs: 1000
-# Opaque declaration metadata, retained verbatim when it is a mapping.
-config:
-  label: Turn audit
-activation:
-  requiresConfig: [auditEndpoint]
-```
+Only basenames listed in `contents.hooks` load. Hook IDs are stable and pack-local. Modules resolve
+relative to the hook YAML and must remain inside the pack root. Declared names and notification
+scope/name pairs must be canonical and duplicate-free. Optional `capabilities`, `budget`, `config`,
+and `activation.requiresConfig` use the same strict loader and registry activation path as other
+pack contributions.
 
-The declaration fields are strict:
+Runtime ordering follows winning packs from low to high precedence and then declaration/name order.
+The host checks current activation and grants before invocation and again before applying an
+interceptor result or acknowledging module settlement. Workers have bounded deadlines and are
+cancelled on invalidation. Notification return values are ignored.
 
-- **`id`** is a stable pack-local identifier matching
-  `^[a-z0-9][a-z0-9_.-]*$` case-insensitively. It must be unique within the pack. The same
-  id in separate packs is valid because hook identity is `(packId, hook.id)`.
-- **`module`** is a non-empty relative path from the hook YAML. It must resolve within the
-  pack root after realpath-aware containment checks; absolute, syntactically unsafe, and
-  pack-escaping paths reject the pack.
-- **`events`** is required, non-empty, and duplicate-free. Supported values are
-  `sessionSetup`, `beforePrompt`, `afterTurn`, `beforeCompact`, `sessionShutdown`, and
-  `goalProvisioned`.
-- **`mode`** is required and is exactly `observe` or `decide`.
-- **`capabilities`** is required and duplicate-free. Its only values are `store`, `session`,
-  and `agents`; `[]` is valid. These are descriptive metadata only and do not confer access.
-- **`budget`** is optional. An omitted or non-mapping `budget`, and each missing, non-numeric,
-  or non-finite field, falls back independently to `maxTokens: 1600` and `timeoutMs: 1500`.
-  Finite numeric values are then clamped: `maxTokens` to `64..8192` and `timeoutMs` to
-  `100..10000`.
-- **`config`**, when present, must be a mapping and is retained verbatim. **`activation`**,
-  when present, must be a mapping containing no keys other than optional `requiresConfig`.
-  That value, when present, is a non-empty, duplicate-free array of non-empty strings.
-
-Basenames must be safe pack-local names. The loader resolves `hooks/<basename>.yaml`, then
-`hooks/<basename>.yml`, and never scans the directory. A malformed YAML file or invalid field
-emits a warning and drops only that declaration, so valid siblings and unrelated packs remain
-available. Repeating a manifest basename, repeating a valid hook id within one pack, or using an
-unsafe/escaping module path is an ambiguous or unsafe hard conflict: that winning pack is rejected.
-
-`PackContributionRegistry.listHooks(projectId)` returns the normalized metadata in stable order:
-winning packs from low to high precedence, then each pack's manifest order. When multiple installed
-packs have the same structural `packId`, only the highest-precedence pack is loaded; lower-precedence
-copies are shadowed before their hook files are read.
-
-The existing `pack_activation.hooks` disabled-reference array uses the manifest basename
-(`listName`). After registry invalidation, a disabled reference removes that declaration from both
-the pack contribution and `listHooks`; clearing the reference restores it. This filtering does not
-inspect `config` or `activation`.
-
-**Non-runtime boundary.** Loading or listing hook metadata does not import the `module`, execute
-code, dispatch an event, establish authorization, evaluate `config` or `activation`, start timers,
-mutate state, or register a UI surface. It creates no executable hook registration. Authors must
-not rely on a hook file for any runtime behavior in this release.
+A kindless legacy declaration using `events` plus `mode: observe | decide` remains listable metadata
+but is deliberately inert. Bobbit does not silently activate old files during upgrade. Existing
+`providers/*.yaml` remain the compatibility runtime for Lifecycle Hub context hooks.
 
 ### Providers (`providers/<id>.yaml`) — schema 2; `sessionSetup` wired into sessions
 
@@ -1625,7 +1569,7 @@ providers. Accepted blocks are wrapped in a `<context-block id=… source=… au
 reason=…>` envelope (attribute values are newline-stripped and `"`-escaped). Full algorithm and
 trace details: [docs/lifecycle-hub.md](lifecycle-hub.md).
 
-### `host.session.*` — transcript reads, posts, and live events
+### `host.session.*` and `host.project.notifications` — reads, posts, and live facts
 
 Reads are **own-session-scoped**; writes require a **genuine user gesture + a server-minted
 permit**.
@@ -1637,8 +1581,15 @@ const env = await host.session.readTranscript({ offset: 0, limit: 50, pattern: "
 const call = await host.session.readToolCall(toolUseId);
 //   → ToolCallRecord | null
 
-// LIVE EVENTS (typed; returns an unsubscribe fn):
+// LEGACY LIVE EVENTS (typed; returns an unsubscribe fn):
 const off = host.session.subscribe("tool_result", ({ record }) => { /* … */ });
+
+// CANONICAL COMMITTED FACTS (Host contract v5):
+const offStatus = host.session.notifications.subscribe("statusChanged", (event) => {
+  console.log(event.payload.status, event.aggregate.revision);
+});
+const offGoal = host.project.notifications.subscribe("goalUpdated", () => refreshGoals());
+const offGap = host.project.notifications.onRefreshRequired(() => refreshGoals());
 
 // WRITE — drives the agent. MUST be called from a real user gesture:
 await host.session.postMessage({ role: "user", text: "re-run the tests", resumeTurn: true });
@@ -1653,6 +1604,11 @@ await host.session.postMessage({ role: "user", text: "re-run the tests", resumeT
   session WebSocket path and carries a one-time, content-bound, server-minted permit —
   captured/replayed/forged/tampered posts are rejected server-side.
 - **Cross-session posting is impossible** — the target is the WS connection's own session.
+- **Canonical notifications are snapshot invalidations, not replay.** Session facts are bound to
+  this session; project facts are bound to its server-resolved project with no client-supplied ID.
+  Mount, reconnect, stream gaps, and pressure call `onRefreshRequired`; re-read the authoritative
+  snapshot instead of reconstructing state from event history. Subscription cleanup functions are
+  idempotent. See [Unified Host hooks](host-hooks.md#browser-host-api).
 
 ### `host.agents` — launch and orchestrate child agents
 
@@ -2072,6 +2028,8 @@ sandbox/read-only enforcement. As an author, your obligations are:
 - [ ] **Never build a URL or hash string** — `host.ui.openPanel` / `host.ui.navigate` take structured `{ panelId | route, params }` targets.
 - [ ] **No post / navigate / action / surprising process start on mount** — `host.session.postMessage` requires a real user gesture; actions/navigations/process-like channel opens should be user-driven UX, even though channel authorization is scoped declaration + one-shot permit rather than launcher activation.
 - [ ] **Never supply a pack id, `tool`, token, or transport to a scoped call** — pack identity is server-derived from the surface-binding token held in the Host API closure.
+- [ ] **Choose hook authority correctly** — use an interceptor only to participate before commit; use a notification to observe an immutable committed fact. Never treat a notification return value as an applied mutation.
+- [ ] **Refresh rather than replay notifications** — subscribe to `onRefreshRequired`, read the authoritative snapshot on mount/reconnect/gap, and use idempotent teardown functions.
 - [ ] **Declare channels in `contents.channels` + `channels/<name>.yaml`** — `host.channels.open` succeeds only for the calling pack's declared channels; do not use routes as streaming transports.
 - [ ] **Treat `openGrant` as protocol integrity, not user authority** — Bobbit-owned code mints/consumes it from a validated surface token + declared channel; missing/expired/replayed/mismatched permits fail closed.
 - [ ] **Handle channel backpressure and close events** — every `open`/`attach`/`send`/`close` promise can reject, and `onClose` is the lifecycle source of truth.

--- a/docs/extension-host-authoring.md
+++ b/docs/extension-host-authoring.md
@@ -1656,6 +1656,13 @@ handler that already started is not aborted by registry invalidation: it remains
 deadline, its return value is ignored, and the host detects revocation at settlement. Its settlement
 cannot affect other handlers or roll back the already-published source fact.
 
+For a session-scoped notification handler, declared `ctx.host.session` and `ctx.host.agents`
+capabilities remain feature-detectable but are live-authorized against the source session and the
+project captured for the handler. Each operation checks before work and after asynchronous
+settlement. Moving the session to another project therefore makes later operations fail, withholds
+an in-flight read/result, and best-effort dismisses a child whose spawn raced the move. The handler
+may finish its own bounded computation, but it cannot carry old-project session authority forward.
+
 A kindless legacy declaration using `events` plus `mode: observe | decide` remains listable metadata
 but is deliberately inert. Bobbit does not silently activate old files during upgrade. Existing
 `providers/*.yaml` remain the compatibility runtime for Lifecycle Hub context hooks.
@@ -1792,9 +1799,11 @@ await host.session.postMessage({ role: "user", text: "re-run the tests", resumeT
 - **Cross-session posting is impossible** — the target is the WS connection's own session.
 - **Canonical notifications are snapshot invalidations, not replay.** Session facts are bound to
   this session; project facts are bound to its server-resolved project with no client-supplied ID.
-  Mount, reconnect, stream gaps, and pressure call `onRefreshRequired`; re-read the authoritative
-  snapshot instead of reconstructing state from event history. Subscription cleanup functions are
-  idempotent. See [Unified Host hooks](host-hooks.md#browser-host-api).
+  Mount, a server-observed session project move, reconnect, stream gaps, and pressure call
+  `onRefreshRequired`; re-read the authoritative snapshot instead of reconstructing state from
+  event history. On a move, the server rebinds the live socket and suppresses project deltas until
+  that refresh, so the next read must use the destination project's authoritative state.
+  Subscription cleanup functions are idempotent. See [Unified Host hooks](host-hooks.md#browser-host-api).
 
 ### `host.agents` — launch and orchestrate child agents
 

--- a/docs/extension-host-authoring.md
+++ b/docs/extension-host-authoring.md
@@ -1473,8 +1473,11 @@ pack contributions.
 
 Runtime ordering follows winning packs from low to high precedence and then declaration/name order.
 The host checks current activation and grants before invocation and again before applying an
-interceptor result or acknowledging module settlement. Workers have bounded deadlines and are
-cancelled on invalidation. Notification return values are ignored.
+interceptor result. Registry invalidation removes a disabled hook from future selection. It also
+aborts an in-flight interceptor dispatch, whose result cannot apply. An observational notification
+handler that already started is not aborted by registry invalidation: it remains bounded by its
+deadline, its return value is ignored, and the host detects revocation at settlement. Its settlement
+cannot affect other handlers or roll back the already-published source fact.
 
 A kindless legacy declaration using `events` plus `mode: observe | decide` remains listable metadata
 but is deliberately inert. Bobbit does not silently activate old files during upgrade. Existing

--- a/docs/host-hooks.md
+++ b/docs/host-hooks.md
@@ -81,8 +81,8 @@ Each publisher calls the shared dispatcher only after the named authority bounda
 | `turnStarted` | Session manager accepted the canonical `agent_start`. | `turnIndex` |
 | `turnCompleted` | Session manager accepted the final non-retrying `agent_end`. | completed turn index |
 | `messageAppended` | Session event owner accepted `message_end` into the event buffer. | event-buffer cursor |
-| `toolCallStarted` | Session manager admitted tool execution. | tool-call start cursor |
-| `toolCallCompleted` | The post-policy result `message_end` was accepted. | result-message cursor |
+| `toolCallStarted` | A current-writer Pi `tool_execution_start` entered the session event buffer, the exact callback claimed its cursor, and permission plus `beforeToolCall` settled as admitted. | accepted start-event cursor |
+| `toolCallCompleted` | The admitted call reached `tool_execution_end` only after post-result policy, then its matching post-policy tool-result `message_end` entered the event buffer. | accepted result-message cursor |
 | `sessionCreated` | Strict session persistence succeeded. | persisted session `updatedAt` |
 | `sessionArchived` | Asynchronous session-store archive committed. | persisted `archivedAt` |
 | `sessionForked` | Destination history/session materialisation completed. | destination session `updatedAt` |
@@ -195,6 +195,8 @@ export default {
 
 Notification handlers receive the same frozen canonical envelope as browsers and staff triggers. They run asynchronously after publication, in deterministic order, with bounded deadlines and live activation/grant checks. Return values are ignored. Throws, timeouts, revocation, and diagnostics are isolated from both other handlers and the already-committed source operation.
 
+A session-scoped handler's `ctx.host.session` and `ctx.host.agents` capabilities are also fenced to the source session's captured project. Every operation revalidates current host-owned session authority before work and after asynchronous settlement. If that session moves projects while the handler is running, transcript and agent results are withheld; a child minted during the race is best-effort dismissed before the call fails. The observational handler itself may continue until its deadline, but its old-project capabilities cannot cross the move.
+
 ### Interceptor catalogue
 
 | Name | Result | Deadline: default / max / whole dispatch | Authority and failure behavior |
@@ -249,7 +251,9 @@ offRefresh();
 
 `host.session.notifications` is bound to the panel's current session. `host.project.notifications` is bound to that session's server-resolved project and accepts no client-supplied project ID. The server routes session facts only to the exact authenticated session socket and project facts only to authenticated app sockets in the same project. Sandbox principals and unbound/viewer sockets do not receive this Host API stream.
 
-Delivery is ordered and live per connection, not durable replay. `onRefreshRequired` schedules one initial snapshot read when registered and coalesces reconnect, epoch change, sequence gap, queue overflow, and burst invalidations. A discontinuous event is not applied as a delta. Always re-read the authoritative snapshot on mount or refresh-required; do not reconstruct state from notification history.
+The server revalidates the socket's authentication-time binding against current live and persisted session authority before every delta and refresh. When a session moves projects, the frame that discovers the move is suppressed, the socket is rebound, and old- and new-project deltas remain fenced behind one project `onRefreshRequired` callback. The panel must then read the destination project's authoritative snapshot. Missing or conflicting live/persisted authority unbinds the socket and fails closed rather than selecting a project.
+
+Delivery is ordered and live per connection, not durable replay. `onRefreshRequired` schedules one initial snapshot read when registered and coalesces project moves, reconnect, epoch change, sequence gap, queue overflow, and burst invalidations. A discontinuous event is not applied as a delta. Always re-read the authoritative snapshot on mount or refresh-required; do not reconstruct state from notification history.
 
 The legacy `host.session.subscribe("status" | "message" | "tool_result", handler)` remains available and unchanged. It is a separate adapter over rich session events, not a source for canonical notifications.
 
@@ -281,13 +285,16 @@ Pausing/retiring staff or disabling/deleting a trigger cancels pending work. Bou
 
 Notification input is not interpolated into prompt text. The inbox stores it as host-owned metadata and emits a generic wake prompt. Browser/operator inbox lists and WebSocket events return a redacted entry with `notificationInput`, root correlation, and causation depth removed. Only the exact live owning staff session may read or transition a notification entry with full metadata, authenticated by its gateway-issued `BOBBIT_SESSION_SECRET` sent as `X-Bobbit-Session-Secret`. The server resolves that secret to the live staff session and verifies staff and project ownership; bearer/cookie auth, public session IDs, request bodies, and client project claims are insufficient. The secret is per-session, in-memory, injected only into the owning process, and regenerated when a gateway restart respawns that process. Same-project sandbox sessions retain the existing shared-container, same-UID `/proc` residual risk; stronger isolation requires per-session containers.
 
+For Pi tool-hook callbacks, that exact-session secret authenticates only the callback transport. Lifecycle authority comes separately from a current-writer Pi execution event accepted at a host-owned cursor. Each matching `{ session generation, toolCallId, toolName, phase }` claim is single-use. A missing or forged secret is rejected before body processing; forged, duplicate, mismatched, terminal, or stale-generation callbacks cannot invoke an interceptor, publish a tool fact, or admit downstream staff delivery.
+
 See [Staff triggers](staff-triggers.md) for legacy trigger compatibility and [Staff inbox](staff-inbox.md) for the redacted/full read surfaces.
 
 ## Publication and delivery guarantees
 
 - Publication occurs after each catalogue definition's authoritative persistence/publication boundary. Consumer failure is observational and cannot roll back the mutation.
 - `turnCompleted` is emitted only at the final non-retrying terminal boundary. Retry attempts, duplicate/late terminal frames, and restore replay cannot emit another completion. Errored and aborted turns remain explicit outcomes.
-- Tool completion order is: handler result → protected `afterToolResult` policy → approved or synthetic result persisted/published → `toolCallCompleted`. Only safe post-policy metadata enters the event.
+- Tool start order is: current-writer Pi `tool_execution_start` observed → start accepted at an event-buffer cursor → Pi permission guard → exact one-use callback claim → `beforeToolCall` → admitted settlement → `toolCallStarted` → handler. A blocked or provenance-invalid call publishes no start fact.
+- Tool completion order is: handler result/error → bridge callback attempts the exact admitted-call claim → protected `afterToolResult` policy or its host-owned transport fallback → approved, replaced, preserved original error, or synthetic result returned to Pi → matching current-writer `tool_execution_end` classification → post-policy tool-result `message_end` accepted/published → `messageAppended` → `toolCallCompleted`. Only safe post-policy metadata enters the completion event.
 - `goalCompleted` is a durable completion transition with a stable revision and is distinct from `goalArchived`.
 - `settingsChanged` follows atomic settings commit and carries only the committed revision plus bounded target/key identifiers, never values or secrets.
 - Browser and module delivery are bounded, live, ordered per project, and best-effort. Browser pressure produces refresh-required; module pressure produces bounded diagnostics.

--- a/docs/host-hooks.md
+++ b/docs/host-hooks.md
@@ -1,0 +1,305 @@
+# Unified Extension Host hooks
+
+Bobbit Extension Host hooks let installed packs participate in lifecycle operations or observe committed facts without inventing pack-specific event contracts.
+
+Use the two hook kinds for different jobs:
+
+- **Interceptor** — participate before Bobbit commits an operation. Bobbit awaits the handler, validates its typed proposal, and remains the only authority that can apply it.
+- **Notification** — observe an immutable fact after Bobbit commits the authoritative change. A handler cannot delay, alter, or roll back the source operation.
+
+Legacy Lifecycle Hub providers remain supported for ambient context. New code should use an explicit hook `kind`; a kindless `{ events, mode }` declaration remains inert compatibility metadata. See [Lifecycle Hub](lifecycle-hub.md) for the provider adapter and [the design record](design/unified-host-hooks.md) for alternatives and ownership decisions.
+
+## Canonical contract
+
+The shared catalogue in `src/shared/extension-host/host-hooks.ts` is the runtime and TypeScript source of truth for hook names, schemas, limits, filter fields, publication boundaries, revisions, privacy, and eligible consumers. Server publishers, browser APIs, observational modules, and staff triggers do not maintain parallel event definitions.
+
+A notification has this readonly, host-constructed shape:
+
+```ts
+interface HostNotification<Name extends HostNotificationName> {
+  readonly id: string;
+  readonly scope: "session" | "project";
+  readonly name: Name;
+  readonly payloadVersion: number;
+  readonly occurredAt: number;
+  readonly projectId: string;
+  readonly sessionId?: string;
+  readonly aggregate: {
+    readonly kind: string;
+    readonly id: string;
+    readonly revision: string | number;
+  };
+  readonly correlationId?: string;
+  readonly causationId?: string;
+  readonly payload: Readonly<HostNotificationPayload<Name>>;
+}
+```
+
+The host copies, validates, and deeply freezes the envelope before fanout. Extensions cannot choose its identity, scope, project/session binding, aggregate revision, timestamp, or correlation fields.
+
+### Notification catalogue
+
+Payloads are bounded metadata projections. The **Filters** column lists the only payload fields a notification-based staff trigger may match.
+
+| Scope and name | Payload | Filters |
+|---|---|---|
+| session `statusChanged` | `previousStatus`, `status`, `statusVersion` | `status` |
+| session `turnStarted` | `turnIndex`, `source` | `source` |
+| session `turnCompleted` | `turnIndex`, `outcome`, `durationMs`, `hadToolCalls` | `outcome`, `hadToolCalls` |
+| session `messageAppended` | `messageId`, `cursor`, `role`, `blockKinds` | `role` |
+| session `toolCallStarted` | `toolCallId`, `toolName`, `turnIndex` | `toolName` |
+| session `toolCallCompleted` | `toolCallId`, `toolName`, `status`, `durationMs`, optional `errorStatus` | `toolName`, `status`, `errorStatus` |
+| project `sessionCreated` | `sessionId`, `kind`, optional `goalId` | `kind` |
+| project `sessionArchived` | `sessionId`, `reason` | `reason` |
+| project `sessionForked` | `sourceSessionId`, `sessionId`, optional `cutEntryId`, `forkMode` | `forkMode` |
+| project `sessionStatusChanged` | `sessionId`, `previousStatus`, `status`, `statusVersion` | `status` |
+| project `staffCreated` | `staffId`, `state`, optional `sessionId` | `state` |
+| project `staffConfigChanged` | `staffId`, `changedFields` | — |
+| project `staffRetired` | `staffId` | — |
+| project `staffSessionChanged` | `staffId`, optional previous/current session IDs | — |
+| project `goalCreated` | `goalId`, optional `parentGoalId`, `state` | `state` |
+| project `goalUpdated` | `goalId`, `state`, `changedFields` | `state` |
+| project `goalCompleted` | `goalId`, optional `parentGoalId` | — |
+| project `goalArchived` | `goalId` | — |
+| project `taskCreated` | `taskId`, `goalId`, `type`, `state`, optional `parentTaskId` | `type`, `state` |
+| project `taskUpdated` | `taskId`, `goalId`, `state`, `changedFields` | `state` |
+| project `taskStateChanged` | `taskId`, `goalId`, `previousState`, `state` | `previousState`, `state` |
+| project `gateStatusChanged` | `gateId`, `goalId`, `previousStatus`, `status` | `status` |
+| project `pullRequestStatusChanged` | `goalId`, optional `number`, `state`, `reviewDecision`, `mergeability` | `state`, `reviewDecision`, `mergeability` |
+| project `settingsChanged` | `target`, `changedKeys` | `target` |
+
+`toolCallCompleted` is session-scoped even when a project staff agent consumes it. A selector with project scope is invalid.
+
+### Authoritative publication boundaries
+
+Each publisher calls the shared dispatcher only after the named authority boundary. The
+`aggregate.revision` value comes from the source in the last column.
+
+| Notification | Post-authority boundary | Revision source |
+|---|---|---|
+| `statusChanged` | Session status owner queued the legacy status frame. | `statusVersion` |
+| `turnStarted` | Session manager accepted the canonical `agent_start`. | `turnIndex` |
+| `turnCompleted` | Session manager accepted the final non-retrying `agent_end`. | completed turn index |
+| `messageAppended` | Session event owner accepted `message_end` into the event buffer. | event-buffer cursor |
+| `toolCallStarted` | Session manager admitted tool execution. | tool-call start cursor |
+| `toolCallCompleted` | The post-policy result `message_end` was accepted. | result-message cursor |
+| `sessionCreated` | Strict session persistence succeeded. | persisted session `updatedAt` |
+| `sessionArchived` | Asynchronous session-store archive committed. | persisted `archivedAt` |
+| `sessionForked` | Destination history/session materialisation completed. | destination session `updatedAt` |
+| `sessionStatusChanged` | Session status owner queued the legacy status frame. | `statusVersion` |
+| `staffCreated` | Staff creation was durably accepted. | staff `updatedAt` |
+| `staffConfigChanged` | Strict staff update committed. | staff `updatedAt` |
+| `staffRetired` | Strict retirement commit succeeded. | staff `updatedAt` |
+| `staffSessionChanged` | Current staff session committed strictly. | staff `updatedAt` |
+| `goalCreated` | Strict goal publication succeeded. | goal `updatedAt` |
+| `goalUpdated` | Strict goal update publication succeeded. | goal `updatedAt` |
+| `goalCompleted` | Goal manager durably published the completion transition. | goal `updatedAt` |
+| `goalArchived` | Strict archive publication succeeded. | goal `archivedAt` |
+| `taskCreated` | Task manager strictly published creation. | task `updatedAt` |
+| `taskUpdated` | Task manager strictly published the update. | task `updatedAt` |
+| `taskStateChanged` | Task manager strictly published the state transition. | task `updatedAt` |
+| `gateStatusChanged` | Gate status summary was strictly persisted. | gate status revision |
+| `pullRequestStatusChanged` | PR status store atomically persisted its safe projection. | provider `updatedAt` or safe-projection SHA-256 |
+| `settingsChanged` | Project configuration atomically renamed the committed generation. | committed-config SHA-256 |
+
+“Queued” is the authority point only where the status owner defines publication that way; it does
+not mean a consumer acknowledged delivery. Every downstream adapter remains observational.
+
+### Privacy boundary
+
+Notifications contain identifiers, states, revisions, durations, bounded field-name lists, and safe outcome metadata only. They never contain:
+
+- raw prompts or message text;
+- tool arguments or tool-result bodies;
+- setting values, secrets, or provider credentials;
+- provider error text, stack traces, or mutable store objects.
+
+Consumers fetch an authoritative transcript, snapshot, tool-call record, or pack route when they need larger data. Diagnostic rows contain bounded attribution codes, never notification payloads or thrown errors.
+
+## Authoring runtime hook contributions
+
+Runtime hooks require a schema-2 pack, a hook basename in `contents.hooks`, and an explicit `kind`. Paths resolve relative to the hook YAML and must remain inside the pack root.
+
+### Interceptor example
+
+```yaml
+# pack.yaml
+schema: 2
+contents:
+  roles: []
+  tools: []
+  skills: []
+  hooks: [tool-policy]
+```
+
+```yaml
+# hooks/tool-policy.yaml
+id: policy.tools
+module: ../lib/hooks.mjs
+kind: interceptor
+interceptors: [beforeToolCall, afterToolResult]
+failurePolicy: failClosed
+capabilities: [store]
+budget: { timeoutMs: 1000 }
+```
+
+```js
+// lib/hooks.mjs
+export default {
+  async beforeToolCall(ctx, request) {
+    if (request.toolName === "unsafe_example") {
+      return { action: "block", reasonCode: "not_permitted" };
+    }
+    return { action: "allow" };
+  },
+
+  async afterToolResult(ctx, request) {
+    return { action: "allow" };
+  },
+};
+```
+
+The host runs interceptors sequentially in deterministic pack/contribution order. It checks activation and declared capabilities before invocation and again before applying a result. Requests and results are bounded, copied, frozen, and schema-validated. Invalid, timed-out, cancelled, or late results are discarded or converted to the definition's host-owned fail-closed result. The audit records whether a proposal was received, valid, and applied; a handler return value cannot claim application.
+
+`failurePolicy` is accepted only where the interceptor definition allows it. In particular, context contributions fail open, protected tool boundaries may fail closed, and shutdown/import hooks are non-fatal.
+
+### Notification handler example
+
+```yaml
+# hooks/goal-audit.yaml
+id: audit.goals
+module: ../lib/hooks.mjs
+kind: notification
+notifications:
+  - { scope: project, name: goalUpdated }
+  - { scope: project, name: goalCompleted }
+capabilities: [store]
+budget: { timeoutMs: 1000 }
+```
+
+```js
+// lib/hooks.mjs
+export default {
+  async goalUpdated(ctx, event) {
+    await ctx.host.store.put(
+      `audit/${event.id}`,
+      JSON.stringify({ revision: event.aggregate.revision, state: event.payload.state }),
+    );
+  },
+
+  async goalCompleted(ctx, event) {
+    await ctx.host.store.put(`audit/${event.id}`, "complete");
+  },
+};
+```
+
+Notification handlers receive the same frozen canonical envelope as browsers and staff triggers. They run asynchronously after publication, in deterministic order, with bounded deadlines and live activation/grant checks. Return values are ignored. Throws, timeouts, revocation, and diagnostics are isolated from both other handlers and the already-committed source operation.
+
+### Interceptor catalogue
+
+| Name | Result | Deadline: default / max / whole dispatch | Authority and failure behavior |
+|---|---|---:|---|
+| `sessionSetup` | `{ context }` | 1,500 / 3,000 / 5,000 ms | Host validates, provenance-fences, and budgets context; fail open. |
+| `beforePrompt` | `{ context }` | 500 / 1,000 / 1,500 ms | Adds hidden context without rewriting the user message; fail open. |
+| `beforeToolCall` | `allow`, `block`, or `replaceArgs` | 750 / 1,500 / 2,000 ms | Replacement args are validated against the tool; protected declarations may fail closed. |
+| `afterToolResult` | `allow`, `replaceResult`, or `syntheticError` | 750 / 1,500 / 2,000 ms | Runs before persistence/publication; protected declarations default to fail closed. |
+| `beforeCompact` | optional `context`/`flush` | 1,500 / 3,000 / 5,000 ms | Compaction proceeds on timeout or error. |
+| `sessionShutdown` | optional `flush` | 1,000 / 2,000 / 3,000 ms | Teardown proceeds at the deadline; non-fatal. |
+| `projectImported` | optional `initialised` | 2,000 / 5,000 / 8,000 ms | Runs after import commit; non-fatal failure cannot undo the imported project. |
+
+For exact request/result schemas and deadline caps, use the shared `HOST_INTERCEPTOR_CATALOGUE`; do not duplicate these contracts in pack code.
+
+## Browser Host API
+
+Canonical browser notifications are additive Host contract v5 capabilities. Feature-detect `sessionNotifications` and `projectNotifications` rather than checking member presence.
+
+```js
+if (!host.capabilities.projectNotifications) return;
+
+let refreshPending = false;
+let refreshRunning = false;
+
+function scheduleRefresh() {
+  refreshPending = true;
+  if (refreshRunning) return;
+  queueMicrotask(async () => {
+    if (refreshRunning) return;
+    refreshRunning = true;
+    try {
+      // Repeat when another invalidation arrives during the read.
+      while (refreshPending) {
+        refreshPending = false;
+        renderSnapshot(await host.callRoute("goal-snapshot"));
+      }
+    } finally {
+      refreshRunning = false;
+      if (refreshPending) scheduleRefresh();
+    }
+  });
+}
+
+const offGoal = host.project.notifications.subscribe("goalUpdated", scheduleRefresh);
+const offRefresh = host.project.notifications.onRefreshRequired(scheduleRefresh);
+
+// On panel teardown; both functions are idempotent.
+offGoal();
+offRefresh();
+```
+
+`host.session.notifications` is bound to the panel's current session. `host.project.notifications` is bound to that session's server-resolved project and accepts no client-supplied project ID. The server routes session facts only to the exact authenticated session socket and project facts only to authenticated app sockets in the same project. Sandbox principals and unbound/viewer sockets do not receive this Host API stream.
+
+Delivery is ordered and live per connection, not durable replay. `onRefreshRequired` schedules one initial snapshot read when registered and coalesces reconnect, epoch change, sequence gap, queue overflow, and burst invalidations. A discontinuous event is not applied as a delta. Always re-read the authoritative snapshot on mount or refresh-required; do not reconstruct state from notification history.
+
+The legacy `host.session.subscribe("status" | "message" | "tool_result", handler)` remains available and unchanged. It is a separate adapter over rich session events, not a source for canonical notifications.
+
+## Notification-based staff triggers
+
+A staff trigger can select a canonical notification and optionally apply exact-AND scalar filters from the catalogue:
+
+```json
+{
+  "id": "successful-example-tool",
+  "type": "notification",
+  "notification": {
+    "scope": "session",
+    "name": "toolCallCompleted"
+  },
+  "filter": {
+    "toolName": "example_tool",
+    "status": "succeeded"
+  },
+  "enabled": true
+}
+```
+
+The server may generate `id` when omitted. Unknown names, scope/name mismatches, unknown filter fields, invalid scalar values, oversized filters, and cross-project matches fail closed. Filters compare the named payload fields for exact equality; there is no expression language.
+
+For each matching active subscriber, Bobbit persists a per-project delivery intent containing the complete original validated canonical envelope. Its stable identity is derived from staff, trigger, and notification IDs. Delivery attempts are **at least once**; successful inbox acceptance is idempotent/effectively once for that identity. The gateway marks success only after the inbox write is durably accepted. A crash can retry the attempt, and restart reconciliation resumes pending or expired leased rows without reprojecting current aggregate state. This is not an exactly-once execution or staff-completion guarantee.
+
+Pausing/retiring staff or disabling/deleting a trigger cancels pending work. Bounded attempts, deadlines, subscriber-version checks, and correlation-depth/root checks prevent stale delivery and causal loops. There is no global notification journal or replay API; only rows for matching staff subscribers are durable.
+
+Notification input is not interpolated into prompt text. The inbox stores it as host-owned metadata and emits a generic wake prompt. Browser/operator inbox lists and WebSocket events return a redacted entry with `notificationInput`, root correlation, and causation depth removed. Only the exact live owning staff session may read or transition a notification entry with full metadata, authenticated by its gateway-issued `BOBBIT_SESSION_SECRET` sent as `X-Bobbit-Session-Secret`. The server resolves that secret to the live staff session and verifies staff and project ownership; bearer/cookie auth, public session IDs, request bodies, and client project claims are insufficient. The secret is per-session, in-memory, injected only into the owning process, and regenerated when a gateway restart respawns that process. Same-project sandbox sessions retain the existing shared-container, same-UID `/proc` residual risk; stronger isolation requires per-session containers.
+
+See [Staff triggers](staff-triggers.md) for legacy trigger compatibility and [Staff inbox](staff-inbox.md) for the redacted/full read surfaces.
+
+## Publication and delivery guarantees
+
+- Publication occurs after each catalogue definition's authoritative persistence/publication boundary. Consumer failure is observational and cannot roll back the mutation.
+- `turnCompleted` is emitted only at the final non-retrying terminal boundary. Retry attempts, duplicate/late terminal frames, and restore replay cannot emit another completion. Errored and aborted turns remain explicit outcomes.
+- Tool completion order is: handler result → protected `afterToolResult` policy → approved or synthetic result persisted/published → `toolCallCompleted`. Only safe post-policy metadata enters the event.
+- `goalCompleted` is a durable completion transition with a stable revision and is distinct from `goalArchived`.
+- `settingsChanged` follows atomic settings commit and carries only the committed revision plus bounded target/key identifiers, never values or secrets.
+- Browser and module delivery are bounded, live, ordered per project, and best-effort. Browser pressure produces refresh-required; module pressure produces bounded diagnostics.
+- Matching staff intent admission is durable and independent of live browser/module queues. Attempts are reconciled after restart as described above.
+
+## Compatibility
+
+This API is additive:
+
+- provider contributions and Lifecycle Hub context semantics continue to work;
+- kindless legacy `hooks/*.yaml` declarations stay listable but inert;
+- `schedule`, `git`, `manual`, `goal_created`, and `goal_archived` staff triggers are unchanged;
+- legacy `host.session.subscribe` consumers are unchanged;
+- ordinary packs receive only session and project scope; administrative/system scope remains reserved.
+
+See [Extension Host authoring](extension-host-authoring.md), [Lifecycle Hub](lifecycle-hub.md), [Staff triggers](staff-triggers.md), and [WebSocket protocol](websocket-protocol.md) for the surrounding APIs.

--- a/docs/host-hooks.md
+++ b/docs/host-hooks.md
@@ -229,7 +229,8 @@ function scheduleRefresh() {
       // Repeat when another invalidation arrives during the read.
       while (refreshPending) {
         refreshPending = false;
-        renderSnapshot(await host.callRoute("goal-snapshot"));
+        // This is the pack's own declared route, not a built-in Host API route.
+        renderSnapshot(await host.callRoute("your-snapshot-route"));
       }
     } finally {
       refreshRunning = false;

--- a/docs/lifecycle-hub.md
+++ b/docs/lifecycle-hub.md
@@ -482,6 +482,13 @@ session's gateway-issued secret: the process receives `BOBBIT_SESSION_SECRET`, s
 body. A public session ID or bearer token alone cannot invoke another session's interceptor.
 Diagnostic trace reads retain their normal authenticated inspector policy.
 
+The secret authenticates callback **transport identity**; it is not proof that a particular Pi
+lifecycle boundary occurred. Provider callbacks originate from their named Pi bridge events. Tool
+callbacks use the stronger unified-hook rule: the current session writer must first emit a matching
+execution event that Bobbit accepts at an event-buffer cursor, and the callback can consume that
+exact `{ generation, toolCallId, toolName, phase }` provenance only once. A valid secret therefore
+cannot fabricate or replay tool lifecycle work. See [Unified Host hooks](host-hooks.md#publication-and-delivery-guarantees).
+
 | Method + path | Caller | Behaviour |
 |---|---|---|
 | `POST /api/sessions/:id/provider-hooks/before-prompt` | provider-bridge extension | Body `{ prompt?, turn?: { index } }`. Dispatches `beforePrompt`; responds `{ content, blocks, tail }` while `tail` remains as temporary legacy back-compat for old bridges. |
@@ -537,9 +544,10 @@ The generated extension subscribes to three pi events:
 Transport reads `BOBBIT_GATEWAY_URL` / `BOBBIT_TOKEN` from the environment, falling back to
 `<BOBBIT_DIR || ~/.bobbit>/state/{gateway-url,token}`, and sends the host-issued
 `BOBBIT_SESSION_SECRET` as `X-Bobbit-Session-Secret`. The secret is injected only into the owning
-local or sandbox process, held in gateway memory, and regenerated when gateway restart respawns the process. A missing gateway URL
-short-circuits to "proceed unchanged"; a missing or mismatched session secret fails exact-session
-authentication.
+local or sandbox process, held in gateway memory, and regenerated when gateway restart respawns
+the process. A missing gateway URL short-circuits to "proceed unchanged"; a missing or mismatched
+session secret fails exact-session transport authentication. It does not replace the separate
+current-writer/cursor provenance required by unified tool hooks.
 
 ### The injection invariant (non-negotiable)
 

--- a/docs/lifecycle-hub.md
+++ b/docs/lifecycle-hub.md
@@ -9,8 +9,14 @@
 > [Per-turn + lifecycle wiring (G1.4)](#per-turn--lifecycle-wiring-g14). Built-in production
 > providers include the [Hindsight memory pack](hindsight-memory.md) and PR Walkthrough durable
 > progress provider; both are scoped so an out-of-the-box normal session receives no unrelated
-> Dynamic Context. This page documents the Hub core and its
-> session wiring.
+> Dynamic Context. This page documents the Hub core and its session wiring.
+
+The Hub is now the compatibility adapter for legacy `providers/*.yaml` context hooks. New
+operation participation uses explicit Extension Host **interceptors**, while observation of
+committed facts uses **notifications**. Do not generalize provider `afterTurn` into a new event
+contract; use canonical `turnCompleted`. See [Unified Extension Host hooks](host-hooks.md) for the
+taxonomy, runtime declarations, and shared catalogue.
+
 ## What it is, and why
 
 The Lifecycle Hub is the server-side seam that lets **pack-contributed providers** inject
@@ -470,9 +476,11 @@ and the non-negotiable injection invariant.
 ### The REST surface
 
 Three endpoints back the per-turn hooks and diagnostics. They live in one contiguous block in
-`server.ts`, modeled on `POST /api/sessions/:id/tool-grant-request`, and **inherit the
-admin-bearer auth gate enforced before `handleApiRoute`** — no extra auth code. All are keyed by
-session id and `404` when the session is unknown (neither live nor persisted).
+`server.ts`. Pi-owned mutation callbacks require both the normal bearer gate and the owning
+session's gateway-issued secret: the process receives `BOBBIT_SESSION_SECRET`, sends it as
+`X-Bobbit-Session-Secret`, and the server resolves it to the exact URL session before reading the
+body. A public session ID or bearer token alone cannot invoke another session's interceptor.
+Diagnostic trace reads retain their normal authenticated inspector policy.
 
 | Method + path | Caller | Behaviour |
 |---|---|---|
@@ -526,10 +534,12 @@ The generated extension subscribes to three pi events:
   not retain stale recall. The result is ignored (compaction output is not amended here); all
   failures are swallowed. This `beforeCompact` behavior is unchanged.
 
-Transport and auth are identical to the tool-guard: read `BOBBIT_GATEWAY_URL` / `BOBBIT_TOKEN`
-from the environment, falling back to `<BOBBIT_DIR || ~/.bobbit>/state/{gateway-url,token}`, and
-`fetch` the gateway with a bearer token. A missing gateway URL short-circuits to "proceed
-unchanged".
+Transport reads `BOBBIT_GATEWAY_URL` / `BOBBIT_TOKEN` from the environment, falling back to
+`<BOBBIT_DIR || ~/.bobbit>/state/{gateway-url,token}`, and sends the host-issued
+`BOBBIT_SESSION_SECRET` as `X-Bobbit-Session-Secret`. The secret is injected only into the owning
+local or sandbox process, held in gateway memory, and regenerated when gateway restart respawns the process. A missing gateway URL
+short-circuits to "proceed unchanged"; a missing or mismatched session secret fails exact-session
+authentication.
 
 ### The injection invariant (non-negotiable)
 
@@ -640,7 +650,8 @@ ambient context a session received and why blocks were dropped.
 
 - [Hindsight memory pack](hindsight-memory.md) — the first production provider, a built-in
   (dormant-by-default) memory provider that recalls/retains across sessions.
-- [Extension Host authoring guide](extension-host-authoring.md) — how to write a provider pack.
+- [Unified Extension Host hooks](host-hooks.md) — interceptors, canonical notifications, scoped browser subscriptions, and notification-based staff triggers.
+- [Extension Host authoring guide](extension-host-authoring.md) — how to write provider and runtime-hook packs.
 - [Marketplace → Provider contributions](marketplace.md#provider-contributions-providersidyaml) —
   the provider YAML schema, defaults, and clamps.
 - [Extension Host internals](extension-host-authoring.md) and `module-host-worker.ts` —

--- a/docs/marketplace.md
+++ b/docs/marketplace.md
@@ -167,8 +167,9 @@ shown read-only as "support surfaces").
 > through the Lifecycle Hub, while an explicit `kind: interceptor | notification` hook is eligible
 > for Extension Host dispatch only while its `listName` is active. Installation and indexing never
 > invoke a hook by themselves; the host must also select it for the current canonical boundary,
-> authorize its grants, and recheck activation before invocation and result application. A kindless
-> legacy `{ events, mode }` hook remains listable but inert. **MCP** loads through `McpManager`
+> authorize its grants, and recheck activation before invocation, before interceptor result
+> application, and after observational-handler settlement. A kindless legacy `{ events, mode }`
+> hook remains listable but inert. **MCP** loads through `McpManager`
 > discovery; **pi extensions** resolve to standalone pi `--extension` entries. `runtimes` and
 > `workflows` remain catalogue-only reserved kinds. See
 > [pack.yaml schema 2](#packyaml-schema-2-extension-platform) and
@@ -185,7 +186,7 @@ What disabling does:
   entrypoint never disables a panel.
 - **Disable an MCP contribution or operation** — the contribution id/list name is added to `DisabledRefs.mcp`, or operation names are added under `DisabledRefs.mcpOperations[contributionId]`. Disabled contributions are omitted from Marketplace MCP discovery/connection; disabled operations are omitted from route maps and external `mcp_*` tools. Runtime status refreshes immediately, while disabled rows remain visible in the activation catalogue so they can be re-enabled.
 - **Disable a pi extension** — its `contents.pi-extensions` list name is added to `DisabledRefs.piExtensions`, so Bobbit does not add its `--extension <path>` flag to matching agent sessions. The disabled row remains visible in the activation catalogue, including any last known diagnostics, so it can be re-enabled.
-- **Disable a lifecycle hook** — its `contents.hooks` basename (`listName`) is added to `DisabledRefs.hooks`. Registry invalidation removes it from future active resolution and cancels invalidated worker work, so neither an interceptor nor a notification handler can run while disabled. The catalogue row remains visible for re-enable. Kindless legacy hook metadata remains inert whether enabled or disabled.
+- **Disable a lifecycle hook** — its `contents.hooks` basename (`listName`) is added to `DisabledRefs.hooks`. Registry invalidation removes it from future active resolution, so no new interceptor or notification-handler invocation is selected while disabled. An in-flight interceptor dispatch is aborted and cannot apply a result. A notification handler that already started remains bounded by its deadline; its return value is ignored and revocation is detected at settlement. Disabling never rolls back the already-published source fact. The catalogue row remains visible for re-enable. Kindless legacy hook metadata remains inert whether enabled or disabled.
 
 **Tool toggles are concrete tool names.** `pack.yaml` keeps `contents.tools` as **tool group
 names** (`tools/<group>/`) for manifest compatibility, but the installed catalogue expands

--- a/docs/marketplace.md
+++ b/docs/marketplace.md
@@ -154,7 +154,7 @@ The MVP ships exactly one configured resolution mechanism: **`pack_order`**, the
 Each installed pack exposes per-entity **activation toggles** on the Market installed-pack
 surface, so you can disable individual entities without uninstalling the pack. Schema-1 packs
 toggle user-facing roles, tools, skills, and entrypoints. Schema-2 packs also toggle pack-scoped
-contributions: providers, hook metadata, MCP, and pi extensions. Support surfaces — panels,
+contributions: providers, lifecycle hooks, MCP, and pi extensions. Support surfaces — panels,
 routes, stores, renderers, actions, `lib/` — are **not** independently toggleable (panels may be
 shown read-only as "support surfaces").
 
@@ -162,13 +162,17 @@ shown read-only as "support surfaces").
 > `mcp`, `piExtensions`, and the reserved `runtimes` / `workflows` siblings. They are first-class
 > in `DisabledRefs` and `ACTIVATION_KINDS`, and the `pack-activation` catalogue includes their
 > arrays only for schema-2 packs, so toggles round-trip through the same REST without changing
-> schema-1 catalogue shapes. **Providers** and manifest-listed **hook metadata** load through
-> `PackContributionRegistry`; hook activation filters indexed declarations by manifest basename
-> (`listName`) only. **MCP** loads through `McpManager` discovery; **pi extensions** resolve to
-> standalone pi `--extension` entries. `runtimes` and `workflows` remain catalogue-only reserved
-> kinds. Hook metadata is inert: indexing imports or dispatches nothing and grants no authority.
-> See [pack.yaml schema 2](#packyaml-schema-2-extension-platform) and the
-> [hook metadata contract](extension-host-authoring.md#hook-metadata-hooksnameyaml--schema-2-inert).
+> schema-1 catalogue shapes. **Providers** and manifest-listed **lifecycle hooks** load through
+> `PackContributionRegistry`, but remain separate runtime contribution types: providers dispatch
+> through the Lifecycle Hub, while an explicit `kind: interceptor | notification` hook is eligible
+> for Extension Host dispatch only while its `listName` is active. Installation and indexing never
+> invoke a hook by themselves; the host must also select it for the current canonical boundary,
+> authorize its grants, and recheck activation before invocation and result application. A kindless
+> legacy `{ events, mode }` hook remains listable but inert. **MCP** loads through `McpManager`
+> discovery; **pi extensions** resolve to standalone pi `--extension` entries. `runtimes` and
+> `workflows` remain catalogue-only reserved kinds. See
+> [pack.yaml schema 2](#packyaml-schema-2-extension-platform) and
+> [Unified Extension Host hooks](host-hooks.md).
 
 What disabling does:
 
@@ -181,7 +185,7 @@ What disabling does:
   entrypoint never disables a panel.
 - **Disable an MCP contribution or operation** — the contribution id/list name is added to `DisabledRefs.mcp`, or operation names are added under `DisabledRefs.mcpOperations[contributionId]`. Disabled contributions are omitted from Marketplace MCP discovery/connection; disabled operations are omitted from route maps and external `mcp_*` tools. Runtime status refreshes immediately, while disabled rows remain visible in the activation catalogue so they can be re-enabled.
 - **Disable a pi extension** — its `contents.pi-extensions` list name is added to `DisabledRefs.piExtensions`, so Bobbit does not add its `--extension <path>` flag to matching agent sessions. The disabled row remains visible in the activation catalogue, including any last known diagnostics, so it can be re-enabled.
-- **Disable hook metadata** — its `contents.hooks` basename is added to `DisabledRefs.hooks`, so the registry omits that indexed declaration after invalidation. This does not change runtime behavior: hook metadata has no import, dispatch, authority, config evaluation, or UI surface.
+- **Disable a lifecycle hook** — its `contents.hooks` basename (`listName`) is added to `DisabledRefs.hooks`. Registry invalidation removes it from future active resolution and cancels invalidated worker work, so neither an interceptor nor a notification handler can run while disabled. The catalogue row remains visible for re-enable. Kindless legacy hook metadata remains inert whether enabled or disabled.
 
 **Tool toggles are concrete tool names.** `pack.yaml` keeps `contents.tools` as **tool group
 names** (`tools/<group>/`) for manifest compatibility, but the installed catalogue expands
@@ -198,7 +202,8 @@ Gateway packages also expose operation activation in `DisabledRefs.mcpOperations
 **Why a catalogue/runtime split.** Toggles persist in `pack_activation` (per scope/project,
 keyed by pack name + entity kind + name; tool refs are concrete tool names; entrypoints are
 keyed by their `contents.entrypoints` basename, so one toggle covers both the launcher id and
-the deep-link `routeId` from that file; MCP refs are keyed by contribution id/listName as described above; pi-extension refs are keyed by their `contents.pi-extensions` basename). The toggle UI must render from the **unfiltered
+the deep-link `routeId` from that file; provider, hook, and pi-extension refs use their manifest
+`listName`; MCP refs are keyed by contribution id/listName as described above). The toggle UI must render from the **unfiltered
 catalogue** — read from the installed pack's manifest plus its declared tool-group files via
 `GET /api/marketplace/pack-activation` — *not* from the runtime-filtered `/api/tools`,
 `/api/ext/contributions`, `/api/mcp-servers`, or session spawn args. If the UI read the filtered runtime endpoints, a disabled entity or operation
@@ -661,6 +666,8 @@ contents:                        # REQUIRED. roles/tools/skills required; each M
   entrypoints: [open-review]      #    decided once when adding a source.)
                                  #   OPTIONAL — entrypoints/<name>.yaml basenames (toggleable).
   # schema: 2 only:
+  providers:   [memory]          #   OPTIONAL — providers/<name>.yaml basenames (toggleable; Lifecycle Hub).
+  hooks:       [turn-audit]      #   OPTIONAL — hooks/<name>.yaml|yml basenames (toggleable; explicit kind is runtime-eligible).
   mcp:         [github]          #   OPTIONAL — mcp/<name>.yaml|yml|json basenames (toggleable).
   pi-extensions: [demo]          #   OPTIONAL — pi-extensions/<name>/ or <name>.ts/.js/.mjs/.cjs (toggleable).
 routes:                          # OPTIONAL top-level block — Extension-Host pack routes.
@@ -674,7 +681,8 @@ Validation rules: `name`, `description`, `version` must be non-empty; `name` mus
 
 Schema 2 is the **Extension Platform** workstream's manifest tier. It began as a deliberately
 **additive** change — schema 2 widens what a `pack.yaml` may declare and adds loaders for
-pack-scoped contributions such as **providers** and **MCP** — and remains **fully back-compatible**: existing
+pack-scoped contributions such as **providers**, **lifecycle hooks**, and **MCP** — and remains
+**fully back-compatible**: existing
 schema-1 (v1) packs see zero behaviour change. A pack opts in with a top-level `schema:` field;
 absent (or `1`) keeps the exact v1 semantics.
 **Providers now dispatch through the Lifecycle Hub.** What began as a manifest-only step is
@@ -724,13 +732,23 @@ each defaults to `[]` when absent:
 | `contents` key | YAML key | Runtime loader? | Purpose |
 |---|---|---|---|
 | `providers` | `providers` | **Yes** | `providers/<id>.yaml` provider contributions (below). |
-| `hooks` | `hooks` | **Yes (metadata only)** | Manifest-listed `hooks/<name>.yaml|yml` declarations; validated and indexed without runtime execution. See the [hook metadata contract](extension-host-authoring.md#hook-metadata-hooksnameyaml--schema-2-inert). |
+| `hooks` | `hooks` | **Yes** | Manifest-listed `hooks/<name>.yaml|yml` lifecycle declarations. Explicit `kind: interceptor | notification` contributions can run through the Extension Host; kindless legacy declarations remain inert. See [Unified Extension Host hooks](host-hooks.md). |
 | `mcp` | `mcp` | **Yes** | `mcp/<id>.yaml|yml|json` MCP server contributions. |
 | `piExtensions` | `pi-extensions` | **Yes** | Standalone pi runtime extension basenames under `pi-extensions/`. Note the YAML key is **`pi-extensions`** (kebab-case) but the parsed field is `piExtensions` (camelCase). |
 | `runtimes` | `runtimes` | No (reserved) | Runtime contribution basenames. |
 | `workflows` | `workflows` | No (reserved) | Workflow contribution basenames. |
 
-**`providers`, `hooks`, `mcp`, and `pi-extensions` have loaders.** `providers` and `hooks` load through the Extension-Host contribution registry; hook loading only validates and indexes manifest-listed metadata. It never imports the declared module, dispatches events, grants authority, evaluates configuration or activation metadata, or creates UI. `mcp` loads through the Marketplace MCP path described above; `pi-extensions` resolve to standalone pi `--extension` entries described in [Marketplace pi extensions](#marketplace-pi-extensions). Only `runtimes` and `workflows` remain accepted, normalised, activation-catalogue-only reserved keys.
+**`providers`, `hooks`, `mcp`, and `pi-extensions` have loaders.** Providers and hooks are
+resolved through the Extension Host contribution registry, but providers remain a separate
+Lifecycle Hub compatibility surface. For hooks, the loader validates manifest-listed declarations
+and resolves executable modules only for an explicit `kind: interceptor | notification`; kindless
+legacy `{ events, mode }` rows remain listable inert metadata. Loading or indexing an explicit hook
+does not invoke it. Runtime dispatch additionally requires the declaration to remain active, be
+selected for the current canonical boundary, and pass live grant checks. The exact hook schemas,
+selection rules, deadlines, and failure behavior live in [Unified Extension Host hooks](host-hooks.md).
+`mcp` loads through the Marketplace MCP path described above; `pi-extensions` resolve to standalone
+pi `--extension` entries described in [Marketplace pi extensions](#marketplace-pi-extensions).
+Only `runtimes` and `workflows` remain accepted, normalised, activation-catalogue-only reserved keys.
 
 #### Minimal schema-2 example
 
@@ -747,7 +765,7 @@ contents:
   tools:    []
   skills:   []
   providers: [memory]         # loads providers/memory.yaml (see below)
-  hooks:     [turn-audit]     # validates/indexes hooks/turn-audit.yaml; inert metadata
+  hooks:     [turn-audit]     # loads hooks/turn-audit.yaml; explicit kind makes it runtime-eligible
   mcp:       [github]         # loads mcp/github.yaml (see Marketplace MCP)
   pi-extensions: [demo]       # loads pi-extensions/demo/ or pi-extensions/demo.ts
   # runtimes / workflows are accepted here at schema 2 but remain reserved.
@@ -825,7 +843,7 @@ rule: load via the pack-contribution registry, never the name-merging resolver.
 
 #### Per-contribution activation
 
-Providers, hook metadata, MCP, pi extensions, and the reserved runtime/workflow siblings are
+Providers, lifecycle hooks, MCP, pi extensions, and the reserved runtime/workflow siblings are
 **first-class in the activation system**, so they round-trip through the same
 `GET/PUT /api/marketplace/pack-activation` REST as roles, tools, skills, and entrypoints — see
 [Activation controls](#activation-controls):
@@ -842,11 +860,14 @@ Providers, hook metadata, MCP, pi extensions, and the reserved runtime/workflow 
   generalised analogue of the entrypoint filter), and
   **`listProviders(projectId)`** returns only providers from packs that are **installed +
   active + enabled** for that scope. Entrypoint filtering is byte-identical to before.
-- Hook metadata is toggled by its **`listName`** (its `contents.hooks` basename).
-  `PackContributionRegistry` filters that declaration from the pack contribution and
-  `listHooks(projectId)` after invalidation; it does not inspect `config` or `activation`.
-  The toggle remains metadata-only and never imports a module, dispatches a hook, grants
-  capability/authority, or registers UI. See the [hook metadata contract](extension-host-authoring.md#hook-metadata-hooksnameyaml--schema-2-inert).
+- A lifecycle hook is toggled by its **`listName`** (its `contents.hooks` basename).
+  `PackContributionRegistry` filters disabled declarations from `listHooks(projectId)` after
+  invalidation. An explicit interceptor or notification handler executes only when the declaration
+  is manifest-listed, active, selected for the current canonical boundary, and authorized by live
+  grant checks; disabling its `listName` removes it from future active resolution. Installation or
+  indexing alone never invokes it. A kindless legacy `{ events, mode }` declaration stays listable
+  compatibility metadata and never executes. Providers remain separate Lifecycle Hub contributions.
+  See [Unified Extension Host hooks](host-hooks.md).
 - An authored MCP contribution is toggled by its **`listName`** (its `contents.mcp` basename). A gateway MCP contribution is toggled by its stable installed contribution id, not by runtime key or fingerprint. `McpManager` filters disabled Marketplace MCP contributions before connecting servers or exposing model-facing MCP meta-tools.
 - A pi extension is toggled by its **`listName`** (its `contents.pi-extensions` basename). Session startup filters disabled/unresolved extensions before appending pi `--extension` args, while the activation catalogue keeps disabled/unresolved rows visible with diagnostics.
 

--- a/docs/staff-inbox.md
+++ b/docs/staff-inbox.md
@@ -39,7 +39,8 @@ The inbox sits between trigger fan-in and session fan-out:
                   ┌──────────────────────┐
    cron / git ───►│                      │
    manual API ───►│   InboxManager       │── persist ──► <projectStateDir>/inbox/<staffId>.json
-   manual UI ────►│   .enqueue()         │── broadcast ► WS  inbox.entry.added
+   manual UI ────►│   enqueue*()          │── redacted WS ► exact owning staff session
+   host facts ───►│                      │◄─ durable notification subscriber outbox
                   └──────────┬───────────┘
                              │ poke(staffId)
                              ▼
@@ -68,6 +69,7 @@ Component map (all in `src/server/agent/`):
 | `inbox-nudger.ts` | 15 s tick + microtask poke. Owns the only path that wakes a staff. |
 | `staff-trigger-engine.ts` | Polled `schedule` / `git` triggers — `fireTrigger()` calls `inboxManager.enqueue()`. |
 | `goal-trigger-dispatcher.ts` | Push-based `goal_created` / `goal_archived` triggers fired synchronously from `GoalStore` mutations. See [staff-triggers.md](staff-triggers.md). |
+| `notification-staff-dispatcher.ts` | Matches canonical Host facts, persists project-partitioned delivery intents, and idempotently calls `InboxManager.enqueueWithId()`. |
 
 UI surface (all in `src/app/` and `src/ui/inbox/`):
 
@@ -80,16 +82,12 @@ UI surface (all in `src/app/` and `src/ui/inbox/`):
 
 ## Lifecycle
 
-1. **Enqueue.** A trigger fires, a REST caller hits `POST /api/staff/:id/inbox`,
-   or the UI's "+ Add to inbox" submits the dialog.
-   `InboxManager.enqueue(staffId, { title, prompt, context, source })` runs
-   synchronously:
-   - Stamp `id = randomUUID()`, `createdAt = Date.now()`, `state = "pending"`.
-   - `InboxStore.put(entry)` — synchronous JSON write to
-     `<projectStateDir>/inbox/<staffId>.json`.
-   - Broadcast `{ type: "inbox.entry.added", staffId, entry }` to all WS clients.
-   - Call `inboxNudger.poke(staffId)`, which schedules a one-shot
-     `tickOne(staffId)` on the next microtask.
+1. **Enqueue.** A legacy trigger fires, a REST caller hits `POST /api/staff/:id/inbox`,
+   or the UI submits the dialog. `InboxManager.enqueue()` assigns a random ID and writes the
+   entry synchronously. A matching notification trigger instead enters the durable subscriber
+   outbox first, then calls `enqueueWithId()` with a deterministic delivery ID and the exact
+   canonical event as host-owned metadata. Both paths publish a bounded, redacted live projection
+   only to the exact owning staff session and poke the nudger.
 2. **Nudge.** `InboxNudger.tickOne` runs (either from `poke` or from the 15 s
    `setInterval`). It bails when the staff isn't active, the session isn't
    `idle`, `nudgePending` is already set, or the pending list is empty. If all
@@ -131,7 +129,8 @@ where an entry came from:
 
 | Source | How it gets there | UI badge |
 |---|---|---|
-| `trigger` | Any staff trigger fires — `schedule` / `git` via the polled engine, or `goal_created` / `goal_archived` via the push dispatcher. `source.triggerId` is set in either case. See [staff-triggers.md](staff-triggers.md). | "trigger" + trigger id. |
+| `trigger` | A legacy `schedule`, `git`, `goal_created`, or `goal_archived` trigger fires. `source.triggerId` is set. See [staff-triggers.md](staff-triggers.md). | "trigger" + trigger id. |
+| `notification` | A matching canonical Host notification is durably accepted. Full event input remains protected metadata. | "notification" + trigger id. |
 | `manual_api` | External integration `POST`s `/api/staff/:id/inbox`. The server normalises `source.type` to `manual_api` when the caller doesn't supply `manual_ui`. | "manual_api" + optional `actorId`. |
 | `manual_ui` | User clicks "+ Add to inbox" in the inbox panel or hits "Wake Now" on the staff edit page (both POST `/api/staff/:id/inbox` with `source.type = "manual_ui"`). | "manual_ui" + optional `actorId`. |
 
@@ -166,9 +165,9 @@ Three tools are registered only when the agent process has both
 `BOBBIT_SESSION_ID` and `BOBBIT_STAFF_ID` set in its environment — i.e. only
 for staff sessions. The extension in `defaults/tools/inbox/extension.ts` early-
 returns otherwise, so the tools never appear in the tool catalogue on
-non-staff sessions. This mirrors `defaults/tools/tasks/` and is the only
-gating layer the agent sees; REST handlers additionally verify
-`session.staffId === :id` as defence-in-depth.
+non-staff sessions. REST handlers additionally verify legacy entries against
+staff ownership. Notification entries use the stronger exact-owner rule described
+under [Notification entry security](#notification-entry-security).
 
 | Tool | Params | Effect |
 |---|---|---|
@@ -191,21 +190,40 @@ rest of the gateway.
 
 | Method | Path | Body | 2xx | Notable errors |
 |---|---|---|---|---|
-| `GET` | `/api/staff/:id/inbox?state=&limit=` | — | `200 { entries: InboxEntry[] }` | `404` if staff unknown. |
-| `POST` | `/api/staff/:id/inbox` | `{ title, prompt, context?, source?: { type?: "manual_api" \| "manual_ui" \| "trigger", actorId? } }` | `201 { entry: InboxEntry }` | `400` missing `title`/`prompt`; `404` staff unknown. |
-| `POST` | `/api/staff/:id/inbox/:entryId/complete` | `{ sessionId, summary? }` | `200 { entry }` | `403` if `sessionId.staffId !== :id`; `409` if entry not pending; `404` staff/entry. |
-| `POST` | `/api/staff/:id/inbox/:entryId/dismiss` | `{ sessionId, outcome: "failed" \| "cancelled", reason }` | `200 { entry }` | `400` empty `reason` or bad outcome; `403`; `409`; `404`. |
-| `DELETE` | `/api/staff/:id/inbox/:entryId` | — | `200 { ok: true }` | `404`. |
+| `GET` | `/api/staff/:id/inbox?state=&limit=` | — | `200 { entries }`; full notification metadata only for the exact owner, otherwise redacted | `404` if staff unknown. |
+| `POST` | `/api/staff/:id/inbox` | `{ title, prompt, context?, source?: { type?: "manual_api" \| "manual_ui" \| "trigger", actorId? } }` | `201 { entry }` | `400` missing `title`/`prompt`; `404` staff unknown. |
+| `POST` | `/api/staff/:id/inbox/:entryId/complete` | legacy: `{ sessionId, summary? }`; notification: owner-secret header plus `{ summary? }` | `200 { entry }` | `403` on ownership failure; `409` if not pending; `404`. |
+| `POST` | `/api/staff/:id/inbox/:entryId/dismiss` | legacy: `{ sessionId, outcome, reason }`; notification: owner-secret header plus `{ outcome, reason }` | `200 { entry }` | `400` invalid reason/outcome; `403`; `409`; `404`. |
+| `DELETE` | `/api/staff/:id/inbox/:entryId` | notification deletion requires owner-secret header | `200 { ok: true }` | `403` on notification ownership failure; `404`. |
 
 `source.type` in `POST /api/staff/:id/inbox` defaults to `manual_api` when the
-caller omits it. The `sessionId` body field on `complete` and `dismiss` is the
-defence-in-depth check — only sessions whose `staffId` matches `:id` may
-transition entries.
+caller omits it. For legacy entries, the `sessionId` body field on `complete` and `dismiss` is
+the defence-in-depth check: only sessions whose `staffId` matches `:id` may transition them.
+Notification entries ignore that weaker claim and require exact-owner secret authentication.
 
 The legacy `POST /api/staff/:id/wake` route has been **deleted**. The UI's
 "Wake Now" button is rewired to `POST /api/staff/:id/inbox` with
 `source.type = "manual_ui"`. External callers that previously hit `/wake`
 must migrate.
+
+## Notification entry security
+
+Notification entries keep the exact bounded canonical event in `notificationInput`, alongside
+host-owned root correlation and causation depth. This metadata is never copied into the prompt.
+The stored prompt is the fixed sentence `A host notification is available in this inbox entry's
+notification metadata.`
+
+The browser/operator REST projection and every `inbox.entry.*` WebSocket frame omit
+`notificationInput`. The live projection also copies and bounds ordinary display fields instead
+of returning a mutable store object. Full metadata is returned only when the request presents the
+owning process's gateway-issued `BOBBIT_SESSION_SECRET` as `X-Bobbit-Session-Secret` and the
+server verifies that it resolves to the staff's exact current live, non-dormant session in the
+same project. Public session IDs, body `sessionId`, bearer/cookie auth, and client project claims
+do not establish this authority.
+
+The gateway holds each secret in memory and injects it only into its owning local or sandbox
+process. It is never persisted and rotates when the process is respawned after gateway restart.
+The same exact-owner check protects notification completion, dismissal, and deletion.
 
 ### Examples
 
@@ -236,8 +254,8 @@ panel and in `inbox_list` responses.
 
 ## WebSocket events
 
-Broadcast to all connected clients via `broadcastToAll`. Defined in
-`src/server/ws/protocol.ts`:
+Published only to the exact live owning staff session. Notification metadata and loop controls are
+redacted before publication. Frames are defined in `src/server/ws/protocol.ts`:
 
 | Type | Payload | When |
 |---|---|---|
@@ -311,9 +329,11 @@ they affect.
 
 ## Idempotency contract
 
-The server never auto-cancels, auto-completes, or coalesces entries. Two
-triggers that fire 100 ms apart create two distinct entries. The agent is
-responsible for deduping:
+Legacy/manual inbox entries are neither coalesced nor automatically completed: two fires create
+two distinct IDs and the agent handles semantic deduplication. Notification delivery is different:
+its deterministic staff/trigger/notification identity makes inbox acceptance idempotent across
+retry and restart. That prevents duplicate entries for one canonical fact but does not claim
+exactly-once staff execution. For legacy/manual work:
 
 - **Before doing work**, the agent should call `inbox_list(state="completed")`
   (or check its memory) to detect whether the same work has already been
@@ -350,7 +370,11 @@ One JSON file per staff at `<projectStateDir>/inbox/<staffId>.json`:
 ```
 
 `projectStateDir` is `<project-root>/.bobbit/state/` (single-source from
-`ProjectContext`). Entries are stored FIFO by insertion order.
+`ProjectContext`). Entries are stored FIFO by insertion order. A notification entry additionally stores
+`source.type: "notification"` and its exact canonical `notificationInput`; operator/browser reads
+remain redacted as described above. Matching notification delivery intents live separately in the
+project's `notification-deliveries.json` outbox so pending/leased work can be reconciled after a
+restart.
 
 The file is safe to hand-inspect; it is rewritten on every transition (full-
 file synchronous write, last-writer-wins per id). Hand-editing while the
@@ -405,9 +429,8 @@ operation today.
 
 - [docs/staff-agents.md](staff-agents.md) — staff agent lifecycle, sandbox
   mode, edit page conventions.
-- [docs/staff-triggers.md](staff-triggers.md) — trigger type reference,
-  including the push-based `goal_created` / `goal_archived` dispatcher
-  and its required-prompt rule.
+- [docs/staff-triggers.md](staff-triggers.md) — legacy and canonical notification trigger semantics.
+- [Unified Extension Host hooks](host-hooks.md) — shared envelope, catalogue, and delivery guarantees.
 - [docs/design/staff-inbox.md](design/staff-inbox.md) — original design
   document (kept for reference).
 - [docs/rest-api.md](rest-api.md) — REST surface index.

--- a/docs/staff-triggers.md
+++ b/docs/staff-triggers.md
@@ -2,9 +2,10 @@
 
 Triggers attached to a [staff agent](staff-agents.md) decide when work lands
 in the staff's [inbox](staff-inbox.md). A staff record holds an array of
-`StaffTrigger` entries; each entry has a `type`, a `config` blob, an
-`enabled` flag, and (for some types) a `prompt` that becomes the wake
-message delivered to the agent.
+`StaffTrigger` entries. Legacy triggers use a `config` blob and may provide a
+wake `prompt`. Notification triggers instead select a canonical committed fact
+and an allowlisted exact-match filter; notification data is delivered as
+host-owned metadata, never prompt text.
 
 Triggers themselves never wake the agent directly — they `enqueue` an
 inbox entry, and the [inbox nudger](staff-inbox.md#lifecycle) decides when
@@ -13,16 +14,15 @@ whole point of the inbox; trigger plumbing only has to land the entry.
 
 ## Trigger types
 
-There are two dispatch families:
+There are three dispatch families:
 
 - **Polled** triggers (`schedule`, `git`) are evaluated by
-  `staff-trigger-engine.ts` on a 60 s tick. The engine re-reads cron and
-  git state, decides whether each trigger should fire, and enqueues an
-  inbox entry per fire.
-- **Push-based** triggers (`goal_created`, `goal_archived`) are dispatched
-  synchronously from the relevant store mutation — there is no polling
-  loop. The `manual` type is enqueue-only (the UI button) and is not
-  evaluated by either path.
+  `staff-trigger-engine.ts` on a 60 s tick.
+- **Legacy push-based** triggers (`goal_created`, `goal_archived`) enqueue from
+  their store callbacks. The `manual` type is enqueue-only.
+- **Canonical notification** triggers consume a post-authority Host notification
+  through a per-project durable subscriber outbox. They do not share state with
+  the legacy trigger engine or goal dispatcher.
 
 | Type | Dispatcher | `config` | `prompt` | Fires on |
 |---|---|---|---|---|
@@ -31,10 +31,77 @@ There are two dispatch families:
 | `manual` | (no dispatcher) | `{}` | optional | User clicks "Wake Now" / "+ Add to inbox", or an integration `POST`s to `/api/staff/:id/inbox`. |
 | `goal_created` | `goal-trigger-dispatcher.ts` (push, from `GoalStore.put`) | `{}` | **required** | A new goal id appears in any project's `GoalStore`. |
 | `goal_archived` | `goal-trigger-dispatcher.ts` (push, from `GoalStore.archive`) | `{}` | **required** | A goal transitions from `archived: false` to `archived: true`. |
+| `notification` | canonical Host notification dispatcher | `notification: { scope, name }`, `filter` | ignored for notification input | A committed catalogue fact matches the selector and every filter field. |
 
 `manual` exists primarily so the UI can render a row with a "Wake Now"
 affordance and so a `prompt` can be attached for ad-hoc one-clicks; the
 trigger record itself is never matched against an event.
+
+## Notification triggers
+
+Use notification triggers when staff should react to a committed Bobbit fact rather than a
+legacy poll or goal callback:
+
+```json
+{
+  "id": "successful-example-tool",
+  "type": "notification",
+  "notification": {
+    "scope": "session",
+    "name": "toolCallCompleted"
+  },
+  "filter": {
+    "toolName": "example_tool",
+    "status": "succeeded"
+  },
+  "enabled": true
+}
+```
+
+`id` may be omitted on create/update; the server generates one before validation. The selector
+must use a canonical scope/name pair. `toolCallCompleted` is session-scoped, including when
+project staff consumes it. Filters are an exact-AND comparison over catalogue-owned scalar
+fields. Unknown names, scope mismatches, unfilterable fields, invalid values, or oversized filters
+are rejected. The full catalogue and filter list live in
+[Unified Host hooks](host-hooks.md#notification-catalogue).
+
+### Project isolation and privacy
+
+The dispatcher considers only active staff in `notification.projectId`. It verifies the staff,
+trigger, delivery row, and inbox all belong to that exact project. A session-scoped notification
+also carries its exact authoritative `sessionId`; project membership does not change its scope.
+There is no cross-project fallback or client-provided project binding.
+
+The persisted input is the complete original validated and frozen canonical envelope. That
+envelope is already privacy-bounded: no raw prompt, message content, tool arguments/results,
+setting values, secrets, provider error text, stacks, or mutable store object can pass its schema.
+The wake prompt is generic and never interpolates event data.
+
+Browser/operator inbox reads and inbox WebSocket events are redacted: they omit
+`notificationInput`, root correlation, and causation depth. Only the exact live owning staff
+session receives the full metadata, using its gateway-issued `BOBBIT_SESSION_SECRET` as
+`X-Bobbit-Session-Secret`. The gateway resolves the secret to the staff's current live session and
+verifies staff and project ownership. A bearer token, cookie, public session ID, request body, or
+client project claim is not enough. See [Staff inbox](staff-inbox.md#notification-entry-security).
+
+### Durable acceptance and retries
+
+Bobbit persists one matching delivery intent per deterministic
+`staffId + triggerId + notification.id` identity before inbox delivery. The row retains the exact
+event across retry and restart; it never reprojects a later aggregate. A successful row means the
+inbox write was durably accepted, not that the staff ran or completed the work.
+
+Delivery attempts are **at least once**. Inbox insertion is idempotent/effectively once for the
+stable identity, including a crash after inbox commit but before outbox acknowledgement. Startup
+reconciliation reclaims pending and expired leased rows. Transient storage/unavailable failures
+retry with bounded backoff, attempt count, and final deadline; invalid schema/version/project data
+fails closed. This is not exactly-once execution and there is no global notification journal or
+replay API.
+
+Pausing/retiring staff or disabling/deleting the trigger cancels pending work and aborts a leased
+attempt. Subscriber-version checks prevent late application after configuration changes.
+Host-owned root/depth tracking suppresses causal loops without rewriting the event's correlation
+fields. Successfully accepted inbox work is not rolled back by later retirement.
 
 ## Goal lifecycle triggers (`goal_created`, `goal_archived`)
 
@@ -86,11 +153,10 @@ at the API/store boundary:
   and disables the Save / Propose button until every goal trigger has
   a non-empty prompt.
 
-Other trigger types keep their existing optional-prompt semantics
-because the polled engine synthesises a placeholder if `prompt` is
-blank. Goal triggers do not have that escape hatch by design — a
-silently-fired wake with no instructions is worse than a save-time
-error.
+The other legacy trigger types keep optional prompts because the polled engine can synthesise a
+placeholder. Notification triggers do not use their prompt as event input; the canonical envelope
+is protected inbox metadata and the wake text is host-owned. Goal triggers have neither fallback,
+so a missing prompt is rejected rather than creating a useless wake.
 
 ### Fire-all semantics (no filtering yet)
 
@@ -172,8 +238,8 @@ so one bad staff does not poison the dispatch for the rest.
 
 | Route | Validation |
 |---|---|
-| `POST /api/staff` | Rejects `400` if any element of `triggers[]` has `type === "goal_created"` or `type === "goal_archived"` and a missing / empty / whitespace-only `prompt`. |
-| `PUT /api/staff/:id` | Same validation on the updated `triggers` array. |
+| `POST /api/staff` | Rejects goal lifecycle triggers with an empty prompt; rejects notification triggers with an unknown/mismatched selector or invalid catalogue filter. |
+| `PUT /api/staff/:id` | Applies the same validation to the complete updated `triggers` array. |
 
 The validation lives in `StaffManager.validateTriggers` so both routes
 share one source of truth.
@@ -183,8 +249,8 @@ share one source of truth.
 The user-facing model above is what matters; the file paths below are an
 orientation aid only.
 
-- **Trigger types.** `src/server/agent/staff-store.ts` — `TriggerType`
-  union and the `StaffTrigger` shape.
+- **Trigger types.** `src/server/agent/staff-store.ts` — `TriggerType`, legacy triggers, and the notification selector/filter shape.
+- **Notification delivery.** `notification-staff-dispatcher.ts` and `notification-delivery-store.ts` — project matching, durable subscriber rows, leases, retry/restart reconciliation, and inbox acceptance.
 - **Validation.** `src/server/agent/staff-manager.ts` —
   `validateTriggers()` called from the staff REST routes.
 - **Polled dispatch** (`schedule`, `git`). `src/server/agent/staff-trigger-engine.ts`.
@@ -202,30 +268,21 @@ orientation aid only.
   `src/app/staff-page.ts`. Save buttons consult
   `hasInvalidGoalTriggers*` to block save on empty goal-trigger
   prompts.
-- **Staff-assistant prompt.** `src/server/agent/staff-assistant.ts`
-  documents all five trigger types so creation sessions suggest the
-  goal lifecycle ones with a non-empty prompt.
+- **Staff-assistant prompt.** `src/server/agent/staff-assistant.ts` documents legacy and notification trigger forms, including the required goal prompt and canonical selector/filter rules.
 
 ## Tests
 
-- `tests/goal-trigger-dispatcher.test.ts` — unit: dispatcher fires
-  `goal_created` once per new id; `goal_archived` once per transition;
-  skips disabled triggers and non-active staff; per-trigger error
-  isolation.
-- `tests/e2e/staff-goal-triggers.spec.ts` — API E2E: create goal
-  → assert inbox entry; `POST /archive` → assert entry; re-archive →
-  no new entry; `POST/PUT` with empty prompt → 400.
-- `tests/e2e/ui/staff-triggers.spec.ts` — browser E2E: trigger
-  type dropdown shows the new options; empty prompt blocks save with
-  an inline error; saving with a prompt persists and round-trips on
-  reload.
+Registered Test Suite v2 coverage includes the notification dispatcher, selector/filter
+validation, project isolation, exact canonical-envelope persistence, idempotent inbox acceptance,
+retry/cancellation/loop protection, restart reconciliation, and exact-owner inbox authorization.
+Legacy goal-trigger and UI suites remain compatibility coverage.
 
 ## See also
 
 - [docs/staff-agents.md](staff-agents.md) — staff agent lifecycle,
   sandbox mode, edit page conventions.
-- [docs/staff-inbox.md](staff-inbox.md) — the inbox queue that every
-  trigger enqueues into, plus the nudger that delivers digests.
+- [Unified Extension Host hooks](host-hooks.md) — canonical notification contract, catalogue, and all consumer delivery semantics.
+- [docs/staff-inbox.md](staff-inbox.md) — the inbox queue, notification metadata security, and nudger delivery.
 - [docs/rest-api.md](rest-api.md) — staff REST surface, including the
   trigger validation `400` on `POST` / `PUT /api/staff`.
 - [docs/goals-workflows-tasks.md](goals-workflows-tasks.md) — goal

--- a/docs/staff-triggers.md
+++ b/docs/staff-triggers.md
@@ -84,6 +84,12 @@ session receives the full metadata, using its gateway-issued `BOBBIT_SESSION_SEC
 verifies staff and project ownership. A bearer token, cookie, public session ID, request body, or
 client project claim is not enough. See [Staff inbox](staff-inbox.md#notification-entry-security).
 
+For tool notifications, the session secret on the Pi callback authenticates only the exact callback
+transport. Bobbit separately requires matching current-writer execution provenance and an accepted
+host cursor before it invokes `beforeToolCall` or `afterToolResult` or publishes a tool fact. Forged,
+duplicate, mismatched, terminal, and stale-generation callbacks therefore match no notification
+trigger: they invoke no hook, create no durable delivery intent or inbox entry, and wake no staff.
+
 ### Durable acceptance and retries
 
 Bobbit persists one matching delivery intent per deterministic

--- a/docs/websocket-protocol.md
+++ b/docs/websocket-protocol.md
@@ -409,6 +409,8 @@ semantics and the shared clamp order.
 | Type | Key Fields | Description |
 |---|---|---|
 | `auth_ok` | `capabilities?` | Authentication succeeded. Accepted optional capabilities are echoed with their negotiated version. |
+| `host_notification` | `notification`, `stream: { epoch, sequence }` | One bounded canonical committed fact for an authenticated app socket's exact session/project binding. See [Canonical Host notification stream](#canonical-host-notification-stream). |
+| `host_notifications_refresh_required` | `scope`, `epoch`, `sequence` | The live stream cannot prove a contiguous delta; consumers must re-read the authoritative snapshot. |
 | `auth_failed` | — | Authentication failed |
 | `state` | `data` | Current agent state snapshot. `data.condition` may be `{ code: "MODEL_SELECTION_REQUIRED", provider: string, modelId: string }`; partial snapshots that omit it do not clear it, and the server sends explicit `condition: null` only after verified recovery. |
 | `messages` | `data` | Full message history array |
@@ -458,9 +460,34 @@ semantics and the shared clamp order.
 | `index:progress` | `projectId`, `phase`, `total`, `completed`, `backlog` | Search index progress. `phase` is `"rebuild"` or `"incremental"`. Debounced to 500ms per project. |
 | `index:complete` | `projectId`, `phase`, `durationMs`, `rowsWritten` | Search index run finished (full rebuild or incremental drain) |
 | `index:error` | `projectId`, `message`, `recoverable` | Search worker/indexing error. `recoverable` indicates whether retry or an authoritative rebuild can recover; the current pure-JS engine has no model-download or native-binary failure mode. |
-| `inbox.entry.added` | `staffId`, `entry` | A new inbox entry was enqueued for a staff agent (trigger fire, `POST /api/staff/:id/inbox`, or UI "+ Add to inbox"). See [staff-inbox.md](staff-inbox.md). |
-| `inbox.entry.updated` | `staffId`, `entry` | A staff agent transitioned an inbox entry via `inbox_complete` / `inbox_dismiss`. |
+| `inbox.entry.added` | `staffId`, `entry` | A new inbox entry was enqueued for the exact owning staff session. Canonical notification input and loop controls are redacted. See [staff-inbox.md](staff-inbox.md). |
+| `inbox.entry.updated` | `staffId`, `entry` | The owning staff session transitioned an inbox entry via `inbox_complete` / `inbox_dismiss`; notification metadata remains redacted. |
 | `inbox.entry.removed` | `staffId`, `entryId` | An inbox entry was pruned (`DELETE /api/staff/:id/inbox/:entryId`). Entry body not echoed — clients reconcile by id. |
+
+### Canonical Host notification stream
+
+`host_notification` is the transport for `host.session.notifications` and
+`host.project.notifications`. It is deliberately separate from rich legacy session `event` frames.
+The envelope schema, payload catalogue, privacy limits, and browser examples are documented in
+[Unified Extension Host hooks](host-hooks.md).
+
+The server binds each authenticated **app** session socket to its persisted session and project.
+Session facts route only to that exact socket binding. Project facts route only to app sockets
+bound to the same project. Extension code supplies neither binding, and sandbox principals,
+unbound sockets, and viewer sockets cannot subscribe to this stream. Project isolation is a
+server routing property, not client filtering.
+
+`stream.epoch` and `stream.sequence` provide ephemeral per-connection ordering for each scope.
+They are not durable event cursors. Initial authentication, reconnect, epoch change, sequence gap,
+queue overflow, or persistent socket pressure schedules/coalesces
+`host_notifications_refresh_required`. The browser drops discontinuous facts instead of applying
+a plausible partial delta. Panels then read their authoritative REST or Host API snapshot; Bobbit
+does not replay canonical Host notifications and does not expose a global notification journal.
+
+Live browser and observational-module delivery is best-effort and cannot affect the already
+committed source operation. A separate per-project subscriber outbox durably admits only facts that
+match staff notification triggers; its restart semantics do not turn this WebSocket stream into
+replay. See [Staff triggers](staff-triggers.md#durable-acceptance-and-retries).
 
 ### Gate reset lifecycle payload
 

--- a/docs/websocket-protocol.md
+++ b/docs/websocket-protocol.md
@@ -471,15 +471,24 @@ semantics and the shared clamp order.
 The envelope schema, payload catalogue, privacy limits, and browser examples are documented in
 [Unified Extension Host hooks](host-hooks.md).
 
-The server binds each authenticated **app** session socket to its persisted session and project.
-Session facts route only to that exact socket binding. Project facts route only to app sockets
-bound to the same project. Extension code supplies neither binding, and sandbox principals,
-unbound sockets, and viewer sockets cannot subscribe to this stream. Project isolation is a
-server routing property, not client filtering.
+The server initially binds each authenticated **app** session socket to its host-resolved session
+and project. Before every notification delta and refresh frame, it revalidates that
+authentication-time binding against current live and persisted session authority. Session facts route only to the
+exact session binding; project facts route only to app sockets whose current binding is in that
+project. Extension code supplies neither binding, and sandbox principals, unbound sockets, and
+viewer sockets cannot subscribe to this stream. Project isolation is a server routing property,
+not client filtering.
+
+If a session moves projects, the frame that discovers the move is suppressed. The router rebinds
+the socket, fences both the old-project fact and racing destination-project deltas, and emits one
+project-scoped `host_notifications_refresh_required` before later destination deltas resume. The
+panel must replace its project state from the destination's authoritative snapshot; it must not
+merge pre-move and post-move deltas. If live and persisted ownership conflict, or neither resolves,
+the router unbinds the socket and sends no Host notification rather than guessing a partition.
 
 `stream.epoch` and `stream.sequence` provide ephemeral per-connection ordering for each scope.
-They are not durable event cursors. Initial authentication, reconnect, epoch change, sequence gap,
-queue overflow, or persistent socket pressure schedules/coalesces
+They are not durable event cursors. Initial authentication, a session project move, reconnect, epoch
+change, sequence gap, queue overflow, or persistent socket pressure schedules/coalesces
 `host_notifications_refresh_required`. The browser drops discontinuous facts instead of applying
 a plausible partial delta. Panels then read their authoritative REST or Host API snapshot; Bobbit
 does not replay canonical Host notifications and does not expose a global notification journal.

--- a/scripts/affected/impact-rules.mjs
+++ b/scripts/affected/impact-rules.mjs
@@ -649,6 +649,12 @@ export const DYNAMIC_EXECUTABLE_CONSUMER_AUDIT = Object.freeze([
 		]),
 	},
 	{
+		consumer: "tests2/core/host-tool-interceptor-order.test.ts",
+		operations: frozen([
+			allowedExecutableOperation("dynamic-import", "`${pathToFileURL(file).href}?${Date.now()}-${Math.random()}`", "test-owned generated host tool interceptor bridge"),
+		]),
+	},
+	{
 		consumer: "tests2/core/hung-test-reporter.test.ts",
 		operations: frozen([
 			declaredExecutableOperation("dynamic-import", "reporterUrl", ["indirect:hung-test-reporter-module"]),

--- a/scripts/affected/impact-rules.mjs
+++ b/scripts/affected/impact-rules.mjs
@@ -1106,6 +1106,13 @@ export const UNRESOLVED_REPOSITORY_READ_AUDIT = Object.freeze([
 		]),
 	},
 	{
+		consumer: "tests2/integration/host-hooks-server-boundaries.test.ts",
+		allowReason: "isolated ModuleHost security fixture result written inside the integration gateway",
+		reads: frozen([
+			{ expression: "fixture.resultPath", count: 1 },
+		]),
+	},
+	{
 		consumer: "tests2/integration/history-fork-api.test.ts",
 		allowReason: "isolated integration gateway and test-owned transcript, proposal, and worktree artifacts",
 		reads: frozen([

--- a/scripts/testing-v2/gen-inventory.mjs
+++ b/scripts/testing-v2/gen-inventory.mjs
@@ -272,6 +272,7 @@ export const DAILY_OVERRIDES = new Map([
 	["tests/e2e/worktree-root-override.spec.ts", "Real worktree-root override on disk."],
 	["tests/e2e/goal-archive-branch-cleanup.spec.ts", "Real bare-repo branch cleanup (realpush) fidelity."],
 	["tests/e2e/goal-task-sqlite-upgrade-restart.spec.ts", "Real per-project legacy GoalStore and TaskStore upgrade, collision-safe retirement, supported-API mutation/deletion, graceful gateway restart, native SQLite identity inspection, and Windows handle-release fidelity."],
+	["tests/e2e/host-notifications.spec.ts", "Real WebSocket project routing and durable notification-to-staff delivery reconciliation across a real gateway crash/restart."],
 	["tests/e2e/port-auto-increment.spec.ts", "Real port-binding race / auto-increment."],
 	["tests/e2e/remove-boot-respawn-restart.spec.ts", "Real boot-respawn across a real gateway restart."],
 	["tests/e2e/anthropic-oauth-restart-sandbox-lock.spec.ts", "Real gateway crash/restart preserves an isolated Anthropic OAuth credential and direct mock-model authentication; its companion sandbox and stale-lock checks retain the same secure credential fixture."],

--- a/scripts/testing-v2/test-map-execution.mjs
+++ b/scripts/testing-v2/test-map-execution.mjs
@@ -23,6 +23,7 @@ export const ISOLATED_VITEST_FILES = Object.freeze({
 	"tests2/core/extension-host-action-dispatcher.test.ts": "Extension-host worker registration mutates NODE_OPTIONS and module-global dispatcher state.",
 	"tests2/core/extension-host-channel-registry.test.ts": "Extension-host worker registration mutates NODE_OPTIONS and module-global channel state.",
 	"tests2/core/extension-host-isolation-config-invariant.test.ts": "Extension-host isolation configuration is evaluated from process state at module load.",
+	"tests2/core/extension-host-module-isolation.test.ts": "Spawns real ModuleHost workers and must not share a reusable core fork whose sibling environment guards can restore its worker resolver.",
 	"tests2/core/extension-host-module-memory-isolation.test.ts": "Deliberately OOMs a ModuleHost worker under a 16 MB old-generation limit and must own a dedicated isolated Vitest fork.",
 	"tests2/core/extension-host-route-dispatcher.test.ts": "Extension-host worker registration mutates NODE_OPTIONS and module-global route state.",
 	"tests2/core/extension-host-session-event-bus.test.ts": "Exercises a module-global EventTarget that must not retain sibling listeners.",
@@ -145,7 +146,7 @@ export function loadVitestExecutionMap({
 	for (const [path, owners] of materializedOwnership) {
 		if (owners.length > 1) errors.push(`${path}: duplicate materialized execution ownership (${owners.join(", ")})`);
 	}
-	if (projects.isolated.length > 11) errors.push(`isolated execution has ${projects.isolated.length} files; maximum is 11`);
+	if (projects.isolated.length > 12) errors.push(`isolated execution has ${projects.isolated.length} files; maximum is 12`);
 
 	const physicalVitest = collectVitestFiles(repoRoot);
 	for (const path of physicalVitest) {

--- a/src/app/host-api.ts
+++ b/src/app/host-api.ts
@@ -37,6 +37,10 @@ import { openPackPanel, setPanelHostFactory, setLauncherHostFactory } from "./pa
 import { consumeGesture } from "./gesture-context.js";
 import { postSessionMessageOverWs } from "./session-write-bridge.js";
 import { subscribeHostSessionEvent } from "./session-event-bus.js";
+import {
+	subscribeHostNotification,
+	subscribeHostNotificationRefresh,
+} from "./host-notification-bus.js";
 import { navigateToTarget } from "./pack-entrypoints.js";
 import { createHostChannelsApi, type HostChannelsApi } from "./channel-bridge.js";
 import { mintPackSurfaceTokenOverWs } from "./surface-token-bridge.js";
@@ -233,10 +237,12 @@ export function getHostApi(
 		ui: true,
 		store: true,
 		channels: true,
+		sessionNotifications: true,
+		projectNotifications: true,
 	};
 	const api = {
 		version: HOST_API_VERSION,
-		contractVersion: Math.max(HOST_CONTRACT_VERSION, 4),
+		contractVersion: HOST_CONTRACT_VERSION,
 		capabilities: {
 			...flags,
 			has: (name: string) => (flags as Record<string, boolean>)[name] === true,
@@ -367,7 +373,21 @@ export function getHostApi(
 				event: E,
 				cb: (payload: HostSessionEventMap[E]) => void,
 			): (() => void) => subscribeHostSessionEvent(sessionId, event, cb),
+			// Canonical facts use the separate privacy-bounded bus. The closure supplies
+			// the trusted RemoteAgent session binding; extension code supplies no ID.
+			notifications: {
+				subscribe: (name, handler) => subscribeHostNotification(sessionId, "session", name, handler),
+				onRefreshRequired: (handler) => subscribeHostNotificationRefresh(sessionId, "session", handler),
+			},
 		} as HostApi["session"],
+		project: {
+			// Project authority is the project already bound to this session's socket.
+			// There is intentionally no projectId parameter or client-side selector.
+			notifications: {
+				subscribe: (name, handler) => subscribeHostNotification(sessionId, "project", name, handler),
+				onRefreshRequired: (handler) => subscribeHostNotificationRefresh(sessionId, "project", handler),
+			},
+		} as HostApi["project"],
 		ui: {
 			// Slice B4: open (or focus) a pack-contributed side panel via the client
 			// pack-panel registry (lazy Blob-URL import + mount). PACK-RELATIVE: BOTH a

--- a/src/app/host-notification-bus.ts
+++ b/src/app/host-notification-bus.ts
@@ -1,0 +1,288 @@
+// Canonical Extension Host notification delivery for browser surfaces.
+//
+// This is deliberately separate from session-event-bus.ts. The legacy bus maps
+// rich raw session frames onto HostMessage/ToolCallRecord and must remain byte-
+// compatible; this bus accepts only the bounded canonical host_notification
+// protocol. Its authority key is the trusted RemoteAgent's bound session, never
+// an identifier supplied by extension code.
+
+import type {
+	HostNotification,
+	HostNotificationName,
+	HostNotificationScope,
+} from "../shared/extension-host/host-hooks.js";
+
+export interface HostNotificationStreamPosition {
+	readonly epoch: string;
+	readonly sequence: number;
+}
+
+export interface HostNotificationFrame {
+	readonly notification: HostNotification;
+	readonly stream: HostNotificationStreamPosition;
+}
+
+export interface HostNotificationRefreshFrame {
+	readonly scope: "session" | "project";
+	readonly epoch: string;
+	readonly sequence: number;
+}
+
+type NotificationHandler = (event: HostNotification) => void;
+type RefreshHandler = () => void;
+type Scope = "session" | "project";
+
+interface Subscription<T> {
+	readonly handler: T;
+	active: boolean;
+	generation: number;
+}
+
+interface StreamState {
+	epoch?: string;
+	sequence: number;
+}
+
+interface BoundBus {
+	readonly notifications: Map<string, Set<Subscription<NotificationHandler>>>;
+	readonly refresh: Record<Scope, Set<Subscription<RefreshHandler>>>;
+	readonly streams: Record<Scope, StreamState>;
+	readonly recentIds: Map<string, true>;
+	readonly refreshScheduled: Record<Scope, boolean>;
+	pendingDeliveries: number;
+}
+
+const buses = new Map<string, BoundBus>();
+const MAX_RECENT_IDS = 512;
+const MAX_PENDING_DELIVERIES = 512;
+
+function createBoundBus(): BoundBus {
+	return {
+		notifications: new Map(),
+		refresh: { session: new Set(), project: new Set() },
+		streams: {
+			session: { sequence: 0 },
+			project: { sequence: 0 },
+		},
+		recentIds: new Map(),
+		refreshScheduled: { session: false, project: false },
+		pendingDeliveries: 0,
+	};
+}
+
+function busFor(sessionId: string): BoundBus {
+	let bus = buses.get(sessionId);
+	if (!bus) {
+		bus = createBoundBus();
+		buses.set(sessionId, bus);
+	}
+	return bus;
+}
+
+function inertUnsubscribe(): () => void {
+	return () => {};
+}
+
+function unsubscribeFrom<T>(set: Set<Subscription<T>>, subscription: Subscription<T>): () => void {
+	return () => {
+		if (!subscription.active) return;
+		subscription.active = false;
+		subscription.generation += 1;
+		set.delete(subscription);
+	};
+}
+
+function scheduleRefresh(bus: BoundBus, scope: Scope): void {
+	if (bus.refreshScheduled[scope]) return;
+	bus.refreshScheduled[scope] = true;
+	queueMicrotask(() => {
+		bus.refreshScheduled[scope] = false;
+		for (const subscription of [...bus.refresh[scope]]) {
+			const generation = subscription.generation;
+			if (!subscription.active) continue;
+			try {
+				if (subscription.active && subscription.generation === generation) subscription.handler();
+			} catch {
+				// One contributed panel must not interrupt another panel's refresh.
+			}
+		}
+	});
+}
+
+/** Subscribe within the RemoteAgent-owned session transport. An unbound host is inert. */
+export function subscribeHostNotification<N extends HostNotificationName>(
+	sessionId: string | undefined,
+	scope: HostNotificationScope<N>,
+	name: N,
+	handler: (event: HostNotification<N>) => void,
+): () => void {
+	if (!sessionId) return inertUnsubscribe();
+	const bus = busFor(sessionId);
+	const key = `${scope}:${name}`;
+	let subscriptions = bus.notifications.get(key);
+	if (!subscriptions) {
+		subscriptions = new Set();
+		bus.notifications.set(key, subscriptions);
+	}
+	const subscription: Subscription<NotificationHandler> = {
+		handler: handler as NotificationHandler,
+		active: true,
+		generation: 0,
+	};
+	subscriptions.add(subscription);
+	return unsubscribeFrom(subscriptions, subscription);
+}
+
+/**
+ * Observe snapshot invalidation for one server-bound scope. Registration itself
+ * schedules the initial snapshot-first refresh; reconnect/gap bursts share the
+ * same microtask coalescer.
+ */
+export function subscribeHostNotificationRefresh(
+	sessionId: string | undefined,
+	scope: Scope,
+	handler: RefreshHandler,
+): () => void {
+	if (!sessionId) return inertUnsubscribe();
+	const bus = busFor(sessionId);
+	const subscription: Subscription<RefreshHandler> = { handler, active: true, generation: 0 };
+	bus.refresh[scope].add(subscription);
+	scheduleRefresh(bus, scope);
+	return unsubscribeFrom(bus.refresh[scope], subscription);
+}
+
+function validPosition(value: unknown): value is HostNotificationStreamPosition {
+	if (!value || typeof value !== "object") return false;
+	const position = value as Partial<HostNotificationStreamPosition>;
+	return typeof position.epoch === "string"
+		&& position.epoch.length > 0
+		&& position.epoch.length <= 256
+		&& Number.isSafeInteger(position.sequence)
+		&& (position.sequence ?? 0) > 0;
+}
+
+function structurallyBoundNotification(value: unknown, transportSessionId: string): value is HostNotification {
+	if (!value || typeof value !== "object") return false;
+	const notification = value as Partial<HostNotification>;
+	if (typeof notification.id !== "string" || notification.id.length === 0) return false;
+	if (typeof notification.name !== "string" || notification.name.length === 0) return false;
+	if (notification.scope !== "session" && notification.scope !== "project") return false;
+	// Session scope has an additional exact client-side fence. Project authority
+	// remains server-owned because extension code never receives a project selector.
+	if (notification.scope === "session" && notification.sessionId !== transportSessionId) return false;
+	return true;
+}
+
+/**
+ * Advance one ephemeral per-connection scope stream. False means the frame is a
+ * duplicate/late frame or crossed a gap/epoch boundary and must not be applied as
+ * a delta. The authoritative refresh is scheduled for discontinuities.
+ */
+function advanceStream(bus: BoundBus, scope: Scope, position: HostNotificationStreamPosition): boolean {
+	const stream = bus.streams[scope];
+	if (stream.epoch === undefined) {
+		stream.epoch = position.epoch;
+		stream.sequence = position.sequence;
+		if (position.sequence !== 1) {
+			scheduleRefresh(bus, scope);
+			return false;
+		}
+		return true;
+	}
+	if (stream.epoch !== position.epoch) {
+		stream.epoch = position.epoch;
+		stream.sequence = position.sequence;
+		scheduleRefresh(bus, scope);
+		return false;
+	}
+	if (position.sequence <= stream.sequence) return false;
+	const contiguous = position.sequence === stream.sequence + 1;
+	stream.sequence = position.sequence;
+	if (!contiguous) {
+		scheduleRefresh(bus, scope);
+		return false;
+	}
+	return true;
+}
+
+function rememberId(bus: BoundBus, id: string): boolean {
+	if (bus.recentIds.has(id)) return false;
+	bus.recentIds.set(id, true);
+	while (bus.recentIds.size > MAX_RECENT_IDS) {
+		const oldest = bus.recentIds.keys().next().value;
+		if (oldest === undefined) break;
+		bus.recentIds.delete(oldest);
+	}
+	return true;
+}
+
+/** Feed one server-canonical notification frame from its bound RemoteAgent. */
+export function publishHostNotificationFrame(
+	transportSessionId: string,
+	frame: HostNotificationFrame,
+): void {
+	if (!transportSessionId || !validPosition(frame?.stream)) return;
+	if (!structurallyBoundNotification(frame?.notification, transportSessionId)) return;
+	const bus = busFor(transportSessionId);
+	const notification = frame.notification;
+	if (!advanceStream(bus, notification.scope, frame.stream)) return;
+	if (!rememberId(bus, notification.id)) return;
+	if (bus.pendingDeliveries >= MAX_PENDING_DELIVERIES) {
+		scheduleRefresh(bus, notification.scope);
+		return;
+	}
+	bus.pendingDeliveries += 1;
+	const key = `${notification.scope}:${notification.name}`;
+	// Snapshot the live subscribers at publication time: a panel mounted before
+	// this microtask runs must not observe a fact emitted before it subscribed.
+	const deliveries = [...(bus.notifications.get(key) ?? [])].map((subscription) => ({
+		subscription,
+		generation: subscription.generation,
+	}));
+	queueMicrotask(() => {
+		bus.pendingDeliveries = Math.max(0, bus.pendingDeliveries - 1);
+		for (const { subscription, generation } of deliveries) {
+			if (!subscription.active) continue;
+			try {
+				if (subscription.generation === generation) subscription.handler(notification);
+			} catch {
+				// Observational callbacks are isolated and cannot affect publication.
+			}
+		}
+	});
+}
+
+/** Feed the server's explicit queue-overflow/refresh-required frame. */
+export function publishHostNotificationRefreshRequired(
+	transportSessionId: string,
+	frame: HostNotificationRefreshFrame,
+): void {
+	if (!transportSessionId || !frame || (frame.scope !== "session" && frame.scope !== "project")) return;
+	if (!validPosition({ epoch: frame.epoch, sequence: frame.sequence })) return;
+	const bus = busFor(transportSessionId);
+	const stream = bus.streams[frame.scope];
+	if (stream.epoch !== frame.epoch || frame.sequence > stream.sequence) {
+		stream.epoch = frame.epoch;
+		stream.sequence = frame.sequence;
+	}
+	scheduleRefresh(bus, frame.scope);
+}
+
+/**
+ * Authentication establishes a fresh ephemeral stream. Called for initial auth
+ * and every reconnect; recent semantic IDs intentionally survive to suppress a
+ * replayed envelope while both scopes refresh from authority.
+ */
+export function resetHostNotificationStreams(transportSessionId: string): void {
+	if (!transportSessionId) return;
+	const bus = busFor(transportSessionId);
+	bus.streams.session = { sequence: 0 };
+	bus.streams.project = { sequence: 0 };
+	scheduleRefresh(bus, "session");
+	scheduleRefresh(bus, "project");
+}
+
+/** Test-only reset; production lifetime follows the app session cache. */
+export function __resetHostNotificationBusForTests(): void {
+	buses.clear();
+}

--- a/src/app/remote-agent.ts
+++ b/src/app/remote-agent.ts
@@ -54,6 +54,11 @@ import { scheduleGateStatusRefreshForGoal, refreshSessions, scheduleSessionListR
 import { applySidePanelWorkspaceFromServer, hydrateSidePanelWorkspace } from "./side-panel-workspace.js";
 import { shouldRefreshGateStatusForEvent } from "./gate-status-events.js";
 import { publishClientMessage, publishClientStatus } from "./session-event-bus.js";
+import {
+	publishHostNotificationFrame,
+	publishHostNotificationRefreshRequired,
+	resetHostNotificationStreams,
+} from "./host-notification-bus.js";
 import { registerSessionPoster, unregisterSessionPoster, type SessionPostRequest } from "./session-write-bridge.js";
 import { registerSurfaceTokenMinter, unregisterSurfaceTokenMinter, type PackSurfaceRef } from "./surface-token-minter-registry.js";
 import { handleMutationPendingEvent, handleMutationDecidedEvent } from "./mutation-approval-events.js";
@@ -1127,6 +1132,10 @@ export class RemoteAgent {
 						this._reconnectAttempt = 0;
 						this._connectionEpoch++;
 						this._setConnectionStatus("connected");
+						// Canonical notification sequence state is ephemeral per authenticated
+						// connection. Reset it on initial auth and reconnect, and coalesce an
+						// authoritative session/project snapshot refresh for mounted panels.
+						resetHostNotificationStreams(this._sessionId);
 						resolve();
 						// Initial hydration is owned by connectToSession after ChatPanel
 						// binding. Reconnects still refresh the server workspace here and
@@ -2304,6 +2313,24 @@ export class RemoteAgent {
 			scheduleGateStatusRefreshForGoal((msg as any).goalId);
 		}
 		switch (msg.type) {
+			case "host_notification": {
+				// This RemoteAgent's authenticated session is the client authority key.
+				// The server has already routed the canonical frame to the exact session /
+				// project socket; extension code never supplies either binding.
+				publishHostNotificationFrame(this._sessionId, {
+					notification: msg.notification,
+					stream: msg.stream,
+				});
+				break;
+			}
+			case "host_notifications_refresh_required": {
+				publishHostNotificationRefreshRequired(this._sessionId, {
+					scope: msg.scope,
+					epoch: msg.epoch,
+					sequence: msg.sequence,
+				});
+				break;
+			}
 			case "ext_surface_token_result": {
 				const pending = this._pendingExtSurfaceTokens.get(msg.requestId);
 				if (pending) {

--- a/src/server/agent/gate-store.ts
+++ b/src/server/agent/gate-store.ts
@@ -103,10 +103,16 @@ interface GateWriteMetrics {
 	durationMs: number;
 }
 
+interface GatePublication {
+	/** Exact gate projections immediately before and after the successful durable write. */
+	previous: ReadonlyMap<string, GateState>;
+	current: ReadonlyMap<string, GateState>;
+}
+
 interface GatePersistence {
 	loadInto(gates: Map<string, GateState>): void;
 	schedule(keys: Iterable<string>): void;
-	publishStrict(keys: Iterable<string>): Promise<void>;
+	publishStrict(keys: Iterable<string>): Promise<GatePublication>;
 	flush(): Promise<void>;
 	close(): Promise<void>;
 	dispose(): void;
@@ -117,6 +123,9 @@ interface GatePersistence {
 class JsonGatePersistence implements GatePersistence {
 	private readonly writer: CoalescedJsonWriter;
 	private readonly storeFile: string;
+	private durable = new Map<string, GateState>();
+	private publishing: GatePublication | null = null;
+	private lastPublication: GatePublication = { previous: new Map(), current: new Map() };
 
 	constructor(
 		private readonly fs: FsLike,
@@ -128,8 +137,22 @@ class JsonGatePersistence implements GatePersistence {
 			fs,
 			stateDir,
 			this.storeFile,
-			() => JSON.stringify(Array.from(gates.values())),
+			() => {
+				const json = JSON.stringify(Array.from(gates.values()));
+				const current = new Map<string, GateState>();
+				for (const gate of JSON.parse(json) as GateState[]) current.set(compositeKey(gate.goalId, gate.gateId), gate);
+				this.publishing = { previous: this.durable, current };
+				return json;
+			},
 			"gate-store",
+			undefined,
+			undefined,
+			() => {
+				if (!this.publishing) return;
+				this.lastPublication = this.publishing;
+				this.durable = new Map(this.publishing.current);
+				this.publishing = null;
+			},
 		);
 	}
 
@@ -141,13 +164,16 @@ class JsonGatePersistence implements GatePersistence {
 			for (const gate of data) {
 				if (gate?.gateId && gate?.goalId) gates.set(compositeKey(gate.goalId, gate.gateId), gate);
 			}
+			this.durable = new Map(JSON.parse(JSON.stringify([...gates.values()])).map((gate: GateState) => [compositeKey(gate.goalId, gate.gateId), gate]));
 		} catch (error) {
 			console.error("[gate-store] Failed to load persisted gates:", error);
 		}
 	}
 
 	schedule(_keys: Iterable<string>): void { this.writer.schedule(); }
-	publishStrict(_keys: Iterable<string>): Promise<void> { return this.writer.publishStrict(); }
+	publishStrict(_keys: Iterable<string>): Promise<GatePublication> {
+		return this.writer.publishStrict().then(() => this.lastPublication);
+	}
 	flush(): Promise<void> { return this.writer.flush(); }
 	async close(): Promise<void> { await this.writer.flush(); }
 	dispose(): void { /* no persistent handle */ }
@@ -348,6 +374,8 @@ class SqliteGatePersistence implements GatePersistence {
 	private lastWriteMetrics: GateWriteMetrics | null = null;
 	private closePromise: Promise<void> | null = null;
 	private closed = false;
+	private durable = new Map<string, GateState>();
+	private lastPublication: GatePublication = { previous: new Map(), current: new Map() };
 
 	constructor(
 		private readonly fs: FsLike,
@@ -555,7 +583,11 @@ class SqliteGatePersistence implements GatePersistence {
 
 	loadInto(gates: Map<string, GateState>): void {
 		const rows = this.readValidatedRows();
-		for (const row of rows) gates.set(compositeKey(row.gate.goalId, row.gate.gateId), row.gate);
+		for (const row of rows) {
+			const key = compositeKey(row.gate.goalId, row.gate.gateId);
+			gates.set(key, row.gate);
+			this.durable.set(key, structuredClone(row.gate));
+		}
 	}
 
 	schedule(keys: Iterable<string>): void {
@@ -581,10 +613,10 @@ class SqliteGatePersistence implements GatePersistence {
 		return this.requestBarrier();
 	}
 
-	publishStrict(keys: Iterable<string>): Promise<void> {
+	publishStrict(keys: Iterable<string>): Promise<GatePublication> {
 		this.assertOpen();
 		for (const key of keys) this.dirty.add(key);
-		return this.requestBarrier();
+		return this.requestBarrier().then(() => this.lastPublication);
 	}
 
 	getLastWriteMetrics(): GateWriteMetrics | null { return this.lastWriteMetrics; }
@@ -661,6 +693,12 @@ class SqliteGatePersistence implements GatePersistence {
 			const snapshots = keys.map(key => ({ key, gate: this.gates.get(key) }));
 			const startedAt = performance.now();
 			let bytes = 0;
+			const previous = new Map<string, GateState>();
+			const current = new Map<string, GateState>();
+			for (const { key } of snapshots) {
+				const durable = this.durable.get(key);
+				if (durable) previous.set(key, durable);
+			}
 			try {
 				if (snapshots.length > 0) {
 					const upsert = this.db.prepare(`
@@ -678,11 +716,19 @@ class SqliteGatePersistence implements GatePersistence {
 							continue;
 						}
 						const payload = JSON.stringify(snapshot.gate);
+						const durableGate = JSON.parse(payload) as GateState;
+						current.set(snapshot.key, durableGate);
 						bytes += Buffer.byteLength(payload);
 						upsert.run(snapshot.gate.goalId, snapshot.gate.gateId, payload);
 					}
 					this.db.exec("COMMIT");
 				}
+				for (const { key } of snapshots) {
+					const durableGate = current.get(key);
+					if (durableGate) this.durable.set(key, durableGate);
+					else this.durable.delete(key);
+				}
+				this.lastPublication = { previous, current };
 				this.lastWriteMetrics = { bytes, durationMs: performance.now() - startedAt };
 				this.settlePublished(revision);
 			} catch (error) {
@@ -729,7 +775,6 @@ export class GateStore {
 	private closePromise: Promise<void> | null = null;
 	private readonly pendingInMemoryStatusCommits = new Map<string, GateStatusCommit[]>();
 	private readonly detachedStatusKeys = new Set<string>();
-	private detachedStatusCommits: GateStatusCommit[] = [];
 	private detachedStatusFlush: Promise<void> | null = null;
 	private detachedStatusFlushScheduled = false;
 
@@ -761,7 +806,7 @@ export class GateStore {
 
 	/** Await all pending persistence, primarily for orderly shutdown/tests. */
 	flush(): Promise<void> {
-		if (this.detachedStatusCommits.length > 0 || this.detachedStatusFlush) {
+		if (this.detachedStatusKeys.size > 0 || this.detachedStatusFlush) {
 			return this.flushDetachedStatusCommits();
 		}
 		return this.persistence.flush();
@@ -773,7 +818,27 @@ export class GateStore {
 		// This synchronous fence makes every mutation linearize either before the
 		// persistence close barrier or before touching the in-memory snapshot.
 		this.acceptingMutations = false;
-		this.closePromise = this.persistence.close();
+		if (this.detachedStatusKeys.size === 0 && !this.detachedStatusFlush) {
+			this.closePromise = this.persistence.close();
+			return this.closePromise;
+		}
+		this.closePromise = (async () => {
+			let lastError: unknown;
+			try {
+				for (let attempt = 0; attempt < GATE_SQLITE_CLOSE_ATTEMPTS; attempt++) {
+					try {
+						await this.flush();
+						await this.persistence.close();
+						return;
+					} catch (error) {
+						lastError = error;
+					}
+				}
+				throw lastError;
+			} finally {
+				if (lastError) this.persistence.dispose();
+			}
+		})();
 		return this.closePromise;
 	}
 
@@ -789,7 +854,7 @@ export class GateStore {
 	}
 
 	/** Strict lifecycle writes share the coalesced persistence queue. */
-	private saveStrict(keys: Iterable<string>): Promise<void> {
+	private saveStrict(keys: Iterable<string>): Promise<GatePublication> {
 		return this.persistence.publishStrict(keys);
 	}
 
@@ -802,10 +867,20 @@ export class GateStore {
 		return { goalId: gate.goalId, gateId: gate.gateId, previousStatus, status, revision: gate.statusRevision };
 	}
 
-	private reportStatusCommits(commits: readonly GateStatusCommit[]): void {
-		for (const commit of commits) {
+	private reportStatusCommits(keys: readonly string[], publication: GatePublication): void {
+		for (const key of keys) {
+			const previous = publication.previous.get(key);
+			const current = publication.current.get(key);
+			if (!previous || !current || previous.status === current.status) continue;
+			const commit: GateStatusCommit = {
+				goalId: current.goalId,
+				gateId: current.gateId,
+				previousStatus: previous.status,
+				status: current.status,
+				revision: current.statusRevision ?? 1,
+			};
 			try {
-				this.onStatusCommitted?.(Object.freeze({ ...commit }));
+				this.onStatusCommitted?.(Object.freeze(commit));
 			} catch (error) {
 				console.error(`[gate-store] Committed status observer failed for ${commit.goalId}/${commit.gateId}:`, error);
 			}
@@ -813,7 +888,8 @@ export class GateStore {
 	}
 
 	private publishStatusCommits(keys: Iterable<string>, commits: readonly GateStatusCommit[]): Promise<void> {
-		return this.saveStrict(keys).then(() => this.reportStatusCommits(commits));
+		const statusKeys = [...new Set(commits.map(commit => compositeKey(commit.goalId, commit.gateId)))];
+		return this.saveStrict(keys).then(publication => this.reportStatusCommits(statusKeys, publication));
 	}
 
 	private publishStatusCommitsDetached(keys: Iterable<string>, commits: readonly GateStatusCommit[]): void {
@@ -821,9 +897,10 @@ export class GateStore {
 			this.save(keys);
 			return;
 		}
+		// The detached strict batch owns scheduling while an observer is installed.
+		// Scheduling a second mutable-map write here could commit the final state
+		// ahead of this batch and consume the durable status delta without a fact.
 		for (const key of keys) this.detachedStatusKeys.add(key);
-		this.detachedStatusCommits.push(...commits);
-		this.save(this.detachedStatusKeys);
 		if (this.detachedStatusFlushScheduled || this.detachedStatusFlush) return;
 		this.detachedStatusFlushScheduled = true;
 		queueMicrotask(() => {
@@ -837,12 +914,16 @@ export class GateStore {
 	private flushDetachedStatusCommits(): Promise<void> {
 		if (this.detachedStatusFlush) return this.detachedStatusFlush;
 		this.detachedStatusFlush = (async () => {
-			while (this.detachedStatusCommits.length > 0) {
-				const commits = this.detachedStatusCommits;
-				this.detachedStatusCommits = [];
+			while (this.detachedStatusKeys.size > 0) {
+				const keys = [...this.detachedStatusKeys];
 				this.detachedStatusKeys.clear();
-				await this.persistence.flush();
-				this.reportStatusCommits(commits);
+				try {
+					const publication = await this.persistence.publishStrict(keys);
+					this.reportStatusCommits(keys, publication);
+				} catch (error) {
+					for (const key of keys) this.detachedStatusKeys.add(key);
+					throw error;
+				}
 			}
 		})().finally(() => {
 			this.detachedStatusFlush = null;

--- a/src/server/agent/gate-store.ts
+++ b/src/server/agent/gate-store.ts
@@ -67,6 +67,8 @@ export interface GateState {
 	gateId: string;
 	goalId: string;
 	status: GateStatus;
+	/** Durable, per-gate revision incremented only when the persisted status changes. */
+	statusRevision?: number;
 	currentContent?: string;
 	currentContentVersion?: number;
 	currentMetadata?: Record<string, string>;
@@ -74,6 +76,14 @@ export interface GateState {
 	/** Signals at or before this timestamp are ineligible for verification-step cache reuse. */
 	verificationCacheInvalidatedAt?: number;
 	updatedAt: number;
+}
+
+export interface GateStatusCommit {
+	goalId: string;
+	gateId: string;
+	previousStatus: GateStatus;
+	status: GateStatus;
+	revision: number;
 }
 
 export interface GateResetResult {
@@ -232,6 +242,9 @@ function validateGateState(value: unknown, label: string, expectedIdentity?: { g
 		throw new Error(`[gate-store] SQLite row identity mismatch for ${expectedIdentity.goalId}/${expectedIdentity.gateId}`);
 	}
 	if (typeof value.status !== "string" || !GATE_STATUSES.has(value.status as GateStatus)) invalidGate(label, `unsupported status ${String(value.status)}`);
+	if (value.statusRevision !== undefined && (!Number.isSafeInteger(value.statusRevision) || (value.statusRevision as number) < 1)) {
+		invalidGate(label, "statusRevision must be a positive safe integer");
+	}
 	if (!Number.isFinite(value.updatedAt)) invalidGate(label, "updatedAt must be finite");
 	if (!Array.isArray(value.signals)) invalidGate(label, "signals must be an array");
 	if (value.currentContent !== undefined && typeof value.currentContent !== "string") invalidGate(label, "currentContent must be a string");
@@ -714,9 +727,16 @@ export class GateStore {
 	private gates: Map<string, GateState> = new Map();
 	private acceptingMutations = true;
 	private closePromise: Promise<void> | null = null;
+	private readonly pendingInMemoryStatusCommits = new Map<string, GateStatusCommit[]>();
+	private readonly detachedStatusKeys = new Set<string>();
+	private detachedStatusCommits: GateStatusCommit[] = [];
+	private detachedStatusFlush: Promise<void> | null = null;
+	private detachedStatusFlushScheduled = false;
 
-	/** Optional callback invoked when gate summary truth changes (for bumping goal generation). */
+	/** Optional legacy callback invoked when gate summary truth changes. */
 	onStatusChange?: (goalId: string, gateId: string) => void;
+	/** Optional canonical observer invoked only after the changed status is persisted. */
+	onStatusCommitted?: (commit: Readonly<GateStatusCommit>) => void;
 
 	constructor(stateDir: string, fsImpl: FsLike = realFs, options: GateStoreOptions = {}) {
 		const persistence = options.persistence ?? (fsImpl === realFs ? "sqlite" : "json");
@@ -741,6 +761,9 @@ export class GateStore {
 
 	/** Await all pending persistence, primarily for orderly shutdown/tests. */
 	flush(): Promise<void> {
+		if (this.detachedStatusCommits.length > 0 || this.detachedStatusFlush) {
+			return this.flushDetachedStatusCommits();
+		}
 		return this.persistence.flush();
 	}
 
@@ -768,6 +791,63 @@ export class GateStore {
 	/** Strict lifecycle writes share the coalesced persistence queue. */
 	private saveStrict(keys: Iterable<string>): Promise<void> {
 		return this.persistence.publishStrict(keys);
+	}
+
+	private nextStatusCommit(gate: GateState, status: GateStatus, now: number): GateStatusCommit | undefined {
+		if (gate.status === status) return undefined;
+		const previousStatus = gate.status;
+		gate.status = status;
+		gate.statusRevision = (gate.statusRevision ?? 0) + 1;
+		gate.updatedAt = Math.max(now, gate.updatedAt + 1);
+		return { goalId: gate.goalId, gateId: gate.gateId, previousStatus, status, revision: gate.statusRevision };
+	}
+
+	private reportStatusCommits(commits: readonly GateStatusCommit[]): void {
+		for (const commit of commits) {
+			try {
+				this.onStatusCommitted?.(Object.freeze({ ...commit }));
+			} catch (error) {
+				console.error(`[gate-store] Committed status observer failed for ${commit.goalId}/${commit.gateId}:`, error);
+			}
+		}
+	}
+
+	private publishStatusCommits(keys: Iterable<string>, commits: readonly GateStatusCommit[]): Promise<void> {
+		return this.saveStrict(keys).then(() => this.reportStatusCommits(commits));
+	}
+
+	private publishStatusCommitsDetached(keys: Iterable<string>, commits: readonly GateStatusCommit[]): void {
+		if (!this.onStatusCommitted || commits.length === 0) {
+			this.save(keys);
+			return;
+		}
+		for (const key of keys) this.detachedStatusKeys.add(key);
+		this.detachedStatusCommits.push(...commits);
+		this.save(this.detachedStatusKeys);
+		if (this.detachedStatusFlushScheduled || this.detachedStatusFlush) return;
+		this.detachedStatusFlushScheduled = true;
+		queueMicrotask(() => {
+			this.detachedStatusFlushScheduled = false;
+			void this.flushDetachedStatusCommits().catch(error => {
+				console.error("[gate-store] Failed to publish gate status change:", error);
+			});
+		});
+	}
+
+	private flushDetachedStatusCommits(): Promise<void> {
+		if (this.detachedStatusFlush) return this.detachedStatusFlush;
+		this.detachedStatusFlush = (async () => {
+			while (this.detachedStatusCommits.length > 0) {
+				const commits = this.detachedStatusCommits;
+				this.detachedStatusCommits = [];
+				this.detachedStatusKeys.clear();
+				await this.persistence.flush();
+				this.reportStatusCommits(commits);
+			}
+		})().finally(() => {
+			this.detachedStatusFlush = null;
+		});
+		return this.detachedStatusFlush;
 	}
 
 	/** Initialize pending gate states for a new goal. */
@@ -805,6 +885,7 @@ export class GateStore {
 		const modifiedIds = new Set(modifiedGateIds);
 		const now = Date.now();
 		const dirtyKeys: string[] = [];
+		const statusCommits: GateStatusCommit[] = [];
 
 		for (const [key, gate] of this.gates) {
 			if (gate.goalId !== goalId) continue;
@@ -817,9 +898,10 @@ export class GateStore {
 
 			remainingGateIds.delete(gate.gateId);
 			if (modifiedIds.has(gate.gateId)) {
-				gate.status = "pending";
+				const commit = this.nextStatusCommit(gate, "pending", now);
+				if (commit) statusCommits.push(commit);
 				gate.verificationCacheInvalidatedAt = now;
-				gate.updatedAt = now;
+				gate.updatedAt = Math.max(now, gate.updatedAt);
 				dirtyKeys.push(key);
 			}
 		}
@@ -836,7 +918,11 @@ export class GateStore {
 			dirtyKeys.push(key);
 		}
 
-		if (dirtyKeys.length > 0) this.save(dirtyKeys);
+		if (dirtyKeys.length > 0) {
+			if (statusCommits.length > 0) this.publishStatusCommitsDetached(dirtyKeys, statusCommits);
+			else this.save(dirtyKeys);
+		}
+		for (const commit of statusCommits) this.onStatusChange?.(commit.goalId, commit.gateId);
 	}
 
 	getGate(goalId: string, gateId: string): GateState | undefined {
@@ -896,9 +982,12 @@ export class GateStore {
 			verification: { status: "passed", steps: [] },
 		};
 		gate.signals.push(signal);
-		gate.status = "bypassed";
-		gate.updatedAt = now;
-		this.save([key]);
+		const commit = this.nextStatusCommit(gate, "bypassed", now);
+		if (commit) this.publishStatusCommitsDetached([key], [commit]);
+		else {
+			gate.updatedAt = Math.max(now, gate.updatedAt + 1);
+			this.save([key]);
+		}
 		this.onStatusChange?.(goalId, gateId);
 		return signal;
 	}
@@ -916,9 +1005,9 @@ export class GateStore {
 		const key = compositeKey(goalId, gateId);
 		const gate = this.gates.get(key);
 		if (!gate) return;
-		gate.status = status;
-		gate.updatedAt = Date.now();
-		this.save([key]);
+		const commit = this.nextStatusCommit(gate, status, Date.now());
+		if (!commit) return;
+		this.publishStatusCommitsDetached([key], [commit]);
 		this.onStatusChange?.(goalId, gateId);
 	}
 
@@ -1023,8 +1112,9 @@ export class GateStore {
 		const changedGateIds: string[] = [];
 		const unchangedGateIds: string[] = [];
 		const previousStatuses: Record<string, GateStatus> = {};
-		const snapshots = new Map<string, { status: GateStatus; updatedAt: number; cacheAt?: number; hadCacheAt: boolean }>();
+		const snapshots = new Map<string, { status: GateStatus; statusRevision?: number; hadStatusRevision: boolean; updatedAt: number; cacheAt?: number; hadCacheAt: boolean }>();
 		const affectedKeys: string[] = [];
+		const statusCommits: GateStatusCommit[] = [];
 		const now = Date.now();
 
 		for (const affectedGateId of affectedGateIds) {
@@ -1037,16 +1127,19 @@ export class GateStore {
 				affectedKeys.push(key);
 				snapshots.set(key, {
 					status: gate.status,
+					statusRevision: gate.statusRevision,
+					hadStatusRevision: Object.prototype.hasOwnProperty.call(gate, "statusRevision"),
 					updatedAt: gate.updatedAt,
 					cacheAt: gate.verificationCacheInvalidatedAt,
 					hadCacheAt: Object.prototype.hasOwnProperty.call(gate, "verificationCacheInvalidatedAt"),
 				});
 				gate.verificationCacheInvalidatedAt = now;
-				gate.updatedAt = now;
+				gate.updatedAt = Math.max(now, gate.updatedAt);
 			}
 
 			if (gate && gate.status !== "pending") {
-				gate.status = "pending";
+				const commit = this.nextStatusCommit(gate, "pending", now)!;
+				statusCommits.push(commit);
 				changedGateIds.push(affectedGateId);
 			} else {
 				unchangedGateIds.push(affectedGateId);
@@ -1054,9 +1147,23 @@ export class GateStore {
 		}
 
 		try {
-			if (affectedKeys.length > 0) {
-				if (strict) await this.saveStrict(affectedKeys);
-				else if (persist) this.save(affectedKeys);
+			if (!persist) {
+				for (const commit of statusCommits) {
+					const key = compositeKey(commit.goalId, commit.gateId);
+					const pending = this.pendingInMemoryStatusCommits.get(key) ?? [];
+					pending.push(commit);
+					this.pendingInMemoryStatusCommits.set(key, pending);
+				}
+			} else if (affectedKeys.length > 0) {
+				const pendingCommits = affectedKeys.flatMap(key => this.pendingInMemoryStatusCommits.get(key) ?? []);
+				if (strict) {
+					await this.publishStatusCommits(affectedKeys, [...pendingCommits, ...statusCommits]);
+				} else if (pendingCommits.length > 0 || statusCommits.length > 0) {
+					this.publishStatusCommitsDetached(affectedKeys, [...pendingCommits, ...statusCommits]);
+				} else {
+					this.save(affectedKeys);
+				}
+				for (const key of affectedKeys) this.pendingInMemoryStatusCommits.delete(key);
 			}
 		} catch (err) {
 			for (const [key, snapshot] of snapshots) {
@@ -1064,6 +1171,8 @@ export class GateStore {
 				if (!gate) continue;
 				gate.status = snapshot.status;
 				gate.updatedAt = snapshot.updatedAt;
+				if (snapshot.hadStatusRevision) gate.statusRevision = snapshot.statusRevision;
+				else delete gate.statusRevision;
 				if (snapshot.hadCacheAt) gate.verificationCacheInvalidatedAt = snapshot.cacheAt;
 				else delete gate.verificationCacheInvalidatedAt;
 			}
@@ -1101,19 +1210,20 @@ export class GateStore {
 		const dependents = this.getDependentGateIds(gateId, workflow, false);
 		const changedGateIds: string[] = [];
 		const dirtyKeys: string[] = [];
+		const commits: GateStatusCommit[] = [];
 		const now = Date.now();
 
 		for (const depId of dependents) {
 			const key = compositeKey(goalId, depId);
 			const gate = this.gates.get(key);
 			if (gate && gate.status !== "pending") {
-				gate.status = "pending";
-				gate.updatedAt = now;
+				commits.push(this.nextStatusCommit(gate, "pending", now)!);
 				changedGateIds.push(depId);
 				dirtyKeys.push(key);
 			}
 		}
-		if (dirtyKeys.length > 0) this.save(dirtyKeys);
+		if (dirtyKeys.length > 0) this.publishStatusCommitsDetached(dirtyKeys, commits);
+		for (const changedGateId of changedGateIds) this.onStatusChange?.(goalId, changedGateId);
 	}
 
 	/** Remove all gates for a goal (cleanup on goal deletion). */

--- a/src/server/agent/goal-manager.ts
+++ b/src/server/agent/goal-manager.ts
@@ -547,7 +547,7 @@ export class GoalManager {
 			goal.workflow = JSON.parse(JSON.stringify(first));
 		}
 
-		this.store.put(goal);
+		await this.store.putStrict(goal);
 		return goal;
 	}
 
@@ -973,9 +973,10 @@ export class GoalManager {
 			console.warn(`[goal-manager] archiveGoalAfterMerge: child ${childId} not found`);
 			return;
 		}
-		// 1. State first.
+		// 1. State first, through the same strict completion boundary as direct
+		// team completion so the durable goalCompleted fact cannot be skipped.
 		if (goal.state !== "complete") {
-			this.store.update(childId, { state: "complete" });
+			await this.updateGoal(childId, { state: "complete" });
 		}
 		// 2. Archive. Always replay the boundary for an already-archived child:
 		// a prior crash may have committed goal intent but not session cleanup.
@@ -1198,7 +1199,7 @@ export class GoalManager {
 			}
 		}
 
-		return this.store.update(id, updates);
+		return this.store.updateStrict(id, updates);
 	}
 
 	/** Narrow explicit deletion because GoalStore.update deliberately ignores undefined fields. */

--- a/src/server/agent/goal-manager.ts
+++ b/src/server/agent/goal-manager.ts
@@ -440,7 +440,10 @@ export class GoalManager {
 			} : {}),
 			branch,
 			repoPath,
-			team,
+			// Explicit false is the legacy standalone shape: omit the durable team
+			// capability before the authoritative create rather than publishing a
+			// transient true value and silently rewriting the stored record later.
+			...(team ? { team: true } : {}),
 			setupStatus,
 			sandboxed: adoptedWorkspace ? adoptedWorkspace.sandboxed : sandboxed,
 		};

--- a/src/server/agent/goal-store.ts
+++ b/src/server/agent/goal-store.ts
@@ -182,6 +182,33 @@ export interface PersistedGoal {
 	maxNestingDepth?: number;
 }
 
+/**
+ * Bounded post-commit goal fact submitted to the canonical host notification
+ * dispatcher by ProjectContext. The store owns the authoritative transition
+ * and revision; consumers never receive the mutable PersistedGoal record.
+ */
+export type GoalStoreNotification =
+	| Readonly<{
+		name: "goalCreated";
+		revision: number;
+		payload: Readonly<{ goalId: string; parentGoalId?: string; state: GoalState }>;
+	}>
+	| Readonly<{
+		name: "goalUpdated";
+		revision: number;
+		payload: Readonly<{ goalId: string; state: GoalState; changedFields: readonly string[] }>;
+	}>
+	| Readonly<{
+		name: "goalCompleted";
+		revision: number;
+		payload: Readonly<{ goalId: string; parentGoalId?: string }>;
+	}>
+	| Readonly<{
+		name: "goalArchived";
+		revision: number;
+		payload: Readonly<{ goalId: string }>;
+	}>;
+
 interface GoalWriteMetrics {
 	bytes: number;
 	durationMs: number;
@@ -253,6 +280,20 @@ const NUMBER_FIELDS = ["archivedAt", "maxConcurrentChildren", "replanCount", "ma
 const STRING_ARRAY_FIELDS = [
 	"skipGateRequirements", "enabledOptionalSteps", "acceptanceCriteria", "dependsOnPlanIds",
 ] as const;
+
+/** Field names safe to expose as bounded goalUpdated metadata. */
+const GOAL_NOTIFICATION_CHANGED_FIELDS = new Set<keyof PersistedGoal>([
+	"title", "cwd", "state", "spec", "worktreePath", "worktreeOwnerSessionId", "branch", "repoPath",
+	"team", "teamLeadSessionId", "skipGateRequirements", "workflowId", "workflow", "setupStatus", "setupError",
+	"schedulerRecovery", "metadata", "reattemptOf", "sandboxed", "autoStartTeam", "enabledOptionalSteps",
+	"repoWorktrees", "parentGoalId", "rootGoalId", "mergeTarget", "divergencePolicy", "maxConcurrentChildren",
+	"acceptanceCriteria", "spawnedFromPlanId", "dependsOnPlanIds", "paused", "pauseSource", "replanCount",
+	"mergeConflict", "suggestedRole", "spawnedBySessionId", "inlineRoles", "subgoalsAllowed", "maxNestingDepth",
+]);
+
+function nextGoalRevision(previous: number): number {
+	return Math.max(Date.now(), previous + 1);
+}
 
 function invalidGoal(label: string, detail: string): never {
 	throw new Error(`[goal-store] Invalid ${label}: ${detail}`);
@@ -820,6 +861,13 @@ export class GoalStore {
 	onIndexUpdate?: (goal: PersistedGoal) => void;
 
 	/**
+	 * Canonical host notification seam. Invoked only after strict persistence
+	 * succeeds. Synchronous throws and rejected promises are isolated because a
+	 * consumer cannot roll back an already-authoritative goal transition.
+	 */
+	onHostNotification?: (notification: GoalStoreNotification) => void | Promise<void>;
+
+	/**
 	 * Called once when a goal id appears in the store for the first time.
 	 * Wired by `ProjectContext.setGoalTriggerDispatcher` from `server.ts`.
 	 * MUST be assigned independently of `onIndexUpdate` — the search index
@@ -853,6 +901,38 @@ export class GoalStore {
 		if (isNew) this.onGoalCreated?.(goal);
 	}
 
+	/** Strict whole-record publication used by the authoritative create path. */
+	async putStrict(goal: PersistedGoal): Promise<void> {
+		this.assertAcceptingMutations();
+		if (goal.setupStatus !== "error") delete goal.setupError;
+		const previous = this.goals.get(goal.id);
+		const isNew = previous === undefined;
+		const mutationRevision = this.recordMutation(goal.id);
+		const mutationGeneration = this.generation;
+		this.goals.set(goal.id, goal);
+		try {
+			await this.saveStrict([goal.id]);
+		} catch (error) {
+			if (this.goalMutationRevisions.get(goal.id) === mutationRevision && this.goals.get(goal.id) === goal) {
+				if (previous) this.goals.set(goal.id, previous);
+				else this.goals.delete(goal.id);
+				if (this.generation === mutationGeneration) this.generation--;
+				else this.generation++;
+				this.goalMutationRevisions.set(goal.id, mutationRevision + 1);
+			}
+			throw error;
+		}
+		if (isNew) {
+			this.dispatchHostNotification({
+				name: "goalCreated",
+				revision: goal.updatedAt,
+				payload: Object.freeze({ goalId: goal.id, ...(goal.parentGoalId ? { parentGoalId: goal.parentGoalId } : {}), state: goal.state }),
+			});
+		}
+		this.onIndexUpdate?.(goal);
+		if (isNew) this.onGoalCreated?.(goal);
+	}
+
 	get(id: string): PersistedGoal | undefined {
 		return this.goals.get(id);
 	}
@@ -877,16 +957,16 @@ export class GoalStore {
 		this.assertAcceptingMutations();
 		const existing = this.goals.get(id);
 		if (!existing) return false;
-		// Capture the transition BEFORE mutating so onGoalArchived fires only
-		// once. Idempotent: re-archiving an already-archived goal still returns
-		// true (back-compat with existing callers) but does NOT re-fire.
-		const wasAlreadyArchived = existing.archived === true;
+		// Re-archive is a genuine no-op: preserve the durable archive revision.
+		if (existing.archived === true) return true;
 		this.recordMutation(id);
+		const revision = nextGoalRevision(existing.updatedAt);
 		existing.archived = true;
-		existing.archivedAt = Date.now();
+		existing.archivedAt = revision;
+		existing.updatedAt = revision;
 		this.save([id]);
 		this.onIndexUpdate?.(existing);
-		if (!wasAlreadyArchived) this.onGoalArchived?.(existing);
+		this.onGoalArchived?.(existing);
 		return true;
 	}
 
@@ -933,10 +1013,13 @@ export class GoalStore {
 			present: Object.prototype.hasOwnProperty.call(existing, "archivedAt"),
 			value: existing.archivedAt,
 		};
+		const previousUpdatedAt = existing.updatedAt;
 		const mutationRevision = this.recordMutation(id);
 		const mutationGeneration = this.generation;
+		const revision = nextGoalRevision(existing.updatedAt);
 		existing.archived = true;
-		existing.archivedAt = Date.now();
+		existing.archivedAt = revision;
+		existing.updatedAt = revision;
 		const appliedArchivedAt = existing.archivedAt;
 		try {
 			await this.saveStrict([id]);
@@ -959,6 +1042,7 @@ export class GoalStore {
 					const record = current as unknown as Record<string, unknown>;
 					if (record.archived === true) this.restoreProperty(record, "archived", previousArchived);
 					if (record.archivedAt === appliedArchivedAt) this.restoreProperty(record, "archivedAt", previousArchivedAt);
+					if (record.updatedAt === revision) record.updatedAt = previousUpdatedAt;
 					this.recordMutation(id);
 				}
 				await this.saveStrict([id]);
@@ -966,6 +1050,11 @@ export class GoalStore {
 			}
 			throw err;
 		}
+		this.dispatchHostNotification({
+			name: "goalArchived",
+			revision,
+			payload: Object.freeze({ goalId: existing.id }),
+		});
 		this.onIndexUpdate?.(existing);
 		this.onGoalArchived?.(existing);
 		return true;
@@ -989,7 +1078,7 @@ export class GoalStore {
 		if (!existing || existing.schedulerRecovery === undefined) return false;
 		this.recordMutation(id);
 		delete existing.schedulerRecovery;
-		existing.updatedAt = Date.now();
+		existing.updatedAt = nextGoalRevision(existing.updatedAt);
 		this.save([id]);
 		this.onIndexUpdate?.(existing);
 		return true;
@@ -1020,8 +1109,35 @@ export class GoalStore {
 	}
 
 	private applyUpdate(existing: PersistedGoal, cleaned: Record<string, unknown>, clearSetupError: boolean): void {
-		Object.assign(existing, cleaned, { updatedAt: Date.now() });
+		Object.assign(existing, cleaned, { updatedAt: nextGoalRevision(existing.updatedAt) });
 		if (clearSetupError) delete existing.setupError;
+	}
+
+	private changedNotificationFields(
+		existing: PersistedGoal,
+		cleaned: Record<string, unknown>,
+		clearSetupError: boolean,
+	): string[] {
+		const record = existing as unknown as Record<string, unknown>;
+		const changed = Object.keys(cleaned)
+			.filter((key): key is keyof PersistedGoal => GOAL_NOTIFICATION_CHANGED_FIELDS.has(key as keyof PersistedGoal))
+			.filter(key => record[key] !== cleaned[key]);
+		if (clearSetupError && existing.setupError !== undefined && !changed.includes("setupError")) changed.push("setupError");
+		return changed.sort();
+	}
+
+	private dispatchHostNotification(notification: GoalStoreNotification): void {
+		if (!this.onHostNotification) return;
+		try {
+			const result = this.onHostNotification(Object.freeze(notification));
+			if (result && typeof result.then === "function") {
+				void result.catch(() => {
+					console.warn(`[goal-store] Host notification consumer rejected ${notification.name} (non-fatal)`);
+				});
+			}
+		} catch {
+			console.warn(`[goal-store] Host notification consumer threw for ${notification.name} (non-fatal)`);
+		}
 	}
 
 	update(id: string, updates: Partial<Omit<PersistedGoal, "id" | "createdAt">>): boolean {
@@ -1113,6 +1229,7 @@ export class GoalStore {
 			return true;
 		}
 
+		const changedFields = this.changedNotificationFields(existing, cleaned, clearSetupError);
 		const previous = { ...existing };
 		const ownedKeys = new Set(Object.keys(cleaned));
 		if (clearSetupError) ownedKeys.add("setupError");
@@ -1123,6 +1240,19 @@ export class GoalStore {
 		const mutationRevision = this.recordMutation(id);
 		const mutationGeneration = this.generation;
 		this.applyUpdate(existing, cleaned, clearSetupError);
+		const notificationRevision = existing.updatedAt;
+		const updatedNotification: GoalStoreNotification = {
+			name: "goalUpdated",
+			revision: notificationRevision,
+			payload: Object.freeze({ goalId: existing.id, state: existing.state, changedFields: Object.freeze(changedFields) }),
+		};
+		const completedNotification: GoalStoreNotification | undefined = previous.state !== "complete" && existing.state === "complete"
+			? {
+				name: "goalCompleted",
+				revision: notificationRevision,
+				payload: Object.freeze({ goalId: existing.id, ...(existing.parentGoalId ? { parentGoalId: existing.parentGoalId } : {}) }),
+			}
+			: undefined;
 		const appliedOwned = new Map([...ownedKeys].map((key) => [key, {
 			present: Object.prototype.hasOwnProperty.call(existing, key),
 			value: (existing as unknown as Record<string, unknown>)[key],
@@ -1155,6 +1285,8 @@ export class GoalStore {
 			}
 			throw err;
 		}
+		this.dispatchHostNotification(updatedNotification);
+		if (completedNotification) this.dispatchHostNotification(completedNotification);
 		this.onIndexUpdate?.(existing);
 		return true;
 	}

--- a/src/server/agent/goal-store.ts
+++ b/src/server/agent/goal-store.ts
@@ -7,6 +7,7 @@ import type Database from "better-sqlite3";
 import { normalizeWorkflow, type Workflow } from "./workflow-store.js";
 import { readDeletionTombstones, recordDeletionTombstone } from "./deletion-tombstones.js";
 import { CoalescedJsonWriter } from "./coalesced-json-writer.js";
+import type { HostNotificationPayload } from "../../shared/extension-host/host-hooks.js";
 
 export type GoalState = "todo" | "in-progress" | "complete" | "shelved" | "blocked";
 
@@ -187,26 +188,53 @@ export interface PersistedGoal {
  * dispatcher by ProjectContext. The store owns the authoritative transition
  * and revision; consumers never receive the mutable PersistedGoal record.
  */
+type CatalogueGoalUpdatedChangedField = HostNotificationPayload<"goalUpdated">["changedFields"][number];
+
+/** Map only catalogue-approved public mutation identifiers. Internal lifecycle,
+ * checkout, scheduler, and diagnostic fields intentionally produce an empty
+ * changedFields projection rather than leaking their names. */
+const GOAL_NOTIFICATION_CHANGED_FIELD_MAP = {
+	title: "title",
+	spec: "spec",
+	state: "state",
+	workflow: "workflow",
+	metadata: "metadata",
+	team: "team",
+	paused: "paused",
+	divergencePolicy: "divergencePolicy",
+	maxConcurrentChildren: "maxConcurrentChildren",
+} as const satisfies Partial<Record<keyof PersistedGoal, CatalogueGoalUpdatedChangedField>>;
+
+type GoalUpdatedChangedField = (typeof GOAL_NOTIFICATION_CHANGED_FIELD_MAP)[keyof typeof GOAL_NOTIFICATION_CHANGED_FIELD_MAP];
+
+function isGoalNotificationChangedField(key: string): key is keyof typeof GOAL_NOTIFICATION_CHANGED_FIELD_MAP {
+	return Object.prototype.hasOwnProperty.call(GOAL_NOTIFICATION_CHANGED_FIELD_MAP, key);
+}
+
+type FrozenGoalUpdatedPayload = Readonly<Omit<HostNotificationPayload<"goalUpdated">, "changedFields">> & Readonly<{
+	changedFields: readonly GoalUpdatedChangedField[];
+}>;
+
 export type GoalStoreNotification =
 	| Readonly<{
 		name: "goalCreated";
 		revision: number;
-		payload: Readonly<{ goalId: string; parentGoalId?: string; state: GoalState }>;
+		payload: Readonly<HostNotificationPayload<"goalCreated">>;
 	}>
 	| Readonly<{
 		name: "goalUpdated";
 		revision: number;
-		payload: Readonly<{ goalId: string; state: GoalState; changedFields: readonly string[] }>;
+		payload: FrozenGoalUpdatedPayload;
 	}>
 	| Readonly<{
 		name: "goalCompleted";
 		revision: number;
-		payload: Readonly<{ goalId: string; parentGoalId?: string }>;
+		payload: Readonly<HostNotificationPayload<"goalCompleted">>;
 	}>
 	| Readonly<{
 		name: "goalArchived";
 		revision: number;
-		payload: Readonly<{ goalId: string }>;
+		payload: Readonly<HostNotificationPayload<"goalArchived">>;
 	}>;
 
 interface GoalWriteMetrics {
@@ -280,16 +308,6 @@ const NUMBER_FIELDS = ["archivedAt", "maxConcurrentChildren", "replanCount", "ma
 const STRING_ARRAY_FIELDS = [
 	"skipGateRequirements", "enabledOptionalSteps", "acceptanceCriteria", "dependsOnPlanIds",
 ] as const;
-
-/** Field names safe to expose as bounded goalUpdated metadata. */
-const GOAL_NOTIFICATION_CHANGED_FIELDS = new Set<keyof PersistedGoal>([
-	"title", "cwd", "state", "spec", "worktreePath", "worktreeOwnerSessionId", "branch", "repoPath",
-	"team", "teamLeadSessionId", "skipGateRequirements", "workflowId", "workflow", "setupStatus", "setupError",
-	"schedulerRecovery", "metadata", "reattemptOf", "sandboxed", "autoStartTeam", "enabledOptionalSteps",
-	"repoWorktrees", "parentGoalId", "rootGoalId", "mergeTarget", "divergencePolicy", "maxConcurrentChildren",
-	"acceptanceCriteria", "spawnedFromPlanId", "dependsOnPlanIds", "paused", "pauseSource", "replanCount",
-	"mergeConflict", "suggestedRole", "spawnedBySessionId", "inlineRoles", "subgoalsAllowed", "maxNestingDepth",
-]);
 
 function nextGoalRevision(previous: number): number {
 	return Math.max(Date.now(), previous + 1);
@@ -1116,14 +1134,13 @@ export class GoalStore {
 	private changedNotificationFields(
 		existing: PersistedGoal,
 		cleaned: Record<string, unknown>,
-		clearSetupError: boolean,
-	): string[] {
+	): GoalUpdatedChangedField[] {
 		const record = existing as unknown as Record<string, unknown>;
-		const changed = Object.keys(cleaned)
-			.filter((key): key is keyof PersistedGoal => GOAL_NOTIFICATION_CHANGED_FIELDS.has(key as keyof PersistedGoal))
-			.filter(key => record[key] !== cleaned[key]);
-		if (clearSetupError && existing.setupError !== undefined && !changed.includes("setupError")) changed.push("setupError");
-		return changed.sort();
+		const changed = Object.keys(cleaned).flatMap((key): GoalUpdatedChangedField[] => {
+			if (record[key] === cleaned[key] || !isGoalNotificationChangedField(key)) return [];
+			return [GOAL_NOTIFICATION_CHANGED_FIELD_MAP[key]];
+		});
+		return [...new Set(changed)].sort();
 	}
 
 	private dispatchHostNotification(notification: GoalStoreNotification): void {
@@ -1229,7 +1246,7 @@ export class GoalStore {
 			return true;
 		}
 
-		const changedFields = this.changedNotificationFields(existing, cleaned, clearSetupError);
+		const changedFields = this.changedNotificationFields(existing, cleaned);
 		const previous = { ...existing };
 		const ownedKeys = new Set(Object.keys(cleaned));
 		if (clearSetupError) ownedKeys.add("setupError");

--- a/src/server/agent/inbox-manager.ts
+++ b/src/server/agent/inbox-manager.ts
@@ -2,11 +2,12 @@ import { randomUUID } from "node:crypto";
 import type { ProjectContextManager } from "./project-context-manager.js";
 import type { StaffManager } from "./staff-manager.js";
 import type { InboxNudger } from "./inbox-nudger.js";
-import type { InboxStore, InboxEntry, InboxEntryState, InboxEntrySource } from "./inbox-store.js";
+import type { HostNotification } from "../../shared/extension-host/host-hooks.js";
+import type { InboxStore, InboxEntry, InboxEntryState, InboxEntrySource, NotificationInboxMetadata } from "./inbox-store.js";
 
 // Re-export for convenience so callers can import everything from
 // `inbox-manager` without reaching into the store module directly.
-export type { InboxEntry, InboxEntryState, InboxEntrySource } from "./inbox-store.js";
+export type { InboxEntry, InboxEntryState, InboxEntrySource, NotificationInboxMetadata } from "./inbox-store.js";
 
 /**
  * Facade over per-project `InboxStore`s. Provides a single point for
@@ -92,6 +93,50 @@ export class InboxManager {
 			console.error(`[inbox-manager] nudger.poke failed for staff ${staffId}:`, err);
 		}
 		return entry;
+	}
+
+	/**
+	 * Idempotently accept one notification delivery under its deterministic ID.
+	 * The full canonical event is host metadata, never interpolated into prompt.
+	 */
+	enqueueWithId(
+		entryId: string,
+		staffId: string,
+		input: {
+			title: string;
+			triggerId: string;
+			notification: HostNotification;
+			rootCorrelationId: string;
+			causationDepth: number;
+		},
+	): InboxEntry {
+		const store = this.resolveStore(staffId);
+		if (!store) throw new Error(`Staff agent not found: ${staffId}`);
+		const notificationInput: NotificationInboxMetadata = {
+			notification: input.notification,
+			rootCorrelationId: input.rootCorrelationId,
+			causationDepth: input.causationDepth,
+		};
+		const entry: InboxEntry = {
+			id: entryId,
+			staffId,
+			source: { type: "notification", triggerId: input.triggerId },
+			title: input.title,
+			prompt: "A host notification is available in this inbox entry's notification metadata.",
+			notificationInput,
+			state: "pending",
+			createdAt: Date.now(),
+		};
+		const accepted = store.putStrict(entry);
+		if (accepted.inserted) {
+			this.broadcastToAll({ type: "inbox.entry.added", staffId, entry: accepted.entry });
+			try {
+				this.nudger?.poke(staffId);
+			} catch (err) {
+				console.error(`[inbox-manager] nudger.poke failed for staff ${staffId}:`, err);
+			}
+		}
+		return accepted.entry;
 	}
 
 	listForStaff(staffId: string, state?: InboxEntryState, limit?: number): InboxEntry[] {

--- a/src/server/agent/inbox-manager.ts
+++ b/src/server/agent/inbox-manager.ts
@@ -28,8 +28,8 @@ function bounded(value: string | undefined, max: number): string | undefined {
 	return value === undefined ? undefined : value.slice(0, max);
 }
 
-/** Never return a source store object through WebSocket publication. */
-function liveEntry(entry: InboxEntry): InboxLiveEntry {
+/** Never return a source store object through WebSocket or operator publication. */
+export function toInboxLiveEntry(entry: InboxEntry): InboxLiveEntry {
 	const triggerId = bounded(entry.source.triggerId, 256);
 	const actorId = bounded(entry.source.actorId, 256);
 	const context = bounded(entry.context, 2_048);
@@ -145,7 +145,7 @@ export class InboxManager {
 			createdAt: Date.now(),
 		};
 		store.put(entry);
-		this.publishForStaff(staffId, { type: "inbox.entry.added", staffId, entry: liveEntry(entry) });
+		this.publishForStaff(staffId, { type: "inbox.entry.added", staffId, entry: toInboxLiveEntry(entry) });
 		try {
 			this.nudger?.poke(staffId);
 		} catch (err) {
@@ -188,7 +188,7 @@ export class InboxManager {
 		};
 		const accepted = store.putStrict(entry);
 		if (accepted.inserted) {
-			this.publishForStaff(staffId, { type: "inbox.entry.added", staffId, entry: liveEntry(accepted.entry) });
+			this.publishForStaff(staffId, { type: "inbox.entry.added", staffId, entry: toInboxLiveEntry(accepted.entry) });
 			try {
 				this.nudger?.poke(staffId);
 			} catch (err) {
@@ -226,7 +226,7 @@ export class InboxManager {
 			result: summary,
 		});
 		const entry = store.get(staffId, entryId)!;
-		this.publishForStaff(staffId, { type: "inbox.entry.updated", staffId, entry: liveEntry(entry) });
+		this.publishForStaff(staffId, { type: "inbox.entry.updated", staffId, entry: toInboxLiveEntry(entry) });
 		return entry;
 	}
 
@@ -255,7 +255,7 @@ export class InboxManager {
 			error: reason,
 		});
 		const entry = store.get(staffId, entryId)!;
-		this.publishForStaff(staffId, { type: "inbox.entry.updated", staffId, entry: liveEntry(entry) });
+		this.publishForStaff(staffId, { type: "inbox.entry.updated", staffId, entry: toInboxLiveEntry(entry) });
 		return entry;
 	}
 

--- a/src/server/agent/inbox-manager.ts
+++ b/src/server/agent/inbox-manager.ts
@@ -9,6 +9,51 @@ import type { InboxStore, InboxEntry, InboxEntryState, InboxEntrySource, Notific
 // `inbox-manager` without reaching into the store module directly.
 export type { InboxEntry, InboxEntryState, InboxEntrySource, NotificationInboxMetadata } from "./inbox-store.js";
 
+/** Browser-safe live projection. Canonical notification input and loop controls
+ * remain available only through the authenticated staff inbox read surface. */
+export type InboxLiveEntry = Omit<InboxEntry, "notificationInput">;
+
+export type InboxLiveEvent =
+	| { type: "inbox.entry.added"; staffId: string; entry: InboxLiveEntry }
+	| { type: "inbox.entry.updated"; staffId: string; entry: InboxLiveEntry }
+	| { type: "inbox.entry.removed"; staffId: string; entryId: string };
+
+export interface InboxLiveAddress {
+	readonly staffId: string;
+	readonly staffSessionId: string;
+	readonly projectId: string;
+}
+
+function bounded(value: string | undefined, max: number): string | undefined {
+	return value === undefined ? undefined : value.slice(0, max);
+}
+
+/** Never return a source store object through WebSocket publication. */
+function liveEntry(entry: InboxEntry): InboxLiveEntry {
+	const triggerId = bounded(entry.source.triggerId, 256);
+	const actorId = bounded(entry.source.actorId, 256);
+	const context = bounded(entry.context, 2_048);
+	const result = bounded(entry.result, 2_048);
+	const error = bounded(entry.error, 2_048);
+	return Object.freeze({
+		id: entry.id.slice(0, 256),
+		staffId: entry.staffId.slice(0, 256),
+		source: Object.freeze({
+			type: entry.source.type,
+			...(triggerId !== undefined ? { triggerId } : {}),
+			...(actorId !== undefined ? { actorId } : {}),
+		}),
+		title: entry.title.slice(0, 512),
+		prompt: entry.prompt.slice(0, 2_048),
+		...(context !== undefined ? { context } : {}),
+		state: entry.state,
+		createdAt: entry.createdAt,
+		...(entry.completedAt !== undefined ? { completedAt: entry.completedAt } : {}),
+		...(result !== undefined ? { result } : {}),
+		...(error !== undefined ? { error } : {}),
+	});
+}
+
 /**
  * Facade over per-project `InboxStore`s. Provides a single point for
  * server.ts / REST handlers / inbox-tool extension code to enqueue work,
@@ -17,7 +62,7 @@ export type { InboxEntry, InboxEntryState, InboxEntrySource, NotificationInboxMe
  *
  * Side effects per mutation:
  *  - Persists to the underlying `InboxStore` (synchronous JSON write).
- *  - Broadcasts a WS event via the injected `broadcastToAll`:
+ *  - Publishes a bounded WS invalidation only to the owning staff session:
  *      "inbox.entry.added" | "inbox.entry.updated" | "inbox.entry.removed".
  *  - `enqueue` additionally calls `nudger.poke(staffId)` so an idle staff
  *    session is woken on the next tick (or earlier — `poke` schedules a
@@ -30,17 +75,17 @@ export type { InboxEntry, InboxEntryState, InboxEntrySource, NotificationInboxMe
 export class InboxManager {
 	private nudger: InboxNudger | null = null;
 	private readonly pcm: ProjectContextManager;
-	/** Held for API parity with the design doc; reserved for higher-layer lookups. */
 	private readonly staffManager: StaffManager;
-	private readonly broadcastToAll: (event: unknown) => void;
+	private readonly publishLive: (event: InboxLiveEvent, address?: InboxLiveAddress) => void;
 
-	constructor(pcm: ProjectContextManager, staffManager: StaffManager, broadcastToAll: (event: unknown) => void) {
+	constructor(
+		pcm: ProjectContextManager,
+		staffManager: StaffManager,
+		publishLive: (event: InboxLiveEvent, address?: InboxLiveAddress) => void,
+	) {
 		this.pcm = pcm;
 		this.staffManager = staffManager;
-		this.broadcastToAll = broadcastToAll;
-		// Touch staffManager so the unused-private-property check stays happy
-		// while preserving the constructor signature the design doc pins.
-		void this.staffManager;
+		this.publishLive = publishLive;
 	}
 
 	/**
@@ -61,6 +106,20 @@ export class InboxManager {
 			if (ctx.staffStore.get(staffId)) return ctx.inboxStore;
 		}
 		return null;
+	}
+
+	private publishForStaff(staffId: string, event: InboxLiveEvent): void {
+		const getStaff = (this.staffManager as StaffManager & { getStaff?: StaffManager["getStaff"] }).getStaff;
+		const staff = typeof getStaff === "function" ? getStaff.call(this.staffManager, staffId) : undefined;
+		const address = staff?.currentSessionId && staff.projectId ? {
+			staffId,
+			staffSessionId: staff.currentSessionId,
+			projectId: staff.projectId,
+		} : undefined;
+		// The production publisher fails closed when address is absent. Keeping the
+		// optional address also preserves narrow manager test doubles that observe
+		// persistence events without constructing a SessionManager.
+		this.publishLive(event, address);
 	}
 
 	/**
@@ -86,7 +145,7 @@ export class InboxManager {
 			createdAt: Date.now(),
 		};
 		store.put(entry);
-		this.broadcastToAll({ type: "inbox.entry.added", staffId, entry });
+		this.publishForStaff(staffId, { type: "inbox.entry.added", staffId, entry: liveEntry(entry) });
 		try {
 			this.nudger?.poke(staffId);
 		} catch (err) {
@@ -129,7 +188,7 @@ export class InboxManager {
 		};
 		const accepted = store.putStrict(entry);
 		if (accepted.inserted) {
-			this.broadcastToAll({ type: "inbox.entry.added", staffId, entry: accepted.entry });
+			this.publishForStaff(staffId, { type: "inbox.entry.added", staffId, entry: liveEntry(accepted.entry) });
 			try {
 				this.nudger?.poke(staffId);
 			} catch (err) {
@@ -167,7 +226,7 @@ export class InboxManager {
 			result: summary,
 		});
 		const entry = store.get(staffId, entryId)!;
-		this.broadcastToAll({ type: "inbox.entry.updated", staffId, entry });
+		this.publishForStaff(staffId, { type: "inbox.entry.updated", staffId, entry: liveEntry(entry) });
 		return entry;
 	}
 
@@ -196,7 +255,7 @@ export class InboxManager {
 			error: reason,
 		});
 		const entry = store.get(staffId, entryId)!;
-		this.broadcastToAll({ type: "inbox.entry.updated", staffId, entry });
+		this.publishForStaff(staffId, { type: "inbox.entry.updated", staffId, entry: liveEntry(entry) });
 		return entry;
 	}
 
@@ -206,7 +265,7 @@ export class InboxManager {
 		if (!store) return false;
 		const ok = store.remove(staffId, entryId);
 		if (ok) {
-			this.broadcastToAll({ type: "inbox.entry.removed", staffId, entryId });
+			this.publishForStaff(staffId, { type: "inbox.entry.removed", staffId, entryId: entryId.slice(0, 256) });
 		}
 		return ok;
 	}

--- a/src/server/agent/inbox-nudger.ts
+++ b/src/server/agent/inbox-nudger.ts
@@ -4,7 +4,7 @@ import { realClock } from "../gateway-deps.js";
 import { cpuDiagnosticsEnabled, getCpuDiagnostics } from "./cpu-diagnostics.js";
 import type { SessionManager } from "./session-manager.js";
 import type { StaffManager } from "./staff-manager.js";
-import type { InboxStore } from "./inbox-store.js";
+import type { InboxEntry, InboxStore } from "./inbox-store.js";
 import type { PersistedStaff } from "./staff-store.js";
 
 /**
@@ -162,7 +162,7 @@ export class InboxNudger {
 			if (counters) counters.pendingEntries = pending.length;
 			if (pending.length === 0) { if (counters) counters.skippedNoPending = 1; return; }
 			if (counters) counters.nudgesScheduled = 1;
-			void this.applyPolicyThenNudge(staff, pending.length);
+			void this.applyPolicyThenNudge(staff, pending);
 		} finally {
 			if (diagEnabled) {
 				getCpuDiagnostics().recordTimer("inbox-nudger:tickOne", performance.now() - diagStart, counters);
@@ -170,7 +170,7 @@ export class InboxNudger {
 		}
 	}
 
-	private async applyPolicyThenNudge(staff: PersistedStaff, count: number): Promise<void> {
+	private async applyPolicyThenNudge(staff: PersistedStaff, pending: InboxEntry[]): Promise<void> {
 		const diagEnabled = cpuDiagnosticsEnabled();
 		const diagStart = diagEnabled ? performance.now() : 0;
 		const counters = diagEnabled ? { attempts: 1, compactCalls: 0, updateStaffErrors: 0, nudgesSent: 0, errors: 0 } : undefined;
@@ -180,10 +180,15 @@ export class InboxNudger {
 				if (counters) counters.compactCalls = 1;
 				await this.runCompact(staff.currentSessionId!);
 			}
+			// Never merge unrelated notification roots into one staff turn. If any
+			// notification is pending, reserve this wake for its exact entry only;
+			// later roots are delivered by later idle ticks.
+			const notificationEntry = pending.find((entry) => entry.source.type === "notification");
+			const count = notificationEntry ? 1 : pending.length;
 			const word = count === 1 ? "item" : "items";
-			const msg =
-				`[INBOX] You have ${count} pending ${word}. ` +
-				`Use inbox_list to inspect, then process each with inbox_complete or inbox_dismiss.`;
+			const msg = notificationEntry
+				? `[INBOX] Process only pending inbox entry ${notificationEntry.id}, then use inbox_complete or inbox_dismiss for that entry.`
+				: `[INBOX] You have ${count} pending ${word}. Use inbox_list to inspect, then process each with inbox_complete or inbox_dismiss.`;
 			// `lastWakeAt` is now owned by the nudger — the sole driver of staff
 			// wakes post-inbox (the legacy public method on StaffManager is
 			// removed; see docs/design/staff-inbox.md §9). Persists across
@@ -195,7 +200,21 @@ export class InboxNudger {
 				if (counters) counters.updateStaffErrors = 1;
 				console.warn(`[inbox-nudger] updateStaff(lastWakeAt) failed for ${staff.id} (non-fatal):`, err);
 			}
-			await this.sessionManager.enqueuePrompt(staff.currentSessionId!, msg, { isSteered: true, source: "system" });
+			if (notificationEntry?.notificationInput && notificationEntry.source.triggerId) {
+				const input = notificationEntry.notificationInput;
+				const notification = input.notification;
+				const result = await this.sessionManager.enqueueStaffNotificationPrompt(staff.currentSessionId!, msg, {
+					projectId: notification.projectId,
+					staffId: staff.id,
+					triggerId: notificationEntry.source.triggerId,
+					notificationId: notification.id,
+					rootCorrelationId: input.rootCorrelationId,
+					causationDepth: input.causationDepth,
+				});
+				if (result.status !== "dispatched") this.nudgePending.delete(staff.id);
+			} else {
+				await this.sessionManager.enqueuePrompt(staff.currentSessionId!, msg, { isSteered: true, source: "system" });
+			}
 			if (counters) counters.nudgesSent = 1;
 		} catch (err) {
 			if (counters) counters.errors = 1;

--- a/src/server/agent/inbox-store.ts
+++ b/src/server/agent/inbox-store.ts
@@ -1,15 +1,24 @@
 import type { FsLike } from "../gateway-deps.js";
 import { realFs } from "../gateway-deps.js";
 import path from "node:path";
+import type { HostNotification } from "../../shared/extension-host/host-hooks.js";
 
 export type InboxEntryState = "pending" | "completed" | "failed" | "cancelled";
 
 export interface InboxEntrySource {
-	type: "trigger" | "manual_api" | "manual_ui";
+	type: "trigger" | "notification" | "manual_api" | "manual_ui";
 	/** Set when source.type === "trigger". The trigger id from PersistedStaff.triggers[].id. */
 	triggerId?: string;
 	/** Optional caller identifier for manual_api / manual_ui sources (e.g. user id, integration name). */
 	actorId?: string;
+}
+
+export interface NotificationInboxMetadata {
+	/** The exact validated canonical event; never a mutable aggregate projection. */
+	notification: HostNotification;
+	/** Host-owned loop controls, deliberately separate from envelope correlation. */
+	rootCorrelationId: string;
+	causationDepth: number;
 }
 
 export interface InboxEntry {
@@ -19,6 +28,8 @@ export interface InboxEntry {
 	title: string;
 	prompt: string;
 	context?: string;
+	/** Present only for source.type === "notification". */
+	notificationInput?: NotificationInboxMetadata;
 	state: InboxEntryState;
 	createdAt: number;
 	completedAt?: number;
@@ -77,15 +88,26 @@ export class InboxStore {
 		return this.byStaff.get(staffId)!;
 	}
 
-	private save(staffId: string): void {
+	private saveStrict(staffId: string): void {
 		const entries = this.byStaff.get(staffId) ?? [];
+		if (!this.fs.existsSync(this.inboxDir)) {
+			this.fs.mkdirSync(this.inboxDir, { recursive: true });
+		}
+		const file = this.fileFor(staffId);
+		const temporary = `${file}.${process.pid}.${Date.now()}.tmp`;
 		try {
-			if (!this.fs.existsSync(this.inboxDir)) {
-				this.fs.mkdirSync(this.inboxDir, { recursive: true });
-			}
-			const file = this.fileFor(staffId);
 			const payload = JSON.stringify({ staffId, entries }, null, 2);
-			this.fs.writeFileSync(file, payload, "utf-8");
+			this.fs.writeFileSync(temporary, payload, "utf-8");
+			this.fs.renameSync(temporary, file);
+		} catch (err) {
+			try { if (this.fs.existsSync(temporary)) this.fs.unlinkSync(temporary); } catch { /* preserve original error */ }
+			throw err;
+		}
+	}
+
+	private save(staffId: string): void {
+		try {
+			this.saveStrict(staffId);
 		} catch (err) {
 			console.error(`[inbox-store] Failed to save inbox for staff ${staffId}:`, err);
 		}
@@ -95,12 +117,37 @@ export class InboxStore {
 	put(entry: InboxEntry): void {
 		const entries = this.ensureLoaded(entry.staffId);
 		const idx = entries.findIndex((e) => e.id === entry.id);
-		if (idx >= 0) {
-			entries[idx] = entry;
-		} else {
-			entries.push(entry);
-		}
+		if (idx >= 0) entries[idx] = entry;
+		else entries.push(entry);
 		this.save(entry.staffId);
+	}
+
+	/**
+	 * Fail-loud idempotent insertion. An existing deterministic id is accepted
+	 * only when it carries the same canonical notification input.
+	 */
+	putStrict(entry: InboxEntry): { entry: InboxEntry; inserted: boolean } {
+		const entries = this.ensureLoaded(entry.staffId);
+		const idx = entries.findIndex((e) => e.id === entry.id);
+		if (idx >= 0) {
+			const existing = entries[idx];
+			const sameNotification = existing.source.type === "notification"
+				&& entry.source.type === "notification"
+				&& existing.source.triggerId === entry.source.triggerId
+				&& JSON.stringify(existing.notificationInput) === JSON.stringify(entry.notificationInput);
+			if (!sameNotification) {
+				throw Object.assign(new Error(`Inbox entry identity collision: ${entry.id}`), { code: "INBOX_IDENTITY_COLLISION" });
+			}
+			return { entry: existing, inserted: false };
+		}
+		entries.push(entry);
+		try {
+			this.saveStrict(entry.staffId);
+			return { entry, inserted: true };
+		} catch (err) {
+			entries.pop();
+			throw err;
+		}
 	}
 
 	get(staffId: string, entryId: string): InboxEntry | undefined {

--- a/src/server/agent/lifecycle-hub.ts
+++ b/src/server/agent/lifecycle-hub.ts
@@ -240,6 +240,36 @@ export class LifecycleHub {
 		base: HookDispatchBase,
 		scopeInput?: Readonly<HookScopeResolutionInput>,
 	): Promise<{ blocks: ContextBlock[]; diagnostics: HubDiagnostic[] }> {
+		return this.dispatchInternal(hook, base, scopeInput);
+	}
+
+	/** Execute one already-normalized legacy provider without duplicating its
+	 * validation, budgets, provenance, trace, or scope-resolution semantics. */
+	async dispatchProvider(
+		hook: LifecycleHook,
+		base: HookDispatchBase,
+		providerRef: Readonly<{ id: string; listName: string; packRoot: string }>,
+		scopeInput?: Readonly<HookScopeResolutionInput>,
+		execution?: Readonly<{ signal?: AbortSignal; timeoutMs?: number }>,
+	): Promise<{ blocks: ContextBlock[]; diagnostics: HubDiagnostic[] }> {
+		return this.dispatchInternal(
+			hook,
+			base,
+			scopeInput,
+			(provider) => provider.id === providerRef.id
+				&& provider.listName === providerRef.listName
+				&& provider.packRoot === providerRef.packRoot,
+			execution,
+		);
+	}
+
+	private async dispatchInternal(
+		hook: LifecycleHook,
+		base: HookDispatchBase,
+		scopeInput?: Readonly<HookScopeResolutionInput>,
+		selectProvider?: (provider: ReturnType<PackContributionRegistry["listProviders"]>[number]) => boolean,
+		execution?: Readonly<{ signal?: AbortSignal; timeoutMs?: number }>,
+	): Promise<{ blocks: ContextBlock[]; diagnostics: HubDiagnostic[] }> {
 		let scopeContext: HookScopeContext | undefined;
 		if (this.scopeContextResolver) {
 			try {
@@ -249,7 +279,9 @@ export class LifecycleHub {
 			}
 		}
 		const disabled = this.disabledProviders(base.goalId, base.projectId);
-		const providers = this.registry.listProviders(base.projectId).filter((p) => !disabled.has(p.id) && p.hooks.includes(hook));
+		const providers = this.registry.listProviders(base.projectId).filter(
+			(p) => !disabled.has(p.id) && p.hooks.includes(hook) && (!selectProvider || selectProvider(p)),
+		);
 		const diagnostics: HubDiagnostic[] = [];
 		const collected: ContextBlock[] = [];
 		const traceStates = new Map<string, ProviderTraceState>();
@@ -280,7 +312,8 @@ export class LifecycleHub {
 					ctx: { ...hookCtx, workingDir: base.cwd, host: providerHost } as unknown as InvokeRequest["ctx"],
 					arg: undefined,
 					workingDir: base.cwd,
-				}, provider.budget.timeoutMs);
+					signal: execution?.signal,
+				}, Math.min(provider.budget.timeoutMs, execution?.timeoutMs ?? Number.POSITIVE_INFINITY));
 				ms = Math.round(performance.now() - t0);
 
 				const candidates = extractBlocks(result);

--- a/src/server/agent/notification-delivery-store.ts
+++ b/src/server/agent/notification-delivery-store.ts
@@ -1,0 +1,197 @@
+import { randomUUID } from "node:crypto";
+import path from "node:path";
+import { realClock, realFs, type Clock, type FsLike } from "../gateway-deps.js";
+import type { HostNotification } from "../../shared/extension-host/host-hooks.js";
+
+export type NotificationDeliveryState = "pending" | "leased" | "accepted" | "cancelled" | "failed";
+
+export interface NotificationDeliveryRow {
+	deliveryId: string;
+	projectId: string;
+	staffId: string;
+	triggerId: string;
+	subscriberVersion: string;
+	notification: HostNotification;
+	safeContext?: Record<string, string | number | boolean>;
+	state: NotificationDeliveryState;
+	attempt: number;
+	nextAttemptAt: number;
+	leaseUntil?: number;
+	/** Opaque compare-and-set fence for a single worker attempt. */
+	leaseId?: string;
+	rootCorrelationId: string;
+	causationDepth: number;
+	createdAt: number;
+	updatedAt: number;
+	diagnosticCode?: string;
+}
+
+/**
+ * Per-project durable subscriber outbox. This deliberately stores only rows
+ * for matching staff subscribers; it is not a notification journal.
+ */
+export class NotificationDeliveryStore {
+	private readonly file: string;
+	private readonly rows = new Map<string, NotificationDeliveryRow>();
+
+	constructor(
+		stateDir: string,
+		readonly projectId: string,
+		private readonly fs: FsLike = realFs,
+		private readonly clock: Clock = realClock,
+	) {
+		this.file = path.join(stateDir, "notification-deliveries.json");
+		this.load();
+	}
+
+	private load(): void {
+		try {
+			if (!this.fs.existsSync(this.file)) return;
+			const decoded = JSON.parse(this.fs.readFileSync(this.file, "utf-8") as string) as unknown;
+			if (!Array.isArray(decoded)) throw new Error("notification delivery store must be an array");
+			for (const candidate of decoded) {
+				if (!candidate || typeof candidate !== "object") continue;
+				const row = candidate as NotificationDeliveryRow;
+				if (typeof row.deliveryId !== "string" || this.rows.has(row.deliveryId)) continue;
+				// Keep individually addressable malformed rows recoverable so the worker
+				// can revalidate and durably fail them closed instead of silently skipping.
+				if (!(["pending", "leased", "accepted", "cancelled", "failed"] as unknown[]).includes(row.state)) row.state = "pending";
+				if (!Number.isFinite(row.attempt)) row.attempt = 0;
+				if (!Number.isFinite(row.nextAttemptAt)) row.nextAttemptAt = 0;
+				if (!Number.isFinite(row.createdAt)) row.createdAt = 0;
+				if (!Number.isFinite(row.updatedAt)) row.updatedAt = 0;
+				this.rows.set(row.deliveryId, row);
+			}
+		} catch (err) {
+			console.error(`[notification-delivery-store] Failed to load project ${this.projectId}:`, err);
+			this.rows.clear();
+		}
+	}
+
+	private saveStrict(): void {
+		const directory = path.dirname(this.file);
+		if (!this.fs.existsSync(directory)) this.fs.mkdirSync(directory, { recursive: true });
+		const temporary = `${this.file}.${process.pid}.${this.clock.now()}.${randomUUID()}.tmp`;
+		try {
+			this.fs.writeFileSync(temporary, JSON.stringify(Array.from(this.rows.values()), null, 2), "utf-8");
+			this.fs.renameSync(temporary, this.file);
+		} catch (err) {
+			try { if (this.fs.existsSync(temporary)) this.fs.unlinkSync(temporary); } catch { /* preserve original error */ }
+			throw err;
+		}
+	}
+
+	private mutateStrict<T>(mutation: () => T): T {
+		const before = new Map(Array.from(this.rows, ([id, row]) => [id, structuredClone(row)]));
+		try {
+			const result = mutation();
+			this.saveStrict();
+			return result;
+		} catch (err) {
+			this.rows.clear();
+			for (const [id, row] of before) this.rows.set(id, row);
+			throw err;
+		}
+	}
+
+	get(deliveryId: string): NotificationDeliveryRow | undefined {
+		const row = this.rows.get(deliveryId);
+		return row ? structuredClone(row) : undefined;
+	}
+
+	list(): NotificationDeliveryRow[] {
+		return Array.from(this.rows.values(), (row) => structuredClone(row));
+	}
+
+	insertPending(row: NotificationDeliveryRow): { row: NotificationDeliveryRow; inserted: boolean } {
+		if (row.projectId !== this.projectId || row.notification?.projectId !== this.projectId) {
+			throw Object.assign(new Error("Notification delivery project partition mismatch"), { code: "PROJECT_PARTITION_MISMATCH" });
+		}
+		const existing = this.rows.get(row.deliveryId);
+		if (existing) {
+			const sameIdentity = existing.staffId === row.staffId
+				&& existing.triggerId === row.triggerId
+				&& existing.subscriberVersion === row.subscriberVersion
+				&& JSON.stringify(existing.notification) === JSON.stringify(row.notification);
+			if (!sameIdentity) {
+				throw Object.assign(new Error(`Notification delivery identity collision: ${row.deliveryId}`), { code: "DELIVERY_IDENTITY_COLLISION" });
+			}
+			return { row: structuredClone(existing), inserted: false };
+		}
+		return this.mutateStrict(() => {
+			this.rows.set(row.deliveryId, structuredClone(row));
+			return { row: structuredClone(row), inserted: true };
+		});
+	}
+
+	hasSubscriberRoot(rootCorrelationId: string, staffId: string, triggerId: string): boolean {
+		return Array.from(this.rows.values()).some((row) =>
+			row.rootCorrelationId === rootCorrelationId
+			&& row.staffId === staffId
+			&& row.triggerId === triggerId
+			&& row.state !== "failed"
+			&& row.state !== "cancelled");
+	}
+
+	/** Claim pending or expired-leased rows and durably publish every lease. */
+	claimDue(now: number, leaseMs: number, limit: number): NotificationDeliveryRow[] {
+		const candidates = Array.from(this.rows.values())
+			.filter((row) => (row.state === "pending" && row.nextAttemptAt <= now)
+				|| (row.state === "leased" && (row.leaseUntil ?? 0) <= now))
+			.sort((a, b) => a.nextAttemptAt - b.nextAttemptAt || a.createdAt - b.createdAt)
+			.slice(0, Math.max(0, limit));
+		if (candidates.length === 0) return [];
+		return this.mutateStrict(() => candidates.map((candidate) => {
+			const row = this.rows.get(candidate.deliveryId)!;
+			row.state = "leased";
+			row.attempt += 1;
+			row.leaseId = randomUUID();
+			row.leaseUntil = now + leaseMs;
+			row.updatedAt = now;
+			delete row.diagnosticCode;
+			return structuredClone(row);
+		}));
+	}
+
+	/** Compare-and-set a leased row. Terminal rows can never be reopened. */
+	finishLease(
+		deliveryId: string,
+		leaseId: string,
+		state: "accepted" | "failed" | "cancelled" | "pending",
+		options: { nextAttemptAt?: number; diagnosticCode?: string } = {},
+	): boolean {
+		const current = this.rows.get(deliveryId);
+		if (!current || current.state !== "leased" || current.leaseId !== leaseId) return false;
+		return this.mutateStrict(() => {
+			const row = this.rows.get(deliveryId)!;
+			if (row.state !== "leased" || row.leaseId !== leaseId) return false;
+			row.state = state;
+			row.updatedAt = this.clock.now();
+			delete row.leaseId;
+			delete row.leaseUntil;
+			if (options.nextAttemptAt !== undefined) row.nextAttemptAt = options.nextAttemptAt;
+			if (options.diagnosticCode) row.diagnosticCode = options.diagnosticCode;
+			return true;
+		});
+	}
+
+	/** Cancel non-terminal work for retired/deleted/disabled subscribers. */
+	cancelWhere(predicate: (row: Readonly<NotificationDeliveryRow>) => boolean, diagnosticCode = "SUBSCRIBER_INACTIVE"): string[] {
+		const ids = Array.from(this.rows.values())
+			.filter((row) => (row.state === "pending" || row.state === "leased") && predicate(row))
+			.map((row) => row.deliveryId);
+		if (ids.length === 0) return [];
+		return this.mutateStrict(() => {
+			const now = this.clock.now();
+			for (const id of ids) {
+				const row = this.rows.get(id)!;
+				row.state = "cancelled";
+				row.updatedAt = now;
+				row.diagnosticCode = diagnosticCode;
+				delete row.leaseId;
+				delete row.leaseUntil;
+			}
+			return ids;
+		});
+	}
+}

--- a/src/server/agent/notification-delivery-store.ts
+++ b/src/server/agent/notification-delivery-store.ts
@@ -128,9 +128,7 @@ export class NotificationDeliveryStore {
 		return Array.from(this.rows.values()).some((row) =>
 			row.rootCorrelationId === rootCorrelationId
 			&& row.staffId === staffId
-			&& row.triggerId === triggerId
-			&& row.state !== "failed"
-			&& row.state !== "cancelled");
+			&& row.triggerId === triggerId);
 	}
 
 	/** Claim pending or expired-leased rows and durably publish every lease. */

--- a/src/server/agent/notification-staff-dispatcher.ts
+++ b/src/server/agent/notification-staff-dispatcher.ts
@@ -95,6 +95,7 @@ function currentNotificationTrigger(staff: PersistedStaff | undefined, triggerId
 /** Durable, project-partitioned delivery adapter for notification staff triggers. */
 export class NotificationStaffDispatcher {
 	readonly consumer = "staff" as const;
+	readonly admission = "durable-subscriber" as const;
 	private readonly stores = new Map<string, NotificationDeliveryStore>();
 	private readonly aborters = new Map<string, AbortController>();
 	private interval: ReturnType<Clock["setInterval"]> | null = null;
@@ -155,9 +156,14 @@ export class NotificationStaffDispatcher {
 		});
 	}
 
-	/** Canonical dispatcher adapter surface. */
+	/** Canonical dispatcher adapter surface. The host invokes this in its own
+	 * microtask, so this method crosses the durable subscriber admission seam
+	 * directly without occupying (or being dropped by) a bounded live queue. */
 	deliver(notification: HostNotification): void {
-		this.enqueue(notification);
+		try { this.enqueueNow(notification); }
+		catch {
+			this.diagnostic({ code: "OUTBOX_INSERT_FAILED", projectId: notification.projectId, notificationName: notification.name });
+		}
 	}
 
 	/** Alias for narrow domain integrations that also propagate loop controls. */

--- a/src/server/agent/notification-staff-dispatcher.ts
+++ b/src/server/agent/notification-staff-dispatcher.ts
@@ -12,8 +12,12 @@ import type { InboxManager } from "./inbox-manager.js";
 import type { StaffManager } from "./staff-manager.js";
 import type { NotificationStaffTrigger, PersistedStaff } from "./staff-store.js";
 import { NotificationDeliveryStore, type NotificationDeliveryRow } from "./notification-delivery-store.js";
+import {
+	currentStaffNotificationTurnContext,
+	MAX_NOTIFICATION_CAUSATION_DEPTH,
+} from "./staff-notification-causation.js";
 
-const MAX_CAUSATION_DEPTH = 8;
+const MAX_CAUSATION_DEPTH = MAX_NOTIFICATION_CAUSATION_DEPTH;
 const MAX_ATTEMPTS = 5;
 const FINAL_DEADLINE_MS = 24 * 60 * 60 * 1_000;
 const LEASE_MS = 30_000;
@@ -109,6 +113,7 @@ export class NotificationStaffDispatcher {
 			clock?: Clock;
 			storeFactory?: (stateDir: string, projectId: string) => NotificationDeliveryStore;
 			onDiagnostic?: (diagnostic: NotificationStaffDiagnostic) => void;
+			isTurnContextCurrent?: (context: ReturnType<typeof currentStaffNotificationTurnContext>) => boolean;
 		} = {},
 	) {
 		this.clock = options.clock ?? realClock;
@@ -156,11 +161,20 @@ export class NotificationStaffDispatcher {
 		});
 	}
 
-	/** Canonical dispatcher adapter surface. The host invokes this in its own
-	 * microtask, so this method crosses the durable subscriber admission seam
-	 * directly without occupying (or being dropped by) a bounded live queue. */
+	/** Canonical dispatcher adapter surface. AsyncLocalStorage propagation from
+	 * an exact session-authenticated mutation supplies loop controls separately;
+	 * the canonical envelope remains byte-identical for every consumer. */
 	deliver(notification: HostNotification): void {
-		try { this.enqueueNow(notification); }
+		const candidate = currentStaffNotificationTurnContext();
+		const turn = candidate
+			&& candidate.projectId === notification.projectId
+			&& (this.options.isTurnContextCurrent?.(candidate) ?? true)
+			? candidate
+			: undefined;
+		const controls = turn
+			? { rootCorrelationId: turn.rootCorrelationId, causationDepth: turn.causationDepth }
+			: undefined;
+		try { this.enqueueNow(notification, controls); }
 		catch {
 			this.diagnostic({ code: "OUTBOX_INSERT_FAILED", projectId: notification.projectId, notificationName: notification.name });
 		}

--- a/src/server/agent/notification-staff-dispatcher.ts
+++ b/src/server/agent/notification-staff-dispatcher.ts
@@ -82,7 +82,8 @@ export function validateStaffNotification(value: unknown, projectId: string): Ho
 
 function transientDeliveryError(error: unknown): boolean {
 	const code = (error as { code?: unknown } | null)?.code;
-	return code === "EAGAIN" || code === "EBUSY" || code === "ETIMEDOUT" || code === "UNAVAILABLE";
+	return code === "EAGAIN" || code === "EBUSY" || code === "ETIMEDOUT" || code === "UNAVAILABLE"
+		|| code === "EIO" || code === "ENOSPC" || code === "EMFILE" || code === "ENFILE";
 }
 
 function currentNotificationTrigger(staff: PersistedStaff | undefined, triggerId: string): NotificationStaffTrigger | undefined {
@@ -178,6 +179,11 @@ export class NotificationStaffDispatcher {
 		}
 		const rootCorrelationId = controls.rootCorrelationId ?? event.correlationId ?? event.id;
 		const causationDepth = controls.causationDepth ?? 0;
+		if (typeof rootCorrelationId !== "string" || rootCorrelationId.length === 0 || rootCorrelationId.length > 256
+			|| !Number.isSafeInteger(causationDepth) || causationDepth < 0) {
+			this.diagnostic({ code: "INVALID_DELIVERY_CONTROLS", projectId: event.projectId, notificationName: event.name });
+			return 0;
+		}
 		let inserted = 0;
 		for (const staff of this.staffManager.listStaff(event.projectId)) {
 			if (staff.projectId !== event.projectId || staff.state !== "active") continue;
@@ -204,7 +210,11 @@ export class NotificationStaffDispatcher {
 					createdAt: now,
 					updatedAt: now,
 				};
-				if (store.insertPending(row).inserted) inserted++;
+				try {
+					if (store.insertPending(row).inserted) inserted++;
+				} catch {
+					this.diagnostic({ code: "OUTBOX_INSERT_FAILED", projectId: event.projectId, notificationName: event.name, staffId: staff.id, triggerId: trigger.id, deliveryId });
+				}
 			}
 		}
 		this.queueDrain();

--- a/src/server/agent/notification-staff-dispatcher.ts
+++ b/src/server/agent/notification-staff-dispatcher.ts
@@ -1,11 +1,10 @@
 import { createHash } from "node:crypto";
 import {
-	HOST_NOTIFICATION_CATALOGUE,
-	validateNotificationFilter,
-	validateNotificationPayload,
-	type HostHookScope,
+	deepFreezeHostValue,
+	getHostNotificationDefinition,
+	notificationMatchesFilter,
+	validateHostNotification,
 	type HostNotification,
-	type HostNotificationName,
 } from "../../shared/extension-host/host-hooks.js";
 import { realClock, type Clock } from "../gateway-deps.js";
 import type { ProjectContextManager } from "./project-context-manager.js";
@@ -14,7 +13,6 @@ import type { StaffManager } from "./staff-manager.js";
 import type { NotificationStaffTrigger, PersistedStaff } from "./staff-store.js";
 import { NotificationDeliveryStore, type NotificationDeliveryRow } from "./notification-delivery-store.js";
 
-const MAX_EVENT_BYTES = 32 * 1024;
 const MAX_CAUSATION_DEPTH = 8;
 const MAX_ATTEMPTS = 5;
 const FINAL_DEADLINE_MS = 24 * 60 * 60 * 1_000;
@@ -22,14 +20,6 @@ const LEASE_MS = 30_000;
 const BATCH_SIZE = 32;
 
 type Scalar = string | number | boolean;
-type DefinitionView = {
-	name: string;
-	scope: HostHookScope;
-	payloadVersion: number;
-	aggregateKind: string;
-	consumers: ReadonlySet<string> | readonly string[];
-	filterFields: Readonly<Record<string, unknown>>;
-};
 
 export interface NotificationDeliveryControls {
 	/** Host-owned root propagated from a prior notification staff wake. */
@@ -45,35 +35,6 @@ export interface NotificationStaffDiagnostic {
 	triggerId?: string;
 	deliveryId?: string;
 	attempt?: number;
-}
-
-function definitionFor(name: string): DefinitionView | undefined {
-	return (HOST_NOTIFICATION_CATALOGUE as unknown as Record<string, DefinitionView>)[name];
-}
-
-function consumerAllowed(definition: DefinitionView, consumer: string): boolean {
-	return definition.consumers instanceof Set
-		? definition.consumers.has(consumer)
-		: Array.isArray(definition.consumers) && definition.consumers.includes(consumer);
-}
-
-function isBoundedString(value: unknown, max = 512): value is string {
-	return typeof value === "string" && value.length > 0 && value.length <= max;
-}
-
-function hasOnlyKeys(value: Record<string, unknown>, allowed: ReadonlySet<string>): boolean {
-	return Object.keys(value).every((key) => allowed.has(key));
-}
-
-const ENVELOPE_KEYS = new Set(["id", "scope", "name", "payloadVersion", "occurredAt", "projectId", "sessionId", "aggregate", "correlationId", "causationId", "payload"]);
-const AGGREGATE_KEYS = new Set(["kind", "id", "revision"]);
-
-function deepFreeze<T>(value: T): T {
-	if (value && typeof value === "object" && !Object.isFrozen(value)) {
-		Object.freeze(value);
-		for (const child of Object.values(value as Record<string, unknown>)) deepFreeze(child);
-	}
-	return value;
 }
 
 function cloneJson<T>(value: T): T {
@@ -99,10 +60,7 @@ export function notificationSubscriberVersion(trigger: NotificationStaffTrigger)
 
 function selectorAndFilterMatch(trigger: NotificationStaffTrigger, event: HostNotification): boolean {
 	if (trigger.notification.scope !== event.scope || trigger.notification.name !== event.name) return false;
-	const checked = validateNotificationFilter(event.scope, event.name, trigger.filter ?? {});
-	if (!checked.ok) return false;
-	const payload = event.payload as unknown as Record<string, unknown>;
-	return Object.entries(checked.filter).every(([key, value]) => payload[key] === value);
+	return notificationMatchesFilter(event, trigger.filter ?? {});
 }
 
 /**
@@ -111,32 +69,12 @@ function selectorAndFilterMatch(trigger: NotificationStaffTrigger, event: HostNo
  * scope, version, aggregate, consumer eligibility, partition, and size.
  */
 export function validateStaffNotification(value: unknown, projectId: string): HostNotification | null {
-	if (!value || typeof value !== "object" || Array.isArray(value)) return null;
-	let encoded: string;
-	try { encoded = JSON.stringify(value); } catch { return null; }
-	if (Buffer.byteLength(encoded, "utf-8") > MAX_EVENT_BYTES) return null;
-	const event = value as Record<string, unknown>;
-	if (!hasOnlyKeys(event, ENVELOPE_KEYS)) return null;
-	if (!isBoundedString(event.id) || !isBoundedString(event.name, 128)) return null;
-	const definition = definitionFor(event.name);
-	if (!definition || !consumerAllowed(definition, "staff")) return null;
-	if (event.scope !== definition.scope || event.projectId !== projectId || !isBoundedString(event.projectId)) return null;
-	if (event.payloadVersion !== definition.payloadVersion) return null;
-	if (typeof event.occurredAt !== "number" || !Number.isFinite(event.occurredAt) || event.occurredAt < 0) return null;
-	if (definition.scope === "session" && !isBoundedString(event.sessionId)) return null;
-	if (event.sessionId !== undefined && !isBoundedString(event.sessionId)) return null;
-	if (event.correlationId !== undefined && !isBoundedString(event.correlationId)) return null;
-	if (event.causationId !== undefined && !isBoundedString(event.causationId)) return null;
-	if (!event.aggregate || typeof event.aggregate !== "object" || Array.isArray(event.aggregate)) return null;
-	const aggregate = event.aggregate as Record<string, unknown>;
-	if (!hasOnlyKeys(aggregate, AGGREGATE_KEYS)) return null;
-	if (aggregate.kind !== definition.aggregateKind || !isBoundedString(aggregate.id)) return null;
-	if (aggregate.revision !== undefined
-		&& typeof aggregate.revision !== "string"
-		&& (typeof aggregate.revision !== "number" || !Number.isFinite(aggregate.revision))) return null;
-	if (!validateNotificationPayload(event.name as HostNotificationName, event.payload)) return null;
+	if (!validateHostNotification(value) || value.projectId !== projectId) return null;
+	const definition = getHostNotificationDefinition(value.name);
+	if (!definition || !definition.consumers.has("staff") || definition.delivery.staff !== "durable-intent") return null;
 	try {
-		return deepFreeze(cloneJson(value as HostNotification));
+		const copy = cloneJson(value);
+		return deepFreezeHostValue(copy) as HostNotification;
 	} catch {
 		return null;
 	}
@@ -155,6 +93,7 @@ function currentNotificationTrigger(staff: PersistedStaff | undefined, triggerId
 
 /** Durable, project-partitioned delivery adapter for notification staff triggers. */
 export class NotificationStaffDispatcher {
+	readonly consumer = "staff" as const;
 	private readonly stores = new Map<string, NotificationDeliveryStore>();
 	private readonly aborters = new Map<string, AbortController>();
 	private interval: ReturnType<Clock["setInterval"]> | null = null;
@@ -215,7 +154,12 @@ export class NotificationStaffDispatcher {
 		});
 	}
 
-	/** Alias suitable for a notification-dispatcher consumer callback. */
+	/** Canonical dispatcher adapter surface. */
+	deliver(notification: HostNotification): void {
+		this.enqueue(notification);
+	}
+
+	/** Alias for narrow domain integrations that also propagate loop controls. */
 	onNotification(notification: HostNotification, controls?: NotificationDeliveryControls): void {
 		this.enqueue(notification, controls);
 	}

--- a/src/server/agent/notification-staff-dispatcher.ts
+++ b/src/server/agent/notification-staff-dispatcher.ts
@@ -1,0 +1,368 @@
+import { createHash } from "node:crypto";
+import {
+	HOST_NOTIFICATION_CATALOGUE,
+	validateNotificationFilter,
+	validateNotificationPayload,
+	type HostHookScope,
+	type HostNotification,
+	type HostNotificationName,
+} from "../../shared/extension-host/host-hooks.js";
+import { realClock, type Clock } from "../gateway-deps.js";
+import type { ProjectContextManager } from "./project-context-manager.js";
+import type { InboxManager } from "./inbox-manager.js";
+import type { StaffManager } from "./staff-manager.js";
+import type { NotificationStaffTrigger, PersistedStaff } from "./staff-store.js";
+import { NotificationDeliveryStore, type NotificationDeliveryRow } from "./notification-delivery-store.js";
+
+const MAX_EVENT_BYTES = 32 * 1024;
+const MAX_CAUSATION_DEPTH = 8;
+const MAX_ATTEMPTS = 5;
+const FINAL_DEADLINE_MS = 24 * 60 * 60 * 1_000;
+const LEASE_MS = 30_000;
+const BATCH_SIZE = 32;
+
+type Scalar = string | number | boolean;
+type DefinitionView = {
+	name: string;
+	scope: HostHookScope;
+	payloadVersion: number;
+	aggregateKind: string;
+	consumers: ReadonlySet<string> | readonly string[];
+	filterFields: Readonly<Record<string, unknown>>;
+};
+
+export interface NotificationDeliveryControls {
+	/** Host-owned root propagated from a prior notification staff wake. */
+	rootCorrelationId?: string;
+	causationDepth?: number;
+}
+
+export interface NotificationStaffDiagnostic {
+	code: string;
+	projectId: string;
+	notificationName?: string;
+	staffId?: string;
+	triggerId?: string;
+	deliveryId?: string;
+	attempt?: number;
+}
+
+function definitionFor(name: string): DefinitionView | undefined {
+	return (HOST_NOTIFICATION_CATALOGUE as unknown as Record<string, DefinitionView>)[name];
+}
+
+function consumerAllowed(definition: DefinitionView, consumer: string): boolean {
+	return definition.consumers instanceof Set
+		? definition.consumers.has(consumer)
+		: Array.isArray(definition.consumers) && definition.consumers.includes(consumer);
+}
+
+function isBoundedString(value: unknown, max = 512): value is string {
+	return typeof value === "string" && value.length > 0 && value.length <= max;
+}
+
+function hasOnlyKeys(value: Record<string, unknown>, allowed: ReadonlySet<string>): boolean {
+	return Object.keys(value).every((key) => allowed.has(key));
+}
+
+const ENVELOPE_KEYS = new Set(["id", "scope", "name", "payloadVersion", "occurredAt", "projectId", "sessionId", "aggregate", "correlationId", "causationId", "payload"]);
+const AGGREGATE_KEYS = new Set(["kind", "id", "revision"]);
+
+function deepFreeze<T>(value: T): T {
+	if (value && typeof value === "object" && !Object.isFrozen(value)) {
+		Object.freeze(value);
+		for (const child of Object.values(value as Record<string, unknown>)) deepFreeze(child);
+	}
+	return value;
+}
+
+function cloneJson<T>(value: T): T {
+	return JSON.parse(JSON.stringify(value)) as T;
+}
+
+function stableFilter(filter: Readonly<Record<string, Scalar>>): Record<string, Scalar> {
+	return Object.fromEntries(Object.entries(filter).sort(([a], [b]) => a.localeCompare(b)));
+}
+
+export function notificationDeliveryId(staffId: string, triggerId: string, notificationId: string): string {
+	return createHash("sha256").update(`${staffId}|${triggerId}|${notificationId}`).digest("hex");
+}
+
+export function notificationSubscriberVersion(trigger: NotificationStaffTrigger): string {
+	return createHash("sha256").update(JSON.stringify({
+		enabled: trigger.enabled,
+		notification: trigger.notification,
+		filter: stableFilter(trigger.filter ?? {}),
+		prompt: trigger.prompt ?? null,
+	})).digest("hex");
+}
+
+function selectorAndFilterMatch(trigger: NotificationStaffTrigger, event: HostNotification): boolean {
+	if (trigger.notification.scope !== event.scope || trigger.notification.name !== event.name) return false;
+	const checked = validateNotificationFilter(event.scope, event.name, trigger.filter ?? {});
+	if (!checked.ok) return false;
+	const payload = event.payload as unknown as Record<string, unknown>;
+	return Object.entries(checked.filter).every(([key, value]) => payload[key] === value);
+}
+
+/**
+ * Revalidate and clone the complete canonical event before persistence or use.
+ * The shared payload schema remains authoritative; this wrapper pins envelope,
+ * scope, version, aggregate, consumer eligibility, partition, and size.
+ */
+export function validateStaffNotification(value: unknown, projectId: string): HostNotification | null {
+	if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+	let encoded: string;
+	try { encoded = JSON.stringify(value); } catch { return null; }
+	if (Buffer.byteLength(encoded, "utf-8") > MAX_EVENT_BYTES) return null;
+	const event = value as Record<string, unknown>;
+	if (!hasOnlyKeys(event, ENVELOPE_KEYS)) return null;
+	if (!isBoundedString(event.id) || !isBoundedString(event.name, 128)) return null;
+	const definition = definitionFor(event.name);
+	if (!definition || !consumerAllowed(definition, "staff")) return null;
+	if (event.scope !== definition.scope || event.projectId !== projectId || !isBoundedString(event.projectId)) return null;
+	if (event.payloadVersion !== definition.payloadVersion) return null;
+	if (typeof event.occurredAt !== "number" || !Number.isFinite(event.occurredAt) || event.occurredAt < 0) return null;
+	if (definition.scope === "session" && !isBoundedString(event.sessionId)) return null;
+	if (event.sessionId !== undefined && !isBoundedString(event.sessionId)) return null;
+	if (event.correlationId !== undefined && !isBoundedString(event.correlationId)) return null;
+	if (event.causationId !== undefined && !isBoundedString(event.causationId)) return null;
+	if (!event.aggregate || typeof event.aggregate !== "object" || Array.isArray(event.aggregate)) return null;
+	const aggregate = event.aggregate as Record<string, unknown>;
+	if (!hasOnlyKeys(aggregate, AGGREGATE_KEYS)) return null;
+	if (aggregate.kind !== definition.aggregateKind || !isBoundedString(aggregate.id)) return null;
+	if (aggregate.revision !== undefined
+		&& typeof aggregate.revision !== "string"
+		&& (typeof aggregate.revision !== "number" || !Number.isFinite(aggregate.revision))) return null;
+	if (!validateNotificationPayload(event.name as HostNotificationName, event.payload)) return null;
+	try {
+		return deepFreeze(cloneJson(value as HostNotification));
+	} catch {
+		return null;
+	}
+}
+
+function transientDeliveryError(error: unknown): boolean {
+	const code = (error as { code?: unknown } | null)?.code;
+	return code === "EAGAIN" || code === "EBUSY" || code === "ETIMEDOUT" || code === "UNAVAILABLE";
+}
+
+function currentNotificationTrigger(staff: PersistedStaff | undefined, triggerId: string): NotificationStaffTrigger | undefined {
+	if (!staff || staff.state !== "active") return undefined;
+	const trigger = staff.triggers.find((candidate) => candidate.id === triggerId);
+	return trigger?.type === "notification" && trigger.enabled ? trigger : undefined;
+}
+
+/** Durable, project-partitioned delivery adapter for notification staff triggers. */
+export class NotificationStaffDispatcher {
+	private readonly stores = new Map<string, NotificationDeliveryStore>();
+	private readonly aborters = new Map<string, AbortController>();
+	private interval: ReturnType<Clock["setInterval"]> | null = null;
+	private drainQueued = false;
+
+	constructor(
+		private readonly pcm: ProjectContextManager,
+		private readonly staffManager: StaffManager,
+		private readonly inboxManager: InboxManager,
+		private readonly options: {
+			clock?: Clock;
+			storeFactory?: (stateDir: string, projectId: string) => NotificationDeliveryStore;
+			onDiagnostic?: (diagnostic: NotificationStaffDiagnostic) => void;
+		} = {},
+	) {
+		this.clock = options.clock ?? realClock;
+		this.staffManager.setNotificationDeliveryReconciler?.((projectId, staffId) => {
+			this.reconcileProject(projectId, staffId);
+		});
+	}
+
+	private readonly clock: Clock;
+
+	start(): void {
+		if (this.interval) return;
+		this.reconcileAll();
+		this.interval = this.clock.setInterval(() => this.reconcileAll(), 1_000);
+	}
+
+	stop(): void {
+		if (this.interval) this.clock.clearInterval(this.interval);
+		this.interval = null;
+		for (const aborter of this.aborters.values()) aborter.abort();
+		this.aborters.clear();
+	}
+
+	private diagnostic(diagnostic: NotificationStaffDiagnostic): void {
+		try { this.options.onDiagnostic?.(diagnostic); } catch { /* diagnostics cannot affect delivery */ }
+	}
+
+	private storeFor(projectId: string): NotificationDeliveryStore | null {
+		const cached = this.stores.get(projectId);
+		if (cached) return cached;
+		const ctx = this.pcm.getOrCreate(projectId);
+		if (!ctx || ctx.project.id !== projectId) return null;
+		const store = this.options.storeFactory
+			? this.options.storeFactory(ctx.stateDir, projectId)
+			: new NotificationDeliveryStore(ctx.stateDir, projectId, undefined, this.clock);
+		this.stores.set(projectId, store);
+		return store;
+	}
+
+	/** Non-blocking fanout entry point used by the canonical dispatcher. */
+	enqueue(notification: HostNotification, controls: NotificationDeliveryControls = {}): void {
+		queueMicrotask(() => {
+			try { this.enqueueNow(notification, controls); }
+			catch { this.diagnostic({ code: "OUTBOX_INSERT_FAILED", projectId: notification.projectId, notificationName: notification.name }); }
+		});
+	}
+
+	/** Alias suitable for a notification-dispatcher consumer callback. */
+	onNotification(notification: HostNotification, controls?: NotificationDeliveryControls): void {
+		this.enqueue(notification, controls);
+	}
+
+	/** Synchronous seam for boot reconciliation and focused tests. */
+	enqueueNow(notification: HostNotification, controls: NotificationDeliveryControls = {}): number {
+		const event = validateStaffNotification(notification, notification.projectId);
+		if (!event) {
+			this.diagnostic({ code: "INVALID_NOTIFICATION", projectId: notification.projectId, notificationName: notification.name });
+			return 0;
+		}
+		const store = this.storeFor(event.projectId);
+		if (!store) {
+			this.diagnostic({ code: "UNKNOWN_PROJECT", projectId: event.projectId, notificationName: event.name });
+			return 0;
+		}
+		const rootCorrelationId = controls.rootCorrelationId ?? event.correlationId ?? event.id;
+		const causationDepth = controls.causationDepth ?? 0;
+		let inserted = 0;
+		for (const staff of this.staffManager.listStaff(event.projectId)) {
+			if (staff.projectId !== event.projectId || staff.state !== "active") continue;
+			for (const trigger of staff.triggers) {
+				if (trigger.type !== "notification" || !trigger.enabled || !selectorAndFilterMatch(trigger, event)) continue;
+				if (causationDepth > MAX_CAUSATION_DEPTH || store.hasSubscriberRoot(rootCorrelationId, staff.id, trigger.id)) {
+					this.diagnostic({ code: "LOOP_SUPPRESSED", projectId: event.projectId, notificationName: event.name, staffId: staff.id, triggerId: trigger.id });
+					continue;
+				}
+				const now = this.clock.now();
+				const deliveryId = notificationDeliveryId(staff.id, trigger.id, event.id);
+				const row: NotificationDeliveryRow = {
+					deliveryId,
+					projectId: event.projectId,
+					staffId: staff.id,
+					triggerId: trigger.id,
+					subscriberVersion: notificationSubscriberVersion(trigger),
+					notification: event,
+					state: "pending",
+					attempt: 0,
+					nextAttemptAt: now,
+					rootCorrelationId,
+					causationDepth,
+					createdAt: now,
+					updatedAt: now,
+				};
+				if (store.insertPending(row).inserted) inserted++;
+			}
+		}
+		this.queueDrain();
+		return inserted;
+	}
+
+	private queueDrain(): void {
+		if (this.drainQueued) return;
+		this.drainQueued = true;
+		queueMicrotask(() => {
+			this.drainQueued = false;
+			this.reconcileAll();
+		});
+	}
+
+	reconcileAll(): void {
+		for (const ctx of this.pcm.all()) this.reconcileProject(ctx.project.id);
+	}
+
+	reconcileProject(projectId: string, changedStaffId?: string): void {
+		const store = this.storeFor(projectId);
+		if (!store) return;
+		try {
+			const cancelled = store.cancelWhere((row) => {
+				if (changedStaffId && row.staffId !== changedStaffId) return false;
+				const staff = this.staffManager.getStaff(row.staffId);
+				const trigger = currentNotificationTrigger(staff, row.triggerId);
+				return !staff || staff.projectId !== projectId || !trigger;
+			});
+			for (const id of cancelled) {
+				this.aborters.get(id)?.abort();
+				this.aborters.delete(id);
+			}
+			const claimed = store.claimDue(this.clock.now(), LEASE_MS, BATCH_SIZE);
+			for (const row of claimed) this.deliver(store, row);
+		} catch {
+			this.diagnostic({ code: "OUTBOX_RECONCILE_FAILED", projectId });
+		}
+	}
+
+	private deliver(store: NotificationDeliveryStore, row: NotificationDeliveryRow): void {
+		const leaseId = row.leaseId!;
+		const aborter = new AbortController();
+		this.aborters.set(row.deliveryId, aborter);
+		try {
+			if (row.attempt > 1 && this.clock.now() >= row.createdAt + FINAL_DEADLINE_MS) {
+				store.finishLease(row.deliveryId, leaseId, "failed", { diagnosticCode: "DELIVERY_DEADLINE_EXCEEDED" });
+				return;
+			}
+			const event = validateStaffNotification(row.notification, row.projectId);
+			if (!event || row.projectId !== store.projectId) {
+				store.finishLease(row.deliveryId, leaseId, "failed", { diagnosticCode: "INVALID_PERSISTED_NOTIFICATION" });
+				return;
+			}
+			const staff = this.staffManager.getStaff(row.staffId);
+			const trigger = currentNotificationTrigger(staff, row.triggerId);
+			if (!staff || staff.projectId !== row.projectId || !trigger) {
+				store.finishLease(row.deliveryId, leaseId, "cancelled", { diagnosticCode: "SUBSCRIBER_INACTIVE" });
+				return;
+			}
+			if (notificationSubscriberVersion(trigger) !== row.subscriberVersion) {
+				store.finishLease(row.deliveryId, leaseId, "failed", { diagnosticCode: "SUBSCRIBER_VERSION_CHANGED" });
+				return;
+			}
+			if (!selectorAndFilterMatch(trigger, event)) {
+				store.finishLease(row.deliveryId, leaseId, "failed", { diagnosticCode: "SELECTOR_MISMATCH" });
+				return;
+			}
+			if (row.causationDepth > MAX_CAUSATION_DEPTH) {
+				store.finishLease(row.deliveryId, leaseId, "failed", { diagnosticCode: "CAUSATION_DEPTH_EXCEEDED" });
+				return;
+			}
+			if (aborter.signal.aborted || currentNotificationTrigger(this.staffManager.getStaff(row.staffId), row.triggerId) !== trigger) {
+				store.finishLease(row.deliveryId, leaseId, "cancelled", { diagnosticCode: "SUBSCRIBER_CANCELLED" });
+				return;
+			}
+			this.inboxManager.enqueueWithId(row.deliveryId, row.staffId, {
+				title: `Host notification: ${event.name}`,
+				triggerId: row.triggerId,
+				notification: event,
+				rootCorrelationId: row.rootCorrelationId,
+				causationDepth: row.causationDepth + 1,
+			});
+			if (store.finishLease(row.deliveryId, leaseId, "accepted")) {
+				this.staffManager.updateTriggerState(row.staffId, row.triggerId, { lastFired: this.clock.now() });
+			}
+		} catch (err) {
+			const now = this.clock.now();
+			const retryable = transientDeliveryError(err)
+				&& row.attempt < MAX_ATTEMPTS
+				&& now < row.createdAt + FINAL_DEADLINE_MS;
+			try {
+				if (retryable) {
+					const backoff = Math.min(60_000, 1_000 * (2 ** Math.max(0, row.attempt - 1)));
+					store.finishLease(row.deliveryId, leaseId, "pending", { nextAttemptAt: now + backoff, diagnosticCode: "TRANSIENT_DELIVERY_FAILURE" });
+				} else {
+					store.finishLease(row.deliveryId, leaseId, "failed", { diagnosticCode: "PERMANENT_DELIVERY_FAILURE" });
+				}
+			} catch { /* leave the durable lease for restart recovery */ }
+			this.diagnostic({ code: retryable ? "DELIVERY_RETRY" : "DELIVERY_FAILED", projectId: row.projectId, notificationName: row.notification.name, staffId: row.staffId, triggerId: row.triggerId, deliveryId: row.deliveryId, attempt: row.attempt });
+		} finally {
+			this.aborters.delete(row.deliveryId);
+		}
+	}
+}

--- a/src/server/agent/notification-staff-dispatcher.ts
+++ b/src/server/agent/notification-staff-dispatcher.ts
@@ -249,13 +249,13 @@ export class NotificationStaffDispatcher {
 				this.aborters.delete(id);
 			}
 			const claimed = store.claimDue(this.clock.now(), LEASE_MS, BATCH_SIZE);
-			for (const row of claimed) this.deliver(store, row);
+			for (const row of claimed) this.deliverClaim(store, row);
 		} catch {
 			this.diagnostic({ code: "OUTBOX_RECONCILE_FAILED", projectId });
 		}
 	}
 
-	private deliver(store: NotificationDeliveryStore, row: NotificationDeliveryRow): void {
+	private deliverClaim(store: NotificationDeliveryStore, row: NotificationDeliveryRow): void {
 		const leaseId = row.leaseId!;
 		const aborter = new AbortController();
 		this.aborters.set(row.deliveryId, aborter);

--- a/src/server/agent/pack-contributions.ts
+++ b/src/server/agent/pack-contributions.ts
@@ -12,7 +12,7 @@
 //   - `channels/<name>.yaml`    → ChannelContribution[] (filtered by
 //                                  manifest.contents.channels[])
 //   - `hooks/<name>.yaml`       → HookContribution[] (filtered by
-//                                  manifest.contents.hooks[]; metadata only)
+//                                  manifest.contents.hooks[]; explicit kind opts in)
 //   - `pack.yaml.routes`        → RouteContribution
 //
 // Mirrors the tolerance of `tool-contributions.ts`: a malformed file is warned +
@@ -39,6 +39,7 @@ import type { EntrypointIconId } from "../../shared/entrypoint-icons.js";
 import { isSafeBasename, isValidPackName } from "./pack-manifest.js";
 import { isPackPathWithinRoot } from "../extension-host/path-guard.js";
 import type { McpServerConfig } from "../mcp/mcp-types.js";
+import { HOST_INTERCEPTOR_CATALOGUE, HOST_NOTIFICATION_CATALOGUE } from "../../shared/extension-host/host-hooks.js";
 
 // Panel ids may use dotted namespaces (e.g. `artifacts.viewer`).
 const PANEL_ID_RE = /^[a-z0-9][a-z0-9_.-]*$/i;
@@ -62,7 +63,9 @@ const PROVIDER_HOOKS = new Set([
 const HOOK_ID_RE = /^[a-z0-9][a-z0-9_.-]*$/i;
 const HOOK_EVENTS = new Set(["sessionSetup", "beforePrompt", "afterTurn", "beforeCompact", "sessionShutdown", "goalProvisioned"] as const);
 const HOOK_CAPABILITIES = new Set(["store", "session", "agents"] as const);
-const HOOK_TOP_LEVEL_KEYS = new Set(["id", "module", "events", "mode", "capabilities", "budget", "config", "activation"]);
+const LEGACY_HOOK_TOP_LEVEL_KEYS = new Set(["id", "module", "events", "mode", "capabilities", "budget", "config", "activation"]);
+const INTERCEPTOR_HOOK_TOP_LEVEL_KEYS = new Set(["id", "module", "kind", "interceptors", "failurePolicy", "capabilities", "budget", "config", "activation"]);
+const NOTIFICATION_HOOK_TOP_LEVEL_KEYS = new Set(["id", "module", "kind", "notifications", "capabilities", "budget", "config", "activation"]);
 
 /** A hard pack-contribution conflict (§5.4). Throwing aborts the pack's load so
  *  the registry can surface a loud error instead of silently registering an
@@ -235,22 +238,56 @@ export interface ProviderContribution {
 export type HookEvent = "sessionSetup" | "beforePrompt" | "afterTurn" | "beforeCompact" | "sessionShutdown" | "goalProvisioned";
 export type HookMode = "observe" | "decide";
 export type HookCapability = "store" | "session" | "agents";
+export type HookFailurePolicy = "failOpen" | "failClosed";
 
-/** A manifest-listed, inert hook metadata declaration. This is never imported,
- * authorized, config-gated, or registered for dispatch by the contribution loader. */
-export interface HookContribution {
+interface HookContributionBase {
 	id: string;
 	module: string;
-	events: HookEvent[];
-	mode: HookMode;
 	capabilities: HookCapability[];
-	budget: { maxTokens: number; timeoutMs: number };
+	budget: { maxTokens: number; timeoutMs: number; declaredTimeoutMs?: number };
 	config?: Record<string, unknown>;
 	activation?: { requiresConfig: string[] };
 	listName: string;
 	sourceFile: string;
 	packRoot: string;
 }
+
+/** The pre-host-hooks declaration remains listable metadata and is deliberately inert. */
+export interface LegacyInertHookContribution extends HookContributionBase {
+	kind?: undefined;
+	events: HookEvent[];
+	mode: HookMode;
+	interceptors?: undefined;
+	notifications?: undefined;
+	failurePolicy?: undefined;
+}
+
+/** An explicit, executable pre-authority interceptor declaration. */
+export interface InterceptorHookContribution extends HookContributionBase {
+	kind: "interceptor";
+	interceptors: Array<keyof typeof HOST_INTERCEPTOR_CATALOGUE>;
+	failurePolicy?: HookFailurePolicy;
+	events?: undefined;
+	mode?: undefined;
+	notifications?: undefined;
+}
+
+export interface HookNotificationSelector {
+	scope: "session" | "project";
+	name: keyof typeof HOST_NOTIFICATION_CATALOGUE;
+}
+
+/** An explicit, observational post-authority notification declaration. */
+export interface NotificationHookContribution extends HookContributionBase {
+	kind: "notification";
+	notifications: HookNotificationSelector[];
+	events?: undefined;
+	mode?: undefined;
+	interceptors?: undefined;
+	failurePolicy?: undefined;
+}
+
+export type HookContribution = LegacyInertHookContribution | InterceptorHookContribution | NotificationHookContribution;
 
 /** Pack-store key under which a provider's persisted flat config overrides live
  *  (server-derived packId scopes the store; this names the per-provider record).
@@ -302,7 +339,7 @@ export interface PackContributions {
 	providers: ProviderContribution[];
 	/** Channel handler files listed by contents.channels[]. */
 	channels: ChannelContribution[];
-	/** Schema-2 hook metadata files listed by contents.hooks[]. Never executable. */
+	/** Schema-2 hook files. Kindless legacy rows are inert; explicit kinds are runtime contributions. */
 	hooks: HookContribution[];
 	/** Schema-2 MCP contribution files listed by contents.mcp[]. */
 	mcp?: McpPackContribution[];
@@ -633,8 +670,8 @@ function parseHookActivation(raw: unknown): ParsedHookActivation {
 	return { activation: { requiresConfig } };
 }
 
-/** Load `hooks/<name>.yaml` ONLY for schema-2 names listed in contents.hooks.
- * These are inert declarations: loading only validates and indexes metadata. */
+/** Load manifest-listed hook declarations. Legacy `{events,mode}` rows stay inert;
+ * only an explicit `kind` opts a declaration into runtime execution. */
 export function loadHooks(packRoot: string, manifest: PackManifest): HookContribution[] {
 	if ((manifest.schema ?? 1) < 2) return [];
 	const listNames = manifest.contents.hooks ?? [];
@@ -648,12 +685,8 @@ export function loadHooks(packRoot: string, manifest: PackManifest): HookContrib
 			console.warn(`[pack-contributions] hook listName ${JSON.stringify(listName)} is not a safe basename; skipping`);
 			continue;
 		}
-		// Check duplicate refs before reading so malformed files cannot hide this
-		// ambiguous activation identity.
 		if (seenListName.has(listName)) {
-			throw new PackContributionError(
-				`pack "${packIdFromRoot(packRoot)}" declares hook listName "${listName}" more than once; hook listNames must be unique within a pack`,
-			);
+			throw new PackContributionError(`pack "${packIdFromRoot(packRoot)}" declares hook listName "${listName}" more than once; hook listNames must be unique within a pack`);
 		}
 		seenListName.add(listName);
 		const sourceFile = resolveContributionFile(dir, listName);
@@ -662,9 +695,8 @@ export function loadHooks(packRoot: string, manifest: PackManifest): HookContrib
 			continue;
 		}
 		let data: unknown;
-		try {
-			data = readYaml(sourceFile);
-		} catch (err) {
+		try { data = readYaml(sourceFile); }
+		catch (err) {
 			console.warn(`[pack-contributions] skipping missing/malformed hook '${listName}' (${sourceFile}): ${String(err)}`);
 			continue;
 		}
@@ -672,7 +704,13 @@ export function loadHooks(packRoot: string, manifest: PackManifest): HookContrib
 			console.warn(`[pack-contributions] hook '${listName}' (${sourceFile}) is not a mapping; dropping`);
 			continue;
 		}
-		const unknownKey = Object.keys(data).find((key) => !HOOK_TOP_LEVEL_KEYS.has(key));
+		const kind = data.kind;
+		const allowedKeys = kind === "interceptor"
+			? INTERCEPTOR_HOOK_TOP_LEVEL_KEYS
+			: kind === "notification"
+				? NOTIFICATION_HOOK_TOP_LEVEL_KEYS
+				: LEGACY_HOOK_TOP_LEVEL_KEYS;
+		const unknownKey = Object.keys(data).find((key) => !allowedKeys.has(key));
 		if (unknownKey !== undefined) {
 			console.warn(`[pack-contributions] hook '${listName}' (${sourceFile}) has unknown top-level key ${JSON.stringify(unknownKey)}; dropping`);
 			continue;
@@ -687,62 +725,12 @@ export function loadHooks(packRoot: string, manifest: PackManifest): HookContrib
 			console.warn(`[pack-contributions] hook '${id}' (${sourceFile}) has missing module; dropping`);
 			continue;
 		}
-		if (!isSafeRelativePath(mod)) {
-			throw new PackContributionError(
-				`pack "${packIdFromRoot(packRoot)}" hook "${id}" has unsafe module path`,
-			);
+		if (!isSafeRelativePath(mod)) throw new PackContributionError(`pack "${packIdFromRoot(packRoot)}" hook "${id}" has unsafe module path`);
+		if (!isPackPathWithinRoot(packRoot, path.resolve(path.dirname(sourceFile), mod))) {
+			throw new PackContributionError(`pack "${packIdFromRoot(packRoot)}" hook "${id}" module resolves outside the pack root`);
 		}
-		const resolvedModule = path.resolve(path.dirname(sourceFile), mod);
-		if (!isPackPathWithinRoot(packRoot, resolvedModule)) {
-			throw new PackContributionError(
-				`pack "${packIdFromRoot(packRoot)}" hook "${id}" module resolves outside the pack root`,
-			);
-		}
-		const events = data.events;
-		if (!Array.isArray(events) || events.length === 0) {
-			console.warn(`[pack-contributions] hook '${id}' (${sourceFile}) has invalid events; dropping`);
-			continue;
-		}
-		const normalizedEvents: HookEvent[] = [];
-		const seenEvents = new Set<string>();
-		let invalidEvents = false;
-		for (const event of events) {
-			if (typeof event !== "string" || !HOOK_EVENTS.has(event as HookEvent) || seenEvents.has(event)) {
-				invalidEvents = true;
-				break;
-			}
-			seenEvents.add(event);
-			normalizedEvents.push(event as HookEvent);
-		}
-		if (invalidEvents) {
-			console.warn(`[pack-contributions] hook '${id}' (${sourceFile}) events must be supported and duplicate-free; dropping`);
-			continue;
-		}
-		const mode = data.mode;
-		if (mode !== "observe" && mode !== "decide") {
-			console.warn(`[pack-contributions] hook '${id}' (${sourceFile}) has invalid mode; dropping`);
-			continue;
-		}
-		const capabilities = data.capabilities;
-		if (!Array.isArray(capabilities)) {
-			console.warn(`[pack-contributions] hook '${id}' (${sourceFile}) has invalid capabilities; dropping`);
-			continue;
-		}
-		const normalizedCapabilities: HookCapability[] = [];
-		const seenCapabilities = new Set<string>();
-		let invalidCapabilities = false;
-		for (const capability of capabilities) {
-			if (typeof capability !== "string" || !HOOK_CAPABILITIES.has(capability as HookCapability) || seenCapabilities.has(capability)) {
-				invalidCapabilities = true;
-				break;
-			}
-			seenCapabilities.add(capability);
-			normalizedCapabilities.push(capability as HookCapability);
-		}
-		if (invalidCapabilities) {
-			console.warn(`[pack-contributions] hook '${id}' (${sourceFile}) capabilities must be supported and duplicate-free; dropping`);
-			continue;
-		}
+		const capabilities = parseHookCapabilities(data.capabilities, id, sourceFile);
+		if (!capabilities) continue;
 		let config: Record<string, unknown> | undefined;
 		if (data.config !== undefined) {
 			if (!isPlainObject(data.config)) {
@@ -756,30 +744,112 @@ export function loadHooks(packRoot: string, manifest: PackManifest): HookContrib
 			console.warn(`[pack-contributions] hook '${id}' (${sourceFile}) ${parsedActivation.error}; dropping`);
 			continue;
 		}
-		if (seenId.has(id)) {
-			throw new PackContributionError(
-				`pack "${packIdFromRoot(packRoot)}" declares hook id "${id}" more than once; hook ids must be unique within a pack`,
-			);
-		}
-		seenId.add(id);
+		if (seenId.has(id)) throw new PackContributionError(`pack "${packIdFromRoot(packRoot)}" declares hook id "${id}" more than once; hook ids must be unique within a pack`);
 		const budgetRaw = isPlainObject(data.budget) ? data.budget : {};
-		const hook: HookContribution = {
-			id,
-			module: mod,
-			events: normalizedEvents,
-			mode,
-			capabilities: normalizedCapabilities,
+		const base = {
+			id, module: mod, capabilities,
 			budget: {
 				maxTokens: clampNumber(budgetRaw.maxTokens, 1600, 64, 8192),
 				timeoutMs: clampNumber(budgetRaw.timeoutMs, 1500, 100, 10000),
+				...(kind !== undefined && typeof budgetRaw.timeoutMs === "number" && Number.isFinite(budgetRaw.timeoutMs)
+					? { declaredTimeoutMs: clampNumber(budgetRaw.timeoutMs, 1500, 100, 10000) }
+					: {}),
 			},
-			listName,
-			sourceFile,
-			packRoot,
+			listName, sourceFile, packRoot,
+			...(config === undefined ? {} : { config }),
+			...(parsedActivation.activation ? { activation: parsedActivation.activation } : {}),
 		};
-		if (config !== undefined) hook.config = config;
-		if (parsedActivation.activation) hook.activation = parsedActivation.activation;
+		let hook: HookContribution | undefined;
+		if (kind === "interceptor") {
+			const interceptors = parseHookNames(data.interceptors, HOST_INTERCEPTOR_CATALOGUE);
+			if (!interceptors) {
+				console.warn(`[pack-contributions] hook '${id}' (${sourceFile}) interceptors must be canonical and duplicate-free; dropping`);
+				continue;
+			}
+			const failurePolicy = data.failurePolicy;
+			if (failurePolicy !== undefined && failurePolicy !== "failOpen" && failurePolicy !== "failClosed") {
+				console.warn(`[pack-contributions] hook '${id}' (${sourceFile}) has invalid failurePolicy; dropping`);
+				continue;
+			}
+			if (failurePolicy && interceptors.some((name) => !HOST_INTERCEPTOR_CATALOGUE[name].allowedFailurePolicies.has(failurePolicy))) {
+				console.warn(`[pack-contributions] hook '${id}' (${sourceFile}) failurePolicy is not allowed by every declared interceptor; dropping`);
+				continue;
+			}
+			hook = { ...base, kind, interceptors, ...(failurePolicy ? { failurePolicy } : {}) } as InterceptorHookContribution;
+		} else if (kind === "notification") {
+			const notifications = parseNotificationSelectors(data.notifications);
+			if (!notifications) {
+				console.warn(`[pack-contributions] hook '${id}' (${sourceFile}) notifications must contain canonical scope/name selectors and be duplicate-free; dropping`);
+				continue;
+			}
+			hook = { ...base, kind, notifications } as NotificationHookContribution;
+		} else {
+			if (kind !== undefined) {
+				console.warn(`[pack-contributions] hook '${id}' (${sourceFile}) has invalid kind; dropping`);
+				continue;
+			}
+			const events = parseHookNames(data.events, Object.fromEntries([...HOOK_EVENTS].map((name) => [name, true])));
+			if (!events) {
+				console.warn(`[pack-contributions] hook '${id}' (${sourceFile}) events must be supported and duplicate-free; dropping`);
+				continue;
+			}
+			if (data.mode !== "observe" && data.mode !== "decide") {
+				console.warn(`[pack-contributions] hook '${id}' (${sourceFile}) has invalid mode; dropping`);
+				continue;
+			}
+			hook = { ...base, events: events as HookEvent[], mode: data.mode } as LegacyInertHookContribution;
+		}
+		seenId.add(id);
 		out.push(hook);
+	}
+	return out;
+}
+
+function parseHookCapabilities(raw: unknown, id: string, sourceFile: string): HookCapability[] | undefined {
+	if (!Array.isArray(raw)) {
+		console.warn(`[pack-contributions] hook '${id}' (${sourceFile}) has invalid capabilities; dropping`);
+		return undefined;
+	}
+	const out: HookCapability[] = [];
+	const seen = new Set<string>();
+	for (const value of raw) {
+		if (typeof value !== "string" || !HOOK_CAPABILITIES.has(value as HookCapability) || seen.has(value)) {
+			console.warn(`[pack-contributions] hook '${id}' (${sourceFile}) capabilities must be supported and duplicate-free; dropping`);
+			return undefined;
+		}
+		seen.add(value);
+		out.push(value as HookCapability);
+	}
+	return out;
+}
+
+function parseHookNames<T extends Record<string, unknown>>(raw: unknown, catalogue: T): Array<keyof T> | undefined {
+	if (!Array.isArray(raw) || raw.length === 0) return undefined;
+	const out: Array<keyof T> = [];
+	const seen = new Set<string>();
+	for (const value of raw) {
+		if (typeof value !== "string" || !Object.prototype.hasOwnProperty.call(catalogue, value) || seen.has(value)) return undefined;
+		seen.add(value);
+		out.push(value as keyof T);
+	}
+	return out;
+}
+
+function parseNotificationSelectors(raw: unknown): HookNotificationSelector[] | undefined {
+	if (!Array.isArray(raw) || raw.length === 0) return undefined;
+	const out: HookNotificationSelector[] = [];
+	const seen = new Set<string>();
+	for (const value of raw) {
+		if (!isPlainObject(value) || Object.keys(value).some((key) => key !== "scope" && key !== "name")) return undefined;
+		const { scope, name } = value;
+		if ((scope !== "session" && scope !== "project") || typeof name !== "string") return undefined;
+		if (!Object.prototype.hasOwnProperty.call(HOST_NOTIFICATION_CATALOGUE, name)) return undefined;
+		const definition = HOST_NOTIFICATION_CATALOGUE[name as keyof typeof HOST_NOTIFICATION_CATALOGUE];
+		if (definition.scope !== scope) return undefined;
+		const key = `${scope}:${name}`;
+		if (seen.has(key)) return undefined;
+		seen.add(key);
+		out.push({ scope, name: name as keyof typeof HOST_NOTIFICATION_CATALOGUE });
 	}
 	return out;
 }

--- a/src/server/agent/pr-status-store.ts
+++ b/src/server/agent/pr-status-store.ts
@@ -1,6 +1,7 @@
+import { createHash, randomUUID } from "node:crypto";
+import path from "node:path";
 import type { FsLike } from "../gateway-deps.js";
 import { realFs } from "../gateway-deps.js";
-import path from "node:path";
 
 export interface PrStatusEntry {
 	state: string;
@@ -16,11 +17,85 @@ export interface PrStatusEntry {
 	updatedAt?: string;
 }
 
+export interface PrStatusChangedPayload {
+	readonly goalId: string;
+	readonly number?: number;
+	readonly state: string;
+	readonly reviewDecision?: string;
+	readonly mergeability?: string;
+}
+
+/** Safe post-commit projection consumed by the host notification wiring. */
+export interface PrStatusChangedFact {
+	readonly goalId: string;
+	readonly revision: string;
+	readonly payload: Readonly<PrStatusChangedPayload>;
+}
+
+/** Thrown when the PR cache cannot be atomically published. */
+export class PrStatusPersistenceError extends Error {
+	readonly code = "PR_STATUS_PERSIST_FAILED";
+	constructor() {
+		super("Pull request status could not be published. Verify the state directory is writable and retry.");
+		this.name = "PrStatusPersistenceError";
+	}
+}
+
+const MAX_GOAL_ID_LENGTH = 128;
+const MAX_STATUS_IDENTIFIER_LENGTH = 64;
+
+function boundedIdentifier(value: unknown, maxLength: number): string | undefined {
+	return typeof value === "string" && value.length > 0 && value.length <= maxLength
+		? value
+		: undefined;
+}
+
+/** Build only the catalogue-owned public status fields; never retain cache objects. */
+function safeStatusProjection(goalId: string, entry: PrStatusEntry): Readonly<PrStatusChangedPayload> | undefined {
+	const safeGoalId = boundedIdentifier(goalId, MAX_GOAL_ID_LENGTH);
+	const state = boundedIdentifier(entry.state, MAX_STATUS_IDENTIFIER_LENGTH);
+	if (!safeGoalId || !state) return undefined;
+	const number = Number.isSafeInteger(entry.number) && (entry.number as number) > 0
+		? entry.number
+		: undefined;
+	const reviewDecision = boundedIdentifier(entry.reviewDecision, MAX_STATUS_IDENTIFIER_LENGTH);
+	const mergeability = boundedIdentifier(entry.mergeable, MAX_STATUS_IDENTIFIER_LENGTH);
+	return Object.freeze({
+		goalId: safeGoalId,
+		...(number === undefined ? {} : { number }),
+		state,
+		...(reviewDecision === undefined ? {} : { reviewDecision }),
+		...(mergeability === undefined ? {} : { mergeability }),
+	});
+}
+
+function sameSafeProjection(
+	left: Readonly<PrStatusChangedPayload> | undefined,
+	right: Readonly<PrStatusChangedPayload> | undefined,
+): boolean {
+	return JSON.stringify(left) === JSON.stringify(right);
+}
+
+function safeRevision(entry: PrStatusEntry, payload: Readonly<PrStatusChangedPayload>): string {
+	// GitHub's updatedAt is an ISO timestamp. Do not let an arbitrary cache field
+	// become public revision metadata when it is not a provider timestamp.
+	if (typeof entry.updatedAt === "string"
+		&& entry.updatedAt.length <= 64
+		&& /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z$/.test(entry.updatedAt)
+		&& Number.isFinite(Date.parse(entry.updatedAt))) {
+		return entry.updatedAt;
+	}
+	return createHash("sha256").update(JSON.stringify(payload)).digest("hex");
+}
+
 export class PrStatusStore {
 	private cache: Map<string, PrStatusEntry> = new Map();
 	private readonly storeDir: string;
 	private readonly storeFile: string;
 	private readonly fs: FsLike;
+
+	/** Invoked after a changed safe projection is atomically committed. */
+	onPullRequestStatusChanged?: (fact: PrStatusChangedFact) => void;
 
 	constructor(stateDir: string, fsImpl: FsLike = realFs) {
 		this.fs = fsImpl;
@@ -44,12 +119,39 @@ export class PrStatusStore {
 		}
 	}
 
-	private save(): void {
+	private existingTargetMode(): number | undefined {
 		try {
+			const mode = this.fs.statSync(this.storeFile).mode;
+			return typeof mode === "number" ? mode & 0o777 : undefined;
+		} catch (error) {
+			if ((error as NodeJS.ErrnoException | undefined)?.code === "ENOENT") return undefined;
+			throw error;
+		}
+	}
+
+	private save(candidate: ReadonlyMap<string, PrStatusEntry>): void {
+		const temp = `${this.storeFile}.${process.pid}.${randomUUID()}.tmp`;
+		try {
+			const targetMode = this.existingTargetMode();
 			if (!this.fs.existsSync(this.storeDir)) this.fs.mkdirSync(this.storeDir, { recursive: true });
-			this.fs.writeFileSync(this.storeFile, JSON.stringify(Object.fromEntries(this.cache), null, 2), "utf-8");
-		} catch (err) {
-			console.error("[pr-status-store] Failed to save:", err);
+			const bytes = JSON.stringify(Object.fromEntries(candidate), null, 2);
+			this.fs.writeFileSync(temp, bytes, targetMode === undefined
+				? "utf-8"
+				: { encoding: "utf-8", mode: targetMode });
+			this.fs.renameSync(temp, this.storeFile);
+		} catch {
+			try { this.fs.unlinkSync(temp); } catch { /* only clean this invocation's temp file */ }
+			throw new PrStatusPersistenceError();
+		}
+	}
+
+	private notify(fact: PrStatusChangedFact): void {
+		try {
+			this.onPullRequestStatusChanged?.(fact);
+		} catch {
+			// The cache is already authoritative. Observers are non-fatal and must not
+			// make a successful PR status commit appear to have failed.
+			console.error("[pr-status-store] Post-commit status observer failed");
 		}
 	}
 
@@ -58,8 +160,23 @@ export class PrStatusStore {
 	}
 
 	set(goalId: string, data: PrStatusEntry): void {
-		this.cache.set(goalId, data);
-		this.save();
+		const previous = this.cache.get(goalId);
+		const committed = { ...data };
+		const previousSafe = previous ? safeStatusProjection(goalId, previous) : undefined;
+		const nextSafe = safeStatusProjection(goalId, committed);
+		const candidate = new Map(this.cache);
+		candidate.set(goalId, committed);
+
+		this.save(candidate);
+		this.cache = candidate;
+
+		if (nextSafe && !sameSafeProjection(previousSafe, nextSafe)) {
+			this.notify(Object.freeze({
+				goalId,
+				revision: safeRevision(committed, nextSafe),
+				payload: nextSafe,
+			}));
+		}
 	}
 
 	getAll(): Record<string, PrStatusEntry> {
@@ -67,6 +184,10 @@ export class PrStatusStore {
 	}
 
 	remove(goalId: string): void {
-		if (this.cache.delete(goalId)) this.save();
+		if (!this.cache.has(goalId)) return;
+		const candidate = new Map(this.cache);
+		candidate.delete(goalId);
+		this.save(candidate);
+		this.cache = candidate;
 	}
 }

--- a/src/server/agent/project-config-store.ts
+++ b/src/server/agent/project-config-store.ts
@@ -1,7 +1,7 @@
 import type { FsLike } from "../gateway-deps.js";
 import { realFs } from "../gateway-deps.js";
 import path from "node:path";
-import { randomUUID } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import yaml from "yaml";
 
 // ── Component yaml normalization ────────────────────────────
@@ -102,6 +102,17 @@ export interface ProjectConfigDraft {
 	setPackActivation(scope: PackOrderScope, packName: string, disabled: DisabledRefs): void;
 	setComponents(components: Component[]): void;
 	setWorkflows(workflows: Record<string, InlineWorkflowDef> | undefined): void;
+}
+
+export interface ProjectSettingsChangedPayload {
+	readonly target: "project";
+	readonly changedKeys: readonly string[];
+}
+
+/** Safe post-commit projection consumed by project-scoped notification wiring. */
+export interface ProjectSettingsChangedFact {
+	readonly revision: string;
+	readonly payload: Readonly<ProjectSettingsChangedPayload>;
 }
 
 /** Thrown when a config file needs repair before it can be safely overwritten. */
@@ -469,6 +480,9 @@ export class ProjectConfigStore {
 	private readonly configFile: string;
 	private readonly fs: FsLike;
 
+	/** Invoked after changed canonical project settings are atomically committed. */
+	onSettingsChanged?: (fact: ProjectSettingsChangedFact) => void;
+
 	constructor(configDir: string, fsImpl: FsLike = realFs) {
 		this.fs = fsImpl;
 		this.configFile = path.join(configDir, "project.yaml");
@@ -600,7 +614,7 @@ export class ProjectConfigStore {
 		if (this.loadFailed) throw new ProjectConfigLoadError(this.configFile);
 	}
 
-	private serialize(state: ConfigStoreState): string {
+	private serializedObject(state: ConfigStoreState): Record<string, unknown> {
 		const out: Record<string, unknown> = {};
 		for (const [k, v] of Object.entries(state.data)) {
 			if (!MIGRATED_KEYS.has(k)) out[k] = v;
@@ -611,12 +625,27 @@ export class ProjectConfigStore {
 			out.config_directories = state.configDirectories.map(e => ({ path: e.path, types: [...e.types] }));
 		}
 		if (state.present.sandbox_tokens || state.sandboxTokens.length > 0) {
-			// Values are accepted at API ingress only; project.yaml must never contain them.
+			// Values are accepted at API ingress only; project.yaml and notification
+			// metadata must never contain them.
 			out.sandbox_tokens = state.sandboxTokens.map(e => ({ key: e.key, enabled: e.enabled }));
 		}
 		if (state.present.pack_order || this.packOrderNonEmpty(state.packOrder)) out.pack_order = this.serializePackOrder(state.packOrder);
 		if (state.present.pack_activation || this.packActivationNonEmpty(state.packActivation)) out.pack_activation = this.serializePackActivation(state.packActivation);
-		return yaml.stringify(out);
+		return out;
+	}
+
+	private serialize(state: ConfigStoreState): string {
+		return yaml.stringify(this.serializedObject(state));
+	}
+
+	private changedSettingKeys(before: ConfigStoreState, after: ConfigStoreState): string[] {
+		const previous = this.serializedObject(before);
+		const next = this.serializedObject(after);
+		return [...new Set([...Object.keys(previous), ...Object.keys(next)])]
+			.filter(key => key.length > 0 && key.length <= 128)
+			.filter(key => JSON.stringify(previous[key]) !== JSON.stringify(next[key]))
+			.sort()
+			.slice(0, 32);
 	}
 
 	private existingTargetMode(): number | undefined {
@@ -631,19 +660,23 @@ export class ProjectConfigStore {
 		}
 	}
 
-	private publish(state: ConfigStoreState): void {
+	private publish(state: ConfigStoreState): string {
 		const dir = path.dirname(this.configFile);
 		const temp = `${this.configFile}.${process.pid}.${randomUUID()}.tmp`;
 		try {
+			// Serialize once so the returned revision hashes the exact canonical bytes
+			// atomically published by rename.
+			const bytes = this.serialize(state);
 			// Rename publishes the temp inode's mode. Seed it from the existing
 			// target before the POSIX atomic replacement, rather than chmodding the
 			// destination after publication (which could widen a private config).
 			const targetMode = this.existingTargetMode();
 			if (!this.fs.existsSync(dir)) this.fs.mkdirSync(dir, { recursive: true });
-			this.fs.writeFileSync(temp, this.serialize(state), targetMode === undefined
+			this.fs.writeFileSync(temp, bytes, targetMode === undefined
 				? "utf-8"
 				: { encoding: "utf-8", mode: targetMode });
 			this.fs.renameSync(temp, this.configFile);
+			return bytes;
 		} catch {
 			try { this.fs.unlinkSync(temp); } catch { /* only clean this invocation's temp file */ }
 			// Filesystem/YAML errors can contain config contents or token values.
@@ -651,16 +684,27 @@ export class ProjectConfigStore {
 		}
 	}
 
-	private commit(candidate: ConfigStoreState): void {
+	private commit(candidate: ConfigStoreState): string {
 		this.assertCanSave();
-		this.publish(candidate);
+		const committedBytes = this.publish(candidate);
 		candidate.dirty = false;
 		this.apply(candidate);
+		return createHash("sha256").update(committedBytes).digest("hex");
+	}
+
+	private notifySettingsChanged(fact: ProjectSettingsChangedFact): void {
+		try {
+			this.onSettingsChanged?.(fact);
+		} catch {
+			// Publication is already authoritative; observational fanout is non-fatal.
+			console.error("[project-config-store] Post-commit settings observer failed");
+		}
 	}
 
 	/** Apply several changes as one durable, all-or-nothing publication. */
 	mutate(mutator: (draft: ProjectConfigDraft) => void): void {
 		this.assertCanSave();
+		const before = this.snapshot();
 		const candidate = this.snapshot();
 		const draft: ProjectConfigDraft = {
 			set: (key, value) => this.setStateValue(candidate, key, value),
@@ -682,7 +726,15 @@ export class ProjectConfigStore {
 			setWorkflows: workflows => { candidate.workflows = workflows ? structuredClone(workflows) : undefined; },
 		};
 		mutator(draft);
-		this.commit(candidate);
+		const changedKeys = this.changedSettingKeys(before, candidate);
+		const revision = this.commit(candidate);
+		if (changedKeys.length > 0) {
+			const payload = Object.freeze({
+				target: "project" as const,
+				changedKeys: Object.freeze([...changedKeys]),
+			});
+			this.notifySettingsChanged(Object.freeze({ revision, payload }));
+		}
 	}
 
 	private setStateValue(state: ConfigStoreState, key: string, value: string): void {

--- a/src/server/agent/project-context-manager.ts
+++ b/src/server/agent/project-context-manager.ts
@@ -8,6 +8,7 @@ import type { ProjectConfigStore } from "./project-config-store.js";
 import type { Clock, CommandRunner, FsLike } from "../gateway-deps.js";
 import type { RemoteGitPolicy } from "../skills/git.js";
 import { bootLog, SLOW_PHASE_MS } from "../boot-profile.js";
+import type { HostNotificationDispatcher } from "../extension-host/host-notification-dispatcher.js";
 
 /**
  * Minimal session-resolver surface needed by the search orphan filter.
@@ -41,6 +42,7 @@ export class ProjectContextManager {
    * ProjectContext gets the same dispatcher reference.
    */
   private goalTriggerDispatcher: GoalTriggerDispatcher | null = null;
+  private hostNotificationDispatcher: HostNotificationDispatcher | null = null;
   private goalArchiveReconciler: ((goalId: string) => Promise<unknown>) | undefined;
   /**
    * Optional post-create configurator applied to every context (existing and
@@ -108,6 +110,9 @@ export class ProjectContextManager {
     if (this.goalTriggerDispatcher) {
       ctx.setGoalTriggerDispatcher(this.goalTriggerDispatcher);
     }
+    if (this.hostNotificationDispatcher) {
+      ctx.setHostNotificationDispatcher(this.hostNotificationDispatcher);
+    }
     if (this.goalArchiveReconciler) {
       ctx.setGoalArchiveReconciler(this.goalArchiveReconciler);
     }
@@ -129,6 +134,14 @@ export class ProjectContextManager {
     this.goalTriggerDispatcher = dispatcher;
     for (const ctx of this.contexts.values()) {
       ctx.setGoalTriggerDispatcher(dispatcher);
+    }
+  }
+
+  /** Late-bind canonical notification fanout to existing and future contexts. */
+  setHostNotificationDispatcher(dispatcher: HostNotificationDispatcher | null): void {
+    this.hostNotificationDispatcher = dispatcher;
+    for (const ctx of this.contexts.values()) {
+      ctx.setHostNotificationDispatcher(dispatcher);
     }
   }
 

--- a/src/server/agent/project-context.ts
+++ b/src/server/agent/project-context.ts
@@ -24,6 +24,14 @@ import { SecretsStore } from "./secrets-store.js";
 import { PlanMutationStore } from "./plan-mutation-store.js";
 import { realFs, type Clock, type CommandRunner, type FsLike } from "../gateway-deps.js";
 import type { RemoteGitPolicy } from "../skills/git.js";
+import type {
+  HostNotificationDispatcher,
+  HostNotificationPublication,
+} from "../extension-host/host-notification-dispatcher.js";
+import type {
+  HostNotification,
+  HostNotificationName,
+} from "../../shared/extension-host/host-hooks.js";
 
 /**
  * A container holding a complete set of stores scoped to one project.
@@ -67,6 +75,7 @@ export class ProjectContext {
    * that don't need the trigger surface.
    */
   private goalTriggerDispatcher: GoalTriggerDispatcher | null = null;
+  private hostNotificationDispatcher: HostNotificationDispatcher | null = null;
   private closePromise: Promise<void> | null = null;
 
   // Config stores
@@ -190,6 +199,22 @@ export class ProjectContext {
   setGoalTriggerDispatcher(dispatcher: GoalTriggerDispatcher | null): void {
     this.goalTriggerDispatcher = dispatcher;
     this.applyGoalTriggerDispatcher();
+  }
+
+  /** Late-bind the canonical post-authority notification publisher. */
+  setHostNotificationDispatcher(dispatcher: HostNotificationDispatcher | null): void {
+    this.hostNotificationDispatcher = dispatcher;
+  }
+
+  /** Narrow publisher callback for project-owned mutation boundaries. */
+  publishHostNotification<N extends HostNotificationName>(
+    name: N,
+    publication: Omit<HostNotificationPublication<N>, "projectId">,
+  ): HostNotification<N> | undefined {
+    return this.hostNotificationDispatcher?.publish(name, {
+      ...publication,
+      projectId: this.project.id,
+    } as HostNotificationPublication<N>);
   }
 
   /** Wire the authoritative post-archive cross-store reconciliation boundary. */

--- a/src/server/agent/provider-bridge-extension.ts
+++ b/src/server/agent/provider-bridge-extension.ts
@@ -17,7 +17,8 @@
  *
  * Transport/auth mirrors `tool-guard-extension.ts`: read
  * `BOBBIT_GATEWAY_URL` / `BOBBIT_TOKEN`, falling back to
- * `<BOBBIT_DIR || ~/.bobbit>/state/{gateway-url,token}`. All failures are
+ * `<BOBBIT_DIR || ~/.bobbit>/state/{gateway-url,token}`. The per-session secret
+ * binds the callback to this exact server-derived session. All failures are
  * swallowed so a turn always proceeds even when the gateway or a provider is
  * down (the non-fatal invariant).
  */
@@ -39,7 +40,7 @@ export const TURN_BRIDGE_HOOKS: readonly LifecycleHook[] = ["beforePrompt", "bef
 /** Timeout (ms) for the before-prompt callback — blocking-with-timeout. */
 export const BEFORE_PROMPT_TIMEOUT_MS = 2500;
 /** Timeout (ms) for the before-compact callback. */
-export const BEFORE_COMPACT_TIMEOUT_MS = 5000;
+export const BEFORE_COMPACT_TIMEOUT_MS = 5500;
 
 /**
  * Idempotently remove a prior Bobbit dynamic-context region from a system
@@ -198,6 +199,7 @@ export default function(pi) {
   const gwUrl = readState("gateway-url", "BOBBIT_GATEWAY_URL");
   const token = readState("token", "BOBBIT_TOKEN");
   const fetchImpl = globalThis.fetch.bind(globalThis);
+  const sessionSecret = process.env.BOBBIT_SESSION_SECRET;
 
   // TLS for the local gateway is handled entirely by the spawner's inherited
   // env (the CA cert is pinned via NODE_EXTRA_CA_CERTS when present, with the
@@ -210,10 +212,11 @@ export default function(pi) {
     const controller = new AbortController();
     const timer = setTimeout(() => controller.abort(), timeoutMs);
     try {
-      const res = await fetchImpl(gwUrl + "/api/sessions/" + sessionId + route, {
+      const res = await fetchImpl(gwUrl + "/api/sessions/" + encodeURIComponent(sessionId) + route, {
         method: "POST",
         headers: {
           "Authorization": "Bearer " + token,
+          ...(sessionSecret ? { "X-Bobbit-Session-Secret": sessionSecret } : {}),
           "Content-Type": "application/json",
         },
         body: JSON.stringify(body),

--- a/src/server/agent/session-manager.ts
+++ b/src/server/agent/session-manager.ts
@@ -919,14 +919,54 @@ export interface SessionHostInterceptorPort {
 	requiresFailClosed?(name: string, projectId?: string, goalId?: string): boolean;
 }
 
+type ToolCallLifecyclePhase =
+	| "observed"
+	| "before-running"
+	| "admitted"
+	| "after-running"
+	| "after-applied"
+	| "ended";
+
 interface ToolCallLifecycleEntry {
 	toolCallId: string;
 	toolName: string;
+	generation: number;
 	turnIndex: number;
 	startedAt: number;
+	startCursor?: number;
+	phase: ToolCallLifecyclePhase;
+	lease: number;
+	controller: AbortController;
 	status?: "succeeded" | "errored";
 	errorStatus?: "handler_error";
 }
+
+interface ToolCallBeforeWaiter {
+	toolCallId: string;
+	toolName: string;
+	generation: number;
+	timer: ReturnType<typeof setTimeout>;
+	resolve: (claim: ToolCallInterceptorClaim | undefined) => void;
+}
+
+declare const toolCallInterceptorClaimBrand: unique symbol;
+/** Opaque, process-local authority for one exact host-observed Pi tool boundary. */
+export type ToolCallInterceptorClaim = {
+	readonly [toolCallInterceptorClaimBrand]: true;
+};
+
+interface OwnedToolCallInterceptorClaim {
+	kind: "before" | "after";
+	session: SessionInfo;
+	entry: ToolCallLifecycleEntry;
+	generation: number;
+	lease: number;
+	settled: boolean;
+}
+
+const MAX_TRACKED_HOST_TOOL_CALLS = 128;
+const TOOL_CALL_START_ARRIVAL_GRACE_MS = 100;
+const MAX_HOST_TOOL_IDENTITY_LENGTH = 512;
 
 export interface SessionInfo {
 	id: string;
@@ -1053,8 +1093,10 @@ export interface SessionInfo {
 	staffNotificationTurnContext?: StaffNotificationTurnContext;
 	/** Last turn index whose canonical agent_start notification was published. */
 	hostTurnStartedIndex?: number;
-	/** Bounded, metadata-only tool calls admitted by the host interceptor seam. */
+	/** Bounded, metadata-only tool provenance created only by accepted Pi lifecycle events. */
 	hostToolCallLifecycle?: Map<string, ToolCallLifecycleEntry>;
+	/** Bounded pre-arrival reservations for HTTP callbacks that race Pi stdout. */
+	hostToolCallBeforeWaiters?: Map<string, ToolCallBeforeWaiter>;
 	/** Post-authority status observer installed by SessionManager. */
 	onStatusChanged?: import("./session-status.js").BroadcastableSession["onStatusChanged"];
 	/** Called only after a live event entered EventBuffer and its legacy frame was queued. */
@@ -3277,6 +3319,8 @@ type PendingVerifierPromptReceipt = {
 
 export class SessionManager {
 	private sessions = new Map<string, SessionInfo>();
+	/** Opaque claims keep lifecycle authority out of route-visible values. */
+	private readonly _toolCallInterceptorClaims = new WeakMap<object, OwnedToolCallInterceptorClaim>();
 	/** Exact verifier rows waiting for provider acceptance, keyed by session/row. */
 	private _verifierPromptReceipts?: Map<string, Map<string, PendingVerifierPromptReceipt>>;
 	/** Sessions with at least one attached WS client. Keeps heartbeat work proportional to active viewers. */
@@ -3605,6 +3649,16 @@ export class SessionManager {
 		return (session.lifecycleGeneration ?? 0) === this._currentRespawnGeneration(session.id);
 	}
 
+	private clearToolCallProvenance(session: SessionInfo): void {
+		for (const entry of session.hostToolCallLifecycle?.values() ?? []) entry.controller.abort("tool-lifecycle-cleared");
+		session.hostToolCallLifecycle?.clear();
+		for (const waiter of session.hostToolCallBeforeWaiters?.values() ?? []) {
+			this.clock.clearTimeout(waiter.timer);
+			waiter.resolve(undefined);
+		}
+		session.hostToolCallBeforeWaiters?.clear();
+	}
+
 	/** Read-only admission view over the existing replacement coordinator. */
 	getModelSelectionRecoveryAdmission(sessionId: string): {
 		condition?: ModelSelectionRequiredCondition;
@@ -3636,7 +3690,7 @@ export class SessionManager {
 		session.lifecycleFenced = true;
 		session.lifecycleGeneration = replacingGeneration - 1;
 		session.staffNotificationTurnContext = undefined;
-		session.hostToolCallLifecycle?.clear();
+		this.clearToolCallProvenance(session);
 		session.dormant = true;
 		session.status = "terminated";
 		session.clients.clear();
@@ -3738,6 +3792,11 @@ export class SessionManager {
 				generation: this._nextRespawnGeneration(sessionId),
 				kind,
 			};
+			// Advancing the canonical generation invalidates every outstanding tool
+			// callback claim, including in-place bridge replacements that retain the
+			// same SessionInfo object and session secret.
+			const priorWriter = this.sessions.get(sessionId);
+			if (priorWriter) this.clearToolCallProvenance(priorWriter);
 			owned.active = token;
 			try {
 				const result = await operation(token);
@@ -3899,7 +3958,7 @@ export class SessionManager {
 		session.onStatusChanged = (change) => {
 			if (change.status === "terminated") {
 				session.staffNotificationTurnContext = undefined;
-				session.hostToolCallLifecycle?.clear();
+				this.clearToolCallProvenance(session);
 			}
 			this.publishSessionNotification(session, "statusChanged", session.id, change.statusVersion, {
 				previousStatus: change.previousStatus,
@@ -3916,38 +3975,238 @@ export class SessionManager {
 		session.onEventAccepted = (event, cursor) => this.publishAcceptedSessionEvent(session, event, cursor);
 	}
 
-	/**
-	 * Admission seam called by the beforeToolCall route after permission and the
-	 * interceptor router have approved the final tool name/arguments.
-	 */
-	markToolCallAdmitted(sessionId: string, toolCallId: string, toolName: string): void {
-		const session = this.sessions.get(sessionId);
-		if (!session || !this._sessionWriterIsCurrent(session)) return;
-		if (!toolCallId || !toolName) return;
+	private isBoundedToolIdentity(value: unknown): value is string {
+		return typeof value === "string" && value.length > 0 && value.length <= MAX_HOST_TOOL_IDENTITY_LENGTH;
+	}
+
+	private deleteToolCallEntry(session: SessionInfo, entry: ToolCallLifecycleEntry, reason: string): void {
+		if (session.hostToolCallLifecycle?.get(entry.toolCallId) === entry) {
+			session.hostToolCallLifecycle.delete(entry.toolCallId);
+		}
+		entry.controller.abort(reason);
+	}
+
+	private createToolCallClaim(
+		session: SessionInfo,
+		entry: ToolCallLifecycleEntry,
+		kind: "before" | "after",
+	): ToolCallInterceptorClaim | undefined {
+		const expectedPhase = kind === "before" ? "observed" : "admitted";
+		if (!this._sessionWriterIsCurrent(session)
+			|| entry.generation !== (session.lifecycleGeneration ?? 0)
+			|| session.hostToolCallLifecycle?.get(entry.toolCallId) !== entry
+			|| entry.phase !== expectedPhase
+			|| (kind === "before" && entry.startCursor === undefined)) return undefined;
+		entry.phase = kind === "before" ? "before-running" : "after-running";
+		entry.lease += 1;
+		const claim = Object.freeze({}) as ToolCallInterceptorClaim;
+		this._toolCallInterceptorClaims.set(claim, {
+			kind,
+			session,
+			entry,
+			generation: entry.generation,
+			lease: entry.lease,
+			settled: false,
+		});
+		return claim;
+	}
+
+	private toolCallClaimIsCurrent(owned: OwnedToolCallInterceptorClaim): boolean {
+		return !owned.settled
+			&& this._sessionWriterIsCurrent(owned.session)
+			&& owned.generation === (owned.session.lifecycleGeneration ?? 0)
+			&& owned.session.hostToolCallLifecycle?.get(owned.entry.toolCallId) === owned.entry
+			&& owned.entry.lease === owned.lease
+			&& owned.entry.phase === (owned.kind === "before" ? "before-running" : "after-running")
+			&& !owned.entry.controller.signal.aborted;
+	}
+
+	private resolveToolCallBeforeWaiter(session: SessionInfo, toolCallId: string, claim: ToolCallInterceptorClaim | undefined): void {
+		const waiter = session.hostToolCallBeforeWaiters?.get(toolCallId);
+		if (!waiter) return;
+		session.hostToolCallBeforeWaiters!.delete(toolCallId);
+		this.clock.clearTimeout(waiter.timer);
+		waiter.resolve(claim);
+	}
+
+	private observeToolCallStart(session: SessionInfo, event: any): void {
+		if (!this._sessionWriterIsCurrent(session)) return;
+		const toolCallId = event?.toolCallId;
+		const toolName = event?.toolName;
+		if (!this.isBoundedToolIdentity(toolCallId) || !this.isBoundedToolIdentity(toolName)) return;
+		const generation = session.lifecycleGeneration ?? 0;
 		const tracker = session.hostToolCallLifecycle ??= new Map<string, ToolCallLifecycleEntry>();
-		if (tracker.has(toolCallId)) return;
-		while (tracker.size >= 128) tracker.delete(tracker.keys().next().value!);
-		const turnIndex = (session.completedTurnCount ?? 0) + 1;
-		tracker.set(toolCallId, { toolCallId, toolName, turnIndex, startedAt: performance.now() });
-		this.publishSessionNotification(session, "toolCallStarted", toolCallId, toolCallId, {
+		const existing = tracker.get(toolCallId);
+		if (existing) {
+			if (existing.generation === generation && existing.toolName === toolName) return;
+			this.deleteToolCallEntry(session, existing, "tool-start-conflict");
+			this.resolveToolCallBeforeWaiter(session, toolCallId, undefined);
+			return;
+		}
+		if (tracker.size >= MAX_TRACKED_HOST_TOOL_CALLS) {
+			const evictable = Array.from(tracker.values()).find(entry => entry.phase === "observed");
+			if (!evictable) {
+				this.resolveToolCallBeforeWaiter(session, toolCallId, undefined);
+				return;
+			}
+			this.deleteToolCallEntry(session, evictable, "tool-provenance-capacity");
+			this.resolveToolCallBeforeWaiter(session, evictable.toolCallId, undefined);
+		}
+		tracker.set(toolCallId, {
 			toolCallId,
 			toolName,
-			turnIndex,
+			generation,
+			turnIndex: (session.completedTurnCount ?? 0) + 1,
+			startedAt: this.clock.now(),
+			phase: "observed",
+			lease: 0,
+			controller: new AbortController(),
 		});
 	}
 
+	private acceptToolCallStartCursor(session: SessionInfo, event: any, cursor: number): void {
+		if (!this._sessionWriterIsCurrent(session)) return;
+		const toolCallId = event?.toolCallId;
+		const toolName = event?.toolName;
+		if (!this.isBoundedToolIdentity(toolCallId) || !this.isBoundedToolIdentity(toolName)) return;
+		const entry = session.hostToolCallLifecycle?.get(toolCallId);
+		if (!entry || entry.phase !== "observed" || entry.toolName !== toolName
+			|| entry.generation !== (session.lifecycleGeneration ?? 0)) return;
+		entry.startCursor = cursor;
+		const waiter = session.hostToolCallBeforeWaiters?.get(toolCallId);
+		if (!waiter) return;
+		if (waiter.toolName !== toolName || waiter.generation !== entry.generation) {
+			this.resolveToolCallBeforeWaiter(session, toolCallId, undefined);
+			return;
+		}
+		this.resolveToolCallBeforeWaiter(session, toolCallId, this.createToolCallClaim(session, entry, "before"));
+	}
+
+	/** Claim one exact accepted Pi start. Waiting covers only stdout/HTTP transport reordering. */
+	claimToolCallBefore(sessionId: string, toolCallId: string, toolName: string): Promise<ToolCallInterceptorClaim | undefined> {
+		const session = this.sessions.get(sessionId);
+		if (!session || !this._sessionWriterIsCurrent(session)
+			|| !this.isBoundedToolIdentity(toolCallId) || !this.isBoundedToolIdentity(toolName)) {
+			return Promise.resolve(undefined);
+		}
+		const entry = session.hostToolCallLifecycle?.get(toolCallId);
+		if (entry) {
+			if (entry.toolName !== toolName || entry.generation !== (session.lifecycleGeneration ?? 0) || entry.phase !== "observed") {
+				return Promise.resolve(undefined);
+			}
+			if (entry.startCursor !== undefined) return Promise.resolve(this.createToolCallClaim(session, entry, "before"));
+		}
+		const waiters = session.hostToolCallBeforeWaiters ??= new Map<string, ToolCallBeforeWaiter>();
+		if (waiters.has(toolCallId) || waiters.size >= MAX_TRACKED_HOST_TOOL_CALLS) return Promise.resolve(undefined);
+		return new Promise(resolve => {
+			const generation = session.lifecycleGeneration ?? 0;
+			const waiter: ToolCallBeforeWaiter = {
+				toolCallId,
+				toolName,
+				generation,
+				resolve,
+				timer: this.clock.setTimeout(() => {
+					if (session.hostToolCallBeforeWaiters?.get(toolCallId) !== waiter) return;
+					session.hostToolCallBeforeWaiters.delete(toolCallId);
+					resolve(undefined);
+				}, TOOL_CALL_START_ARRIVAL_GRACE_MS),
+			};
+			waiters.set(toolCallId, waiter);
+		});
+	}
+
+	/** Claim the single post-handler callback for an admitted current-generation call. */
+	claimToolCallAfter(sessionId: string, toolCallId: string, toolName: string): ToolCallInterceptorClaim | undefined {
+		const session = this.sessions.get(sessionId);
+		if (!session || !this._sessionWriterIsCurrent(session)
+			|| !this.isBoundedToolIdentity(toolCallId) || !this.isBoundedToolIdentity(toolName)) return undefined;
+		const entry = session.hostToolCallLifecycle?.get(toolCallId);
+		if (!entry || entry.toolName !== toolName || entry.generation !== (session.lifecycleGeneration ?? 0)) return undefined;
+		return this.createToolCallClaim(session, entry, "after");
+	}
+
+	/** Dispatch through a claim-derived context; routes never receive lifecycle state or generation. */
+	dispatchClaimedToolInterceptor(
+		claim: ToolCallInterceptorClaim,
+		input: { args?: Record<string, unknown>; result?: unknown },
+	): Promise<any> | undefined {
+		const owned = this._toolCallInterceptorClaims.get(claim);
+		if (!owned || !this.toolCallClaimIsCurrent(owned) || !this.hostInterceptors) return undefined;
+		const request = owned.kind === "before"
+			? { toolCallId: owned.entry.toolCallId, toolName: owned.entry.toolName, args: input.args ?? {} }
+			: { toolCallId: owned.entry.toolCallId, toolName: owned.entry.toolName, result: input.result };
+		return this.hostInterceptors.dispatch(owned.kind === "before" ? "beforeToolCall" : "afterToolResult", request, {
+			projectId: owned.session.projectId,
+			sessionId: owned.session.id,
+			goalId: owned.session.goalId ?? owned.session.teamGoalId,
+			cwd: owned.session.cwd,
+			signal: owned.entry.controller.signal,
+		});
+	}
+
+	/** Apply one before decision. A block consumes provenance without publishing a start fact. */
+	settleToolCallBefore(claim: ToolCallInterceptorClaim, admitted: boolean): boolean {
+		const owned = this._toolCallInterceptorClaims.get(claim);
+		if (!owned || owned.kind !== "before" || !this.toolCallClaimIsCurrent(owned)) return false;
+		owned.settled = true;
+		if (!admitted) {
+			this.deleteToolCallEntry(owned.session, owned.entry, "tool-call-blocked");
+			return true;
+		}
+		owned.entry.phase = "admitted";
+		this.publishSessionNotification(owned.session, "toolCallStarted", owned.entry.toolCallId, owned.entry.startCursor, {
+			toolCallId: owned.entry.toolCallId,
+			toolName: owned.entry.toolName,
+			turnIndex: owned.entry.turnIndex,
+		});
+		return true;
+	}
+
+	/** Apply one approved/synthetic post-policy result before Pi can persist it. */
+	settleToolCallAfter(claim: ToolCallInterceptorClaim): boolean {
+		const owned = this._toolCallInterceptorClaims.get(claim);
+		if (!owned || owned.kind !== "after" || !this.toolCallClaimIsCurrent(owned)) return false;
+		owned.settled = true;
+		owned.entry.phase = "after-applied";
+		return true;
+	}
+
+	cancelToolCallInterceptorClaim(claim: ToolCallInterceptorClaim): void {
+		const owned = this._toolCallInterceptorClaims.get(claim);
+		if (!owned || owned.settled) return;
+		owned.settled = true;
+		this.deleteToolCallEntry(owned.session, owned.entry, "tool-callback-cancelled");
+	}
+
 	private recordToolCallTerminal(session: SessionInfo, event: any): void {
-		const toolCallId = typeof event?.toolCallId === "string" ? event.toolCallId : undefined;
-		if (!toolCallId) return;
+		if (!this._sessionWriterIsCurrent(session)) return;
+		const toolCallId = event?.toolCallId;
+		const toolName = event?.toolName;
+		if (!this.isBoundedToolIdentity(toolCallId) || !this.isBoundedToolIdentity(toolName)) return;
 		const tracked = session.hostToolCallLifecycle?.get(toolCallId);
 		if (!tracked) return;
+		if (tracked.toolName !== toolName || tracked.generation !== (session.lifecycleGeneration ?? 0)) {
+			this.deleteToolCallEntry(session, tracked, "tool-end-mismatch");
+			return;
+		}
+		if (tracked.phase === "ended") return;
+		if (tracked.phase !== "admitted" && tracked.phase !== "after-applied") {
+			this.deleteToolCallEntry(session, tracked, "tool-end-before-policy-settlement");
+			return;
+		}
+		tracked.phase = "ended";
 		tracked.status = event.isError === true ? "errored" : "succeeded";
 		tracked.errorStatus = event.isError === true ? "handler_error" : undefined;
+		tracked.controller.abort("tool-execution-ended");
 	}
 
 	private publishAcceptedSessionEvent(session: SessionInfo, accepted: unknown, cursor: number): void {
-		if (!accepted || typeof accepted !== "object") return;
-		const event = accepted as { type?: unknown; message?: any };
+		if (!this._sessionWriterIsCurrent(session) || !accepted || typeof accepted !== "object") return;
+		const event = accepted as { type?: unknown; toolCallId?: unknown; toolName?: unknown; message?: any };
+		if (event.type === "tool_execution_start") {
+			this.acceptToolCallStartCursor(session, event, cursor);
+			return;
+		}
 		if (event.type !== "message_end" || !event.message || typeof event.message !== "object") return;
 		const message = event.message;
 		const rawRole = typeof message.role === "string" ? message.role : "";
@@ -3977,14 +4236,18 @@ export class SessionManager {
 		const toolCallId = typeof message.toolCallId === "string" ? message.toolCallId : undefined;
 		if (!toolCallId) return;
 		const tracked = session.hostToolCallLifecycle?.get(toolCallId);
-		if (!tracked) return;
+		if (!tracked || tracked.phase !== "ended" || tracked.generation !== (session.lifecycleGeneration ?? 0)) return;
+		if (typeof message.toolName === "string" && message.toolName !== tracked.toolName) {
+			this.deleteToolCallEntry(session, tracked, "tool-result-mismatch");
+			return;
+		}
 		session.hostToolCallLifecycle!.delete(toolCallId);
 		const failed = tracked.status === "errored" || message.isError === true;
 		this.publishSessionNotification(session, "toolCallCompleted", toolCallId, cursor, {
 			toolCallId,
 			toolName: tracked.toolName,
 			status: failed ? "errored" : "succeeded",
-			durationMs: Math.max(0, Math.round(performance.now() - tracked.startedAt)),
+			durationMs: Math.max(0, Math.round(this.clock.now() - tracked.startedAt)),
 			...(failed ? { errorStatus: tracked.errorStatus ?? "handler_error" } : {}),
 		});
 	}
@@ -8909,8 +9172,11 @@ export class SessionManager {
 			session.latestMessageUpdate = undefined;
 		}
 
-		// Track tool execution during this turn
+		// Track tool execution during this turn. Provenance is created only from a
+		// current Pi writer; the later EventBuffer acceptance attaches its cursor
+		// before any waiting HTTP callback can claim it.
 		if (event.type === "tool_execution_start") {
+			if (writerIsCurrent) this.observeToolCallStart(session, event);
 			session.turnHadToolCalls = true;
 
 			// Enforce allowedTools — log when a disallowed tool slips past the guard
@@ -9180,7 +9446,7 @@ export class SessionManager {
 			if (completedNotificationId) {
 				queueMicrotask(() => this.clearStaffNotificationTurnContext(session.id, completedNotificationId));
 			}
-			session.hostToolCallLifecycle?.clear();
+			this.clearToolCallProvenance(session);
 			this.resolveIdleWaiters(session.id);
 			this.schedulePromptCursorRefresh(session, { settleBindings: true });
 			// Don't drain the queue if the turn ended with a model error —
@@ -15621,6 +15887,7 @@ export class SessionManager {
 		session.lifecycleFenced = true;
 		session.dormant = true;
 		session.staffNotificationTurnContext = undefined;
+		this.clearToolCallProvenance(session);
 		this.cancelPendingAutoRetry(session, "terminated");
 		try { this.purgeVerifierPromptRows(id, `Verifier session ${id} was quiesced before dispatch`); } catch { /* best-effort */ }
 		if (session.pendingMetadataPersist) {
@@ -17961,6 +18228,7 @@ export class SessionManager {
 			const session = this.sessions.get(id);
 			if (!session) continue;
 
+			this.clearToolCallProvenance(session);
 			await this.closeExtensionChannelsForSession(id, "gateway-shutdown");
 
 			// Snapshot the current active state before we kill the process.

--- a/src/server/agent/session-manager.ts
+++ b/src/server/agent/session-manager.ts
@@ -881,6 +881,42 @@ function sandboxWorktreeOwnerCoordinates(
 	return name ? { root, name } : undefined;
 }
 
+export type HostSessionNotificationName =
+	| "statusChanged"
+	| "turnStarted"
+	| "turnCompleted"
+	| "messageAppended"
+	| "toolCallStarted"
+	| "toolCallCompleted"
+	| "sessionStatusChanged";
+
+export interface HostSessionNotificationPublication {
+	projectId: string;
+	sessionId: string;
+	aggregateId: string;
+	aggregateRevision?: string | number;
+	payload: Readonly<Record<string, unknown>>;
+}
+
+/** Narrow post-authority port; the Extension Host dispatcher owns validation and fanout. */
+export interface HostSessionNotificationPublisher {
+	publish(name: HostSessionNotificationName, publication: HostSessionNotificationPublication): unknown;
+}
+
+export interface SessionHostInterceptorPort {
+	dispatch(name: string, input: Record<string, unknown>, context: Record<string, unknown>): Promise<any>;
+	hasAny?(names: readonly string[], projectId?: string, goalId?: string): boolean;
+}
+
+interface ToolCallLifecycleEntry {
+	toolCallId: string;
+	toolName: string;
+	turnIndex: number;
+	startedAt: number;
+	status?: "succeeded" | "failed";
+	errorStatus?: "tool_error";
+}
+
 export interface SessionInfo {
 	id: string;
 	title: string;
@@ -1002,6 +1038,14 @@ export interface SessionInfo {
 	lastAssistantTerminalIdentity?: string;
 	/** Deduplicates repeated/late final agent_end frames within one turn. */
 	turnTerminalHandled?: boolean;
+	/** Last turn index whose canonical agent_start notification was published. */
+	hostTurnStartedIndex?: number;
+	/** Bounded, metadata-only tool calls admitted by the host interceptor seam. */
+	hostToolCallLifecycle?: Map<string, ToolCallLifecycleEntry>;
+	/** Post-authority status observer installed by SessionManager. */
+	onStatusChanged?: import("./session-status.js").BroadcastableSession["onStatusChanged"];
+	/** Called only after a live event entered EventBuffer and its legacy frame was queued. */
+	onEventAccepted?: (event: unknown, cursor: number) => void;
 	/** A non-retryable terminal failure left durable work parked for manual Retry. */
 	manualRetryRequired?: boolean;
 	/** Number of consecutive auto-retries attempted for transient errors on this turn */
@@ -2818,7 +2862,7 @@ export function isRetryableAgentEnd(event: unknown): boolean {
  *  Retryable agent_end events (`isRetryableAgentEnd`) are suppressed by callers
  *  before reaching here so clients never see a non-terminal turn-end.
  *  See docs/design/streaming-dedup-reorder.md §4.2. */
-export function emitSessionEvent(session: { clients: Set<WebSocket>; eventBuffer: EventBuffer; pendingSkillExpansions?: PendingSkillSidecarEnvelope[]; previousAssistantStreamMessage?: any }, truncated: unknown): void {
+export function emitSessionEvent(session: { clients: Set<WebSocket>; eventBuffer: EventBuffer; pendingSkillExpansions?: PendingSkillSidecarEnvelope[]; previousAssistantStreamMessage?: any; onEventAccepted?: (event: unknown, cursor: number) => void }, truncated: unknown): import("./event-buffer.js").BufferedEvent {
 	const normalizeStartedAt = performance.now();
 	const normalized = normalizeToolResultErrorEvent(truncated);
 	const sanitized = sanitizeProviderAuthEventForEmit(normalized);
@@ -2830,6 +2874,11 @@ export function emitSessionEvent(session: { clients: Set<WebSocket>; eventBuffer
 	const retainStartedAt = performance.now();
 	const entry = session.eventBuffer.push(spliced);
 	const retainMs = performance.now() - retainStartedAt;
+	// EventBuffer acceptance is the authoritative live-message fence. Fanout is
+	// isolated here so a later socket failure cannot suppress the committed fact.
+	if (session.onEventAccepted) {
+		try { session.onEventAccepted(spliced, entry.seq); } catch { /* observational fanout is isolated */ }
+	}
 	const baseFrame = { type: "event" as const, data: spliced, seq: entry.seq, ts: entry.ts };
 	const assistantStreamUpdate = isAssistantStreamMessageUpdate(spliced);
 	let scanned = 0;
@@ -2959,6 +3008,7 @@ export function emitSessionEvent(session: { clients: Set<WebSocket>; eventBuffer
 			sendMs,
 		});
 	}
+	return entry;
 }
 
 /**
@@ -3129,6 +3179,8 @@ export interface SessionManagerOptions {
 	previewPurgeOperation?: SessionPreviewPurgeOperation;
 	/** Late-bound graph guard supplied by goal/team ownership. A reason blocks direct destruction. */
 	promotedSessionLifecycleGuard?: PromotedSessionLifecycleGuard;
+	/** Narrow canonical notification publication seam. */
+	hostNotificationPublisher?: HostSessionNotificationPublisher;
 }
 
 type SessionReplacementToken = {
@@ -3263,6 +3315,8 @@ export class SessionManager {
 	sandboxManager: SandboxManager | null = null;
 	sandboxTokenStore: import("../auth/sandbox-token.js").SandboxTokenStore | null = null;
 	lifecycleHub?: LifecycleHub;
+	private hostInterceptors?: SessionHostInterceptorPort;
+	private hostNotificationPublisher?: HostSessionNotificationPublisher;
 	/**
 	 * S1 — per-session capability secret store. Injected into the owning
 	 * session's env as `BOBBIT_SESSION_SECRET` and used by the orchestration
@@ -3567,6 +3621,7 @@ export class SessionManager {
 		this._taskIdCache.delete(session.id);
 		session.lifecycleFenced = true;
 		session.lifecycleGeneration = replacingGeneration - 1;
+		session.hostToolCallLifecycle?.clear();
 		session.dormant = true;
 		session.status = "terminated";
 		session.clients.clear();
@@ -3770,6 +3825,137 @@ export class SessionManager {
 	/** Subscribe to newly created visible sessions. Listeners are invoked after initial persistence. */
 	addCreationListener(fn: (session: SessionInfo) => void): void {
 		this._creationListeners.push(fn);
+	}
+
+	/** Late-bind the interceptor router while preserving LifecycleHub as fallback. */
+	setHostInterceptorPort(port: SessionHostInterceptorPort | undefined): void {
+		this.hostInterceptors = port;
+	}
+
+	/** Server route seam for prompt/compact/tool boundaries owned inside Pi. */
+	dispatchHostInterceptor(sessionId: string, name: string, input: Record<string, unknown>): Promise<any> | undefined {
+		const session = this.sessions.get(sessionId);
+		if (!session || !this.hostInterceptors) return undefined;
+		const controller = new AbortController();
+		return this.hostInterceptors.dispatch(name, input, {
+			projectId: session.projectId,
+			sessionId,
+			goalId: session.goalId ?? session.teamGoalId,
+			cwd: session.cwd,
+			signal: controller.signal,
+		});
+	}
+
+	/** Late-bind the canonical Extension Host dispatcher without giving sessions fanout ownership. */
+	setHostNotificationPublisher(publisher: HostSessionNotificationPublisher | undefined): void {
+		this.hostNotificationPublisher = publisher;
+		for (const session of this.sessions.values()) this.attachHostLifecycleObservers(session);
+	}
+
+	private publishSessionNotification(
+		session: SessionInfo,
+		name: HostSessionNotificationName,
+		aggregateId: string,
+		aggregateRevision: string | number | undefined,
+		payload: Readonly<Record<string, unknown>>,
+	): void {
+		if (!this.hostNotificationPublisher || !session.projectId) return;
+		try {
+			this.hostNotificationPublisher.publish(name, {
+				projectId: session.projectId,
+				sessionId: session.id,
+				aggregateId,
+				aggregateRevision,
+				payload,
+			});
+		} catch {
+			console.warn(`[session-manager] host notification publication failed code=publisher_error name=${name} session=${session.id}`);
+		}
+	}
+
+	private attachHostLifecycleObservers(session: SessionInfo): void {
+		session.onStatusChanged = (change) => {
+			if (change.status === "terminated" || change.status === "archived") {
+				session.hostToolCallLifecycle?.clear();
+			}
+			this.publishSessionNotification(session, "statusChanged", session.id, change.statusVersion, {
+				previousStatus: change.previousStatus,
+				status: change.status,
+				statusVersion: change.statusVersion,
+			});
+			this.publishSessionNotification(session, "sessionStatusChanged", session.id, change.statusVersion, {
+				sessionId: session.id,
+				previousStatus: change.previousStatus,
+				status: change.status,
+				statusVersion: change.statusVersion,
+			});
+		};
+		session.onEventAccepted = (event, cursor) => this.publishAcceptedSessionEvent(session, event, cursor);
+	}
+
+	/**
+	 * Admission seam called by the beforeToolCall route after permission and the
+	 * interceptor router have approved the final tool name/arguments.
+	 */
+	markToolCallAdmitted(sessionId: string, toolCallId: string, toolName: string): void {
+		const session = this.sessions.get(sessionId);
+		if (!session || !this._sessionWriterIsCurrent(session)) return;
+		if (!toolCallId || !toolName) return;
+		const tracker = session.hostToolCallLifecycle ??= new Map<string, ToolCallLifecycleEntry>();
+		if (tracker.has(toolCallId)) return;
+		while (tracker.size >= 128) tracker.delete(tracker.keys().next().value!);
+		const turnIndex = (session.completedTurnCount ?? 0) + 1;
+		tracker.set(toolCallId, { toolCallId, toolName, turnIndex, startedAt: performance.now() });
+		this.publishSessionNotification(session, "toolCallStarted", toolCallId, toolCallId, {
+			toolCallId,
+			toolName,
+			turnIndex,
+		});
+	}
+
+	private recordToolCallTerminal(session: SessionInfo, event: any): void {
+		const toolCallId = typeof event?.toolCallId === "string" ? event.toolCallId : undefined;
+		if (!toolCallId) return;
+		const tracked = session.hostToolCallLifecycle?.get(toolCallId);
+		if (!tracked) return;
+		tracked.status = event.isError === true ? "failed" : "succeeded";
+		tracked.errorStatus = event.isError === true ? "tool_error" : undefined;
+	}
+
+	private publishAcceptedSessionEvent(session: SessionInfo, accepted: unknown, cursor: number): void {
+		if (!accepted || typeof accepted !== "object") return;
+		const event = accepted as { type?: unknown; message?: any };
+		if (event.type !== "message_end" || !event.message || typeof event.message !== "object") return;
+		const message = event.message;
+		const role = typeof message.role === "string" ? message.role : "unknown";
+		const content = Array.isArray(message.content) ? message.content : [];
+		const blockKinds = [...new Set(content
+			.map((block: unknown) => block && typeof block === "object" && typeof (block as { type?: unknown }).type === "string"
+				? (block as { type: string }).type
+				: "unknown"))].slice(0, 16);
+		const explicitMessageId = typeof message.id === "string" && message.id.length > 0 ? message.id : undefined;
+		const messageId = explicitMessageId ?? `${session.id}:${cursor}`;
+		this.publishSessionNotification(session, "messageAppended", messageId, cursor, {
+			messageId,
+			cursor,
+			role,
+			blockKinds,
+		});
+
+		if (role !== "toolResult") return;
+		const toolCallId = typeof message.toolCallId === "string" ? message.toolCallId : undefined;
+		if (!toolCallId) return;
+		const tracked = session.hostToolCallLifecycle?.get(toolCallId);
+		if (!tracked) return;
+		session.hostToolCallLifecycle!.delete(toolCallId);
+		const failed = tracked.status === "failed" || message.isError === true;
+		this.publishSessionNotification(session, "toolCallCompleted", toolCallId, cursor, {
+			toolCallId,
+			toolName: tracked.toolName,
+			status: failed ? "failed" : "succeeded",
+			durationMs: Math.max(0, Math.round(performance.now() - tracked.startedAt)),
+			...(failed ? { errorStatus: tracked.errorStatus ?? "tool_error" } : {}),
+		});
 	}
 
 	private notifySessionCreated(session: SessionInfo): void {
@@ -4061,6 +4247,7 @@ export class SessionManager {
 		this.archiveStat = options?.archiveStat ?? ((filePath) => fsp.stat(filePath));
 		this.previewPurgeOperation = options?.previewPurgeOperation ?? (async (_sessionId, operation) => operation());
 		this.promotedSessionLifecycleGuard = options?.promotedSessionLifecycleGuard;
+		this.hostNotificationPublisher = options?.hostNotificationPublisher;
 		sessionManagerModuleClock = this.clock;
 		this.agentCliPath = options?.agentCliPath;
 		this.systemPromptPath = options?.systemPromptPath;
@@ -4544,6 +4731,7 @@ export class SessionManager {
 			groupPolicyStore: this.groupPolicyStore ?? null,
 			configCascade: this.configCascade,
 			lifecycleHub: this.lifecycleHub,
+			hostInterceptors: this.hostInterceptors,
 			costTracker: resolvedCostTracker,
 			store: resolvedStore,
 			searchIndex: resolvedSearchIndex,
@@ -4555,6 +4743,7 @@ export class SessionManager {
 			applySandboxWiring: (opts, id, sandboxOpts) => this.applySandboxWiring(opts, id, sandboxOpts),
 			finalizeSpawnOptions: (opts, requested) => this.finalizeSpawnOptions(opts, requested),
 			prepareVisibleAgentEvent: (session, event) => this.prepareVisibleAgentEvent(session, event),
+			bindHostLifecycle: (session) => this.attachHostLifecycleObservers(session),
 			handleAgentLifecycle: (session, event) => this.handleAgentLifecycle(session, event),
 			trackCostFromEvent: (session, event) => this.trackCostFromEvent(session, event),
 			recordPiExtensionDiagnostic: (session, diagnostic, extension) => this.recordPiExtensionDiagnostic(session, diagnostic, extension),
@@ -5629,7 +5818,10 @@ export class SessionManager {
 		// so a goal that disabled a provider stays bridge-free after respawn too.
 		// Zero overhead when no enabled provider declares those hooks — the bridge
 		// is neither written nor pushed onto the spawn args.
-		if (this.lifecycleHub && hasProviderBridgeHooks(this.lifecycleHub, projectId, effectiveGoalId)) {
+		const turnHooksNeeded = this.hostInterceptors?.hasAny?.(
+			["beforePrompt", "beforeCompact"], projectId, effectiveGoalId,
+		) ?? (!!this.lifecycleHub && hasProviderBridgeHooks(this.lifecycleHub, projectId, effectiveGoalId));
+		if (turnHooksNeeded) {
 			const bridgePath = writeProviderBridgeExtension(sessionId);
 			if (bridgePath) {
 				args.push("--extension", bridgePath);
@@ -5651,7 +5843,17 @@ export class SessionManager {
 			args.push("--extension", aigwDnsGuardPath);
 		}
 
-		return { args, env: activation.env, runtimeExtensions: piExtensionActivation.runtimeExtensions };
+		const toolHooksNeeded = this.hostInterceptors?.hasAny?.(
+			["beforeToolCall", "afterToolResult"], projectId, effectiveGoalId,
+		) ?? !!this.hostInterceptors;
+		return {
+			args,
+			env: {
+				...activation.env,
+				...(toolHooksNeeded ? { BOBBIT_HOST_HOOKS_ENABLED: "1" } : {}),
+			},
+			runtimeExtensions: piExtensionActivation.runtimeExtensions,
+		};
 	}
 
 	private messageAuthorDependencies(
@@ -8516,6 +8718,7 @@ export class SessionManager {
 			abortAttemptOutcome?: "ambiguous" | "proven-no-start";
 		},
 	): void {
+		if (!session.onStatusChanged || !session.onEventAccepted) this.attachHostLifecycleObservers(session);
 		// Inbound turn progress is also the acknowledgement fence for prompt RPCs.
 		// Record it for the current canonical generation even while a replacement
 		// coordinator suppresses ordinary lifecycle effects: poison redrive and boot
@@ -8589,6 +8792,7 @@ export class SessionManager {
 		// (for example, recovered/pre-existing rows). Fresh live steers and
 		// steer_queued promotions dispatch immediately through _dispatchSteer.
 		if (event.type === "tool_execution_end") {
+			this.recordToolCallTerminal(session, event);
 			// Compaction and Stop are active turns. Neither tool completion nor a
 			// stale boundary may bypass their sole release owner.
 			if (session.status === "aborting" || session.isCompacting) return;
@@ -8681,6 +8885,14 @@ export class SessionManager {
 				manualRetryRequired: false,
 			});
 			broadcastStatus(session, "streaming", { streamingStartedAt: session.streamingStartedAt });
+			const turnIndex = (session.completedTurnCount ?? 0) + 1;
+			if (session.hostTurnStartedIndex !== turnIndex) {
+				session.hostTurnStartedIndex = turnIndex;
+				this.publishSessionNotification(session, "turnStarted", `${session.id}:${turnIndex}`, turnIndex, {
+					turnIndex,
+					source: session.lastPromptSource ?? "user",
+				});
+			}
 			// Pi has durably appended the user prompt by agent_start. Refresh the
 			// authoritative cursor plane now so prompt actions appear during the turn.
 			this.schedulePromptCursorRefresh(session);
@@ -8734,6 +8946,13 @@ export class SessionManager {
 
 			const wasAborting = session.status === "aborting";
 			const abortShapedTerminal = session.abortShapedTerminal === true;
+			const terminalOutcome: "succeeded" | "errored" | "aborted" = wasAborting || abortShapedTerminal
+				? "aborted"
+				: session.lastTurnErrored || event.error === true || event.success === false
+					? "errored"
+					: "succeeded";
+			const terminalStartedAt = session.streamingStartedAt;
+			const terminalHadToolCalls = session.turnHadToolCalls === true;
 			// Consume this turn's classification at the sole final boundary. A late
 			// duplicate agent_end cannot reinterpret the next turn as cancelled.
 			session.abortShapedTerminal = undefined;
@@ -8804,6 +9023,14 @@ export class SessionManager {
 				manualRetryRequired: session.manualRetryRequired === true,
 			});
 			broadcastStatus(session, "idle");
+			const completedTurnIndex = session.completedTurnCount;
+			this.publishSessionNotification(session, "turnCompleted", `${session.id}:${completedTurnIndex}`, completedTurnIndex, {
+				turnIndex: completedTurnIndex,
+				outcome: terminalOutcome,
+				durationMs: terminalStartedAt === undefined ? 0 : Math.max(0, this.clock.now() - terminalStartedAt),
+				hadToolCalls: terminalHadToolCalls,
+			});
+			session.hostToolCallLifecycle?.clear();
 			this.resolveIdleWaiters(session.id);
 			this.schedulePromptCursorRefresh(session, { settleBindings: true });
 			// Don't drain the queue if the turn ended with a model error —
@@ -15085,6 +15312,41 @@ export class SessionManager {
 		}
 	}
 
+	private async dispatchSessionShutdownInterceptor(
+		src: Pick<SessionInfo, "id" | "projectId" | "cwd" | "goalId" | "teamGoalId" | "role">,
+		reason: "archived" | "quiesced" | "terminated",
+	): Promise<void> {
+		try {
+			if (this.hostInterceptors) {
+				const controller = new AbortController();
+				await this.hostInterceptors.dispatch("sessionShutdown", {
+					sessionId: src.id,
+					projectId: src.projectId,
+					reason,
+				}, {
+					projectId: src.projectId,
+					sessionId: src.id,
+					goalId: src.goalId ?? src.teamGoalId,
+					cwd: src.cwd,
+					signal: controller.signal,
+				});
+				return;
+			}
+			if (this.lifecycleHub) {
+				await this.lifecycleHub.dispatch("sessionShutdown", {
+					sessionId: src.id,
+					projectId: src.projectId,
+					scope: src.projectId ? "project" : "global",
+					cwd: src.cwd,
+					goalId: src.goalId ?? src.teamGoalId,
+					roleName: src.role,
+				}, lifecycleScopeInput(src));
+			}
+		} catch {
+			console.warn(`[session-manager] sessionShutdown interceptor failed code=dispatch_error session=${src.id}`);
+		}
+	}
+
 	/**
 	 * The single runtime archive seam (OrchestrationCore §6). EVERY runtime
 	 * archive entry point that can archive a PARENT session routes through here
@@ -15104,32 +15366,10 @@ export class SessionManager {
 		// goal archival has already made the canonical guard return undefined here.
 		this.assertPromotedSessionRecoveryAllowed(id, "archive its session record");
 		await this.cascadeReapOwner(id, options);
-		// Extension Platform G1.4: notify lifecycle providers the session is
-		// shutting down. Best-effort and bounded by the hub's per-provider
-		// timeouts; wrapped in try/catch so archival always completes even if a
-		// provider hangs or throws. Resolve context from the live session when
-		// present, else the persisted record (dormant sessions still archive).
-		if (this.lifecycleHub) {
-			const live = this.sessions.get(id);
-			const persisted = live ? undefined : this.getPersistedSession(id);
-			const src = live ?? persisted;
-			if (src) {
-				try {
-					await this.lifecycleHub.dispatch("sessionShutdown", {
-						sessionId: id,
-						projectId: src.projectId,
-						scope: src.projectId ? "project" : "global",
-						cwd: src.cwd,
-						// Effective goal (goalId ?? teamGoalId) so disabled-provider
-						// filtering applies to members/delegates/reviewers too.
-						goalId: src.goalId ?? src.teamGoalId,
-						roleName: src.role,
-					}, lifecycleScopeInput(src));
-				} catch (err) {
-					console.warn(`[session-manager] sessionShutdown dispatch failed for ${id}:`, err);
-				}
-			}
-		}
+		const live = this.sessions.get(id);
+		const persisted = live ? undefined : this.getPersistedSession(id);
+		const shutdownSource = live ?? persisted;
+		if (shutdownSource) await this.dispatchSessionShutdownInterceptor(shutdownSource, "archived");
 		const target = store ?? this.resolveStoreForId(id);
 		if (!target) return false;
 		try { return await target.archiveAsync(id); } catch { return false; }
@@ -15215,20 +15455,7 @@ export class SessionManager {
 		this.sessions.delete(id);
 		this._taskIdCache.delete(id);
 		try { await this.cleanupScopedMcpManagersForSessionScope(scope); } catch { /* runtime authority is already removed */ }
-		if (this.lifecycleHub) {
-			try {
-				await this.lifecycleHub.dispatch("sessionShutdown", {
-					sessionId: id,
-					projectId: session.projectId,
-					scope: session.projectId ? "project" : "global",
-					cwd: session.cwd,
-					goalId: session.goalId ?? session.teamGoalId,
-					roleName: session.role,
-				}, lifecycleScopeInput(session));
-			} catch (err) {
-				console.warn(`[session-manager] sessionShutdown dispatch failed for quiesced ${id}:`, err);
-			}
-		}
+		await this.dispatchSessionShutdownInterceptor(session, "quiesced");
 		if (bridgeStopError) {
 			throw new Error(`Session ${id} runtime was detached after its bridge stop failed: ${bridgeStopError instanceof Error ? bridgeStopError.message : String(bridgeStopError)}`, { cause: bridgeStopError });
 		}
@@ -15408,28 +15635,7 @@ export class SessionManager {
 		this.sessions.delete(id);
 		this._taskIdCache.delete(id);
 		await this.cleanupScopedMcpManagersForSessionScope(terminatedScope);
-		// Extension Platform G1.4: notify lifecycle providers the session is
-		// shutting down on the live DELETE/stop path too. terminateSession
-		// archives directly (bypassing archiveWithCascade), so the dispatch
-		// must also fire here. Best-effort and bounded by the hub's per-provider
-		// timeouts; wrapped in try/catch so termination always completes. Uses
-		// the live `session` context captured at the top of this method.
-		if (this.lifecycleHub) {
-			try {
-				await this.lifecycleHub.dispatch("sessionShutdown", {
-					sessionId: id,
-					projectId: session.projectId,
-					scope: session.projectId ? "project" : "global",
-					cwd: session.cwd,
-					// Effective goal (goalId ?? teamGoalId) so disabled-provider
-					// filtering applies to members/delegates/reviewers too.
-					goalId: session.goalId ?? session.teamGoalId,
-					roleName: session.role,
-				}, lifecycleScopeInput(session));
-			} catch (err) {
-				console.warn(`[session-manager] sessionShutdown dispatch failed for ${id}:`, err);
-			}
-		}
+		await this.dispatchSessionShutdownInterceptor(session, "terminated");
 		// Always archive — even without an agentSessionFile the metadata
 		// (title, goal association, timestamps) is valuable and the search
 		// index may reference this session.  Purge will clean it up later.

--- a/src/server/agent/session-manager.ts
+++ b/src/server/agent/session-manager.ts
@@ -3990,7 +3990,16 @@ export class SessionManager {
 	 * creation listener shares the same authority boundary.
 	 */
 	private async notifySessionCreated(session: SessionInfo, store: SessionStore): Promise<void> {
-		await store.flushAsync();
+		if (store instanceof SessionStore) {
+			// Production stores must cross the atomic publication fence. Do not make
+			// this optional: a failed initial write must suppress the committed fact.
+			await store.flushAsync();
+		} else {
+			// Historical in-process harnesses inject small synchronous recording
+			// stores through the SessionStore seam. Their put/update calls are the
+			// committed boundary; richer doubles may still expose an async barrier.
+			await (store as unknown as { flushAsync?: () => void | Promise<void> }).flushAsync?.();
+		}
 		for (const fn of this._creationListeners) {
 			try { fn(session); } catch (err) {
 				console.error(`[session-manager] session creation listener failed for ${session.id}:`, err);

--- a/src/server/agent/session-manager.ts
+++ b/src/server/agent/session-manager.ts
@@ -172,6 +172,12 @@ import { WorktreePool } from "./worktree-pool.js";
 import { BACKGROUND_IO_CONCURRENCY, mapWithConcurrency, removeTree } from "./bounded-async-work.js";
 import { backfillStaffIds as backfillStaffIdsImpl } from "./staff-backfill.js";
 import {
+	freezeStaffNotificationTurnContext,
+	MAX_STAFF_NOTIFICATION_TURN_DEPTH,
+	runWithStaffNotificationTurnContext,
+	type StaffNotificationTurnContext,
+} from "./staff-notification-causation.js";
+import {
 	type SessionSetupPlan,
 	type PipelineContext,
 	type SandboxWiringOptions,
@@ -1038,6 +1044,8 @@ export interface SessionInfo {
 	lastAssistantTerminalIdentity?: string;
 	/** Deduplicates repeated/late final agent_end frames within one turn. */
 	turnTerminalHandled?: boolean;
+	/** Host-only causal binding for one exact notification-triggered staff turn. */
+	staffNotificationTurnContext?: StaffNotificationTurnContext;
 	/** Last turn index whose canonical agent_start notification was published. */
 	hostTurnStartedIndex?: number;
 	/** Bounded, metadata-only tool calls admitted by the host interceptor seam. */
@@ -3621,6 +3629,7 @@ export class SessionManager {
 		this._taskIdCache.delete(session.id);
 		session.lifecycleFenced = true;
 		session.lifecycleGeneration = replacingGeneration - 1;
+		session.staffNotificationTurnContext = undefined;
 		session.hostToolCallLifecycle?.clear();
 		session.dormant = true;
 		session.status = "terminated";
@@ -3865,13 +3874,16 @@ export class SessionManager {
 	): void {
 		if (!this.hostNotificationPublisher || !session.projectId) return;
 		try {
-			this.hostNotificationPublisher.publish(name, {
-				projectId: session.projectId,
+			const publish = () => this.hostNotificationPublisher!.publish(name, {
+				projectId: session.projectId!,
 				sessionId: session.id,
 				aggregateId,
 				aggregateRevision,
 				payload,
 			});
+			const causalTurn = this.getStaffNotificationTurnContext(session.id);
+			if (causalTurn) runWithStaffNotificationTurnContext(causalTurn, publish);
+			else publish();
 		} catch {
 			console.warn(`[session-manager] host notification publication failed code=publisher_error name=${name} session=${session.id}`);
 		}
@@ -3880,6 +3892,7 @@ export class SessionManager {
 	private attachHostLifecycleObservers(session: SessionInfo): void {
 		session.onStatusChanged = (change) => {
 			if (change.status === "terminated") {
+				session.staffNotificationTurnContext = undefined;
 				session.hostToolCallLifecycle?.clear();
 			}
 			this.publishSessionNotification(session, "statusChanged", session.id, change.statusVersion, {
@@ -4051,6 +4064,82 @@ export class SessionManager {
 
 	setInboxNudger(nudger: import("./inbox-nudger.js").InboxNudger | null): void {
 		this._inboxNudger = nudger;
+	}
+
+	/** Return causal controls only while every exact staff/session/lifecycle fence
+	 * remains authoritative. Invalid bindings are erased on observation. */
+	getStaffNotificationTurnContext(sessionId: string): StaffNotificationTurnContext | undefined {
+		const session = this.sessions.get(sessionId);
+		const context = session?.staffNotificationTurnContext;
+		if (!session || !context) return undefined;
+		const staff = this.staffRecordSource?.getStaff(context.staffId);
+		if (session.lifecycleFenced === true
+			|| !this._sessionWriterIsCurrent(session)
+			|| session.id !== context.sessionId
+			|| session.projectId !== context.projectId
+			|| session.staffId !== context.staffId
+			|| (session.lifecycleGeneration ?? 0) !== context.lifecycleGeneration
+			|| !staff
+			|| staff.state !== "active"
+			|| staff.currentSessionId !== session.id
+			|| staff.projectId !== context.projectId) {
+			session.staffNotificationTurnContext = undefined;
+			return undefined;
+		}
+		return context;
+	}
+
+	clearStaffNotificationTurnContext(sessionId: string, notificationId?: string): void {
+		const session = this.sessions.get(sessionId);
+		if (!session?.staffNotificationTurnContext) return;
+		if (notificationId && session.staffNotificationTurnContext.notificationId !== notificationId) return;
+		session.staffNotificationTurnContext = undefined;
+	}
+
+	/** Atomically reserve an otherwise-empty idle staff turn for one notification
+	 * root, then dispatch the host-owned wake prompt. Batching roots is forbidden. */
+	async enqueueStaffNotificationPrompt(
+		sessionId: string,
+		text: string,
+		input: Omit<StaffNotificationTurnContext, "sessionId" | "lifecycleGeneration">,
+	): Promise<{ status: "dispatched" | "queued" }> {
+		const session = this.sessions.get(sessionId);
+		const staff = this.staffRecordSource?.getStaff(input.staffId);
+		const validString = (value: string) => value.length > 0 && value.length <= 256;
+		if (!session
+			|| session.status !== "idle"
+			|| !session.promptQueue.isEmpty
+			|| session.lifecycleFenced === true
+			|| !this._sessionWriterIsCurrent(session)
+			|| session.projectId !== input.projectId
+			|| session.staffId !== input.staffId
+			|| !staff
+			|| staff.state !== "active"
+			|| staff.currentSessionId !== sessionId
+			|| staff.projectId !== input.projectId
+			|| !validString(input.staffId)
+			|| !validString(input.triggerId)
+			|| !validString(input.notificationId)
+			|| !validString(input.rootCorrelationId)
+			|| !Number.isSafeInteger(input.causationDepth)
+			|| input.causationDepth < 0
+			|| input.causationDepth > MAX_STAFF_NOTIFICATION_TURN_DEPTH) {
+			return { status: "queued" };
+		}
+		const context = freezeStaffNotificationTurnContext({
+			...input,
+			sessionId,
+			lifecycleGeneration: session.lifecycleGeneration ?? 0,
+		});
+		session.staffNotificationTurnContext = context;
+		try {
+			const result = await this.enqueuePrompt(sessionId, text, { isSteered: true, source: "system" });
+			if (result.status !== "dispatched") this.clearStaffNotificationTurnContext(sessionId, context.notificationId);
+			return result;
+		} catch (error) {
+			this.clearStaffNotificationTurnContext(sessionId, context.notificationId);
+			throw error;
+		}
 	}
 
 	setStaffManager(sm: { getStaff(id: string): import("./staff-store.js").PersistedStaff | undefined }): void {
@@ -9042,6 +9131,13 @@ export class SessionManager {
 				durationMs: terminalStartedAt === undefined ? 0 : Math.max(0, this.clock.now() - terminalStartedAt),
 				hadToolCalls: terminalHadToolCalls,
 			});
+			// turnCompleted is the last fact allowed to inherit this root. The
+			// dispatcher admits durable subscribers in its already-queued microtask;
+			// clear immediately after that admission seam, fenced by notification id.
+			const completedNotificationId = session.staffNotificationTurnContext?.notificationId;
+			if (completedNotificationId) {
+				queueMicrotask(() => this.clearStaffNotificationTurnContext(session.id, completedNotificationId));
+			}
 			session.hostToolCallLifecycle?.clear();
 			this.resolveIdleWaiters(session.id);
 			this.schedulePromptCursorRefresh(session, { settleBindings: true });
@@ -15419,6 +15515,7 @@ export class SessionManager {
 		// mutated by this seam.
 		session.lifecycleFenced = true;
 		session.dormant = true;
+		session.staffNotificationTurnContext = undefined;
 		this.cancelPendingAutoRetry(session, "terminated");
 		try { this.purgeVerifierPromptRows(id, `Verifier session ${id} was quiesced before dispatch`); } catch { /* best-effort */ }
 		if (session.pendingMetadataPersist) {
@@ -17264,6 +17361,7 @@ export class SessionManager {
 	async abortSessionTurn(id: string): Promise<void> {
 		const session = this.sessions.get(id);
 		if (!session || session.status !== "streaming") return;
+		session.staffNotificationTurnContext = undefined;
 		broadcastStatus(session, "aborting");
 		try { await session.rpcClient.abort(); } catch { /* best-effort */ }
 	}
@@ -17341,6 +17439,8 @@ export class SessionManager {
 		if (!this._replacementTokenIsCurrent(id, token)) {
 			throw new Error(`Session ${id} force-abort was superseded before start`);
 		}
+		// Abort permanently severs any notification-turn causal authority.
+		session.staffNotificationTurnContext = undefined;
 		// Broadcast aborting status so UI shows feedback during grace period
 		broadcastStatus(session, "aborting");
 

--- a/src/server/agent/session-manager.ts
+++ b/src/server/agent/session-manager.ts
@@ -5951,12 +5951,16 @@ export class SessionManager {
 		const beforeToolCallFailClosed = this.hostInterceptors?.requiresFailClosed?.(
 			"beforeToolCall", projectId, effectiveGoalId,
 		) === true;
+		const afterToolResultFailClosed = this.hostInterceptors?.requiresFailClosed?.(
+			"afterToolResult", projectId, effectiveGoalId,
+		) === true;
 		return {
 			args,
 			env: {
 				...activation.env,
 				...(toolHooksNeeded ? { BOBBIT_HOST_HOOKS_ENABLED: "1" } : {}),
 				BOBBIT_HOST_BEFORE_TOOL_CALL_FAIL_CLOSED: beforeToolCallFailClosed ? "1" : "0",
+				BOBBIT_HOST_AFTER_TOOL_RESULT_FAIL_CLOSED: afterToolResultFailClosed ? "1" : "0",
 			},
 			runtimeExtensions: piExtensionActivation.runtimeExtensions,
 		};

--- a/src/server/agent/session-manager.ts
+++ b/src/server/agent/session-manager.ts
@@ -3984,7 +3984,13 @@ export class SessionManager {
 		});
 	}
 
-	private notifySessionCreated(session: SessionInfo): void {
+	/**
+	 * Publish the legacy/canonical creation seam only after the structural row is
+	 * atomically durable. The store barrier is intentionally owned here so every
+	 * creation listener shares the same authority boundary.
+	 */
+	private async notifySessionCreated(session: SessionInfo, store: SessionStore): Promise<void> {
+		await store.flushAsync();
 		for (const fn of this._creationListeners) {
 			try { fn(session); } catch (err) {
 				console.error(`[session-manager] session creation listener failed for ${session.id}:`, err);
@@ -5945,9 +5951,6 @@ export class SessionManager {
 			args.push("--extension", aigwDnsGuardPath);
 		}
 
-		const toolHooksNeeded = this.hostInterceptors?.hasAny?.(
-			["beforeToolCall", "afterToolResult"], projectId, effectiveGoalId,
-		) ?? !!this.hostInterceptors;
 		const beforeToolCallFailClosed = this.hostInterceptors?.requiresFailClosed?.(
 			"beforeToolCall", projectId, effectiveGoalId,
 		) === true;
@@ -5958,7 +5961,10 @@ export class SessionManager {
 			args,
 			env: {
 				...activation.env,
-				...(toolHooksNeeded ? { BOBBIT_HOST_HOOKS_ENABLED: "1" } : {}),
+				// The same exact-auth bridge owns canonical tool lifecycle metadata even
+				// when no interceptor contributes a decision. Failure policy remains
+				// contribution-derived through the two flags below.
+				BOBBIT_HOST_HOOKS_ENABLED: "1",
 				BOBBIT_HOST_BEFORE_TOOL_CALL_FAIL_CLOSED: beforeToolCallFailClosed ? "1" : "0",
 				BOBBIT_HOST_AFTER_TOOL_RESULT_FAIL_CLOSED: afterToolResultFailClosed ? "1" : "0",
 			},
@@ -12456,14 +12462,22 @@ export class SessionManager {
 				bridgeOptions: { cwd },
 			};
 
-			// Persist immediately with all known structural fields
+			// Persist immediately with all known structural fields. Creation listeners
+			// remain silent until the final structural generation crosses the store's
+			// atomic publication fence.
 			persistOnce(session, plan, ctx.store);
 			if (session.repoWorktrees && session.repoWorktrees.length > 0) {
 				ctx.store.update(session.id, {
 					repoWorktrees: Object.fromEntries(session.repoWorktrees.map(w => [w.repo, w.worktreePath])),
 				});
 			}
-			this.notifySessionCreated(session);
+			try {
+				await this.notifySessionCreated(session, ctx.store);
+			} catch (err) {
+				const persistenceError = err instanceof Error ? err : new Error(String(err));
+				handleSetupFailure(session, plan, persistenceError, ctx);
+				throw persistenceError;
+			}
 
 			// Finish the pipeline. Most callers keep the historical preparing-session UX
 			// and let setup complete in the background. Continue-Archived opts in to
@@ -12570,7 +12584,13 @@ export class SessionManager {
 			if (opts?.skipAutoModel && opts.skipAutoThinking && selectedSpawnModel) {
 				await this.tryAutoSelectModel(session);
 			}
-			this.notifySessionCreated(session);
+			try {
+				await this.notifySessionCreated(session, ctx.store);
+			} catch (err) {
+				const persistenceError = err instanceof Error ? err : new Error(String(err));
+				handleSetupFailure(session, plan, persistenceError, ctx);
+				throw persistenceError;
+			}
 
 			// Persist session metadata (fire-and-forget, but tracked for terminate).
 			// Rehydrated sessions already have a cloned/adopted transcript path recorded;
@@ -15388,6 +15408,48 @@ export class SessionManager {
 		return parseImageModelPref(pref);
 	}
 
+	/** Notify existing termination listeners from the one durable archive boundary. */
+	private async notifySessionArchived(
+		id: string,
+		source: SessionInfo | PersistedSession,
+	): Promise<void> {
+		const repoWorktrees = Array.isArray(source.repoWorktrees)
+			? source.repoWorktrees.map(worktree => ({ worktreePath: worktree.worktreePath }))
+			: source.repoWorktrees
+				? Object.values(source.repoWorktrees).map(worktreePath => ({ worktreePath }))
+				: undefined;
+		const info: SessionTerminationInfo = {
+			projectId: source.projectId,
+			reason: "archived",
+			cwd: source.cwd,
+			worktreePath: source.worktreePath,
+			repoWorktrees,
+		};
+		for (const listener of this._terminationListeners) {
+			try {
+				await listener(id, info);
+			} catch (err) {
+				console.error(`[session ${id}] termination listener failed:`, err);
+			}
+		}
+	}
+
+	/**
+	 * Archive one row and notify observers exactly once, after successful atomic
+	 * publication. Consumer failure remains observational and cannot roll back the
+	 * durable transition.
+	 */
+	private async archivePersistedSession(
+		id: string,
+		store: SessionStore,
+		source: SessionInfo | PersistedSession,
+	): Promise<boolean> {
+		const archived = await store.archiveAsync(id);
+		if (!archived) return false;
+		await this.notifySessionArchived(id, source);
+		return true;
+	}
+
 	/**
 	 * Cascade-reap an owner's child agents (OrchestrationCore §6).
 	 *
@@ -15420,7 +15482,10 @@ export class SessionManager {
 		for (const ps of allLiveForTerminate) {
 			const isChild = ps.delegateOf === id || (!!ps.childKind && ps.parentSessionId === id);
 			if (isChild && (!options.cascadeSessionIds || options.cascadeSessionIds.has(ps.id)) && !this.sessions.has(ps.id)) {
-				try { await this.getSessionStore(ps.projectId).archiveAsync(ps.id); } catch { /* project gone */ }
+				try {
+					await this.dispatchSessionShutdownInterceptor(ps, "archived");
+					await this.archivePersistedSession(ps.id, this.getSessionStore(ps.projectId), ps);
+				} catch { /* project gone or archive publication failed */ }
 			}
 		}
 		// Keep the OrchestrationCore in-memory index consistent.
@@ -15482,14 +15547,18 @@ export class SessionManager {
 		// Defense in depth for internal recovery and maintenance callers. Ordered
 		// goal archival has already made the canonical guard return undefined here.
 		this.assertPromotedSessionRecoveryAllowed(id, "archive its session record");
-		await this.cascadeReapOwner(id, options);
-		const live = this.sessions.get(id);
-		const persisted = live ? undefined : this.getPersistedSession(id);
-		const shutdownSource = live ?? persisted;
-		if (shutdownSource) await this.dispatchSessionShutdownInterceptor(shutdownSource, "archived");
 		const target = store ?? this.resolveStoreForId(id);
-		if (!target) return false;
-		try { return await target.archiveAsync(id); } catch { return false; }
+		const initial = target?.get(id);
+		if (!target || !initial || initial.archived) return false;
+		await this.cascadeReapOwner(id, options);
+		// A concurrent archive may have completed while the child cascade settled.
+		if (target.get(id)?.archived) return false;
+		const live = this.sessions.get(id);
+		const persisted = live ? undefined : target.get(id);
+		const shutdownSource = live ?? persisted;
+		if (!shutdownSource) return false;
+		await this.dispatchSessionShutdownInterceptor(shutdownSource, "archived");
+		try { return await this.archivePersistedSession(id, target, shutdownSource); } catch { return false; }
 	}
 
 	/**
@@ -15756,8 +15825,9 @@ export class SessionManager {
 		await this.dispatchSessionShutdownInterceptor(session, "terminated");
 		// Always archive — even without an agentSessionFile the metadata
 		// (title, goal association, timestamps) is valuable and the search
-		// index may reference this session.  Purge will clean it up later.
-		await terminateStore.archiveAsync(id);
+		// index may reference this session. Purge will clean it up later. Existing
+		// listeners observe the same post-success boundary as dormant/cascade paths.
+		await this.archivePersistedSession(id, terminateStore, session);
 
 		// Bug 2 (docs/design/orphan-remote-branch-cleanup.md): eagerly push-delete
 		// the remote branch for non-delegate `session/*` sessions whose branch is
@@ -15786,22 +15856,6 @@ export class SessionManager {
 			}).catch(err => {
 				console.warn(`[session-manager] Eager remote-delete failed for ${id}:`, err);
 			});
-		}
-
-		// Notify termination listeners (e.g. user-question harness cleanup, sidebar broadcast).
-		// Pass cwd/worktreePath/repoWorktrees in the info so listeners
-		// can't be defeated by the `sessions.delete(id)` above —
-		// `getSession(id)` would return undefined here and refcounts would leak.
-		const projectIdForListeners = session.projectId;
-		const sessionCwd = session.cwd;
-		const sessionWorktreePath = session.worktreePath;
-		const sessionRepoWorktrees = session.repoWorktrees;
-		for (const listener of this._terminationListeners) {
-			try {
-				await listener(id, { projectId: projectIdForListeners, reason: "archived", cwd: sessionCwd, worktreePath: sessionWorktreePath, repoWorktrees: sessionRepoWorktrees });
-			} catch (err) {
-				console.error(`[session ${id}] termination listener failed:`, err);
-			}
 		}
 
 		// Don't remove color or session prompt — they're needed for archived view

--- a/src/server/agent/session-manager.ts
+++ b/src/server/agent/session-manager.ts
@@ -912,6 +912,7 @@ export interface HostSessionNotificationPublisher {
 export interface SessionHostInterceptorPort {
 	dispatch(name: string, input: Record<string, unknown>, context: Record<string, unknown>): Promise<any>;
 	hasAny?(names: readonly string[], projectId?: string, goalId?: string): boolean;
+	requiresFailClosed?(name: string, projectId?: string, goalId?: string): boolean;
 }
 
 interface ToolCallLifecycleEntry {
@@ -5947,11 +5948,15 @@ export class SessionManager {
 		const toolHooksNeeded = this.hostInterceptors?.hasAny?.(
 			["beforeToolCall", "afterToolResult"], projectId, effectiveGoalId,
 		) ?? !!this.hostInterceptors;
+		const beforeToolCallFailClosed = this.hostInterceptors?.requiresFailClosed?.(
+			"beforeToolCall", projectId, effectiveGoalId,
+		) === true;
 		return {
 			args,
 			env: {
 				...activation.env,
 				...(toolHooksNeeded ? { BOBBIT_HOST_HOOKS_ENABLED: "1" } : {}),
+				BOBBIT_HOST_BEFORE_TOOL_CALL_FAIL_CLOSED: beforeToolCallFailClosed ? "1" : "0",
 			},
 			runtimeExtensions: piExtensionActivation.runtimeExtensions,
 		};

--- a/src/server/agent/session-manager.ts
+++ b/src/server/agent/session-manager.ts
@@ -7,6 +7,13 @@ import {
 	isPiTranscriptEntryId,
 } from "../../shared/message-author.js";
 import type { PromptSource } from "../../shared/prompt-source.js";
+import type {
+	HostInterceptorName,
+	HostInterceptorRequest,
+	HostNotificationName,
+	HostNotificationPayload,
+	SessionNotificationName,
+} from "../../shared/extension-host/host-hooks.js";
 export type { PromptSource } from "../../shared/prompt-source.js";
 import { createHash, randomUUID } from "node:crypto";
 import fs from "node:fs";
@@ -881,26 +888,19 @@ function sandboxWorktreeOwnerCoordinates(
 	return name ? { root, name } : undefined;
 }
 
-export type HostSessionNotificationName =
-	| "statusChanged"
-	| "turnStarted"
-	| "turnCompleted"
-	| "messageAppended"
-	| "toolCallStarted"
-	| "toolCallCompleted"
-	| "sessionStatusChanged";
+export type HostSessionNotificationName = SessionNotificationName | Extract<HostNotificationName, "sessionStatusChanged">;
 
-export interface HostSessionNotificationPublication {
+export interface HostSessionNotificationPublication<N extends HostSessionNotificationName> {
 	projectId: string;
 	sessionId: string;
 	aggregateId: string;
 	aggregateRevision?: string | number;
-	payload: Readonly<Record<string, unknown>>;
+	payload: Readonly<HostNotificationPayload<N>>;
 }
 
 /** Narrow post-authority port; the Extension Host dispatcher owns validation and fanout. */
 export interface HostSessionNotificationPublisher {
-	publish(name: HostSessionNotificationName, publication: HostSessionNotificationPublication): unknown;
+	publish<N extends HostSessionNotificationName>(name: N, publication: HostSessionNotificationPublication<N>): unknown;
 }
 
 export interface SessionHostInterceptorPort {
@@ -913,8 +913,8 @@ interface ToolCallLifecycleEntry {
 	toolName: string;
 	turnIndex: number;
 	startedAt: number;
-	status?: "succeeded" | "failed";
-	errorStatus?: "tool_error";
+	status?: "succeeded" | "errored";
+	errorStatus?: "handler_error";
 }
 
 export interface SessionInfo {
@@ -3833,11 +3833,15 @@ export class SessionManager {
 	}
 
 	/** Server route seam for prompt/compact/tool boundaries owned inside Pi. */
-	dispatchHostInterceptor(sessionId: string, name: string, input: Record<string, unknown>): Promise<any> | undefined {
+	dispatchHostInterceptor<N extends HostInterceptorName>(
+		sessionId: string,
+		name: N,
+		input: HostInterceptorRequest<N>,
+	): Promise<any> | undefined {
 		const session = this.sessions.get(sessionId);
 		if (!session || !this.hostInterceptors) return undefined;
 		const controller = new AbortController();
-		return this.hostInterceptors.dispatch(name, input, {
+		return this.hostInterceptors.dispatch(name, input as Record<string, unknown>, {
 			projectId: session.projectId,
 			sessionId,
 			goalId: session.goalId ?? session.teamGoalId,
@@ -3852,12 +3856,12 @@ export class SessionManager {
 		for (const session of this.sessions.values()) this.attachHostLifecycleObservers(session);
 	}
 
-	private publishSessionNotification(
+	private publishSessionNotification<N extends HostSessionNotificationName>(
 		session: SessionInfo,
-		name: HostSessionNotificationName,
+		name: N,
 		aggregateId: string,
 		aggregateRevision: string | number | undefined,
-		payload: Readonly<Record<string, unknown>>,
+		payload: Readonly<HostNotificationPayload<N>>,
 	): void {
 		if (!this.hostNotificationPublisher || !session.projectId) return;
 		try {
@@ -3875,7 +3879,7 @@ export class SessionManager {
 
 	private attachHostLifecycleObservers(session: SessionInfo): void {
 		session.onStatusChanged = (change) => {
-			if (change.status === "terminated" || change.status === "archived") {
+			if (change.status === "terminated") {
 				session.hostToolCallLifecycle?.clear();
 			}
 			this.publishSessionNotification(session, "statusChanged", session.id, change.statusVersion, {
@@ -3918,8 +3922,8 @@ export class SessionManager {
 		if (!toolCallId) return;
 		const tracked = session.hostToolCallLifecycle?.get(toolCallId);
 		if (!tracked) return;
-		tracked.status = event.isError === true ? "failed" : "succeeded";
-		tracked.errorStatus = event.isError === true ? "tool_error" : undefined;
+		tracked.status = event.isError === true ? "errored" : "succeeded";
+		tracked.errorStatus = event.isError === true ? "handler_error" : undefined;
 	}
 
 	private publishAcceptedSessionEvent(session: SessionInfo, accepted: unknown, cursor: number): void {
@@ -3927,12 +3931,20 @@ export class SessionManager {
 		const event = accepted as { type?: unknown; message?: any };
 		if (event.type !== "message_end" || !event.message || typeof event.message !== "object") return;
 		const message = event.message;
-		const role = typeof message.role === "string" ? message.role : "unknown";
+		const rawRole = typeof message.role === "string" ? message.role : "";
+		const role: "user" | "assistant" | "system" = rawRole === "user"
+			? "user"
+			: rawRole === "assistant" ? "assistant" : "system";
 		const content = Array.isArray(message.content) ? message.content : [];
-		const blockKinds = [...new Set(content
-			.map((block: unknown) => block && typeof block === "object" && typeof (block as { type?: unknown }).type === "string"
-				? (block as { type: string }).type
-				: "unknown"))].slice(0, 16);
+		const blockKinds = Array.from(new Set<"text" | "tool_use" | "tool_result">(
+			content.flatMap((block: unknown): Array<"text" | "tool_use" | "tool_result"> => {
+				const kind = block && typeof block === "object" ? (block as { type?: unknown }).type : undefined;
+				if (kind === "text") return ["text"];
+				if (kind === "toolCall" || kind === "tool_use") return ["tool_use"];
+				if (kind === "toolResult" || kind === "tool_result") return ["tool_result"];
+				return [];
+			}),
+		)).slice(0, 8);
 		const explicitMessageId = typeof message.id === "string" && message.id.length > 0 ? message.id : undefined;
 		const messageId = explicitMessageId ?? `${session.id}:${cursor}`;
 		this.publishSessionNotification(session, "messageAppended", messageId, cursor, {
@@ -3942,19 +3954,19 @@ export class SessionManager {
 			blockKinds,
 		});
 
-		if (role !== "toolResult") return;
+		if (rawRole !== "toolResult" && rawRole !== "tool_result" && rawRole !== "tool") return;
 		const toolCallId = typeof message.toolCallId === "string" ? message.toolCallId : undefined;
 		if (!toolCallId) return;
 		const tracked = session.hostToolCallLifecycle?.get(toolCallId);
 		if (!tracked) return;
 		session.hostToolCallLifecycle!.delete(toolCallId);
-		const failed = tracked.status === "failed" || message.isError === true;
+		const failed = tracked.status === "errored" || message.isError === true;
 		this.publishSessionNotification(session, "toolCallCompleted", toolCallId, cursor, {
 			toolCallId,
 			toolName: tracked.toolName,
-			status: failed ? "failed" : "succeeded",
+			status: failed ? "errored" : "succeeded",
 			durationMs: Math.max(0, Math.round(performance.now() - tracked.startedAt)),
-			...(failed ? { errorStatus: tracked.errorStatus ?? "tool_error" } : {}),
+			...(failed ? { errorStatus: tracked.errorStatus ?? "handler_error" } : {}),
 		});
 	}
 

--- a/src/server/agent/session-setup.ts
+++ b/src/server/agent/session-setup.ts
@@ -1095,9 +1095,6 @@ function _resolveToolActivation(plan: SessionSetupPlan, ctx: PipelineContext): v
 	plan.bridgeOptions.args = prependToolResultErrorBridge([...activation.args, ...piExtensionActivation.args, ...(plan.bridgeOptions.args || [])]);
 	plan.bridgeOptions.piExtensions = [...(plan.bridgeOptions.piExtensions ?? []), ...piExtensionActivation.runtimeExtensions];
 	const goalId = effectiveGoalId(plan);
-	const toolHooksNeeded = ctx.hostInterceptors?.hasAny?.(
-		["beforeToolCall", "afterToolResult"], plan.projectId, goalId,
-	) ?? !!ctx.hostInterceptors;
 	const beforeToolCallFailClosed = ctx.hostInterceptors?.requiresFailClosed?.(
 		"beforeToolCall", plan.projectId, goalId,
 	) === true;
@@ -1107,7 +1104,9 @@ function _resolveToolActivation(plan: SessionSetupPlan, ctx: PipelineContext): v
 	plan.bridgeOptions.env = {
 		...(plan.bridgeOptions.env || {}),
 		...activation.env,
-		...(toolHooksNeeded ? { BOBBIT_HOST_HOOKS_ENABLED: "1" } : {}),
+		// Tool lifecycle notifications use this exact-auth callback path even when
+		// no interceptor contributes a decision. Only failure policy is opt-in.
+		BOBBIT_HOST_HOOKS_ENABLED: "1",
 		BOBBIT_HOST_BEFORE_TOOL_CALL_FAIL_CLOSED: beforeToolCallFailClosed ? "1" : "0",
 		BOBBIT_HOST_AFTER_TOOL_RESULT_FAIL_CLOSED: afterToolResultFailClosed ? "1" : "0",
 	};

--- a/src/server/agent/session-setup.ts
+++ b/src/server/agent/session-setup.ts
@@ -1100,11 +1100,15 @@ function _resolveToolActivation(plan: SessionSetupPlan, ctx: PipelineContext): v
 	const beforeToolCallFailClosed = ctx.hostInterceptors?.requiresFailClosed?.(
 		"beforeToolCall", plan.projectId, goalId,
 	) === true;
+	const afterToolResultFailClosed = ctx.hostInterceptors?.requiresFailClosed?.(
+		"afterToolResult", plan.projectId, goalId,
+	) === true;
 	plan.bridgeOptions.env = {
 		...(plan.bridgeOptions.env || {}),
 		...activation.env,
 		...(toolHooksNeeded ? { BOBBIT_HOST_HOOKS_ENABLED: "1" } : {}),
 		BOBBIT_HOST_BEFORE_TOOL_CALL_FAIL_CLOSED: beforeToolCallFailClosed ? "1" : "0",
+		BOBBIT_HOST_AFTER_TOOL_RESULT_FAIL_CLOSED: afterToolResultFailClosed ? "1" : "0",
 	};
 
 	// Generate and add the tool_call guard extension if any tools have 'ask' or 'never' policy.

--- a/src/server/agent/session-setup.ts
+++ b/src/server/agent/session-setup.ts
@@ -437,6 +437,7 @@ export interface PipelineContext {
 	hostInterceptors?: {
 		dispatch: (name: string, input: Record<string, unknown>, context: Record<string, unknown>) => Promise<any>;
 		hasAny?: (names: readonly string[], projectId?: string, goalId?: string) => boolean;
+		requiresFailClosed?: (name: string, projectId?: string, goalId?: string) => boolean;
 	};
 	/**
 	 * Resolve the EFFECTIVE (ancestry-merged) per-goal metadata for a goal id.
@@ -1092,13 +1093,18 @@ function _resolveToolActivation(plan: SessionSetupPlan, ctx: PipelineContext): v
 
 	plan.bridgeOptions.args = prependToolResultErrorBridge([...activation.args, ...piExtensionActivation.args, ...(plan.bridgeOptions.args || [])]);
 	plan.bridgeOptions.piExtensions = [...(plan.bridgeOptions.piExtensions ?? []), ...piExtensionActivation.runtimeExtensions];
+	const goalId = effectiveGoalId(plan);
 	const toolHooksNeeded = ctx.hostInterceptors?.hasAny?.(
-		["beforeToolCall", "afterToolResult"], plan.projectId, effectiveGoalId(plan),
+		["beforeToolCall", "afterToolResult"], plan.projectId, goalId,
 	) ?? !!ctx.hostInterceptors;
+	const beforeToolCallFailClosed = ctx.hostInterceptors?.requiresFailClosed?.(
+		"beforeToolCall", plan.projectId, goalId,
+	) === true;
 	plan.bridgeOptions.env = {
 		...(plan.bridgeOptions.env || {}),
 		...activation.env,
 		...(toolHooksNeeded ? { BOBBIT_HOST_HOOKS_ENABLED: "1" } : {}),
+		BOBBIT_HOST_BEFORE_TOOL_CALL_FAIL_CLOSED: beforeToolCallFailClosed ? "1" : "0",
 	};
 
 	// Generate and add the tool_call guard extension if any tools have 'ask' or 'never' policy.

--- a/src/server/agent/session-setup.ts
+++ b/src/server/agent/session-setup.ts
@@ -818,9 +818,10 @@ export async function resolveDynamicContext(plan: SessionSetupPlan, ctx: Pipelin
 			const controller = new AbortController();
 			const result = await ctx.hostInterceptors.dispatch("sessionSetup", {
 				sessionId: plan.id,
-				projectId: plan.projectId,
-				goalId: effectiveGoal,
-				roleName: plan.roleName,
+				...(plan.projectId ? { projectId: plan.projectId } : {}),
+				...(effectiveGoal ? { goalId: effectiveGoal } : {}),
+				scope: plan.projectId ? "project" : "global",
+				...(plan.roleName ? { roleName: plan.roleName } : {}),
 			}, {
 				projectId: plan.projectId,
 				sessionId: plan.id,

--- a/src/server/agent/session-setup.ts
+++ b/src/server/agent/session-setup.ts
@@ -433,6 +433,11 @@ export interface PipelineContext {
 	groupPolicyStore: ToolGroupPolicyStore | null;
 	configCascade: ConfigCascade | null;
 	lifecycleHub?: LifecycleHub;
+	/** Additive typed interceptor port. Its implementation composes legacy providers. */
+	hostInterceptors?: {
+		dispatch: (name: string, input: Record<string, unknown>, context: Record<string, unknown>) => Promise<any>;
+		hasAny?: (names: readonly string[], projectId?: string, goalId?: string) => boolean;
+	};
 	/**
 	 * Resolve the EFFECTIVE (ancestry-merged) per-goal metadata for a goal id.
 	 * Wired by SessionManager to `goalManager.getEffectiveGoalMetadata`. Optional
@@ -458,6 +463,8 @@ export interface PipelineContext {
 	) => Promise<void>;
 	/** SessionManager-owned author normalization, including current staff/role lookup. */
 	prepareVisibleAgentEvent?: (session: SessionInfo, event: unknown) => unknown;
+	/** Installs narrow post-authority notification observers before live events. */
+	bindHostLifecycle?: (session: SessionInfo) => void;
 	handleAgentLifecycle: (session: SessionInfo, event: any) => void;
 	trackCostFromEvent: (session: SessionInfo, event: any) => void;
 	recordPiExtensionDiagnostic?: (session: SessionInfo, diagnostic: import("./rpc-bridge.js").RuntimePiExtensionDiagnostic, extension: RuntimePiExtensionInfo) => void;
@@ -803,21 +810,40 @@ function lookupRole(name: string, plan: SessionSetupPlan, ctx: PipelineContext):
 }
 
 export async function resolveDynamicContext(plan: SessionSetupPlan, ctx: PipelineContext): Promise<void> {
-	if (!ctx.lifecycleHub) return;
+	if (!ctx.hostInterceptors && !ctx.lifecycleHub) return;
 	try {
-		const { blocks } = await ctx.lifecycleHub.dispatch("sessionSetup", {
+		const effectiveGoal = effectiveGoalId(plan);
+		if (ctx.hostInterceptors) {
+			const controller = new AbortController();
+			const result = await ctx.hostInterceptors.dispatch("sessionSetup", {
+				sessionId: plan.id,
+				projectId: plan.projectId,
+				goalId: effectiveGoal,
+				roleName: plan.roleName,
+			}, {
+				projectId: plan.projectId,
+				sessionId: plan.id,
+				goalId: effectiveGoal,
+				cwd: plan.cwd,
+				signal: controller.signal,
+			});
+			const context = result?.value?.context ?? result?.context ?? result?.blocks;
+			plan.dynamicContextBlocks = Array.isArray(context) ? context : [];
+			return;
+		}
+		const { blocks } = await ctx.lifecycleHub!.dispatch("sessionSetup", {
 			sessionId: plan.id,
 			projectId: plan.projectId,
 			scope: plan.projectId ? "project" : "global",
 			cwd: plan.cwd,
 			// Effective goal so metadata-disabled providers are filtered for the
 			// whole subtree (members/sub-agents resolve the inherited metadata).
-			goalId: effectiveGoalId(plan),
+			goalId: effectiveGoal,
 			roleName: plan.roleName,
 			prompt: plan.instructions,
 		}, {
 			projectId: plan.projectId,
-			goalId: effectiveGoalId(plan),
+			goalId: effectiveGoal,
 			roleName: plan.roleName,
 			cwd: plan.cwd,
 			worktreePath: plan.worktreePath,
@@ -825,8 +851,8 @@ export async function resolveDynamicContext(plan: SessionSetupPlan, ctx: Pipelin
 			repoWorktrees: plan.repoWorktrees,
 		});
 		plan.dynamicContextBlocks = blocks;
-	} catch (err) {
-		console.error(`[session-setup] sessionSetup dynamic context failed for ${plan.id}:`, err);
+	} catch {
+		console.warn(`[session-setup] sessionSetup interceptor failed code=dispatch_error session=${plan.id}`);
 	}
 }
 
@@ -1066,7 +1092,14 @@ function _resolveToolActivation(plan: SessionSetupPlan, ctx: PipelineContext): v
 
 	plan.bridgeOptions.args = prependToolResultErrorBridge([...activation.args, ...piExtensionActivation.args, ...(plan.bridgeOptions.args || [])]);
 	plan.bridgeOptions.piExtensions = [...(plan.bridgeOptions.piExtensions ?? []), ...piExtensionActivation.runtimeExtensions];
-	plan.bridgeOptions.env = { ...(plan.bridgeOptions.env || {}), ...activation.env };
+	const toolHooksNeeded = ctx.hostInterceptors?.hasAny?.(
+		["beforeToolCall", "afterToolResult"], plan.projectId, effectiveGoalId(plan),
+	) ?? !!ctx.hostInterceptors;
+	plan.bridgeOptions.env = {
+		...(plan.bridgeOptions.env || {}),
+		...activation.env,
+		...(toolHooksNeeded ? { BOBBIT_HOST_HOOKS_ENABLED: "1" } : {}),
+	};
 
 	// Generate and add the tool_call guard extension if any tools have 'ask' or 'never' policy.
 	const guardPath = ctx.toolManager ? writeToolGuardExtension(
@@ -1088,7 +1121,10 @@ function _resolveToolActivation(plan: SessionSetupPlan, ctx: PipelineContext): v
 	// session's project declares those hooks. When no provider is interested the
 	// bridge is never written or passed to pi — preserving zero overhead and
 	// keeping spawn args byte-identical to the no-provider baseline.
-	if (ctx.lifecycleHub && hasProviderBridgeHooks(ctx.lifecycleHub, plan.projectId, effectiveGoalId(plan))) {
+	const turnHooksNeeded = ctx.hostInterceptors?.hasAny?.(
+		["beforePrompt", "beforeCompact"], plan.projectId, effectiveGoalId(plan),
+	) ?? (!!ctx.lifecycleHub && hasProviderBridgeHooks(ctx.lifecycleHub, plan.projectId, effectiveGoalId(plan)));
+	if (turnHooksNeeded) {
 		const bridgePath = writeProviderBridgeExtension(plan.id);
 		if (bridgePath) {
 			plan.bridgeOptions.args.push("--extension", bridgePath);
@@ -1126,6 +1162,7 @@ export function subscribeToEvents(
 		now: ctx.now,
 		suppressUntilPrompt: opts.suppressUntilPrompt,
 	});
+	ctx.bindHostLifecycle?.(session);
 	return session.rpcClient.onEvent((event: any) => {
 		const preparedEvent = ctx.prepareVisibleAgentEvent
 			? ctx.prepareVisibleAgentEvent(session, event)
@@ -1733,6 +1770,7 @@ async function spawnAgent(plan: SessionSetupPlan, ctx: PipelineContext): Promise
 		role: plan.role ?? plan.roleName,
 		accessory: plan.accessory,
 		nonInteractive: plan.nonInteractive,
+		projectId: plan.projectId,
 		...(plan.repoWorktrees && plan.repoPath ? {
 			worktreePath: plan.worktreePath,
 			repoPath: plan.repoPath,

--- a/src/server/agent/session-status.ts
+++ b/src/server/agent/session-status.ts
@@ -21,11 +21,19 @@ import type { ServerMessage } from "../ws/protocol.js";
 import { isSocketSendable } from "../ws/socket-sendability.js";
 
 /** Subset of `SessionInfo` the helper actually touches. */
+export interface SessionStatusChange {
+	previousStatus: string;
+	status: string;
+	statusVersion: number;
+}
+
 export interface BroadcastableSession {
 	status: string;
 	statusVersion: number;
 	clients: Set<WebSocket>;
 	streamingStartedAt?: number;
+	/** Post-broadcast observer owned by the session lifecycle host. */
+	onStatusChanged?: (change: SessionStatusChange) => void;
 }
 
 /** Internal: send a single `session_status` frame to every OPEN client. */
@@ -49,6 +57,7 @@ export function broadcastStatus<S extends BroadcastableSession>(
 	status: S["status"],
 	extras?: { streamingStartedAt?: number; archivedAt?: number },
 ): void {
+	const previousStatus = session.status;
 	session.status = status;
 	session.statusVersion = (session.statusVersion ?? 0) + 1;
 	broadcastFrame(session.clients, {
@@ -58,4 +67,14 @@ export function broadcastStatus<S extends BroadcastableSession>(
 		...(extras?.streamingStartedAt ? { streamingStartedAt: extras.streamingStartedAt } : {}),
 		...(extras?.archivedAt ? { archivedAt: extras.archivedAt } : {}),
 	});
+	// The authoritative legacy frame is queued before observers see the fact.
+	// Same-status writes retain their compatibility version bump/frame but are
+	// not lifecycle transitions and therefore do not publish notifications.
+	if (previousStatus !== status && session.onStatusChanged) {
+		try {
+			session.onStatusChanged({ previousStatus, status, statusVersion: session.statusVersion });
+		} catch {
+			// Observational fanout cannot roll back or fail the status transition.
+		}
+	}
 }

--- a/src/server/agent/session-store.ts
+++ b/src/server/agent/session-store.ts
@@ -400,6 +400,19 @@ export class SessionStore {
 	private persistenceFailureSequence = 0;
 	private lastPersistenceError: unknown = null;
 	private lastPersistenceMetrics: PersistenceMetrics | null = null;
+	/**
+	 * Archives hidden from live/restore reads but not yet acknowledged through an
+	 * async durability fence. The row remains archived after a failed write; this
+	 * process-only ledger distinguishes that retryable state from rows loaded as
+	 * durably archived on boot.
+	 */
+	private pendingArchives = new Map<string, {
+		generation: number;
+		row: PersistedSession;
+		archivedAt: number;
+	}>();
+	/** One archive writer/acknowledgement owner per row. */
+	private archiveAttempts = new Map<string, Promise<boolean>>();
 	/** Legacy delivery ledger rows were upgraded in-memory during load. */
 	private loadedDeliveryLedgerMigration = false;
 
@@ -941,44 +954,67 @@ export class SessionStore {
 	}
 
 	/**
-	 * Promise-based archive. Preserves archive()'s record mutation and immediate
-	 * durability without writing a deletion tombstone. Concurrent synchronous
-	 * mutations fold into the same serialized writer rather than racing its
-	 * snapshot.
+	 * Promise-based archive. The row is hidden from live/restore reads before the
+	 * write starts and remains hidden after failure. A failed publication stays
+	 * explicitly retryable in this process, while exactly one caller receives
+	 * `true` after the archive generation crosses a durable fence. Rows loaded as
+	 * archived, and calls after that acknowledgement, return `false`.
 	 */
 	async archiveAsync(id: string): Promise<boolean> {
 		const existing = this.sessions.get(id);
-		if (!existing || existing.archived) {
+		if (!existing) {
 			if (this.asyncSaveInFlight) await this.asyncSaveInFlight;
 			return false;
 		}
-		const previousArchived = existing.archived;
-		const previousArchivedAt = existing.archivedAt;
-		const failureSequence = this.persistenceFailureSequence;
-		this.generation++;
-		const targetGeneration = this.generation;
-		const archivedAt = this.clock.now();
-		existing.archived = true;
-		existing.archivedAt = archivedAt;
+
+		const activeAttempt = this.archiveAttempts.get(id);
+		if (activeAttempt) {
+			// Join the durability outcome, but leave transition ownership with the
+			// caller that started the attempt so SessionManager cannot notify twice.
+			await activeAttempt;
+			return false;
+		}
+
+		let pending = this.pendingArchives.get(id);
+		if (!pending) {
+			if (existing.archived) {
+				if (this.asyncSaveInFlight) await this.asyncSaveInFlight;
+				return false;
+			}
+			this.generation++;
+			existing.archived = true;
+			existing.archivedAt = this.clock.now();
+			pending = {
+				generation: this.generation,
+				row: existing,
+				archivedAt: existing.archivedAt,
+			};
+			this.pendingArchives.set(id, pending);
+		}
+
 		if (this.saveTimer) {
 			this.clock.clearTimeout(this.saveTimer);
 			this.saveTimer = null;
 		}
-		try {
-			await this.persistThroughGeneration(targetGeneration, failureSequence);
-		} catch (err) {
-			// A failed publication is not an archive transition. Restore the exact
-			// in-memory shape so a later explicit retry can cross a fresh fence.
-			if (existing.archived === true && existing.archivedAt === archivedAt) {
-				if (previousArchived === undefined) delete existing.archived;
-				else existing.archived = previousArchived;
-				if (previousArchivedAt === undefined) delete existing.archivedAt;
-				else existing.archivedAt = previousArchivedAt;
+		const archivePending = pending;
+		const failureSequence = this.persistenceFailureSequence;
+		const attempt = (async (): Promise<boolean> => {
+			await this.persistThroughGeneration(archivePending.generation, failureSequence);
+			if (this.pendingArchives.get(id) !== archivePending) return false;
+			this.pendingArchives.delete(id);
+			const current = this.sessions.get(id);
+			if (current !== archivePending.row || current.archived !== true || current.archivedAt !== archivePending.archivedAt) {
+				return false;
 			}
-			throw err;
+			this.onIndexUpdate?.(current);
+			return true;
+		})();
+		this.archiveAttempts.set(id, attempt);
+		try {
+			return await attempt;
+		} finally {
+			if (this.archiveAttempts.get(id) === attempt) this.archiveAttempts.delete(id);
 		}
-		this.onIndexUpdate?.(existing);
-		return true;
 	}
 
 	/** Get all archived sessions. */
@@ -1082,16 +1118,16 @@ export class SessionStore {
 	 */
 	private async persistThroughGeneration(targetGeneration: number, failureSequence: number): Promise<void> {
 		// Stop as soon as this call's generation is durable; unrelated traffic
-		// must not make creation/shutdown barriers wait indefinitely.
+		// must not make creation/shutdown barriers wait indefinitely. A shared drain
+		// may publish the target and then fail a later generation, so publication is
+		// checked before attributing that unrelated failure to this barrier.
 		while (this.publishedGeneration < targetGeneration) {
 			const pending = this.asyncSaveInFlight ?? this.requestAsyncSave();
 			await pending;
+			if (this.publishedGeneration >= targetGeneration) return;
 			if (this.persistenceFailureSequence !== failureSequence) {
 				throw this.lastPersistenceError ?? new Error("Session persistence failed");
 			}
-		}
-		if (this.persistenceFailureSequence !== failureSequence) {
-			throw this.lastPersistenceError ?? new Error("Session persistence failed");
 		}
 	}
 }

--- a/src/server/agent/session-store.ts
+++ b/src/server/agent/session-store.ts
@@ -928,10 +928,10 @@ export class SessionStore {
 		return true;
 	}
 
-	/** Mark a session as archived. */
+	/** Mark a session as archived. A durable/archive-in-flight row is a no-op. */
 	archive(id: string): boolean {
 		const existing = this.sessions.get(id);
-		if (!existing) return false;
+		if (!existing || existing.archived) return false;
 		this.generation++;
 		existing.archived = true;
 		existing.archivedAt = this.clock.now();
@@ -948,20 +948,35 @@ export class SessionStore {
 	 */
 	async archiveAsync(id: string): Promise<boolean> {
 		const existing = this.sessions.get(id);
-		if (!existing) {
+		if (!existing || existing.archived) {
 			if (this.asyncSaveInFlight) await this.asyncSaveInFlight;
 			return false;
 		}
+		const previousArchived = existing.archived;
+		const previousArchivedAt = existing.archivedAt;
 		const failureSequence = this.persistenceFailureSequence;
 		this.generation++;
 		const targetGeneration = this.generation;
+		const archivedAt = this.clock.now();
 		existing.archived = true;
-		existing.archivedAt = this.clock.now();
+		existing.archivedAt = archivedAt;
 		if (this.saveTimer) {
 			this.clock.clearTimeout(this.saveTimer);
 			this.saveTimer = null;
 		}
-		await this.persistThroughGeneration(targetGeneration, failureSequence);
+		try {
+			await this.persistThroughGeneration(targetGeneration, failureSequence);
+		} catch (err) {
+			// A failed publication is not an archive transition. Restore the exact
+			// in-memory shape so a later explicit retry can cross a fresh fence.
+			if (existing.archived === true && existing.archivedAt === archivedAt) {
+				if (previousArchived === undefined) delete existing.archived;
+				else existing.archived = previousArchived;
+				if (previousArchivedAt === undefined) delete existing.archivedAt;
+				else existing.archivedAt = previousArchivedAt;
+			}
+			throw err;
+		}
 		this.onIndexUpdate?.(existing);
 		return true;
 	}

--- a/src/server/agent/staff-assistant.ts
+++ b/src/server/agent/staff-assistant.ts
@@ -4,7 +4,7 @@
 
 export const STAFF_ASSISTANT_PROMPT = `## Staff Agent Assistant
 
-Staff agents in Bobbit are persistent, autonomous agents that live in the workspace. Unlike goal agents (which are ephemeral and work on specific goals), staff agents wake on triggers (schedule, git events, manual) and perform recurring work. Your job is to help the user define a staff agent — its persona, mission, and triggers.
+Staff agents in Bobbit are persistent, autonomous agents that live in the workspace. Unlike goal agents (which are ephemeral and work on specific goals), staff agents wake on triggers (schedule, git events, committed host notifications, manual) and perform recurring work. Your job is to help the user define a staff agent — its persona, mission, and triggers.
 
 ## First message
 
@@ -41,8 +41,9 @@ When ready, call the \`propose_staff\` tool with these parameters:
 - **manual**: On-demand, user-invoked. Config: \`{}\`
 - **goal_created**: Fires when a new goal is created in any project. Config: \`{}\`. **Prompt is required.**
 - **goal_archived**: Fires when a goal is archived. Config: \`{}\`. **Prompt is required.**
+- **notification**: Fires from a committed canonical host fact. Use \`notification: { scope, name }\` and an exact-AND scalar \`filter\`, for example \`{ "type": "notification", "notification": { "scope": "session", "name": "toolCallCompleted" }, "filter": { "toolName": "example_tool", "status": "succeeded" }, "enabled": true }\`. Notification payload is delivered as host-owned inbox metadata, never copied into prompt text.
 
-Each trigger can have an optional \`prompt\` field — the message sent to the agent when that trigger fires — EXCEPT for \`goal_created\` and \`goal_archived\`, where \`prompt\` is mandatory (a non-empty string). The server returns 400 if a goal-* trigger is saved with an empty prompt.
+Each legacy trigger can have an optional \`prompt\` field — the message sent to the agent when that trigger fires — EXCEPT for \`goal_created\` and \`goal_archived\`, where \`prompt\` is mandatory (a non-empty string). The server returns 400 if a goal-* trigger is saved with an empty prompt. Notification selector and filter fields must come from the canonical catalogue.
 
 After proposing, wait for feedback. The user may ask you to revise — just call \`propose_staff\` again with the changes.
 

--- a/src/server/agent/staff-manager.ts
+++ b/src/server/agent/staff-manager.ts
@@ -26,8 +26,9 @@ type StaffFactPublisher = {
 	}): unknown;
 };
 
-const STAFF_PUBLIC_CONFIG_FIELDS = new Set([
-	"name", "description", "systemPrompt", "cwd", "state", "triggers", "memory", "roleId", "accessory", "contextPolicy",
+type StaffConfigChangedField = Extract<HostNotificationPayload<"staffConfigChanged">["changedFields"][number], string>;
+const STAFF_PUBLIC_CONFIG_FIELDS: ReadonlySet<StaffConfigChangedField> = new Set([
+	"name", "description", "systemPrompt", "state", "triggers", "roleId", "accessory", "contextPolicy",
 ]);
 
 function sanitiseBranchName(name: string): string {
@@ -573,7 +574,7 @@ export class StaffManager {
 		searchIndex?.indexStaff(staff, found.projectId);
 
 		const changedFields = Object.keys(updates)
-			.filter((field) => STAFF_PUBLIC_CONFIG_FIELDS.has(field)
+			.filter((field): field is StaffConfigChangedField => STAFF_PUBLIC_CONFIG_FIELDS.has(field as StaffConfigChangedField)
 				&& JSON.stringify(before[field as keyof PersistedStaff]) !== JSON.stringify(staff[field as keyof PersistedStaff]))
 			.sort();
 		if (changedFields.length > 0) {

--- a/src/server/agent/staff-manager.ts
+++ b/src/server/agent/staff-manager.ts
@@ -14,6 +14,21 @@ import { execShellCommand } from "./shell-util.js";
 import { shouldCreateWorktree } from "./worktree-decision.js";
 import { resolveWorktreeSupport } from "./worktree-support.js";
 import { realCommandRunner, type CommandRunner } from "../gateway-deps.js";
+import { validateNotificationFilter, type HostNotificationName, type HostNotificationPayload } from "../../shared/extension-host/host-hooks.js";
+
+type StaffFactName = "staffCreated" | "staffConfigChanged" | "staffRetired" | "staffSessionChanged";
+type StaffFactPublisher = {
+	publish<N extends StaffFactName>(name: N, publication: {
+		projectId: string;
+		aggregateId: string;
+		aggregateRevision?: string | number;
+		payload: HostNotificationPayload<N>;
+	}): unknown;
+};
+
+const STAFF_PUBLIC_CONFIG_FIELDS = new Set([
+	"name", "description", "systemPrompt", "cwd", "state", "triggers", "memory", "roleId", "accessory", "contextPolicy",
+]);
 
 function sanitiseBranchName(name: string): string {
 	return name.toLowerCase().replace(/[^a-z0-9-]/g, '-').replace(/-+/g, '-').replace(/^-|-$/g, '');
@@ -39,6 +54,8 @@ interface StaffWorktreePlan {
 export class StaffManager {
 	private pcm: ProjectContextManager;
 	private inboxManager: InboxManager | null = null;
+	private staffFactPublisher: StaffFactPublisher | null = null;
+	private notificationDeliveryReconciler: ((projectId: string, staffId: string) => void) | null = null;
 	private readonly remotePolicy: RemoteGitPolicy;
 	private readonly worktreeSetupRuntime: { skipNpmCi?: boolean; recordSetupPath?: string };
 	private readonly commandRunner: CommandRunner;
@@ -59,6 +76,33 @@ export class StaffManager {
 	 */
 	setInboxManager(inboxManager: InboxManager): void {
 		this.inboxManager = inboxManager;
+	}
+
+	setStaffNotificationPublisher(publisher: StaffFactPublisher | null): void {
+		this.staffFactPublisher = publisher;
+	}
+
+	setNotificationDeliveryReconciler(reconciler: ((projectId: string, staffId: string) => void) | null): void {
+		this.notificationDeliveryReconciler = reconciler;
+	}
+
+	private publishStaffFact<N extends StaffFactName>(name: N, staff: PersistedStaff, payload: HostNotificationPayload<N>): void {
+		if (!staff.projectId) return;
+		try {
+			this.staffFactPublisher?.publish(name, {
+				projectId: staff.projectId,
+				aggregateId: staff.id,
+				aggregateRevision: staff.updatedAt,
+				payload,
+			});
+		} catch (err) {
+			console.warn(`[staff-manager] ${name} publication failed for ${staff.id}:`, err);
+		}
+	}
+
+	private reconcileNotificationDelivery(projectId: string, staffId: string): void {
+		try { this.notificationDeliveryReconciler?.(projectId, staffId); }
+		catch (err) { console.warn(`[staff-manager] notification delivery reconciliation failed for ${staffId}:`, err); }
 	}
 
 	/**
@@ -85,6 +129,13 @@ export class StaffManager {
 				if (typeof t.prompt !== "string" || t.prompt.trim().length === 0) {
 					throw new Error(`Trigger of type ${t.type} requires a non-empty prompt`);
 				}
+			}
+			if (t?.type === "notification") {
+				if (!t.notification || (t.notification.scope !== "session" && t.notification.scope !== "project") || typeof t.notification.name !== "string") {
+					throw new Error("Notification trigger requires a canonical scope and name");
+				}
+				const checked = validateNotificationFilter(t.notification.scope, t.notification.name as HostNotificationName, t.filter);
+				if (!checked.ok) throw new Error(`Invalid notification trigger: ${checked.code}`);
 			}
 		}
 	}
@@ -333,11 +384,13 @@ export class StaffManager {
 			throw new Error("Cannot create staff: projectId is required");
 		}
 
-		// Auto-assign UUIDs to triggers missing IDs
+		// Auto-assign UUIDs to triggers missing IDs, then validate the exact
+		// persisted selector/filter configuration.
 		const triggers = (opts?.triggers ?? []).map((t) => ({
 			...t,
 			id: t.id || randomUUID(),
 		}));
+		this.validateTriggers(triggers);
 
 		// When the caller didn't supply a usable accessory (absent/empty/"none")
 		// but selected a role, default the persisted accessory to the role's
@@ -381,7 +434,7 @@ export class StaffManager {
 		}
 
 		const store = this.getStore(projectId);
-		store.put(staff);
+		store.putStrict(staff);
 
 		const searchIndex = this.pcm.getOrCreate(projectId)?.searchIndex;
 		searchIndex?.indexStaff(staff, projectId);
@@ -431,8 +484,7 @@ export class StaffManager {
 			const worktreeMeta = this.staffSessionWorktreeMeta(staff, projectId);
 			if (worktreeMeta) sessionManager.updateSessionMeta(session.id, worktreeMeta);
 			await sessionManager.persistSessionMetadata(session);
-			store.update(id, { currentSessionId: session.id });
-			staff.currentSessionId = session.id;
+			this.commitCurrentSession(id, session.id);
 		} catch (err) {
 			// Clean up the orphaned worktree on failure
 			try {
@@ -446,7 +498,14 @@ export class StaffManager {
 			throw err;
 		}
 
-		return staff;
+		const committed = store.get(id)!;
+		this.publishStaffFact("staffCreated", committed, {
+			staffId: committed.id,
+			state: committed.state,
+			...(committed.currentSessionId ? { sessionId: committed.currentSessionId } : {}),
+		});
+		this.reconcileNotificationDelivery(projectId, id);
+		return committed;
 	}
 
 	getStaff(id: string): PersistedStaff | undefined {
@@ -463,6 +522,23 @@ export class StaffManager {
 			all.push(...ctx.staffStore.getAll());
 		}
 		return all;
+	}
+
+	/** Commit every permanent-session replacement/clear through one fact boundary. */
+	commitCurrentSession(staffId: string, sessionId: string | undefined): boolean {
+		const found = this.findStoreForStaff(staffId);
+		if (!found) return false;
+		const previousSessionId = found.staff.currentSessionId;
+		if (previousSessionId === sessionId) return true;
+		const ok = found.store.updateStrict(staffId, { currentSessionId: (sessionId ?? null) as unknown as string });
+		if (!ok) return false;
+		const staff = found.store.get(staffId)!;
+		this.publishStaffFact("staffSessionChanged", staff, {
+			staffId,
+			...(previousSessionId ? { previousSessionId } : {}),
+			...(sessionId ? { sessionId } : {}),
+		});
+		return true;
 	}
 
 	updateStaff(
@@ -483,24 +559,40 @@ export class StaffManager {
 			lastWakeAt?: number;
 		},
 	): boolean {
-		// Auto-assign UUIDs to triggers missing IDs
 		if (updates.triggers) {
-			updates.triggers = updates.triggers.map((t) => ({
-				...t,
-				id: t.id || randomUUID(),
-			}));
+			updates.triggers = updates.triggers.map((t) => ({ ...t, id: t.id || randomUUID() }));
+			this.validateTriggers(updates.triggers);
 		}
 		const found = this.findStoreForStaff(id);
 		if (!found) return false;
-		const ok = found.store.update(id, updates);
-		if (ok) {
-			const staff = found.store.get(id);
-			if (staff) {
-				const searchIndex = this.pcm.getOrCreate(found.projectId)?.searchIndex;
-				searchIndex?.indexStaff(staff, found.projectId);
-			}
+		const before = structuredClone(found.staff);
+		const ok = found.store.updateStrict(id, updates);
+		if (!ok) return false;
+		const staff = found.store.get(id)!;
+		const searchIndex = this.pcm.getOrCreate(found.projectId)?.searchIndex;
+		searchIndex?.indexStaff(staff, found.projectId);
+
+		const changedFields = Object.keys(updates)
+			.filter((field) => STAFF_PUBLIC_CONFIG_FIELDS.has(field)
+				&& JSON.stringify(before[field as keyof PersistedStaff]) !== JSON.stringify(staff[field as keyof PersistedStaff]))
+			.sort();
+		if (changedFields.length > 0) {
+			this.publishStaffFact("staffConfigChanged", staff, { staffId: id, changedFields });
 		}
-		return ok;
+		if (before.state !== "retired" && staff.state === "retired") {
+			this.publishStaffFact("staffRetired", staff, { staffId: id });
+		}
+		if (before.currentSessionId !== staff.currentSessionId) {
+			this.publishStaffFact("staffSessionChanged", staff, {
+				staffId: id,
+				...(before.currentSessionId ? { previousSessionId: before.currentSessionId } : {}),
+				...(staff.currentSessionId ? { sessionId: staff.currentSessionId } : {}),
+			});
+		}
+		if (before.state !== staff.state || JSON.stringify(before.triggers) !== JSON.stringify(staff.triggers)) {
+			this.reconcileNotificationDelivery(found.projectId, id);
+		}
+		return true;
 	}
 
 	async deleteStaff(id: string, sessionManager: SessionManager): Promise<boolean> {
@@ -537,6 +629,7 @@ export class StaffManager {
 		} catch (err) {
 			console.error(`[staff-manager] inbox removeAll failed for staff ${id}:`, err);
 		}
+		this.reconcileNotificationDelivery(found.projectId, id);
 		return true;
 	}
 
@@ -556,7 +649,7 @@ export class StaffManager {
 		if (!trigger) return false;
 
 		if (updates.lastFired !== undefined) trigger.lastFired = updates.lastFired;
-		if (updates.lastSeenSha !== undefined) trigger.lastSeenSha = updates.lastSeenSha;
+		if (updates.lastSeenSha !== undefined && trigger.type !== "notification") trigger.lastSeenSha = updates.lastSeenSha;
 
 		store.update(staffId, { triggers: staff.triggers });
 		return true;
@@ -655,7 +748,7 @@ export class StaffManager {
 	async ensureSessionForStaff(staffId: string, sessionManager: SessionManager): Promise<string> {
 		const found = this.findStoreForStaff(staffId);
 		if (!found) throw new Error("Staff agent not found");
-		const { store, staff } = found;
+		const { staff } = found;
 		if (staff.state !== "active") throw new Error(`Staff agent is ${staff.state}, cannot ensure session`);
 
 		// Branch 1: legacy migration — no permanent session yet, create one
@@ -680,8 +773,7 @@ export class StaffManager {
 			const worktreeMeta = this.staffSessionWorktreeMeta(staff, found.projectId);
 			if (worktreeMeta) sessionManager.updateSessionMeta(session.id, worktreeMeta);
 			await sessionManager.persistSessionMetadata(session);
-			store.update(staffId, { currentSessionId: session.id });
-			staff.currentSessionId = session.id;
+			this.commitCurrentSession(staffId, session.id);
 			console.log(`[staff-manager] Created permanent session for staff "${staff.name}" (${staffId}) → ${session.id} (legacy migration)`);
 			return session.id;
 		}
@@ -693,8 +785,7 @@ export class StaffManager {
 				await sessionManager.ensureSessionAlive(staff.currentSessionId);
 			} catch {
 				console.log(`[staff-manager] Session ${staff.currentSessionId} unrecoverable, creating new one for "${staff.name}"`);
-				store.update(staffId, { currentSessionId: undefined as any });
-				staff.currentSessionId = undefined as any;
+				this.commitCurrentSession(staffId, undefined);
 				return this.ensureSessionForStaff(staffId, sessionManager);
 			}
 		}

--- a/src/server/agent/staff-notification-causation.ts
+++ b/src/server/agent/staff-notification-causation.ts
@@ -1,0 +1,42 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+
+/**
+ * Host-owned loop controls for one exact notification-triggered staff turn.
+ * These values are never accepted from prompts, notification envelopes, browser
+ * frames, or request bodies.
+ */
+export interface StaffNotificationTurnContext {
+	readonly sessionId: string;
+	readonly projectId: string;
+	readonly staffId: string;
+	readonly triggerId: string;
+	readonly notificationId: string;
+	readonly rootCorrelationId: string;
+	readonly causationDepth: number;
+	readonly lifecycleGeneration: number;
+}
+
+export const MAX_NOTIFICATION_CAUSATION_DEPTH = 8;
+/** A delivered wake increments the source row before binding its staff turn. */
+export const MAX_STAFF_NOTIFICATION_TURN_DEPTH = MAX_NOTIFICATION_CAUSATION_DEPTH + 1;
+
+const requestContext = new AsyncLocalStorage<StaffNotificationTurnContext>();
+
+export function freezeStaffNotificationTurnContext(
+	context: StaffNotificationTurnContext,
+): StaffNotificationTurnContext {
+	return Object.freeze({ ...context });
+}
+
+/** Bind an authenticated server mutation to the exact staff turn that caused it. */
+export function runWithStaffNotificationTurnContext<T>(
+	context: StaffNotificationTurnContext,
+	operation: () => T,
+): T {
+	return requestContext.run(context, operation);
+}
+
+/** Read-only delivery controls for the current server-owned mutation chain. */
+export function currentStaffNotificationTurnContext(): StaffNotificationTurnContext | undefined {
+	return requestContext.getStore();
+}

--- a/src/server/agent/staff-store.ts
+++ b/src/server/agent/staff-store.ts
@@ -1,9 +1,11 @@
 import fs from "node:fs";
 import path from "node:path";
 import { recordDeletionTombstone } from "./deletion-tombstones.js";
+import type { HostHookScope, HostNotificationName } from "../../shared/extension-host/host-hooks.js";
 
 export type StaffState = "active" | "paused" | "retired";
-export type TriggerType = "schedule" | "git" | "manual" | "goal_created" | "goal_archived";
+export type LegacyTriggerType = "schedule" | "git" | "manual" | "goal_created" | "goal_archived";
+export type TriggerType = LegacyTriggerType | "notification";
 
 export interface TriggerConfig {
 	cron?: string;
@@ -13,15 +15,33 @@ export interface TriggerConfig {
 	repo?: string;
 }
 
-export interface StaffTrigger {
+export interface LegacyStaffTrigger {
 	id: string;
-	type: TriggerType;
+	type: LegacyTriggerType;
 	config: TriggerConfig;
 	enabled: boolean;
 	lastFired?: number;
 	prompt?: string;
 	lastSeenSha?: string;
 }
+
+export interface NotificationTriggerSelector<N extends HostNotificationName = HostNotificationName> {
+	scope: HostHookScope;
+	name: N;
+}
+
+/** Additive notification trigger. It never exposes notification data as prompt text. */
+export interface NotificationStaffTrigger<N extends HostNotificationName = HostNotificationName> {
+	id: string;
+	type: "notification";
+	notification: NotificationTriggerSelector<N>;
+	filter: Readonly<Record<string, string | number | boolean>>;
+	enabled: boolean;
+	prompt?: string;
+	lastFired?: number;
+}
+
+export type StaffTrigger = LegacyStaffTrigger | NotificationStaffTrigger;
 
 const STAFF_ACCESSORY_IDS = new Set([
 	"none",
@@ -136,13 +156,24 @@ export class StaffStore {
 		}
 	}
 
+	private saveStrict(): void {
+		if (!fs.existsSync(this.storeDir)) {
+			fs.mkdirSync(this.storeDir, { recursive: true });
+		}
+		const data = Array.from(this.staff.values());
+		const temporary = `${this.storeFile}.${process.pid}.${Date.now()}.tmp`;
+		try {
+			fs.writeFileSync(temporary, JSON.stringify(data, null, 2), "utf-8");
+			fs.renameSync(temporary, this.storeFile);
+		} catch (err) {
+			try { if (fs.existsSync(temporary)) fs.unlinkSync(temporary); } catch { /* preserve original error */ }
+			throw err;
+		}
+	}
+
 	private save(): void {
 		try {
-			if (!fs.existsSync(this.storeDir)) {
-				fs.mkdirSync(this.storeDir, { recursive: true });
-			}
-			const data = Array.from(this.staff.values());
-			fs.writeFileSync(this.storeFile, JSON.stringify(data, null, 2), "utf-8");
+			this.saveStrict();
 		} catch (err) {
 			console.error("[staff-store] Failed to save staff:", err);
 		}
@@ -153,6 +184,19 @@ export class StaffStore {
 		// real values. Mirrors the load-side normalisation.
 		this.staff.set(staff.id, normalizeStaffRecord(staff));
 		this.save();
+	}
+
+	/** Fail-loud atomic publication used by authoritative staff lifecycle facts. */
+	putStrict(staff: PersistedStaff): void {
+		const previous = this.staff.get(staff.id);
+		this.staff.set(staff.id, normalizeStaffRecord(staff));
+		try {
+			this.saveStrict();
+		} catch (err) {
+			if (previous) this.staff.set(staff.id, previous);
+			else this.staff.delete(staff.id);
+			throw err;
+		}
 	}
 
 	get(id: string): PersistedStaff | undefined {
@@ -172,23 +216,39 @@ export class StaffStore {
 		return Array.from(this.staff.values());
 	}
 
-	update(id: string, updates: Partial<Omit<PersistedStaff, "id" | "createdAt">>): boolean {
-		const existing = this.staff.get(id);
-		if (!existing) return false;
+	private applyUpdate(existing: PersistedStaff, updates: Partial<Omit<PersistedStaff, "id" | "createdAt">>): void {
 		// Strip undefined values to avoid overwriting existing fields.
 		// null is treated as "clear this field" (delete the key).
 		const rec = existing as unknown as Record<string, unknown>;
 		for (const [k, v] of Object.entries(updates)) {
 			if (v === undefined) continue;
-			if (v === null) {
-				delete rec[k];
-			} else {
-				rec[k] = v;
-			}
+			if (v === null) delete rec[k];
+			else rec[k] = v;
 		}
 		existing.updatedAt = Date.now();
 		normalizeStaffRecord(existing);
+	}
+
+	update(id: string, updates: Partial<Omit<PersistedStaff, "id" | "createdAt">>): boolean {
+		const existing = this.staff.get(id);
+		if (!existing) return false;
+		this.applyUpdate(existing, updates);
 		this.save();
 		return true;
+	}
+
+	/** Apply an update only if its atomic publication succeeds; otherwise restore memory. */
+	updateStrict(id: string, updates: Partial<Omit<PersistedStaff, "id" | "createdAt">>): boolean {
+		const existing = this.staff.get(id);
+		if (!existing) return false;
+		const previous = structuredClone(existing);
+		this.applyUpdate(existing, updates);
+		try {
+			this.saveStrict();
+			return true;
+		} catch (err) {
+			this.staff.set(id, previous);
+			throw err;
+		}
 	}
 }

--- a/src/server/agent/staff-trigger-engine.ts
+++ b/src/server/agent/staff-trigger-engine.ts
@@ -6,7 +6,7 @@ import { cpuDiagnosticsEnabled, getCpuDiagnostics } from "./cpu-diagnostics.js";
 import type { StaffManager } from "./staff-manager.js";
 import type { SessionManager } from "./session-manager.js";
 import type { InboxManager } from "./inbox-manager.js";
-import type { PersistedStaff, StaffTrigger } from "./staff-store.js";
+import type { LegacyStaffTrigger, PersistedStaff } from "./staff-store.js";
 
 /**
  * Minimal coordinator dependency used by Git-trigger polling. The coordinator
@@ -258,7 +258,7 @@ export class TriggerEngine {
 	}
 
 	/** Returns true if the trigger was fired. */
-	private checkScheduleTrigger(staff: PersistedStaff, trigger: StaffTrigger): boolean {
+	private checkScheduleTrigger(staff: PersistedStaff, trigger: LegacyStaffTrigger): boolean {
 		if (!trigger.config.cron) return false;
 		const now = new Date(this.clock.now());
 		if (!cronMatches(trigger.config.cron, now)) return false;
@@ -275,7 +275,7 @@ export class TriggerEngine {
 	}
 
 	/** Returns true if the trigger was fired. */
-	private async checkGitTrigger(staff: PersistedStaff, trigger: StaffTrigger): Promise<boolean> {
+	private async checkGitTrigger(staff: PersistedStaff, trigger: LegacyStaffTrigger): Promise<boolean> {
 		const repo = trigger.config.repo || staff.cwd;
 		const branch = trigger.config.branch || "HEAD";
 		let hasRemote = false;
@@ -344,7 +344,7 @@ export class TriggerEngine {
 	 * microtask; otherwise the 15 s nudger tick picks it up the next time
 	 * the staff goes idle.
 	 */
-	private fireTrigger(staff: PersistedStaff, trigger: StaffTrigger, extraContext?: string): void {
+	private fireTrigger(staff: PersistedStaff, trigger: LegacyStaffTrigger, extraContext?: string): void {
 		console.log(`[trigger-engine] Firing ${trigger.type} trigger "${trigger.id}" for staff "${staff.name}"`);
 
 		this.staffManager.updateTriggerState(staff.id, trigger.id, { lastFired: this.clock.now() });

--- a/src/server/agent/task-manager.ts
+++ b/src/server/agent/task-manager.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import { TaskStore, type TaskState, type PersistedTask } from "./task-store.js";
+import { TaskStore, type TaskCommittedFact, type TaskState, type PersistedTask } from "./task-store.js";
 
 /** Valid state transitions. Terminal states (complete, skipped) have no outgoing transitions. */
 const VALID_TRANSITIONS: Record<TaskState, TaskState[]> = {
@@ -9,6 +9,22 @@ const VALID_TRANSITIONS: Record<TaskState, TaskState[]> = {
 	complete: [],
 	skipped: [],
 };
+
+const TASK_UPDATED_FIELDS = [
+	"title", "spec", "assignedSessionId", "dependsOn", "workflowGateId", "inputGateIds",
+	"headSha", "baseSha", "branch", "resultSummary",
+] as const;
+
+function valuesEqual(left: unknown, right: unknown): boolean {
+	if (Array.isArray(left) && Array.isArray(right)) {
+		return left.length === right.length && left.every((value, index) => value === right[index]);
+	}
+	return left === right;
+}
+
+function monotonicNow(previous: number): number {
+	return Math.max(Date.now(), previous + 1);
+}
 
 export class TaskManager {
 	private store: TaskStore;
@@ -70,7 +86,15 @@ export class TaskManager {
 			inputGateIds: opts?.inputGateIds?.length ? opts.inputGateIds : undefined,
 		};
 
-		this.store.put(task);
+		this.commitTask(task, [{
+			kind: "taskCreated",
+			taskId: task.id,
+			goalId: task.goalId,
+			type: task.type,
+			state: task.state,
+			parentTaskId: task.parentTaskId,
+			revision: task.updatedAt,
+		}]);
 		return task;
 	}
 
@@ -138,19 +162,47 @@ export class TaskManager {
 			this.detectCycle(id, updates.dependsOn);
 		}
 
-		const now = Date.now();
 		const cleaned: Record<string, unknown> = {};
 		for (const [k, v] of Object.entries(updates)) {
 			if (v !== undefined) cleaned[k] = v;
 		}
+		const changedFields = TASK_UPDATED_FIELDS.filter(field =>
+			Object.prototype.hasOwnProperty.call(cleaned, field)
+			&& !valuesEqual(task[field], cleaned[field]),
+		);
+		const previousState = task.state;
+		const stateChanged = updates.state !== undefined && updates.state !== previousState;
+		if (!stateChanged && changedFields.length === 0) return true;
 
+		const now = monotonicNow(task.updatedAt);
 		// Handle completedAt for terminal states
-		if (updates.state === "complete" || updates.state === "skipped") {
+		if (stateChanged && (updates.state === "complete" || updates.state === "skipped")) {
 			cleaned.completedAt = now;
 		}
 
 		Object.assign(task, cleaned, { updatedAt: now });
-		this.store.put(task);
+		const facts: TaskCommittedFact[] = [];
+		if (changedFields.length > 0) {
+			facts.push({
+				kind: "taskUpdated",
+				taskId: task.id,
+				goalId: task.goalId,
+				state: task.state,
+				changedFields,
+				revision: task.updatedAt,
+			});
+		}
+		if (stateChanged) {
+			facts.push({
+				kind: "taskStateChanged",
+				taskId: task.id,
+				goalId: task.goalId,
+				previousState,
+				state: task.state,
+				revision: task.updatedAt,
+			});
+		}
+		this.commitTask(task, facts);
 		return true;
 	}
 
@@ -177,24 +229,40 @@ export class TaskManager {
 		const task = this.store.get(taskId);
 		if (!task) return false;
 
-		const now = Date.now();
-		task.assignedSessionId = sessionId;
-		task.updatedAt = now;
-
-		// Auto-transition to in-progress if currently todo
-		if (task.state === "todo") {
-			task.state = "in-progress";
+		const assignmentChanged = task.assignedSessionId !== sessionId;
+		const previousState = task.state;
+		const stateChanged = previousState === "todo";
+		if (assignmentChanged || stateChanged) {
+			task.assignedSessionId = sessionId;
+			task.updatedAt = monotonicNow(task.updatedAt);
+			if (stateChanged) task.state = "in-progress";
+			const facts: TaskCommittedFact[] = [];
+			if (assignmentChanged) {
+				facts.push({
+					kind: "taskUpdated", taskId: task.id, goalId: task.goalId,
+					state: task.state, changedFields: ["assignedSessionId"], revision: task.updatedAt,
+				});
+			}
+			if (stateChanged) {
+				facts.push({
+					kind: "taskStateChanged", taskId: task.id, goalId: task.goalId,
+					previousState, state: task.state, revision: task.updatedAt,
+				});
+			}
+			this.commitTask(task, facts);
 		}
-
-		this.store.put(task);
 
 		// Auto-transition parent to in-progress if a sub-task starts
 		if (task.parentTaskId) {
 			const parent = this.store.get(task.parentTaskId);
 			if (parent && parent.state === "todo") {
+				const parentPreviousState = parent.state;
 				parent.state = "in-progress";
-				parent.updatedAt = now;
-				this.store.put(parent);
+				parent.updatedAt = monotonicNow(parent.updatedAt);
+				this.commitTask(parent, [{
+					kind: "taskStateChanged", taskId: parent.id, goalId: parent.goalId,
+					previousState: parentPreviousState, state: parent.state, revision: parent.updatedAt,
+				}]);
 			}
 		}
 
@@ -223,11 +291,15 @@ export class TaskManager {
 			}
 		}
 
-		const now = Date.now();
+		const previousState = task.state;
+		const now = monotonicNow(task.updatedAt);
 		task.state = "complete";
 		task.completedAt = now;
 		task.updatedAt = now;
-		this.store.put(task);
+		this.commitTask(task, [{
+			kind: "taskStateChanged", taskId: task.id, goalId: task.goalId,
+			previousState, state: task.state, revision: task.updatedAt,
+		}]);
 		return true;
 	}
 
@@ -252,7 +324,8 @@ export class TaskManager {
 			return this.completeTask(taskId);
 		}
 
-		const now = Date.now();
+		const previousState = task.state;
+		const now = monotonicNow(task.updatedAt);
 		task.state = newState;
 		task.updatedAt = now;
 
@@ -260,7 +333,10 @@ export class TaskManager {
 			task.completedAt = now;
 		}
 
-		this.store.put(task);
+		this.commitTask(task, [{
+			kind: "taskStateChanged", taskId: task.id, goalId: task.goalId,
+			previousState, state: task.state, revision: task.updatedAt,
+		}]);
 		return true;
 	}
 
@@ -271,6 +347,15 @@ export class TaskManager {
 	}
 
 	// --- Private helpers ---
+
+	private commitTask(task: PersistedTask, facts: readonly TaskCommittedFact[]): void {
+		void this.store.putCommitted(task, facts).catch(error => {
+			// Existing TaskManager methods are synchronous. The strict store barrier
+			// remains observable through TaskStore.flush/close while avoiding an
+			// unhandled rejection on legacy callers.
+			console.error(`[task-manager] Failed to publish task ${task.id}:`, error);
+		});
+	}
 
 	private isValidTransition(from: TaskState, to: TaskState): boolean {
 		return VALID_TRANSITIONS[from].includes(to);

--- a/src/server/agent/task-manager.ts
+++ b/src/server/agent/task-manager.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { TaskStore, type TaskCommittedFact, type TaskState, type PersistedTask } from "./task-store.js";
+import type { HostNotificationPayload } from "../../shared/extension-host/host-hooks.js";
 
 /** Valid state transitions. Terminal states (complete, skipped) have no outgoing transitions. */
 const VALID_TRANSITIONS: Record<TaskState, TaskState[]> = {
@@ -14,6 +15,35 @@ const TASK_UPDATED_FIELDS = [
 	"title", "spec", "assignedSessionId", "dependsOn", "workflowGateId", "inputGateIds",
 	"headSha", "baseSha", "branch", "resultSummary",
 ] as const;
+
+type TaskUpdatedField = (typeof TASK_UPDATED_FIELDS)[number];
+type CatalogueTaskUpdatedPublicField = HostNotificationPayload<"taskUpdated">["changedFields"][number];
+
+/** Internal checkout coordinates are persisted on the task but are not public
+ * notification metadata. Every exposed identifier comes from the catalogue. */
+const TASK_UPDATED_PUBLIC_FIELD_MAP = {
+	title: "title",
+	spec: "spec",
+	assignedSessionId: "assignedSessionId",
+	dependsOn: "dependsOn",
+	workflowGateId: "workflowGateId",
+	inputGateIds: "inputGateIds",
+	headSha: "headSha",
+	resultSummary: "resultSummary",
+} as const satisfies Partial<Record<TaskUpdatedField, CatalogueTaskUpdatedPublicField>>;
+
+type TaskUpdatedPublicField = (typeof TASK_UPDATED_PUBLIC_FIELD_MAP)[keyof typeof TASK_UPDATED_PUBLIC_FIELD_MAP];
+
+function isTaskUpdatedPublicField(field: TaskUpdatedField): field is keyof typeof TASK_UPDATED_PUBLIC_FIELD_MAP {
+	return Object.prototype.hasOwnProperty.call(TASK_UPDATED_PUBLIC_FIELD_MAP, field);
+}
+
+function projectTaskUpdatedFields(changedFields: readonly TaskUpdatedField[]): TaskUpdatedPublicField[] {
+	const projected = changedFields.flatMap((field): TaskUpdatedPublicField[] => {
+		return isTaskUpdatedPublicField(field) ? [TASK_UPDATED_PUBLIC_FIELD_MAP[field]] : [];
+	});
+	return [...new Set(projected)].sort();
+}
 
 function valuesEqual(left: unknown, right: unknown): boolean {
 	if (Array.isArray(left) && Array.isArray(right)) {
@@ -174,6 +204,7 @@ export class TaskManager {
 		const stateChanged = updates.state !== undefined && updates.state !== previousState;
 		if (!stateChanged && changedFields.length === 0) return true;
 
+		const publicChangedFields = projectTaskUpdatedFields(changedFields);
 		const now = monotonicNow(task.updatedAt);
 		// Handle completedAt for terminal states
 		if (stateChanged && (updates.state === "complete" || updates.state === "skipped")) {
@@ -188,7 +219,7 @@ export class TaskManager {
 				taskId: task.id,
 				goalId: task.goalId,
 				state: task.state,
-				changedFields,
+				changedFields: publicChangedFields,
 				revision: task.updatedAt,
 			});
 		}

--- a/src/server/agent/task-store.ts
+++ b/src/server/agent/task-store.ts
@@ -51,9 +51,45 @@ interface TaskWriteMetrics {
 	durationMs: number;
 }
 
+export type TaskCommittedFact =
+	| {
+		kind: "taskCreated";
+		taskId: string;
+		goalId: string;
+		type: string;
+		state: TaskState;
+		parentTaskId?: string;
+		revision: number;
+	}
+	| {
+		kind: "taskUpdated";
+		taskId: string;
+		goalId: string;
+		state: TaskState;
+		changedFields: string[];
+		revision: number;
+	}
+	| {
+		kind: "taskStateChanged";
+		taskId: string;
+		goalId: string;
+		previousState: TaskState;
+		state: TaskState;
+		revision: number;
+	};
+
+interface TaskFactBatch {
+	facts: TaskCommittedFact[];
+	promise: Promise<void>;
+	resolve: () => void;
+	reject: (error: unknown) => void;
+	started: boolean;
+}
+
 interface TaskPersistence {
 	loadInto(tasks: Map<string, PersistedTask>): void;
 	schedule(ids: Iterable<string>): void;
+	publishStrict(ids: Iterable<string>): Promise<void>;
 	flush(): Promise<void>;
 	close(): Promise<void>;
 	dispose(): void;
@@ -97,6 +133,7 @@ class JsonTaskPersistence implements TaskPersistence {
 	}
 
 	schedule(_ids: Iterable<string>): void { this.writer.schedule(); }
+	publishStrict(_ids: Iterable<string>): Promise<void> { return this.writer.publishStrict(); }
 	flush(): Promise<void> { return this.writer.flush(); }
 	async close(): Promise<void> { await this.writer.flush(); }
 	dispose(): void { /* no persistent handle */ }
@@ -457,6 +494,12 @@ class SqliteTaskPersistence implements TaskPersistence {
 		return this.requestBarrier();
 	}
 
+	publishStrict(ids: Iterable<string>): Promise<void> {
+		this.assertOpen();
+		for (const id of ids) this.dirty.add(id);
+		return this.requestBarrier();
+	}
+
 	getLastWriteMetrics(): TaskWriteMetrics | null { return this.lastWriteMetrics; }
 
 	close(): Promise<void> {
@@ -595,6 +638,10 @@ export class TaskStore {
 	private generation = 0;
 	private acceptingMutations = true;
 	private closePromise: Promise<void> | null = null;
+	private committedFactBatch: TaskFactBatch | null = null;
+
+	/** Called only after a fact's task snapshot crosses a strict persistence fence. */
+	onCommittedFact?: (fact: TaskCommittedFact) => void;
 
 	constructor(stateDir: string, fsImpl: FsLike = realFs, options: TaskStoreOptions = {}) {
 		const persistence = options.persistence ?? (fsImpl === realFs ? "sqlite" : "json");
@@ -620,7 +667,14 @@ export class TaskStore {
 	}
 
 	/** Await all pending persistence, primarily for orderly shutdown/tests. */
-	flush(): Promise<void> { return this.persistence.flush(); }
+	flush(): Promise<void> {
+		const batch = this.committedFactBatch;
+		if (batch) {
+			this.startCommittedFactBatch(batch);
+			return batch.promise;
+		}
+		return this.persistence.flush();
+	}
 
 	/** Flush pending persistence and release the SQLite database handle. */
 	close(): Promise<void> {
@@ -647,6 +701,55 @@ export class TaskStore {
 		this.tasks.set(task.id, task);
 		this.save([task.id]);
 		this.generation++;
+	}
+
+	/**
+	 * Publish a task mutation through the fail-loud persistence barrier, then
+	 * report its already-bounded facts. Observer failures are isolated because
+	 * the authoritative task mutation has already committed.
+	 */
+	putCommitted(task: PersistedTask, facts: readonly TaskCommittedFact[]): Promise<void> {
+		this.assertAcceptingMutations();
+		this.tasks.set(task.id, task);
+		this.generation++;
+		this.save([task.id]);
+		// Preserve the historical coalesced hot path until a host observer is
+		// installed. There is no fact to fence in legacy-only contexts.
+		if (!this.onCommittedFact || facts.length === 0) return Promise.resolve();
+
+		let batch = this.committedFactBatch;
+		if (!batch) {
+			let resolve!: () => void;
+			let reject!: (error: unknown) => void;
+			const promise = new Promise<void>((batchResolve, batchReject) => {
+				resolve = batchResolve;
+				reject = batchReject;
+			});
+			batch = { facts: [], promise, resolve, reject, started: false };
+			this.committedFactBatch = batch;
+			queueMicrotask(() => this.startCommittedFactBatch(batch!));
+		}
+		batch.facts.push(...facts);
+		return batch.promise;
+	}
+
+	private startCommittedFactBatch(batch: TaskFactBatch): void {
+		if (batch.started) return;
+		batch.started = true;
+		if (this.committedFactBatch === batch) this.committedFactBatch = null;
+		void this.persistence.flush().then(() => {
+			for (const fact of batch.facts) {
+				try {
+					this.onCommittedFact?.(Object.freeze({
+						...fact,
+						...(fact.kind === "taskUpdated" ? { changedFields: Object.freeze([...fact.changedFields]) as unknown as string[] } : {}),
+					}));
+				} catch (error) {
+					console.error(`[task-store] Committed fact observer failed for ${fact.taskId}:`, error);
+				}
+			}
+			batch.resolve();
+		}, batch.reject);
 	}
 
 	get(id: string): PersistedTask | undefined { return this.tasks.get(id); }

--- a/src/server/agent/task-store.ts
+++ b/src/server/agent/task-store.ts
@@ -86,10 +86,16 @@ interface TaskFactBatch {
 	started: boolean;
 }
 
+interface TaskPublication {
+	/** Exact task projections immediately before and after the successful durable write. */
+	previous: ReadonlyMap<string, PersistedTask>;
+	current: ReadonlyMap<string, PersistedTask>;
+}
+
 interface TaskPersistence {
 	loadInto(tasks: Map<string, PersistedTask>): void;
 	schedule(ids: Iterable<string>): void;
-	publishStrict(ids: Iterable<string>): Promise<void>;
+	publishStrict(ids: Iterable<string>): Promise<TaskPublication>;
 	flush(): Promise<void>;
 	close(): Promise<void>;
 	dispose(): void;
@@ -100,6 +106,9 @@ interface TaskPersistence {
 class JsonTaskPersistence implements TaskPersistence {
 	private readonly writer: CoalescedJsonWriter;
 	private readonly storeFile: string;
+	private durable = new Map<string, PersistedTask>();
+	private publishing: TaskPublication | null = null;
+	private lastPublication: TaskPublication = { previous: new Map(), current: new Map() };
 
 	constructor(
 		private readonly fs: FsLike,
@@ -111,8 +120,24 @@ class JsonTaskPersistence implements TaskPersistence {
 			fs,
 			stateDir,
 			this.storeFile,
-			() => JSON.stringify(Array.from(tasks.values())),
+			() => {
+				const json = JSON.stringify(Array.from(tasks.values()));
+				const current = new Map<string, PersistedTask>();
+				for (const task of JSON.parse(json) as PersistedTask[]) current.set(task.id, task);
+				this.publishing = { previous: this.durable, current };
+				return json;
+			},
 			"task-store",
+			undefined,
+			undefined,
+			() => {
+				// The writer calls onWrite for the snapshot serialized immediately above.
+				// Keep this callback non-throwing: the atomic rename is already authoritative.
+				if (!this.publishing) return;
+				this.lastPublication = this.publishing;
+				this.durable = new Map(this.publishing.current);
+				this.publishing = null;
+			},
 		);
 	}
 
@@ -127,13 +152,16 @@ class JsonTaskPersistence implements TaskPersistence {
 				canonicalizeTask(value as Record<string, unknown>);
 				tasks.set(value.id, value as PersistedTask);
 			}
+			this.durable = new Map(JSON.parse(JSON.stringify([...tasks.values()])).map((task: PersistedTask) => [task.id, task]));
 		} catch (error) {
 			console.error("[task-store] Failed to load persisted tasks:", error);
 		}
 	}
 
 	schedule(_ids: Iterable<string>): void { this.writer.schedule(); }
-	publishStrict(_ids: Iterable<string>): Promise<void> { return this.writer.publishStrict(); }
+	publishStrict(_ids: Iterable<string>): Promise<TaskPublication> {
+		return this.writer.publishStrict().then(() => this.lastPublication);
+	}
 	flush(): Promise<void> { return this.writer.flush(); }
 	async close(): Promise<void> { await this.writer.flush(); }
 	dispose(): void { /* no persistent handle */ }
@@ -221,6 +249,13 @@ function validateTask(value: unknown, label: string, expectedId?: string, valida
 	return value as unknown as PersistedTask;
 }
 
+function taskFactValuesEqual(left: unknown, right: unknown): boolean {
+	if (Array.isArray(left) && Array.isArray(right)) {
+		return left.length === right.length && left.every((value, index) => value === right[index]);
+	}
+	return left === right;
+}
+
 function serializeTaskForPublication(task: PersistedTask, dirtyId: string): string {
 	const label = `runtime task ${dirtyId}`;
 	const payload = JSON.stringify(task);
@@ -268,6 +303,8 @@ class SqliteTaskPersistence implements TaskPersistence {
 	private lastWriteMetrics: TaskWriteMetrics | null = null;
 	private closePromise: Promise<void> | null = null;
 	private closed = false;
+	private durable = new Map<string, PersistedTask>();
+	private lastPublication: TaskPublication = { previous: new Map(), current: new Map() };
 
 	constructor(
 		private readonly fs: FsLike,
@@ -468,7 +505,10 @@ class SqliteTaskPersistence implements TaskPersistence {
 	}
 
 	loadInto(tasks: Map<string, PersistedTask>): void {
-		for (const row of this.readValidatedRows()) tasks.set(row.id, row.task);
+		for (const row of this.readValidatedRows()) {
+			tasks.set(row.id, row.task);
+			this.durable.set(row.id, structuredClone(row.task));
+		}
 	}
 
 	schedule(ids: Iterable<string>): void {
@@ -494,10 +534,10 @@ class SqliteTaskPersistence implements TaskPersistence {
 		return this.requestBarrier();
 	}
 
-	publishStrict(ids: Iterable<string>): Promise<void> {
+	publishStrict(ids: Iterable<string>): Promise<TaskPublication> {
 		this.assertOpen();
 		for (const id of ids) this.dirty.add(id);
-		return this.requestBarrier();
+		return this.requestBarrier().then(() => this.lastPublication);
 	}
 
 	getLastWriteMetrics(): TaskWriteMetrics | null { return this.lastWriteMetrics; }
@@ -573,6 +613,12 @@ class SqliteTaskPersistence implements TaskPersistence {
 			const snapshots = ids.map(id => ({ id, task: this.tasks.get(id) }));
 			const startedAt = performance.now();
 			let bytes = 0;
+			const previous = new Map<string, PersistedTask>();
+			const current = new Map<string, PersistedTask>();
+			for (const { id } of snapshots) {
+				const durable = this.durable.get(id);
+				if (durable) previous.set(id, durable);
+			}
 			try {
 				if (snapshots.length > 0) {
 					const upsert = this.db.prepare(`
@@ -587,11 +633,19 @@ class SqliteTaskPersistence implements TaskPersistence {
 							continue;
 						}
 						const payload = serializeTaskForPublication(snapshot.task, snapshot.id);
+						const durableTask = JSON.parse(payload) as PersistedTask;
+						current.set(snapshot.id, durableTask);
 						bytes += Buffer.byteLength(payload);
 						upsert.run(snapshot.id, payload);
 					}
 					this.db.exec("COMMIT");
 				}
+				for (const { id } of snapshots) {
+					const durableTask = current.get(id);
+					if (durableTask) this.durable.set(id, durableTask);
+					else this.durable.delete(id);
+				}
+				this.lastPublication = { previous, current };
 				this.lastWriteMetrics = { bytes, durationMs: performance.now() - startedAt };
 				this.settlePublished(revision);
 			} catch (error) {
@@ -639,6 +693,9 @@ export class TaskStore {
 	private acceptingMutations = true;
 	private closePromise: Promise<void> | null = null;
 	private committedFactBatch: TaskFactBatch | null = null;
+	private lastFactBatchPromise: Promise<void> | null = null;
+	private factPublishTail: Promise<void> = Promise.resolve();
+	private retryCommittedFacts: TaskCommittedFact[] = [];
 
 	/** Called only after a fact's task snapshot crosses a strict persistence fence. */
 	onCommittedFact?: (fact: TaskCommittedFact) => void;
@@ -668,19 +725,41 @@ export class TaskStore {
 
 	/** Await all pending persistence, primarily for orderly shutdown/tests. */
 	flush(): Promise<void> {
-		const batch = this.committedFactBatch;
-		if (batch) {
-			this.startCommittedFactBatch(batch);
-			return batch.promise;
+		let batch = this.committedFactBatch;
+		if (!batch && this.retryCommittedFacts.length > 0) {
+			batch = this.createCommittedFactBatch();
+			this.committedFactBatch = batch;
 		}
-		return this.persistence.flush();
+		if (batch) this.startCommittedFactBatch(batch);
+		const factBarrier = this.lastFactBatchPromise;
+		return factBarrier ? factBarrier.then(() => this.persistence.flush()) : this.persistence.flush();
 	}
 
 	/** Flush pending persistence and release the SQLite database handle. */
 	close(): Promise<void> {
 		if (this.closePromise) return this.closePromise;
 		this.acceptingMutations = false;
-		this.closePromise = this.persistence.close();
+		if (!this.committedFactBatch && !this.lastFactBatchPromise && this.retryCommittedFacts.length === 0) {
+			this.closePromise = this.persistence.close();
+			return this.closePromise;
+		}
+		this.closePromise = (async () => {
+			let lastError: unknown;
+			try {
+				for (let attempt = 0; attempt < TASK_SQLITE_CLOSE_ATTEMPTS; attempt++) {
+					try {
+						await this.flush();
+						await this.persistence.close();
+						return;
+					} catch (error) {
+						lastError = error;
+					}
+				}
+				throw lastError;
+			} finally {
+				if (lastError) this.persistence.dispose();
+			}
+		})();
 		return this.closePromise;
 	}
 
@@ -712,20 +791,18 @@ export class TaskStore {
 		this.assertAcceptingMutations();
 		this.tasks.set(task.id, task);
 		this.generation++;
-		this.save([task.id]);
 		// Preserve the historical coalesced hot path until a host observer is
-		// installed. There is no fact to fence in legacy-only contexts.
-		if (!this.onCommittedFact || facts.length === 0) return Promise.resolve();
+		// installed. With facts, the serialized strict batch below owns scheduling;
+		// a separate trailing write could otherwise commit its mutable task first
+		// and consume the durable delta before the fact batch observes it.
+		if (!this.onCommittedFact || facts.length === 0) {
+			this.save([task.id]);
+			return Promise.resolve();
+		}
 
 		let batch = this.committedFactBatch;
 		if (!batch) {
-			let resolve!: () => void;
-			let reject!: (error: unknown) => void;
-			const promise = new Promise<void>((batchResolve, batchReject) => {
-				resolve = batchResolve;
-				reject = batchReject;
-			});
-			batch = { facts: [], promise, resolve, reject, started: false };
+			batch = this.createCommittedFactBatch();
 			this.committedFactBatch = batch;
 			queueMicrotask(() => this.startCommittedFactBatch(batch!));
 		}
@@ -733,12 +810,76 @@ export class TaskStore {
 		return batch.promise;
 	}
 
+	private createCommittedFactBatch(): TaskFactBatch {
+		let resolve!: () => void;
+		let reject!: (error: unknown) => void;
+		const promise = new Promise<void>((batchResolve, batchReject) => {
+			resolve = batchResolve;
+			reject = batchReject;
+		});
+		return { facts: [], promise, resolve, reject, started: false };
+	}
+
 	private startCommittedFactBatch(batch: TaskFactBatch): void {
 		if (batch.started) return;
 		batch.started = true;
 		if (this.committedFactBatch === batch) this.committedFactBatch = null;
-		void this.persistence.flush().then(() => {
-			for (const fact of batch.facts) {
+
+		const publish = this.factPublishTail.then(async () => {
+			const intents = [...this.retryCommittedFacts, ...batch.facts];
+			this.retryCommittedFacts = [];
+			const ids = [...new Set(intents.map(fact => fact.taskId))];
+			try {
+				const publication = await this.persistence.publishStrict(ids);
+				this.reportCommittedTaskDeltas(intents, publication);
+			} catch (error) {
+				this.retryCommittedFacts = [...intents, ...this.retryCommittedFacts];
+				throw error;
+			}
+		});
+		this.factPublishTail = publish.catch(() => undefined);
+		this.lastFactBatchPromise = batch.promise;
+		void publish.then(batch.resolve, batch.reject).finally(() => {
+			if (this.lastFactBatchPromise === batch.promise) this.lastFactBatchPromise = null;
+		});
+	}
+
+	private reportCommittedTaskDeltas(intents: readonly TaskCommittedFact[], publication: TaskPublication): void {
+		const orderedIds = [...new Set(intents.map(fact => fact.taskId))];
+		for (const taskId of orderedIds) {
+			const taskIntents = intents.filter(fact => fact.taskId === taskId);
+			const previous = publication.previous.get(taskId);
+			const current = publication.current.get(taskId);
+			if (!current) continue;
+
+			const facts: TaskCommittedFact[] = [];
+			if (!previous) {
+				facts.push({
+					kind: "taskCreated", taskId, goalId: current.goalId, type: current.type,
+					state: current.state, parentTaskId: current.parentTaskId, revision: current.updatedAt,
+				});
+			} else {
+				const updateIntents = taskIntents.filter((fact): fact is Extract<TaskCommittedFact, { kind: "taskUpdated" }> => fact.kind === "taskUpdated");
+				if (updateIntents.length > 0) {
+					const candidates = [...new Set(updateIntents.flatMap(fact => fact.changedFields))];
+					const changedFields = candidates.filter(field => !taskFactValuesEqual(
+						(previous as unknown as Record<string, unknown>)[field],
+						(current as unknown as Record<string, unknown>)[field],
+					)).sort();
+					facts.push({
+						kind: "taskUpdated", taskId, goalId: current.goalId, state: current.state,
+						changedFields, revision: current.updatedAt,
+					});
+				}
+				if (taskIntents.some(fact => fact.kind === "taskStateChanged") && previous.state !== current.state) {
+					facts.push({
+						kind: "taskStateChanged", taskId, goalId: current.goalId,
+						previousState: previous.state, state: current.state, revision: current.updatedAt,
+					});
+				}
+			}
+
+			for (const fact of facts) {
 				try {
 					this.onCommittedFact?.(Object.freeze({
 						...fact,
@@ -748,8 +889,7 @@ export class TaskStore {
 					console.error(`[task-store] Committed fact observer failed for ${fact.taskId}:`, error);
 				}
 			}
-			batch.resolve();
-		}, batch.reject);
+		}
 	}
 
 	get(id: string): PersistedTask | undefined { return this.tasks.get(id); }

--- a/src/server/agent/tool-result-error-bridge-extension.ts
+++ b/src/server/agent/tool-result-error-bridge-extension.ts
@@ -20,10 +20,10 @@ export function generateToolResultErrorBridgeExtension(): string {
 	return `// The client deadline must leave enough margin for the host router's 2s
 // protected-operation deadline to settle and serialize its decision.
 const HOST_HOOK_TIMEOUT_MS = 2500;
-const HOST_PROTECTED_FAILURE = Object.freeze({ action: "syntheticError", code: "handler_error" });
+const HOST_PROTECTED_TOOL_CALL_FAILURE = Object.freeze({ action: "block", reasonCode: "not_permitted" });
+const HOST_PROTECTED_RESULT_FAILURE = Object.freeze({ action: "syntheticError", code: "handler_error" });
 
-async function postHostHook(route, body, protectedResult = false) {
-  const fallback = protectedResult ? HOST_PROTECTED_FAILURE : undefined;
+async function postHostHook(route, body, fallback) {
   if (process.env.BOBBIT_HOST_HOOKS_ENABLED !== "1") return fallback;
   const gatewayUrl = process.env.BOBBIT_GATEWAY_URL;
   const sessionId = process.env.BOBBIT_SESSION_ID;
@@ -172,13 +172,16 @@ function wrapHandler(handler, toolName) {
   async function bobbitToolResultErrorBridgeHandler(...args) {
     const toolCallId = typeof args[0] === "string" ? args[0] : "unknown";
     const originalArgs = isObject(args[1]) ? args[1] : {};
+    const beforeFallback = process.env.BOBBIT_HOST_BEFORE_TOOL_CALL_FAIL_CLOSED === "1"
+      ? HOST_PROTECTED_TOOL_CALL_FAILURE
+      : undefined;
     const before = beforeDecision(await postHostHook("/host-hooks/before-tool-call", {
       toolCallId,
       toolName,
       args: originalArgs,
-    }), originalArgs);
+    }, beforeFallback), originalArgs);
     if (before.block) {
-      const denied = hostSyntheticError("policy_denied");
+      const denied = hostSyntheticError("not_permitted");
       const err = new Error(messageFromToolResult(denied));
       err.name = "BobbitToolPolicyError";
       err.isError = true;
@@ -197,7 +200,7 @@ function wrapHandler(handler, toolName) {
         toolCallId,
         toolName,
         result: { isError: true },
-      }, true);
+      }, HOST_PROTECTED_RESULT_FAILURE);
       const replacement = afterDecision(afterThrown, undefined);
       if (replacement !== undefined) {
         result = replacement;
@@ -210,7 +213,7 @@ function wrapHandler(handler, toolName) {
         toolCallId,
         toolName,
         result,
-      }, true), result);
+      }, HOST_PROTECTED_RESULT_FAILURE), result);
     }
     if (isErroredToolResult(result)) {
       const err = new Error(messageFromToolResult(result));

--- a/src/server/agent/tool-result-error-bridge-extension.ts
+++ b/src/server/agent/tool-result-error-bridge-extension.ts
@@ -17,7 +17,36 @@ import { bobbitStateDir } from "../bobbit-dir.js";
  * rejected property instead of reporting only a root additional-property error.
  */
 export function generateToolResultErrorBridgeExtension(): string {
-	return `function isObject(value) {
+	return `const HOST_HOOK_TIMEOUT_MS = 2000;
+
+async function postHostHook(route, body) {
+  if (process.env.BOBBIT_HOST_HOOKS_ENABLED !== "1") return undefined;
+  const gatewayUrl = process.env.BOBBIT_GATEWAY_URL;
+  const sessionId = process.env.BOBBIT_SESSION_ID;
+  const token = process.env.BOBBIT_TOKEN;
+  if (!gatewayUrl || !sessionId || typeof globalThis.fetch !== "function") return undefined;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), HOST_HOOK_TIMEOUT_MS);
+  try {
+    const response = await globalThis.fetch(gatewayUrl + "/api/sessions/" + sessionId + route, {
+      method: "POST",
+      headers: {
+        ...(token ? { "Authorization": "Bearer " + token } : {}),
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(body),
+      signal: controller.signal,
+    });
+    if (!response.ok) return undefined;
+    return await response.json();
+  } catch {
+    return undefined;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function isObject(value) {
   return !!value && typeof value === "object";
 }
 
@@ -106,10 +135,75 @@ function messageFromToolResult(result) {
   try { return JSON.stringify(result); } catch { return "Tool returned an errored result."; }
 }
 
-function wrapHandler(handler) {
+function hostSyntheticError(code) {
+  return {
+    content: [{ type: "text", text: "Tool result was rejected by host policy (" + code + ")." }],
+    isError: true,
+  };
+}
+
+function beforeDecision(response, originalArgs) {
+  const decision = response && (response.decision || response.result?.decision);
+  if (response?.block === true || decision === "block") return { block: true };
+  const replacement = response?.args ?? response?.result?.args ?? response?.value?.args;
+  return { block: false, args: isObject(replacement) ? replacement : originalArgs };
+}
+
+function afterDecision(response, originalResult) {
+  const decision = response && (response.decision || response.result?.decision);
+  if (decision === "syntheticError" || response?.syntheticError === true) {
+    const code = typeof response?.code === "string" ? response.code : "policy_denied";
+    return hostSyntheticError(code);
+  }
+  const replacement = response?.replacement ?? response?.result?.result ?? response?.value?.result;
+  return replacement === undefined ? originalResult : replacement;
+}
+
+function wrapHandler(handler, toolName) {
   if (typeof handler !== "function" || handler.__bobbitErrorBridgeWrapped) return handler;
   async function bobbitToolResultErrorBridgeHandler(...args) {
-    const result = await handler.apply(this, args);
+    const toolCallId = typeof args[0] === "string" ? args[0] : "unknown";
+    const originalArgs = isObject(args[1]) ? args[1] : {};
+    const before = beforeDecision(await postHostHook("/host-hooks/before-tool-call", {
+      toolCallId,
+      toolName,
+      args: originalArgs,
+    }), originalArgs);
+    if (before.block) {
+      const denied = hostSyntheticError("policy_denied");
+      const err = new Error(messageFromToolResult(denied));
+      err.name = "BobbitToolPolicyError";
+      err.isError = true;
+      err.is_error = true;
+      err.bobbitToolResult = denied;
+      throw err;
+    }
+    if (args.length > 1) args[1] = before.args;
+
+    let result;
+    let afterAlreadyApplied = false;
+    try {
+      result = await handler.apply(this, args);
+    } catch (error) {
+      const afterThrown = await postHostHook("/host-hooks/after-tool-result", {
+        toolCallId,
+        toolName,
+        result: { isError: true },
+      });
+      const replacement = afterDecision(afterThrown, undefined);
+      if (replacement !== undefined) {
+        result = replacement;
+        afterAlreadyApplied = true;
+      } else throw error;
+    }
+
+    if (!afterAlreadyApplied) {
+      result = afterDecision(await postHostHook("/host-hooks/after-tool-result", {
+        toolCallId,
+        toolName,
+        result,
+      }), result);
+    }
     if (isErroredToolResult(result)) {
       const err = new Error(messageFromToolResult(result));
       err.name = "BobbitToolResultError";
@@ -127,26 +221,28 @@ function wrapHandler(handler) {
 function wrapRegistrationArgs(args) {
   const next = Array.from(args);
   if (typeof next[0] === "string") {
+    const toolName = next[0];
     if (isObject(next[1])) {
       const spec = { ...next[1] };
       installUnknownFieldRefinements(spec.parameters);
-      if (typeof spec.handler === "function") spec.handler = wrapHandler(spec.handler);
-      if (typeof spec.execute === "function") spec.execute = wrapHandler(spec.execute);
+      if (typeof spec.handler === "function") spec.handler = wrapHandler(spec.handler, toolName);
+      if (typeof spec.execute === "function") spec.execute = wrapHandler(spec.execute, toolName);
       next[1] = spec;
     } else if (typeof next[1] === "function") {
-      next[1] = wrapHandler(next[1]);
+      next[1] = wrapHandler(next[1], toolName);
     }
-    if (typeof next[2] === "function") next[2] = wrapHandler(next[2]);
+    if (typeof next[2] === "function") next[2] = wrapHandler(next[2], toolName);
     return next;
   }
   if (isObject(next[0])) {
     const spec = { ...next[0] };
+    const toolName = typeof spec.name === "string" ? spec.name : "unknown";
     installUnknownFieldRefinements(spec.parameters);
     if (typeof next[1] === "function") {
-      next[1] = wrapHandler(next[1]);
+      next[1] = wrapHandler(next[1], toolName);
     } else {
-      if (typeof spec.handler === "function") spec.handler = wrapHandler(spec.handler);
-      if (typeof spec.execute === "function") spec.execute = wrapHandler(spec.execute);
+      if (typeof spec.handler === "function") spec.handler = wrapHandler(spec.handler, toolName);
+      if (typeof spec.execute === "function") spec.execute = wrapHandler(spec.execute, toolName);
     }
     next[0] = spec;
   }

--- a/src/server/agent/tool-result-error-bridge-extension.ts
+++ b/src/server/agent/tool-result-error-bridge-extension.ts
@@ -157,12 +157,16 @@ function beforeDecision(response, originalArgs) {
   return { block: false, args: isObject(replacement) ? replacement : originalArgs };
 }
 
-function afterDecision(response, originalResult) {
+function syntheticErrorDecision(response) {
   const decision = response && (response.action || response.decision || response.result?.decision);
-  if (decision === "syntheticError" || response?.syntheticError === true) {
-    const code = typeof response?.code === "string" ? response.code : "handler_error";
-    return hostSyntheticError(code);
-  }
+  if (decision !== "syntheticError" && response?.syntheticError !== true) return undefined;
+  const code = typeof response?.code === "string" ? response.code : "handler_error";
+  return hostSyntheticError(code);
+}
+
+function afterDecision(response, originalResult) {
+  const synthetic = syntheticErrorDecision(response);
+  if (synthetic !== undefined) return synthetic;
   const replacement = response?.result ?? response?.replacement ?? response?.value?.result;
   return replacement === undefined ? originalResult : replacement;
 }
@@ -191,6 +195,9 @@ function wrapHandler(handler, toolName) {
     }
     if (args.length > 1) args[1] = before.args;
 
+    const afterFallback = process.env.BOBBIT_HOST_AFTER_TOOL_RESULT_FAIL_CLOSED === "1"
+      ? HOST_PROTECTED_RESULT_FAILURE
+      : undefined;
     let result;
     let afterAlreadyApplied = false;
     try {
@@ -200,12 +207,15 @@ function wrapHandler(handler, toolName) {
         toolCallId,
         toolName,
         result: { isError: true },
-      }, HOST_PROTECTED_RESULT_FAILURE);
-      const replacement = afterDecision(afterThrown, undefined);
-      if (replacement !== undefined) {
-        result = replacement;
-        afterAlreadyApplied = true;
-      } else throw error;
+      }, afterFallback);
+      // The host sees only the bounded failure flag. An allow/replace response
+      // cannot safely replace a result body that the host deliberately never
+      // received, so preserve the exact original exception unless policy made
+      // this operation terminal.
+      const synthetic = syntheticErrorDecision(afterThrown);
+      if (synthetic === undefined) throw error;
+      result = synthetic;
+      afterAlreadyApplied = true;
     }
 
     if (!afterAlreadyApplied) {
@@ -213,7 +223,7 @@ function wrapHandler(handler, toolName) {
         toolCallId,
         toolName,
         result,
-      }, HOST_PROTECTED_RESULT_FAILURE), result);
+      }, afterFallback), result);
     }
     if (isErroredToolResult(result)) {
       const err = new Error(messageFromToolResult(result));

--- a/src/server/agent/tool-result-error-bridge-extension.ts
+++ b/src/server/agent/tool-result-error-bridge-extension.ts
@@ -17,30 +17,38 @@ import { bobbitStateDir } from "../bobbit-dir.js";
  * rejected property instead of reporting only a root additional-property error.
  */
 export function generateToolResultErrorBridgeExtension(): string {
-	return `const HOST_HOOK_TIMEOUT_MS = 2000;
+	return `// The client deadline must leave enough margin for the host router's 2s
+// protected-operation deadline to settle and serialize its decision.
+const HOST_HOOK_TIMEOUT_MS = 2500;
+const HOST_PROTECTED_FAILURE = Object.freeze({ action: "syntheticError", code: "handler_error" });
 
-async function postHostHook(route, body) {
-  if (process.env.BOBBIT_HOST_HOOKS_ENABLED !== "1") return undefined;
+async function postHostHook(route, body, protectedResult = false) {
+  const fallback = protectedResult ? HOST_PROTECTED_FAILURE : undefined;
+  if (process.env.BOBBIT_HOST_HOOKS_ENABLED !== "1") return fallback;
   const gatewayUrl = process.env.BOBBIT_GATEWAY_URL;
   const sessionId = process.env.BOBBIT_SESSION_ID;
   const token = process.env.BOBBIT_TOKEN;
-  if (!gatewayUrl || !sessionId || typeof globalThis.fetch !== "function") return undefined;
+  const sessionSecret = process.env.BOBBIT_SESSION_SECRET;
+  if (!gatewayUrl || !sessionId || typeof globalThis.fetch !== "function") return fallback;
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), HOST_HOOK_TIMEOUT_MS);
   try {
-    const response = await globalThis.fetch(gatewayUrl + "/api/sessions/" + sessionId + route, {
+    const response = await globalThis.fetch(gatewayUrl + "/api/sessions/" + encodeURIComponent(sessionId) + route, {
       method: "POST",
       headers: {
         ...(token ? { "Authorization": "Bearer " + token } : {}),
+        ...(sessionSecret ? { "X-Bobbit-Session-Secret": sessionSecret } : {}),
         "Content-Type": "application/json",
       },
       body: JSON.stringify(body),
       signal: controller.signal,
     });
-    if (!response.ok) return undefined;
-    return await response.json();
+    if (!response.ok) return fallback;
+    const decision = await response.json();
+    if (!isObject(decision) || (typeof decision.action !== "string" && typeof decision.decision !== "string")) return fallback;
+    return decision;
   } catch {
-    return undefined;
+    return fallback;
   } finally {
     clearTimeout(timer);
   }
@@ -143,19 +151,19 @@ function hostSyntheticError(code) {
 }
 
 function beforeDecision(response, originalArgs) {
-  const decision = response && (response.decision || response.result?.decision);
+  const decision = response && (response.action || response.decision || response.result?.decision);
   if (response?.block === true || decision === "block") return { block: true };
   const replacement = response?.args ?? response?.result?.args ?? response?.value?.args;
   return { block: false, args: isObject(replacement) ? replacement : originalArgs };
 }
 
 function afterDecision(response, originalResult) {
-  const decision = response && (response.decision || response.result?.decision);
+  const decision = response && (response.action || response.decision || response.result?.decision);
   if (decision === "syntheticError" || response?.syntheticError === true) {
-    const code = typeof response?.code === "string" ? response.code : "policy_denied";
+    const code = typeof response?.code === "string" ? response.code : "handler_error";
     return hostSyntheticError(code);
   }
-  const replacement = response?.replacement ?? response?.result?.result ?? response?.value?.result;
+  const replacement = response?.result ?? response?.replacement ?? response?.value?.result;
   return replacement === undefined ? originalResult : replacement;
 }
 
@@ -189,7 +197,7 @@ function wrapHandler(handler, toolName) {
         toolCallId,
         toolName,
         result: { isError: true },
-      });
+      }, true);
       const replacement = afterDecision(afterThrown, undefined);
       if (replacement !== undefined) {
         result = replacement;
@@ -202,7 +210,7 @@ function wrapHandler(handler, toolName) {
         toolCallId,
         toolName,
         result,
-      }), result);
+      }, true), result);
     }
     if (isErroredToolResult(result)) {
       const err = new Error(messageFromToolResult(result));

--- a/src/server/auth/sandbox-guard.ts
+++ b/src/server/auth/sandbox-guard.ts
@@ -17,6 +17,9 @@ function isOwnSessionToolEndpoint(subpath: string, method: string): boolean {
 	if (method === "GET" && subpath === "/google-code-assist/token") return true;
 	if (method === "POST" && subpath === "/tool-grant-request") return true;
 	if (method === "POST" && subpath === "/activate-skill") return true;
+	// Pi's generated bridge may reach only these exact operation callbacks. The
+	// route still requires the owning session secret before accepting any body.
+	if (method === "POST" && (subpath === "/host-hooks/before-tool-call" || subpath === "/host-hooks/after-tool-result")) return true;
 	// Sandboxed agents may upload their own tool output with the owning session
 	// secret, but payload reads and workspace opens are browser/admin surfaces.
 	if (method === "POST" && subpath === "/review-payloads") return true;

--- a/src/server/extension-host/host-hook-contributions.ts
+++ b/src/server/extension-host/host-hook-contributions.ts
@@ -1,0 +1,143 @@
+import type {
+	HookCapability,
+	HookFailurePolicy,
+	HookNotificationSelector,
+	InterceptorHookContribution,
+	NotificationHookContribution,
+	ProviderContribution,
+} from "../agent/pack-contributions.js";
+import type { LifecycleHook } from "../agent/lifecycle-hub.js";
+import type { PackContributionRegistry } from "./pack-contribution-registry.js";
+import type { HostInterceptorName } from "../../shared/extension-host/host-hooks.js";
+
+const LEGACY_INTERCEPTORS: ReadonlySet<string> = new Set([
+	"sessionSetup",
+	"beforePrompt",
+	"beforeCompact",
+	"sessionShutdown",
+]);
+
+interface NormalizedContributionBase {
+	readonly packId: string;
+	readonly contributionId: string;
+	readonly listName: string;
+	readonly module: string;
+	readonly sourceFile: string;
+	readonly packRoot: string;
+	readonly config: Readonly<Record<string, unknown>>;
+	readonly budget: Readonly<{ maxTokens: number; timeoutMs: number; declaredTimeoutMs?: number }>;
+	readonly capabilities: readonly HookCapability[];
+	readonly activationEpoch: number;
+	readonly order: number;
+}
+
+export interface NormalizedInterceptorContribution extends NormalizedContributionBase {
+	readonly kind: "interceptor";
+	readonly name: HostInterceptorName;
+	readonly failurePolicy?: HookFailurePolicy;
+	readonly declaration: InterceptorHookContribution;
+}
+
+export interface NormalizedNotificationContribution extends NormalizedContributionBase {
+	readonly kind: "notification";
+	readonly selector: HookNotificationSelector;
+	readonly declaration: NotificationHookContribution;
+}
+
+export interface NormalizedLegacyProviderContribution extends NormalizedContributionBase {
+	readonly kind: "legacy-provider";
+	readonly name: Extract<LifecycleHook, "sessionSetup" | "beforePrompt" | "beforeCompact" | "sessionShutdown">;
+	readonly providerId: string;
+	readonly declaration: ProviderContribution;
+}
+
+export type RuntimeHookContribution =
+	| NormalizedInterceptorContribution
+	| NormalizedNotificationContribution
+	| NormalizedLegacyProviderContribution;
+
+type HookRegistryView = Pick<PackContributionRegistry, "list" | "listHooks" | "listProviders"> & {
+	getActivationEpoch?: () => number;
+};
+
+/**
+ * Normalize active declarations without importing pack code. Ordering is the
+ * registry's winning-pack low-to-high order, then providers before explicit hook
+ * files within each pack, then each declaration's own name order.
+ */
+export function normalizeHookContributions(
+	registry: HookRegistryView,
+	projectId: string | undefined,
+): readonly RuntimeHookContribution[] {
+	const epoch = registry.getActivationEpoch?.() ?? 0;
+	const rows: RuntimeHookContribution[] = [];
+	let order = 0;
+	for (const pack of registry.list(projectId)) {
+		for (const provider of pack.providers) {
+			for (const candidate of provider.hooks) {
+				if (!LEGACY_INTERCEPTORS.has(candidate)) continue;
+				rows.push({
+					kind: "legacy-provider",
+					name: candidate as NormalizedLegacyProviderContribution["name"],
+					packId: pack.packId,
+					contributionId: provider.id,
+					providerId: provider.id,
+					listName: provider.listName,
+					module: provider.module,
+					sourceFile: provider.sourceFile,
+					packRoot: provider.packRoot,
+					config: provider.config ?? {},
+					budget: provider.budget,
+					capabilities: ["store"],
+					activationEpoch: epoch,
+					order: order++,
+					declaration: provider,
+				});
+			}
+		}
+		for (const declaration of pack.hooks) {
+			if (declaration.kind === "interceptor") {
+				for (const name of declaration.interceptors) {
+					rows.push({
+						kind: "interceptor",
+						name,
+						packId: pack.packId,
+						contributionId: declaration.id,
+						listName: declaration.listName,
+						module: declaration.module,
+						sourceFile: declaration.sourceFile,
+						packRoot: declaration.packRoot,
+						config: declaration.config ?? {},
+						budget: declaration.budget,
+						capabilities: declaration.capabilities,
+						activationEpoch: epoch,
+						order: order++,
+						failurePolicy: declaration.failurePolicy,
+						declaration,
+					});
+				}
+			} else if (declaration.kind === "notification") {
+				for (const selector of declaration.notifications) {
+					rows.push({
+						kind: "notification",
+						selector,
+						packId: pack.packId,
+						contributionId: declaration.id,
+						listName: declaration.listName,
+						module: declaration.module,
+						sourceFile: declaration.sourceFile,
+						packRoot: declaration.packRoot,
+						config: declaration.config ?? {},
+						budget: declaration.budget,
+						capabilities: declaration.capabilities,
+						activationEpoch: epoch,
+						order: order++,
+						declaration,
+					});
+				}
+			}
+			// No `kind` means compatibility metadata: intentionally inert.
+		}
+	}
+	return Object.freeze(rows);
+}

--- a/src/server/extension-host/host-interceptor-audit.ts
+++ b/src/server/extension-host/host-interceptor-audit.ts
@@ -1,0 +1,28 @@
+import type { HostInterceptorAuditDecision } from "./host-interceptor-router.js";
+
+/**
+ * Best-effort production diagnostic for the router's authoritative final
+ * decision. Re-project the existing payload-free contract so an accidental
+ * extra property on a caller-owned object can never enter the diagnostic.
+ */
+export function hostInterceptorAuditSink(decision: HostInterceptorAuditDecision): void {
+	try {
+		console.log("[host-interceptor-audit] %s", JSON.stringify({
+			occurredAt: decision.occurredAt,
+			hook: decision.hook,
+			...(decision.projectId === undefined ? {} : { projectId: decision.projectId }),
+			...(decision.sessionId === undefined ? {} : { sessionId: decision.sessionId }),
+			packId: decision.packId,
+			contributionId: decision.contributionId,
+			durationMs: decision.durationMs,
+			outcome: decision.outcome,
+			proposalReceived: decision.proposalReceived,
+			valid: decision.valid,
+			applied: decision.applied,
+			timedOut: decision.timedOut,
+			cancelled: decision.cancelled,
+		} satisfies HostInterceptorAuditDecision));
+	} catch {
+		// Diagnostics cannot affect interceptor authority or source operations.
+	}
+}

--- a/src/server/extension-host/host-interceptor-router.ts
+++ b/src/server/extension-host/host-interceptor-router.ts
@@ -77,9 +77,9 @@ export interface HostInterceptorRouterOptions {
 		contributionId: string;
 		capabilities: readonly string[];
 	}>) => ServerHostApi | undefined;
-	/** Live parent-owned grant lookup. Omitted means declarations are already
-	 * grant-filtered by the registry. */
-	readonly isCapabilityGranted?: (input: Readonly<{
+	/** Live parent-owned capability authorization. Omitted means the registry
+	 * has already authorized every declared capability. */
+	readonly isCapabilityAuthorized?: (input: Readonly<{
 		projectId?: string;
 		packId: string;
 		contributionId: string;
@@ -112,7 +112,7 @@ export class HostInterceptorRouter {
 			if (contribution.kind !== "interceptor" || contribution.name !== name) return false;
 			const policy = contribution.failurePolicy ?? definition.defaultFailurePolicy;
 			return policy === "failClosed"
-				&& this.isAuthorized(contribution, projectId, definition.requiredGrants);
+				&& this.isAuthorized(contribution, projectId, definition.requiredCapabilities);
 		});
 	}
 
@@ -157,8 +157,8 @@ export class HostInterceptorRouter {
 					if (failed !== undefined) terminal = failed as HostInterceptorResult<N>;
 					break;
 				}
-				const requiredGrants = contribution.kind === "interceptor" ? definition.requiredGrants : [];
-				if (!this.isAuthorized(contribution, context.projectId, requiredGrants)) {
+				const requiredCapabilities = contribution.kind === "interceptor" ? definition.requiredCapabilities : [];
+				if (!this.isAuthorized(contribution, context.projectId, requiredCapabilities)) {
 					this.record(decisions, contribution, name, context, started, "inactive", false, false, false);
 					continue;
 				}
@@ -183,7 +183,7 @@ export class HostInterceptorRouter {
 					}
 					// Authority is deliberately checked again after worker settlement and
 					// immediately before application.
-					if (!this.isAuthorized(contribution, context.projectId, requiredGrants) || dispatchController.signal.aborted) {
+					if (!this.isAuthorized(contribution, context.projectId, requiredCapabilities) || dispatchController.signal.aborted) {
 						this.record(decisions, contribution, name, context, started, "cancelled", true, true, false, false, true);
 						continue;
 					}
@@ -218,13 +218,13 @@ export class HostInterceptorRouter {
 	private isAuthorized(
 		contribution: NormalizedInterceptorContribution | NormalizedLegacyProviderContribution,
 		projectId: string | undefined,
-		requiredGrants: readonly string[],
+		requiredCapabilities: readonly string[],
 	): boolean {
 		const registryAuthorized = contribution.kind === "legacy-provider"
 			? this.options.registry.isProviderAuthorized(projectId, contribution.packId, contribution.providerId, contribution.listName, contribution.activationEpoch)
-			: this.options.registry.isHookAuthorized(projectId, contribution.packId, contribution.contributionId, contribution.listName, contribution.activationEpoch, requiredGrants);
+			: this.options.registry.isHookAuthorized(projectId, contribution.packId, contribution.contributionId, contribution.listName, contribution.activationEpoch, requiredCapabilities);
 		if (!registryAuthorized) return false;
-		return contribution.capabilities.every((capability) => this.options.isCapabilityGranted?.({
+		return contribution.capabilities.every((capability) => this.options.isCapabilityAuthorized?.({
 			projectId,
 			packId: contribution.packId,
 			contributionId: contribution.contributionId,

--- a/src/server/extension-host/host-interceptor-router.ts
+++ b/src/server/extension-host/host-interceptor-router.ts
@@ -1,0 +1,412 @@
+import path from "node:path";
+import { performance } from "node:perf_hooks";
+import { pathToFileURL } from "node:url";
+import { ActionError } from "./action-dispatcher.js";
+import type { ServerHostApi } from "./server-host-api.js";
+import { ModuleHost, type InvokeRequest } from "./module-host-worker.js";
+import { PackContributionRegistry } from "./pack-contribution-registry.js";
+import { LifecycleHub, type HookDispatchBase, type LifecycleHook } from "../agent/lifecycle-hub.js";
+import {
+	normalizeHookContributions,
+	type NormalizedInterceptorContribution,
+	type NormalizedLegacyProviderContribution,
+	type RuntimeHookContribution,
+} from "./host-hook-contributions.js";
+import {
+	deepFreezeHostValue,
+	HOST_HOOK_LIMITS,
+	HOST_INTERCEPTOR_CATALOGUE,
+	validateInterceptorRequest,
+	validateInterceptorResult,
+	type HostInterceptorName,
+	type HostInterceptorRequest,
+	type HostInterceptorResult,
+} from "../../shared/extension-host/host-hooks.js";
+
+export interface HostInterceptorContext {
+	readonly projectId?: string;
+	readonly sessionId?: string;
+	readonly goalId?: string;
+	readonly cwd: string;
+	readonly correlationId?: string;
+	readonly signal: AbortSignal;
+}
+
+export type HostInterceptorAuditOutcome =
+	| "applied"
+	| "inactive"
+	| "invalid-result"
+	| "timed-out"
+	| "cancelled"
+	| "failed-open"
+	| "failed-closed";
+
+/** Payload-free and path-free by construction. */
+export interface HostInterceptorAuditDecision {
+	readonly occurredAt: number;
+	readonly hook: HostInterceptorName;
+	readonly projectId?: string;
+	readonly sessionId?: string;
+	readonly packId: string;
+	readonly contributionId: string;
+	readonly durationMs: number;
+	readonly outcome: HostInterceptorAuditOutcome;
+	readonly proposalReceived: boolean;
+	readonly valid: boolean;
+	readonly applied: boolean;
+	readonly timedOut: boolean;
+	readonly cancelled: boolean;
+}
+
+export interface HostInterceptorDispatchResult<N extends HostInterceptorName> {
+	readonly value: HostInterceptorRequest<N>;
+	readonly decisions: readonly HostInterceptorAuditDecision[];
+	/** A terminal block/synthetic-error decision, when the operation has one. */
+	readonly terminal?: HostInterceptorResult<N>;
+}
+
+type RuntimeInterceptorDefinition = (typeof HOST_INTERCEPTOR_CATALOGUE)[HostInterceptorName];
+
+export interface HostInterceptorRouterOptions {
+	readonly registry: PackContributionRegistry;
+	readonly moduleHost: ModuleHost;
+	readonly lifecycleHub?: LifecycleHub;
+	readonly createHostApi?: (input: Readonly<{
+		context: HostInterceptorContext;
+		packId: string;
+		contributionId: string;
+		capabilities: readonly string[];
+	}>) => ServerHostApi | undefined;
+	/** Live parent-owned grant lookup. Omitted means declarations are already
+	 * grant-filtered by the registry. */
+	readonly isCapabilityGranted?: (input: Readonly<{
+		projectId?: string;
+		packId: string;
+		contributionId: string;
+		capability: string;
+	}>) => boolean;
+	readonly validateToolArgs?: (toolName: string, args: unknown) => boolean;
+	readonly validateToolResult?: (toolName: string, result: unknown) => boolean;
+	readonly audit?: (decision: HostInterceptorAuditDecision) => void;
+	readonly now?: () => number;
+	readonly monotonicNow?: () => number;
+}
+
+/** Typed, sequential pre-authority extension router. It owns no durable state. */
+export class HostInterceptorRouter {
+	private readonly now: () => number;
+	private readonly monotonicNow: () => number;
+
+	constructor(private readonly options: HostInterceptorRouterOptions) {
+		this.now = options.now ?? Date.now;
+		this.monotonicNow = options.monotonicNow ?? performance.now.bind(performance);
+	}
+
+	async dispatch<N extends HostInterceptorName>(
+		name: N,
+		input: HostInterceptorRequest<N>,
+		context: HostInterceptorContext,
+	): Promise<HostInterceptorDispatchResult<N>> {
+		if (!validateInterceptorRequest(name, input)) throw new TypeError(`invalid ${name} interceptor request`);
+		const definition = HOST_INTERCEPTOR_CATALOGUE[name] as RuntimeInterceptorDefinition;
+		const dispatchLimit = definition.dispatchDeadlineMs;
+		const dispatchStarted = this.monotonicNow();
+		const deadline = dispatchStarted + dispatchLimit;
+		const dispatchController = new AbortController();
+		const forwardAbort = (): void => dispatchController.abort(context.signal.reason);
+		context.signal.addEventListener("abort", forwardAbort, { once: true });
+		const stopInvalidation = this.options.registry.onInvalidate(() => dispatchController.abort("registry-invalidated"));
+		const deadlineTimer = setTimeout(() => dispatchController.abort("dispatch-deadline"), dispatchLimit);
+		const decisions: HostInterceptorAuditDecision[] = [];
+		let value = clone(input);
+		let terminal: HostInterceptorResult<N> | undefined;
+		try {
+			const contributions = normalizeHookContributions(this.options.registry, context.projectId)
+				.filter((row): row is NormalizedInterceptorContribution | NormalizedLegacyProviderContribution =>
+					(row.kind === "interceptor" || row.kind === "legacy-provider") && row.name === name,
+				);
+			for (const contribution of contributions) {
+				if (terminal !== undefined) break;
+				const started = this.monotonicNow();
+				if (dispatchController.signal.aborted) {
+					if (dispatchController.signal.reason === "dispatch-deadline") {
+						const failed = this.failClosedResult(name, contribution, definition);
+						this.record(decisions, contribution, name, context, started, failed === undefined ? "timed-out" : "failed-closed", false, false, false, true);
+						if (failed !== undefined) terminal = failed as HostInterceptorResult<N>;
+					}
+					break;
+				}
+				const remaining = Math.floor(deadline - this.monotonicNow());
+				if (remaining <= 0) {
+					const failed = this.failClosedResult(name, contribution, definition);
+					this.record(decisions, contribution, name, context, started, failed === undefined ? "timed-out" : "failed-closed", false, false, false, true);
+					if (failed !== undefined) terminal = failed as HostInterceptorResult<N>;
+					break;
+				}
+				const requiredGrants = contribution.kind === "interceptor" ? definition.requiredGrants : [];
+				if (!this.isAuthorized(contribution, context.projectId, requiredGrants)) {
+					this.record(decisions, contribution, name, context, started, "inactive", false, false, false);
+					continue;
+				}
+				const cap = definition.maxTimeoutMs;
+				const declared = contribution.kind === "legacy-provider"
+					? contribution.budget.timeoutMs
+					: contribution.budget.declaredTimeoutMs ?? definition.defaultTimeoutMs;
+				const timeoutMs = Math.max(1, Math.min(remaining, declared, cap));
+				let proposalReceived = false;
+				let valid = false;
+				try {
+					const proposal = contribution.kind === "legacy-provider"
+						? await this.invokeLegacy(name, value, context, contribution, timeoutMs, dispatchController.signal)
+						: await this.invokeExplicit(name, value, context, contribution, timeoutMs, dispatchController.signal);
+					proposalReceived = true;
+					valid = validateInterceptorResult(name, proposal) && this.validateOperationMutation(name, value, proposal);
+					if (!valid) {
+						const failed = this.failClosedResult(name, contribution, definition);
+						this.record(decisions, contribution, name, context, started, failed === undefined ? "invalid-result" : "failed-closed", true, false, false);
+						if (failed !== undefined) terminal = failed as HostInterceptorResult<N>;
+						continue;
+					}
+					// Authority is deliberately checked again after worker settlement and
+					// immediately before application.
+					if (!this.isAuthorized(contribution, context.projectId, requiredGrants) || dispatchController.signal.aborted) {
+						this.record(decisions, contribution, name, context, started, "cancelled", true, true, false, false, true);
+						continue;
+					}
+					const folded = foldResult(name, value, proposal as HostInterceptorResult<N>);
+					value = folded.value;
+					if (folded.terminal !== undefined) terminal = folded.terminal;
+					this.record(decisions, contribution, name, context, started, "applied", true, true, true);
+				} catch (error) {
+					const deadlineExpired = dispatchController.signal.aborted && dispatchController.signal.reason === "dispatch-deadline";
+					const timedOut = isTimeout(error) || deadlineExpired;
+					const cancelled = !timedOut && (dispatchController.signal.aborted || isCancelled(error));
+					const failed = !cancelled ? this.failClosedResult(name, contribution, definition) : undefined;
+					const outcome: HostInterceptorAuditOutcome = timedOut
+						? (failed === undefined ? "timed-out" : "failed-closed")
+						: cancelled ? "cancelled" : failed === undefined ? "failed-open" : "failed-closed";
+					this.record(decisions, contribution, name, context, started, outcome, proposalReceived, valid, false, timedOut, cancelled);
+					if (failed !== undefined) terminal = failed as HostInterceptorResult<N>;
+				}
+			}
+		} finally {
+			clearTimeout(deadlineTimer);
+			stopInvalidation();
+			context.signal.removeEventListener("abort", forwardAbort);
+		}
+		return Object.freeze({
+			value: deepFreeze(value),
+			decisions: Object.freeze(decisions.slice()),
+			...(terminal === undefined ? {} : { terminal: deepFreeze(terminal) }),
+		});
+	}
+
+	private isAuthorized(
+		contribution: NormalizedInterceptorContribution | NormalizedLegacyProviderContribution,
+		projectId: string | undefined,
+		requiredGrants: readonly string[],
+	): boolean {
+		const registryAuthorized = contribution.kind === "legacy-provider"
+			? this.options.registry.isProviderAuthorized(projectId, contribution.packId, contribution.providerId, contribution.listName, contribution.activationEpoch)
+			: this.options.registry.isHookAuthorized(projectId, contribution.packId, contribution.contributionId, contribution.listName, contribution.activationEpoch, requiredGrants);
+		if (!registryAuthorized) return false;
+		return contribution.capabilities.every((capability) => this.options.isCapabilityGranted?.({
+			projectId,
+			packId: contribution.packId,
+			contributionId: contribution.contributionId,
+			capability,
+		}) !== false);
+	}
+
+	private async invokeExplicit<N extends HostInterceptorName>(
+		name: N,
+		value: HostInterceptorRequest<N>,
+		context: HostInterceptorContext,
+		contribution: NormalizedInterceptorContribution,
+		timeoutMs: number,
+		signal: AbortSignal,
+	): Promise<unknown> {
+		const host = this.options.createHostApi?.({
+			context,
+			packId: contribution.packId,
+			contributionId: contribution.contributionId,
+			capabilities: contribution.capabilities,
+		});
+		const url = `${pathToFileURL(path.resolve(path.dirname(contribution.sourceFile), contribution.module)).href}?e=${contribution.activationEpoch}`;
+		return this.options.moduleHost.invoke({
+			url,
+			packRoot: contribution.packRoot,
+			epoch: contribution.activationEpoch,
+			exportKind: "hooks",
+			member: name,
+			ctx: {
+				host,
+				sessionId: context.sessionId ?? `project:${context.projectId ?? "unbound"}`,
+				projectId: context.projectId,
+				goalId: context.goalId,
+				tool: `host-interceptor:${name}`,
+				workingDir: context.cwd,
+				config: contribution.config,
+				correlationId: context.correlationId,
+			} as unknown as InvokeRequest["ctx"],
+			arg: deepFreeze(clone(value)),
+			workingDir: context.cwd,
+			signal,
+		}, timeoutMs);
+	}
+
+	private async invokeLegacy<N extends HostInterceptorName>(
+		name: N,
+		value: HostInterceptorRequest<N>,
+		context: HostInterceptorContext,
+		contribution: NormalizedLegacyProviderContribution,
+		timeoutMs: number,
+		signal: AbortSignal,
+	): Promise<unknown> {
+		if (!this.options.lifecycleHub) return { context: [] };
+		const base = legacyDispatchBase(value, context);
+		const result = await this.options.lifecycleHub.dispatchProvider(
+			name as LifecycleHook,
+			base,
+			{ id: contribution.providerId, listName: contribution.listName, packRoot: contribution.packRoot },
+			undefined,
+			{ signal, timeoutMs },
+		);
+		if (name === "sessionShutdown") return {};
+		return {
+			context: result.blocks.map((block) => ({
+				id: block.id,
+				title: block.title,
+				authority: block.authority,
+				content: block.content,
+				reason: block.reason,
+				priority: block.priority,
+			})),
+		};
+	}
+
+	private validateOperationMutation<N extends HostInterceptorName>(
+		name: N,
+		value: HostInterceptorRequest<N>,
+		proposal: unknown,
+	): boolean {
+		if (!proposal || typeof proposal !== "object") return true;
+		const record = proposal as Record<string, unknown>;
+		const action = typeof record.action === "string" ? record.action : typeof record.decision === "string" ? record.decision : undefined;
+		if (name === "beforeToolCall" && (action === "replaceArgs" || "args" in record)) {
+			const request = value as unknown as Record<string, unknown>;
+			return !!this.options.validateToolArgs && typeof request.toolName === "string"
+				&& this.options.validateToolArgs(request.toolName, record.args);
+		}
+		if (name === "afterToolResult" && (action === "replaceResult" || "result" in record)) {
+			const request = value as unknown as Record<string, unknown>;
+			return !this.options.validateToolResult || typeof request.toolName !== "string"
+				|| this.options.validateToolResult(request.toolName, record.result);
+		}
+		return true;
+	}
+
+	private failClosedResult<N extends HostInterceptorName>(
+		name: N,
+		contribution: RuntimeHookContribution,
+		definition: RuntimeInterceptorDefinition,
+	): unknown {
+		if (contribution.kind !== "interceptor") return undefined;
+		const policy = contribution.failurePolicy ?? definition.defaultFailurePolicy;
+		if (policy !== "failClosed") return undefined;
+		if (name === "beforeToolCall") return { action: "block", reasonCode: "not_permitted" };
+		if (name === "afterToolResult") return { action: "syntheticError", code: "handler_error" };
+		return undefined;
+	}
+
+	private record(
+		rows: HostInterceptorAuditDecision[],
+		contribution: NormalizedInterceptorContribution | NormalizedLegacyProviderContribution,
+		hook: HostInterceptorName,
+		context: HostInterceptorContext,
+		started: number,
+		outcome: HostInterceptorAuditOutcome,
+		proposalReceived: boolean,
+		valid: boolean,
+		applied: boolean,
+		timedOut = false,
+		cancelled = false,
+	): void {
+		const row = Object.freeze({
+			occurredAt: this.now(), hook,
+			...(context.projectId ? { projectId: context.projectId } : {}),
+			...(context.sessionId ? { sessionId: context.sessionId } : {}),
+			packId: contribution.packId,
+			contributionId: contribution.contributionId,
+			durationMs: Math.min(60_000, Math.max(0, Math.round(this.monotonicNow() - started))),
+			outcome, proposalReceived, valid, applied, timedOut, cancelled,
+		});
+		rows.push(row);
+		try { this.options.audit?.(row); } catch { /* audit cannot affect authority */ }
+	}
+}
+
+function legacyDispatchBase<N extends HostInterceptorName>(
+	value: HostInterceptorRequest<N>,
+	context: HostInterceptorContext,
+): HookDispatchBase {
+	const input = value as unknown as Record<string, unknown>;
+	return {
+		sessionId: context.sessionId ?? String(input.sessionId ?? `project:${context.projectId ?? "unbound"}`),
+		projectId: context.projectId,
+		goalId: context.goalId,
+		cwd: context.cwd,
+		scope: input.scope === "global" || input.scope === "project"
+			? input.scope
+			: context.projectId ? "project" : "global",
+		...(typeof input.roleName === "string" ? { roleName: input.roleName } : {}),
+		...(typeof input.prompt === "string" ? { prompt: input.prompt } : {}),
+		...(typeof input.userText === "string" ? { userText: input.userText } : {}),
+		...(typeof input.span === "string" ? { span: input.span } : {}),
+		...(typeof input.summary === "string" ? { summary: input.summary } : {}),
+		...(typeof input.turnIndex === "number" ? { turn: { index: input.turnIndex } } : {}),
+	};
+}
+
+function foldResult<N extends HostInterceptorName>(
+	name: N,
+	current: HostInterceptorRequest<N>,
+	proposal: HostInterceptorResult<N>,
+): { value: HostInterceptorRequest<N>; terminal?: HostInterceptorResult<N> } {
+	const value = clone(current) as unknown as Record<string, unknown>;
+	const result = proposal as unknown as Record<string, unknown>;
+	if (Array.isArray(result.context)) {
+		const existing = Array.isArray(value.context) ? value.context : [];
+		value.context = [...existing, ...clone(result.context)].slice(0, HOST_HOOK_LIMITS.contextContributions);
+	}
+	if ("flush" in result) value.flush = result.flush;
+	if ("initialised" in result) value.initialised = result.initialised;
+	const action = typeof result.action === "string" ? result.action : typeof result.decision === "string" ? result.decision : undefined;
+	if (name === "beforeToolCall") {
+		if (action === "replaceArgs") value.args = clone(result.args);
+		if (action === "block") return { value: value as HostInterceptorRequest<N>, terminal: proposal };
+	}
+	if (name === "afterToolResult") {
+		if (action === "replaceResult") value.result = clone(result.result);
+		if (action === "syntheticError") return { value: value as HostInterceptorRequest<N>, terminal: proposal };
+	}
+	return { value: value as HostInterceptorRequest<N> };
+}
+
+function isTimeout(error: unknown): boolean {
+	return (error instanceof ActionError && error.status === 504)
+		|| (error instanceof Error && /timed out/i.test(error.message));
+}
+
+function isCancelled(error: unknown): boolean {
+	return (error instanceof ActionError && error.status === 499)
+		|| (error instanceof Error && /cancel/i.test(error.message));
+}
+
+function clone<T>(value: T): T {
+	return structuredClone(value);
+}
+
+function deepFreeze<T>(value: T): T {
+	return deepFreezeHostValue(value) as T;
+}

--- a/src/server/extension-host/host-interceptor-router.ts
+++ b/src/server/extension-host/host-interceptor-router.ts
@@ -374,7 +374,9 @@ function legacyDispatchBase<N extends HostInterceptorName>(
 			? input.scope
 			: context.projectId ? "project" : "global",
 		...(typeof input.roleName === "string" ? { roleName: input.roleName } : {}),
-		...(typeof input.prompt === "string" ? { prompt: input.prompt } : {}),
+		...(typeof input.prompt === "string"
+			? { prompt: input.prompt }
+			: typeof input.userText === "string" ? { prompt: input.userText } : {}),
 		...(typeof input.userText === "string" ? { userText: input.userText } : {}),
 		...(typeof input.span === "string" ? { span: input.span } : {}),
 		...(typeof input.summary === "string" ? { summary: input.summary } : {}),

--- a/src/server/extension-host/host-interceptor-router.ts
+++ b/src/server/extension-host/host-interceptor-router.ts
@@ -102,6 +102,20 @@ export class HostInterceptorRouter {
 		this.monotonicNow = options.monotonicNow ?? performance.now.bind(performance);
 	}
 
+	/** Snapshot whether an active, currently authorized contribution makes a
+	 * transport failure terminal for this operation. Spawn/respawn callers inject
+	 * this host-owned decision into the generated Pi bridge; pack code cannot
+	 * assert protected status itself. */
+	requiresFailClosed(name: HostInterceptorName, projectId?: string): boolean {
+		const definition = HOST_INTERCEPTOR_CATALOGUE[name] as RuntimeInterceptorDefinition;
+		return normalizeHookContributions(this.options.registry, projectId).some((contribution) => {
+			if (contribution.kind !== "interceptor" || contribution.name !== name) return false;
+			const policy = contribution.failurePolicy ?? definition.defaultFailurePolicy;
+			return policy === "failClosed"
+				&& this.isAuthorized(contribution, projectId, definition.requiredGrants);
+		});
+	}
+
 	async dispatch<N extends HostInterceptorName>(
 		name: N,
 		input: HostInterceptorRequest<N>,

--- a/src/server/extension-host/host-notification-dispatcher.ts
+++ b/src/server/extension-host/host-notification-dispatcher.ts
@@ -27,6 +27,11 @@ export type HostNotificationConsumer = "browser" | "module" | "staff";
  */
 export interface HostNotificationDeliveryAdapter {
 	readonly consumer: HostNotificationConsumer;
+	/** Durable subscriber adapters own their admission scheduling and persistence.
+	 * They bypass bounded live queues so browser/module pressure cannot discard an
+	 * event before the subscriber outbox sees it. Their deliver method must return
+	 * without awaiting durable delivery; failures remain observational. */
+	readonly admission?: "bounded-live" | "durable-subscriber";
 	deliver(notification: HostNotification): void | Promise<void>;
 	/** Called asynchronously after an overflow. Browser adapters use it to issue
 	 * a refresh-required frame; live module delivery simply reports the drop. */
@@ -265,6 +270,7 @@ function cloneProjection<T>(value: T): T | undefined {
  */
 export class HostNotificationDispatcher {
 	private readonly queues: ProjectOrderedQueue[];
+	private readonly durableAdapters: HostNotificationDeliveryAdapter[];
 	private readonly resolveSessionProject?: (sessionId: string) => string | undefined;
 	private readonly now: () => number;
 	private readonly idGenerator: () => string;
@@ -282,9 +288,14 @@ export class HostNotificationDispatcher {
 		this.onDiagnostic = options.onDiagnostic;
 		const seen = new Set<HostNotificationConsumer>();
 		this.queues = [];
+		this.durableAdapters = [];
 		for (const adapter of options.adapters ?? []) {
 			if (seen.has(adapter.consumer)) continue;
 			seen.add(adapter.consumer);
+			if (adapter.admission === "durable-subscriber") {
+				this.durableAdapters.push(adapter);
+				continue;
+			}
 			this.queues.push(new ProjectOrderedQueue(
 				adapter,
 				queueCapacity,
@@ -370,6 +381,23 @@ export class HostNotificationDispatcher {
 			if (queue.enqueue(notification)) continue;
 			this.diagnostic("queue_overflow", notification, queue.consumer);
 			queue.refreshRequired(notification);
+		}
+		for (const adapter of this.durableAdapters) {
+			if (!definition.consumers.has(adapter.consumer)) continue;
+			// The durable adapter owns matching, idempotency, and its disk-backed
+			// admission seam. Schedule it independently of bounded live queues so a
+			// browser/module burst cannot drop staff work before persistence.
+			queueMicrotask(() => {
+				let delivery: void | Promise<void>;
+				try { delivery = adapter.deliver(notification); }
+				catch {
+					this.diagnostic("consumer_failure", notification, adapter.consumer);
+					return;
+				}
+				void Promise.resolve(delivery).catch(() => {
+					this.diagnostic("consumer_failure", notification, adapter.consumer);
+				});
+			});
 		}
 		return notification;
 	}

--- a/src/server/extension-host/host-notification-dispatcher.ts
+++ b/src/server/extension-host/host-notification-dispatcher.ts
@@ -1,0 +1,418 @@
+import { randomUUID } from "node:crypto";
+import {
+	HOST_NOTIFICATION_CATALOGUE,
+	buildHostNotification,
+	validateNotificationPayload,
+	type HostNotification,
+	type HostNotificationName,
+	type HostNotificationPayload,
+	type HostNotificationScope,
+} from "../../shared/extension-host/host-hooks.js";
+
+export interface HostNotificationPublication<N extends HostNotificationName> {
+	readonly projectId: string;
+	readonly sessionId?: HostNotificationScope<N> extends "session" ? string : string | undefined;
+	readonly aggregateId: string;
+	readonly aggregateRevision?: string | number;
+	readonly correlationId?: string;
+	readonly causationId?: string;
+	readonly payload: HostNotificationPayload<N>;
+}
+
+export type HostNotificationConsumer = "browser" | "module" | "staff";
+
+/**
+ * One asynchronous fanout target. The adapter receives the exact frozen event
+ * returned by publish; it must not re-project mutable aggregate state.
+ */
+export interface HostNotificationDeliveryAdapter {
+	readonly consumer: HostNotificationConsumer;
+	deliver(notification: HostNotification): void | Promise<void>;
+	/** Called asynchronously after an overflow. Browser adapters use it to issue
+	 * a refresh-required frame; live module delivery simply reports the drop. */
+	refreshRequired?(notification: HostNotification): void | Promise<void>;
+}
+
+export type HostNotificationDiagnosticCode =
+	| "invalid_name"
+	| "invalid_publication"
+	| "invalid_payload"
+	| "project_mismatch"
+	| "queue_overflow"
+	| "consumer_failure";
+
+export interface HostNotificationDiagnostic {
+	readonly code: HostNotificationDiagnosticCode;
+	readonly consumer?: HostNotificationConsumer;
+	readonly projectId?: string;
+	readonly name?: string;
+	readonly occurredAt: number;
+}
+
+export interface HostNotificationModuleHandler {
+	readonly projectId: string;
+	readonly packId: string;
+	readonly contributionId: string;
+	readonly scope: "session" | "project";
+	readonly name: HostNotificationName;
+	readonly timeoutMs?: number;
+}
+
+export type HostNotificationModuleDiagnosticCode =
+	| "handler_timeout"
+	| "handler_failure"
+	| "handler_revoked";
+
+export interface HostNotificationModuleAdapterOptions {
+	/** Must return the normalized winning contributions in deterministic order. */
+	readonly resolve: (notification: HostNotification) => readonly HostNotificationModuleHandler[];
+	/** Live pack activation, winning-ref, and grant check. Called before invoke and
+	 * again after settlement so invalidated late work has no host-observed effect. */
+	readonly isAuthorized: (handler: HostNotificationModuleHandler, notification: HostNotification) => boolean;
+	/** ModuleHost-backed invocation. It must observe signal cancellation and receives
+	 * the exact frozen canonical event. Return values are deliberately discarded. */
+	readonly invoke: (handler: HostNotificationModuleHandler, notification: HostNotification, signal: AbortSignal) => void | Promise<unknown>;
+	readonly maxHandlersPerNotification?: number;
+	readonly defaultTimeoutMs?: number;
+	readonly maxTimeoutMs?: number;
+	readonly onDiagnostic?: (diagnostic: Readonly<{
+		code: HostNotificationModuleDiagnosticCode;
+		projectId: string;
+		packId: string;
+		contributionId: string;
+		name: HostNotificationName;
+	}>) => void;
+}
+
+/** Ordered observational module delivery; every handler failure is isolated. */
+export class HostNotificationModuleAdapter implements HostNotificationDeliveryAdapter {
+	readonly consumer = "module" as const;
+	private readonly maxHandlers: number;
+	private readonly defaultTimeoutMs: number;
+	private readonly maxTimeoutMs: number;
+
+	constructor(private readonly options: HostNotificationModuleAdapterOptions) {
+		this.maxHandlers = Math.max(1, Math.min(options.maxHandlersPerNotification ?? 64, 256));
+		this.maxTimeoutMs = Math.max(1, Math.min(options.maxTimeoutMs ?? 5_000, 30_000));
+		this.defaultTimeoutMs = Math.max(1, Math.min(options.defaultTimeoutMs ?? 1_500, this.maxTimeoutMs));
+	}
+
+	async deliver(notification: HostNotification): Promise<void> {
+		const handlers = this.options.resolve(notification).slice(0, this.maxHandlers);
+		for (const handler of handlers) {
+			if (handler.projectId !== notification.projectId
+				|| handler.scope !== notification.scope
+				|| handler.name !== notification.name) continue;
+			if (!this.safeAuthorized(handler, notification)) {
+				this.report("handler_revoked", handler, notification);
+				continue;
+			}
+			const controller = new AbortController();
+			const declaredTimeout = typeof handler.timeoutMs === "number" && Number.isFinite(handler.timeoutMs)
+				? handler.timeoutMs
+				: this.defaultTimeoutMs;
+			const timeoutMs = Math.max(1, Math.min(declaredTimeout, this.maxTimeoutMs));
+			let timedOut = false;
+			let timer: ReturnType<typeof setTimeout> | undefined;
+			try {
+				const invocation = Promise.resolve(this.options.invoke(handler, notification, controller.signal));
+				await Promise.race([
+					invocation,
+					new Promise<void>((_, reject) => {
+						timer = setTimeout(() => {
+							timedOut = true;
+							controller.abort(new Error("notification handler deadline exceeded"));
+							reject(new Error("notification handler deadline exceeded"));
+						}, timeoutMs);
+					}),
+				]);
+				// Return values are ignored. This second live check is the settlement
+				// fence and intentionally performs no action when authority was revoked.
+				if (!this.safeAuthorized(handler, notification)) this.report("handler_revoked", handler, notification);
+			} catch {
+				this.report(timedOut ? "handler_timeout" : "handler_failure", handler, notification);
+			} finally {
+				if (timer) clearTimeout(timer);
+				controller.abort();
+			}
+		}
+	}
+
+	private safeAuthorized(handler: HostNotificationModuleHandler, notification: HostNotification): boolean {
+		try { return this.options.isAuthorized(handler, notification); }
+		catch { return false; }
+	}
+
+	private report(
+		code: HostNotificationModuleDiagnosticCode,
+		handler: HostNotificationModuleHandler,
+		notification: HostNotification,
+	): void {
+		if (!this.options.onDiagnostic) return;
+		try {
+			this.options.onDiagnostic(Object.freeze({
+				code,
+				projectId: notification.projectId.slice(0, 128),
+				packId: handler.packId.slice(0, 128),
+				contributionId: handler.contributionId.slice(0, 128),
+				name: notification.name,
+			}));
+		} catch { /* observational diagnostics never affect delivery */ }
+	}
+}
+
+export interface HostNotificationDispatcherOptions {
+	readonly adapters?: readonly HostNotificationDeliveryAdapter[];
+	/** Authoritative session-to-project lookup. Session-scoped facts fail closed
+	 * when this authority is absent or disagrees with the publication. */
+	readonly resolveSessionProject?: (sessionId: string) => string | undefined;
+	readonly queueCapacity?: number;
+	readonly diagnosticCapacity?: number;
+	readonly now?: () => number;
+	readonly idGenerator?: () => string;
+	readonly onDiagnostic?: (diagnostic: HostNotificationDiagnostic) => void | Promise<void>;
+}
+
+type QueueLane = {
+	items: HostNotification[];
+	running: boolean;
+};
+
+/** A bounded, independently draining FIFO per project. */
+class ProjectOrderedQueue {
+	private readonly lanes = new Map<string, QueueLane>();
+	readonly consumer: HostNotificationConsumer;
+
+	constructor(
+		private readonly adapter: HostNotificationDeliveryAdapter,
+		private readonly capacity: number,
+		private readonly onFailure: (consumer: HostNotificationConsumer, notification: HostNotification) => void,
+	) {
+		this.consumer = adapter.consumer;
+	}
+
+	refreshRequired(notification: HostNotification): void {
+		if (!this.adapter.refreshRequired) return;
+		queueMicrotask(() => {
+			let delivery: void | Promise<void>;
+			try { delivery = this.adapter.refreshRequired!(notification); }
+			catch { this.onFailure(this.consumer, notification); return; }
+			void Promise.resolve(delivery).catch(() => {
+				this.onFailure(this.consumer, notification);
+			});
+		});
+	}
+
+	enqueue(notification: HostNotification): boolean {
+		let lane = this.lanes.get(notification.projectId);
+		if (!lane) {
+			lane = { items: [], running: false };
+			this.lanes.set(notification.projectId, lane);
+		}
+		if (lane.items.length >= this.capacity) return false;
+		lane.items.push(notification);
+		if (!lane.running) {
+			lane.running = true;
+			queueMicrotask(() => void this.drain(notification.projectId, lane!));
+		}
+		return true;
+	}
+
+	private async drain(projectId: string, lane: QueueLane): Promise<void> {
+		try {
+			while (lane.items.length > 0) {
+				const notification = lane.items.shift()!;
+				try {
+					await this.adapter.deliver(notification);
+				} catch {
+					this.onFailure(this.adapter.consumer, notification);
+				}
+			}
+		} finally {
+			lane.running = false;
+			if (lane.items.length > 0) {
+				lane.running = true;
+				queueMicrotask(() => void this.drain(projectId, lane));
+			} else if (this.lanes.get(projectId) === lane) {
+				this.lanes.delete(projectId);
+			}
+		}
+	}
+}
+
+function isNonEmptyBoundedString(value: unknown, max = 512): value is string {
+	return typeof value === "string" && value.length > 0 && value.length <= max;
+}
+
+function validRevision(value: unknown): value is string | number {
+	return (typeof value === "string" && value.length > 0 && value.length <= 512)
+		|| (typeof value === "number" && Number.isFinite(value));
+}
+
+function cloneProjection<T>(value: T): T | undefined {
+	try {
+		return structuredClone(value);
+	} catch {
+		return undefined;
+	}
+}
+
+/**
+ * Canonical post-authority publication point. publish performs only bounded
+ * validation/copying and queue admission. Socket sends, module invocation, and
+ * durable staff-intent writes always start in a later microtask and can never
+ * fail or roll back the source mutation.
+ */
+export class HostNotificationDispatcher {
+	private readonly queues: ProjectOrderedQueue[];
+	private readonly resolveSessionProject?: (sessionId: string) => string | undefined;
+	private readonly now: () => number;
+	private readonly idGenerator: () => string;
+	private readonly diagnosticCapacity: number;
+	private readonly onDiagnostic?: HostNotificationDispatcherOptions["onDiagnostic"];
+	private readonly diagnosticRows: HostNotificationDiagnostic[] = [];
+	private pendingDiagnosticCallbacks = 0;
+
+	constructor(options: HostNotificationDispatcherOptions = {}) {
+		const queueCapacity = Math.max(1, Math.min(options.queueCapacity ?? 256, 4096));
+		this.resolveSessionProject = options.resolveSessionProject;
+		this.now = options.now ?? Date.now;
+		this.idGenerator = options.idGenerator ?? randomUUID;
+		this.diagnosticCapacity = Math.max(1, Math.min(options.diagnosticCapacity ?? 256, 2048));
+		this.onDiagnostic = options.onDiagnostic;
+		const seen = new Set<HostNotificationConsumer>();
+		this.queues = [];
+		for (const adapter of options.adapters ?? []) {
+			if (seen.has(adapter.consumer)) continue;
+			seen.add(adapter.consumer);
+			this.queues.push(new ProjectOrderedQueue(
+				adapter,
+				queueCapacity,
+				(consumer, notification) => this.diagnostic("consumer_failure", notification, consumer),
+			));
+		}
+	}
+
+	publish<N extends HostNotificationName>(
+		name: N,
+		publication: HostNotificationPublication<N>,
+	): HostNotification<N> | undefined {
+		try {
+			return this.publishValidated(name, publication);
+		} catch {
+			this.diagnostic("invalid_publication", undefined, undefined, undefined, String(name));
+			return undefined;
+		}
+	}
+
+	private publishValidated<N extends HostNotificationName>(
+		name: N,
+		publication: HostNotificationPublication<N>,
+	): HostNotification<N> | undefined {
+		const definition = HOST_NOTIFICATION_CATALOGUE[name];
+		if (!definition) {
+			this.diagnostic("invalid_name", undefined, undefined, undefined, String(name));
+			return undefined;
+		}
+		if (!publication || typeof publication !== "object") {
+			this.diagnostic("invalid_publication", undefined, undefined, undefined, name);
+			return undefined;
+		}
+		if (!isNonEmptyBoundedString(publication.projectId)
+			|| !isNonEmptyBoundedString(publication.aggregateId)
+			|| !validRevision(publication.aggregateRevision)
+			|| (publication.correlationId !== undefined && !isNonEmptyBoundedString(publication.correlationId))
+			|| (publication.causationId !== undefined && !isNonEmptyBoundedString(publication.causationId))) {
+			this.diagnostic("invalid_publication", undefined, undefined, publication.projectId, name);
+			return undefined;
+		}
+
+		const sessionId = publication.sessionId;
+		if (definition.scope === "session" && !isNonEmptyBoundedString(sessionId)) {
+			this.diagnostic("invalid_publication", undefined, undefined, publication.projectId, name);
+			return undefined;
+		}
+		if (sessionId !== undefined) {
+			if (!isNonEmptyBoundedString(sessionId)
+				|| !this.resolveSessionProject
+				|| this.resolveSessionProject(sessionId) !== publication.projectId) {
+				this.diagnostic("project_mismatch", undefined, undefined, publication.projectId, name);
+				return undefined;
+			}
+		}
+
+		const payload = cloneProjection(publication.payload);
+		if (payload === undefined || !validateNotificationPayload(name, payload)) {
+			this.diagnostic("invalid_payload", undefined, undefined, publication.projectId, name);
+			return undefined;
+		}
+
+		const id = this.idGenerator();
+		const occurredAt = this.now();
+		if (!isNonEmptyBoundedString(id) || !Number.isFinite(occurredAt) || occurredAt < 0) {
+			this.diagnostic("invalid_publication", undefined, undefined, publication.projectId, name);
+			return undefined;
+		}
+		const notification = buildHostNotification(name, {
+			id,
+			occurredAt,
+			projectId: publication.projectId,
+			...(definition.scope === "session" ? { sessionId } : {}),
+			aggregateId: publication.aggregateId,
+			aggregateRevision: publication.aggregateRevision,
+			...(publication.correlationId !== undefined ? { correlationId: publication.correlationId } : {}),
+			...(publication.causationId !== undefined ? { causationId: publication.causationId } : {}),
+			payload,
+		});
+
+		for (const queue of this.queues) {
+			if (!definition.consumers.has(queue.consumer)) continue;
+			if (queue.enqueue(notification)) continue;
+			this.diagnostic("queue_overflow", notification, queue.consumer);
+			queue.refreshRequired(notification);
+		}
+		return notification;
+	}
+
+	/** Bounded diagnostics contain attribution codes only, never payloads/errors. */
+	getDiagnostics(): readonly HostNotificationDiagnostic[] {
+		return this.diagnosticRows.slice();
+	}
+
+	private diagnostic(
+		code: HostNotificationDiagnosticCode,
+		notification?: HostNotification,
+		consumer?: HostNotificationConsumer,
+		projectId?: string,
+		name?: string,
+	): void {
+		const rawProjectId = notification?.projectId ?? projectId;
+		const boundedProjectId = typeof rawProjectId === "string" ? rawProjectId.slice(0, 128) : undefined;
+		const boundedName = String(notification?.name ?? name ?? "").slice(0, 128) || undefined;
+		let occurredAt = 0;
+		try {
+			const candidate = this.now();
+			if (Number.isFinite(candidate) && candidate >= 0) occurredAt = candidate;
+		} catch { /* diagnostics must not escape into the source operation */ }
+		const row = Object.freeze({
+			code,
+			...(consumer ? { consumer } : {}),
+			...(boundedProjectId ? { projectId: boundedProjectId } : {}),
+			...(boundedName ? { name: boundedName } : {}),
+			occurredAt,
+		}) as HostNotificationDiagnostic;
+		if (this.diagnosticRows.length >= this.diagnosticCapacity) this.diagnosticRows.shift();
+		this.diagnosticRows.push(row);
+		if (this.onDiagnostic && this.pendingDiagnosticCallbacks < this.diagnosticCapacity) {
+			this.pendingDiagnosticCallbacks++;
+			queueMicrotask(() => {
+				let delivery: void | Promise<void>;
+				try { delivery = this.onDiagnostic!(row); }
+				catch { this.pendingDiagnosticCallbacks--; return; }
+				void Promise.resolve(delivery)
+					.catch(() => {})
+					.finally(() => { this.pendingDiagnosticCallbacks--; });
+			});
+		}
+	}
+}

--- a/src/server/extension-host/host-notification-dispatcher.ts
+++ b/src/server/extension-host/host-notification-dispatcher.ts
@@ -71,8 +71,9 @@ export type HostNotificationModuleDiagnosticCode =
 export interface HostNotificationModuleAdapterOptions {
 	/** Must return the normalized winning contributions in deterministic order. */
 	readonly resolve: (notification: HostNotification) => readonly HostNotificationModuleHandler[];
-	/** Live pack activation, winning-ref, and grant check. Called before invoke and
-	 * again after settlement so invalidated late work has no host-observed effect. */
+	/** Live pack activation, winning-ref, and capability authorization check. Called
+	 * before invoke and again after settlement so invalidated late work has no
+	 * host-observed effect. */
 	readonly isAuthorized: (handler: HostNotificationModuleHandler, notification: HostNotification) => boolean;
 	/** ModuleHost-backed invocation. It must observe signal cancellation and receives
 	 * the exact frozen canonical event. Return values are deliberately discarded. */

--- a/src/server/extension-host/host-notification-socket-router.ts
+++ b/src/server/extension-host/host-notification-socket-router.ts
@@ -6,6 +6,10 @@ import type {
 } from "../../shared/extension-host/host-hooks.js";
 import type { ServerMessage } from "../ws/protocol.js";
 import { isSocketSendable } from "../ws/socket-sendability.js";
+import {
+	hasUiWebSocketPrincipal,
+	type PrincipalTaggedWebSocket,
+} from "../ws/ui-principal.js";
 import type { HostNotificationDeliveryAdapter } from "./host-notification-dispatcher.js";
 
 interface HostNotificationSocketBinding {
@@ -15,10 +19,16 @@ interface HostNotificationSocketBinding {
 
 const SOCKET_BINDINGS = new WeakMap<WebSocket, HostNotificationSocketBinding>();
 
-type BoundWebSocket = WebSocket & {
+type BoundWebSocket = PrincipalTaggedWebSocket & {
 	authenticated?: boolean;
 	isViewer?: boolean;
 };
+
+function eligibleBinding(ws: WebSocket): HostNotificationSocketBinding | undefined {
+	const socket = ws as BoundWebSocket;
+	if (socket.authenticated !== true || socket.isViewer === true || !hasUiWebSocketPrincipal(ws)) return undefined;
+	return SOCKET_BINDINGS.get(ws);
+}
 
 interface StreamState {
 	readonly epoch: string;
@@ -49,7 +59,15 @@ export function bindHostNotificationSocket(
 	ws: WebSocket,
 	binding: { sessionId: string; projectId: string },
 ): void {
-	if (!binding.sessionId || !binding.projectId || binding.sessionId === "__viewer__") {
+	const socket = ws as BoundWebSocket;
+	if (
+		!binding.sessionId
+		|| !binding.projectId
+		|| binding.sessionId === "__viewer__"
+		|| socket.authenticated !== true
+		|| socket.isViewer === true
+		|| !hasUiWebSocketPrincipal(ws)
+	) {
 		unbindHostNotificationSocket(ws);
 		return;
 	}
@@ -60,7 +78,7 @@ export function unbindHostNotificationSocket(ws: WebSocket): void {
 	SOCKET_BINDINGS.delete(ws);
 }
 
-/** Exact, server-authorized live browser delivery. No viewer/client filtering. */
+/** Exact, server-authorized live browser delivery with live principal checks. */
 export class HostNotificationSocketRouter implements HostNotificationDeliveryAdapter {
 	readonly consumer = "browser" as const;
 	private readonly states = new WeakMap<WebSocket, Map<HostHookScope, StreamState>>();
@@ -122,10 +140,8 @@ export class HostNotificationSocketRouter implements HostNotificationDeliveryAda
 	private *recipients(notification: HostNotification): IterableIterator<WebSocket> {
 		const sockets = typeof this.sockets === "function" ? this.sockets() : this.sockets;
 		for (const ws of sockets) {
-			const socket = ws as BoundWebSocket;
-			const binding = SOCKET_BINDINGS.get(ws);
-			if (socket.authenticated !== true || socket.isViewer === true || !binding) continue;
-			if (binding.projectId !== notification.projectId) continue;
+			const binding = eligibleBinding(ws);
+			if (!binding || binding.projectId !== notification.projectId) continue;
 			if (notification.scope === "session" && binding.sessionId !== notification.sessionId) continue;
 			yield ws;
 		}
@@ -169,6 +185,11 @@ export class HostNotificationSocketRouter implements HostNotificationDeliveryAda
 
 	private tryRefresh(ws: WebSocket, scope: HostHookScope, state: StreamState): void {
 		if (!state.active) return;
+		if (!eligibleBinding(ws)) {
+			unbindHostNotificationSocket(ws);
+			this.cleanupSocket(ws);
+			return;
+		}
 		if (!state.refreshRequired) {
 			state.refreshAttempts = 0;
 			return;

--- a/src/server/extension-host/host-notification-socket-router.ts
+++ b/src/server/extension-host/host-notification-socket-router.ts
@@ -1,0 +1,160 @@
+import { randomUUID } from "node:crypto";
+import type { WebSocket } from "ws";
+import type {
+	HostHookScope,
+	HostNotification,
+} from "../../shared/extension-host/host-hooks.js";
+import type { ServerMessage } from "../ws/protocol.js";
+import { isSocketSendable } from "../ws/socket-sendability.js";
+import type { HostNotificationDeliveryAdapter } from "./host-notification-dispatcher.js";
+
+interface HostNotificationSocketBinding {
+	readonly sessionId: string;
+	readonly projectId: string;
+}
+
+const SOCKET_BINDINGS = new WeakMap<WebSocket, HostNotificationSocketBinding>();
+
+type BoundWebSocket = WebSocket & {
+	authenticated?: boolean;
+	isViewer?: boolean;
+};
+
+interface StreamState {
+	readonly epoch: string;
+	sequence: number;
+	refreshRequired: boolean;
+	refreshScheduled: boolean;
+}
+
+export interface HostNotificationSocketRouterOptions {
+	readonly epochGenerator?: () => string;
+	/** If a socket already has this many unsent bytes, drop the delta and require
+	 * an authoritative refresh rather than growing transport memory unbounded. */
+	readonly maxBufferedBytes?: number;
+}
+
+/**
+ * Install the server-derived authority used by canonical notification routing.
+ * Call only after authentication and exact session/project resolution.
+ */
+export function bindHostNotificationSocket(
+	ws: WebSocket,
+	binding: { sessionId: string; projectId: string },
+): void {
+	if (!binding.sessionId || !binding.projectId || binding.sessionId === "__viewer__") {
+		unbindHostNotificationSocket(ws);
+		return;
+	}
+	SOCKET_BINDINGS.set(ws, Object.freeze({ sessionId: binding.sessionId, projectId: binding.projectId }));
+}
+
+export function unbindHostNotificationSocket(ws: WebSocket): void {
+	SOCKET_BINDINGS.delete(ws);
+}
+
+/** Exact, server-authorized live browser delivery. No viewer/client filtering. */
+export class HostNotificationSocketRouter implements HostNotificationDeliveryAdapter {
+	readonly consumer = "browser" as const;
+	private readonly states = new WeakMap<WebSocket, Map<HostHookScope, StreamState>>();
+	private readonly epochGenerator: () => string;
+	private readonly maxBufferedBytes: number;
+
+	constructor(
+		private readonly sockets: Iterable<WebSocket> | (() => Iterable<WebSocket>),
+		options: HostNotificationSocketRouterOptions = {},
+	) {
+		this.epochGenerator = options.epochGenerator ?? randomUUID;
+		this.maxBufferedBytes = Math.max(1, options.maxBufferedBytes ?? 512 * 1024);
+	}
+
+	deliver(notification: HostNotification): void {
+		for (const ws of this.recipients(notification)) {
+			const state = this.state(ws, notification.scope);
+			if (state.refreshRequired) {
+				this.scheduleRefresh(ws, notification.scope, state);
+				continue;
+			}
+			if (!this.canSend(ws)) {
+				state.refreshRequired = true;
+				continue;
+			}
+			const frame: ServerMessage = {
+				type: "host_notification",
+				notification,
+				stream: { epoch: state.epoch, sequence: ++state.sequence },
+			};
+			try {
+				ws.send(JSON.stringify(frame));
+			} catch {
+				state.refreshRequired = true;
+			}
+		}
+	}
+
+	/** Coalesced explicit gap signal used when the dispatcher's browser queue drops. */
+	refreshRequired(notification: HostNotification): void {
+		for (const ws of this.recipients(notification)) {
+			const state = this.state(ws, notification.scope);
+			state.refreshRequired = true;
+			this.scheduleRefresh(ws, notification.scope, state);
+		}
+	}
+
+	private *recipients(notification: HostNotification): IterableIterator<WebSocket> {
+		const sockets = typeof this.sockets === "function" ? this.sockets() : this.sockets;
+		for (const ws of sockets) {
+			const socket = ws as BoundWebSocket;
+			const binding = SOCKET_BINDINGS.get(ws);
+			if (socket.authenticated !== true || socket.isViewer === true || !binding) continue;
+			if (binding.projectId !== notification.projectId) continue;
+			if (notification.scope === "session" && binding.sessionId !== notification.sessionId) continue;
+			yield ws;
+		}
+	}
+
+	private state(ws: WebSocket, scope: HostHookScope): StreamState {
+		let streams = this.states.get(ws);
+		if (!streams) {
+			streams = new Map();
+			this.states.set(ws, streams);
+		}
+		let state = streams.get(scope);
+		if (!state) {
+			state = {
+				epoch: this.epochGenerator(),
+				sequence: 0,
+				refreshRequired: false,
+				refreshScheduled: false,
+			};
+			streams.set(scope, state);
+		}
+		return state;
+	}
+
+	private canSend(ws: WebSocket): boolean {
+		const bufferedAmount = typeof ws.bufferedAmount === "number" ? ws.bufferedAmount : 0;
+		return isSocketSendable(ws) && bufferedAmount < this.maxBufferedBytes;
+	}
+
+	private scheduleRefresh(ws: WebSocket, scope: HostHookScope, state: StreamState): void {
+		if (state.refreshScheduled) return;
+		state.refreshScheduled = true;
+		queueMicrotask(() => {
+			state.refreshScheduled = false;
+			if (!state.refreshRequired || !this.canSend(ws)) return;
+			const frame: ServerMessage = {
+				type: "host_notifications_refresh_required",
+				scope,
+				epoch: state.epoch,
+				sequence: ++state.sequence,
+			};
+			try {
+				ws.send(JSON.stringify(frame));
+				state.refreshRequired = false;
+			} catch {
+				// A later notification/overflow will retry. Never spin on a dead socket.
+			}
+		});
+	}
+}

--- a/src/server/extension-host/host-notification-socket-router.ts
+++ b/src/server/extension-host/host-notification-socket-router.ts
@@ -41,6 +41,8 @@ interface StreamState {
 }
 
 export interface HostNotificationSocketRouterOptions {
+	/** Current host-owned session partition. Undefined removes all routing authority. */
+	readonly resolveSessionProject: (sessionId: string) => string | undefined;
 	readonly epochGenerator?: () => string;
 	/** If a socket already has this many unsent bytes, drop the delta and require
 	 * an authoritative refresh rather than growing transport memory unbounded. */
@@ -83,6 +85,7 @@ export class HostNotificationSocketRouter implements HostNotificationDeliveryAda
 	readonly consumer = "browser" as const;
 	private readonly states = new WeakMap<WebSocket, Map<HostHookScope, StreamState>>();
 	private readonly closeListeners = new WeakSet<WebSocket>();
+	private readonly resolveSessionProject: (sessionId: string) => string | undefined;
 	private readonly epochGenerator: () => string;
 	private readonly maxBufferedBytes: number;
 	private readonly refreshRetryDelayMs: number;
@@ -90,8 +93,9 @@ export class HostNotificationSocketRouter implements HostNotificationDeliveryAda
 
 	constructor(
 		private readonly sockets: Iterable<WebSocket> | (() => Iterable<WebSocket>),
-		options: HostNotificationSocketRouterOptions = {},
+		options: HostNotificationSocketRouterOptions,
 	) {
+		this.resolveSessionProject = options.resolveSessionProject;
 		this.epochGenerator = options.epochGenerator ?? randomUUID;
 		this.maxBufferedBytes = Math.max(1, options.maxBufferedBytes ?? 512 * 1024);
 		this.refreshRetryDelayMs = Math.max(1, Math.min(options.refreshRetryDelayMs ?? 25, 1_000));
@@ -140,11 +144,38 @@ export class HostNotificationSocketRouter implements HostNotificationDeliveryAda
 	private *recipients(notification: HostNotification): IterableIterator<WebSocket> {
 		const sockets = typeof this.sockets === "function" ? this.sockets() : this.sockets;
 		for (const ws of sockets) {
-			const binding = eligibleBinding(ws);
-			if (!binding || binding.projectId !== notification.projectId) continue;
-			if (notification.scope === "session" && binding.sessionId !== notification.sessionId) continue;
+			const authority = this.authoritativeBinding(ws);
+			if (!authority || authority.moved) continue;
+			if (authority.binding.projectId !== notification.projectId) continue;
+			if (notification.scope === "session" && authority.binding.sessionId !== notification.sessionId) continue;
 			yield ws;
 		}
+	}
+
+	/** Revalidate auth-time metadata against current host state. A project move
+	 * suppresses the frame that discovered it and fences later project deltas
+	 * behind one authoritative snapshot refresh. */
+	private authoritativeBinding(ws: WebSocket): { binding: HostNotificationSocketBinding; moved: boolean } | undefined {
+		const binding = eligibleBinding(ws);
+		if (!binding) {
+			unbindHostNotificationSocket(ws);
+			this.cleanupSocket(ws);
+			return undefined;
+		}
+		const projectId = this.resolveSessionProject(binding.sessionId);
+		if (!projectId) {
+			unbindHostNotificationSocket(ws);
+			this.cleanupSocket(ws);
+			return undefined;
+		}
+		if (projectId === binding.projectId) return { binding, moved: false };
+
+		const rebound = Object.freeze({ sessionId: binding.sessionId, projectId });
+		SOCKET_BINDINGS.set(ws, rebound);
+		const projectState = this.state(ws, "project");
+		projectState.refreshRequired = true;
+		this.scheduleRefresh(ws, "project", projectState);
+		return { binding: rebound, moved: true };
 	}
 
 	private state(ws: WebSocket, scope: HostHookScope): StreamState {
@@ -185,11 +216,8 @@ export class HostNotificationSocketRouter implements HostNotificationDeliveryAda
 
 	private tryRefresh(ws: WebSocket, scope: HostHookScope, state: StreamState): void {
 		if (!state.active) return;
-		if (!eligibleBinding(ws)) {
-			unbindHostNotificationSocket(ws);
-			this.cleanupSocket(ws);
-			return;
-		}
+		const authority = this.authoritativeBinding(ws);
+		if (!authority || authority.moved) return;
 		if (!state.refreshRequired) {
 			state.refreshAttempts = 0;
 			return;

--- a/src/server/extension-host/host-notification-socket-router.ts
+++ b/src/server/extension-host/host-notification-socket-router.ts
@@ -25,6 +25,9 @@ interface StreamState {
 	sequence: number;
 	refreshRequired: boolean;
 	refreshScheduled: boolean;
+	refreshAttempts: number;
+	active: boolean;
+	refreshTimer?: ReturnType<typeof setTimeout>;
 }
 
 export interface HostNotificationSocketRouterOptions {
@@ -32,6 +35,10 @@ export interface HostNotificationSocketRouterOptions {
 	/** If a socket already has this many unsent bytes, drop the delta and require
 	 * an authoritative refresh rather than growing transport memory unbounded. */
 	readonly maxBufferedBytes?: number;
+	/** Initial retry delay for a refresh frame rejected by transport pressure. */
+	readonly refreshRetryDelayMs?: number;
+	/** Failed refresh attempts before closing with WebSocket retry-later code 1013. */
+	readonly maxRefreshRetries?: number;
 }
 
 /**
@@ -57,8 +64,11 @@ export function unbindHostNotificationSocket(ws: WebSocket): void {
 export class HostNotificationSocketRouter implements HostNotificationDeliveryAdapter {
 	readonly consumer = "browser" as const;
 	private readonly states = new WeakMap<WebSocket, Map<HostHookScope, StreamState>>();
+	private readonly closeListeners = new WeakSet<WebSocket>();
 	private readonly epochGenerator: () => string;
 	private readonly maxBufferedBytes: number;
+	private readonly refreshRetryDelayMs: number;
+	private readonly maxRefreshRetries: number;
 
 	constructor(
 		private readonly sockets: Iterable<WebSocket> | (() => Iterable<WebSocket>),
@@ -66,6 +76,8 @@ export class HostNotificationSocketRouter implements HostNotificationDeliveryAda
 	) {
 		this.epochGenerator = options.epochGenerator ?? randomUUID;
 		this.maxBufferedBytes = Math.max(1, options.maxBufferedBytes ?? 512 * 1024);
+		this.refreshRetryDelayMs = Math.max(1, Math.min(options.refreshRetryDelayMs ?? 25, 1_000));
+		this.maxRefreshRetries = Math.max(1, Math.min(options.maxRefreshRetries ?? 8, 32));
 	}
 
 	deliver(notification: HostNotification): void {
@@ -77,6 +89,7 @@ export class HostNotificationSocketRouter implements HostNotificationDeliveryAda
 			}
 			if (!this.canSend(ws)) {
 				state.refreshRequired = true;
+				this.scheduleRefresh(ws, notification.scope, state);
 				continue;
 			}
 			const frame: ServerMessage = {
@@ -85,9 +98,14 @@ export class HostNotificationSocketRouter implements HostNotificationDeliveryAda
 				stream: { epoch: state.epoch, sequence: ++state.sequence },
 			};
 			try {
-				ws.send(JSON.stringify(frame));
+				ws.send(JSON.stringify(frame), (error?: Error) => {
+					if (!error) return;
+					state.refreshRequired = true;
+					this.scheduleRefresh(ws, notification.scope, state);
+				});
 			} catch {
 				state.refreshRequired = true;
+				this.scheduleRefresh(ws, notification.scope, state);
 			}
 		}
 	}
@@ -118,6 +136,7 @@ export class HostNotificationSocketRouter implements HostNotificationDeliveryAda
 		if (!streams) {
 			streams = new Map();
 			this.states.set(ws, streams);
+			this.installCloseCleanup(ws);
 		}
 		let state = streams.get(scope);
 		if (!state) {
@@ -126,6 +145,8 @@ export class HostNotificationSocketRouter implements HostNotificationDeliveryAda
 				sequence: 0,
 				refreshRequired: false,
 				refreshScheduled: false,
+				refreshAttempts: 0,
+				active: true,
 			};
 			streams.set(scope, state);
 		}
@@ -138,23 +159,92 @@ export class HostNotificationSocketRouter implements HostNotificationDeliveryAda
 	}
 
 	private scheduleRefresh(ws: WebSocket, scope: HostHookScope, state: StreamState): void {
-		if (state.refreshScheduled) return;
+		if (!state.active || state.refreshScheduled || state.refreshTimer) return;
 		state.refreshScheduled = true;
 		queueMicrotask(() => {
 			state.refreshScheduled = false;
-			if (!state.refreshRequired || !this.canSend(ws)) return;
-			const frame: ServerMessage = {
-				type: "host_notifications_refresh_required",
-				scope,
-				epoch: state.epoch,
-				sequence: ++state.sequence,
-			};
-			try {
-				ws.send(JSON.stringify(frame));
-				state.refreshRequired = false;
-			} catch {
-				// A later notification/overflow will retry. Never spin on a dead socket.
-			}
+			this.tryRefresh(ws, scope, state);
 		});
+	}
+
+	private tryRefresh(ws: WebSocket, scope: HostHookScope, state: StreamState): void {
+		if (!state.active) return;
+		if (!state.refreshRequired) {
+			state.refreshAttempts = 0;
+			return;
+		}
+		if (!isSocketSendable(ws)) {
+			if (ws.readyState === 1) this.closeRetryably(ws);
+			else this.cleanupSocket(ws);
+			return;
+		}
+		if (!this.canSend(ws)) {
+			this.retryRefresh(ws, scope, state);
+			return;
+		}
+		const frame: ServerMessage = {
+			type: "host_notifications_refresh_required",
+			scope,
+			epoch: state.epoch,
+			sequence: ++state.sequence,
+		};
+		state.refreshRequired = false;
+		try {
+			ws.send(JSON.stringify(frame), (error?: Error) => {
+				if (!state.active) return;
+				if (!error) {
+					state.refreshAttempts = 0;
+					return;
+				}
+				state.refreshRequired = true;
+				this.retryRefresh(ws, scope, state);
+			});
+		} catch {
+			state.refreshRequired = true;
+			this.retryRefresh(ws, scope, state);
+		}
+	}
+
+	private retryRefresh(ws: WebSocket, scope: HostHookScope, state: StreamState): void {
+		if (!state.active || !state.refreshRequired || state.refreshTimer) return;
+		state.refreshAttempts++;
+		if (state.refreshAttempts >= this.maxRefreshRetries) {
+			this.closeRetryably(ws);
+			return;
+		}
+		const delay = Math.min(1_000, this.refreshRetryDelayMs * (2 ** Math.max(0, state.refreshAttempts - 1)));
+		state.refreshTimer = setTimeout(() => {
+			state.refreshTimer = undefined;
+			this.tryRefresh(ws, scope, state);
+		}, delay);
+	}
+
+	private installCloseCleanup(ws: WebSocket): void {
+		if (this.closeListeners.has(ws)) return;
+		this.closeListeners.add(ws);
+		const once = (ws as WebSocket & { once?: (event: string, listener: () => void) => unknown }).once;
+		if (typeof once === "function") once.call(ws, "close", () => this.cleanupSocket(ws));
+	}
+
+	private cleanupSocket(ws: WebSocket): void {
+		const streams = this.states.get(ws);
+		if (streams) {
+			for (const state of streams.values()) {
+				state.active = false;
+				if (state.refreshTimer) clearTimeout(state.refreshTimer);
+				state.refreshTimer = undefined;
+				state.refreshScheduled = false;
+				state.refreshRequired = false;
+			}
+		}
+		this.states.delete(ws);
+	}
+
+	private closeRetryably(ws: WebSocket): void {
+		this.cleanupSocket(ws);
+		try { ws.close(1013, "host notification refresh required"); }
+		catch {
+			try { ws.terminate(); } catch { /* transport is already unusable */ }
+		}
 	}
 }

--- a/src/server/extension-host/module-host-bootstrap.ts
+++ b/src/server/extension-host/module-host-bootstrap.ts
@@ -101,7 +101,7 @@ interface InvokeMessage {
 	kind: "invoke";
 	/** The epoch-cache-busted file URL the dispatcher resolved + validated. */
 	url: string;
-	exportKind: "actions" | "routes" | "providers";
+	exportKind: "actions" | "routes" | "providers" | "hooks";
 	member: string;
 	/** Serializable handler context (identity + capability flags; NO live host). */
 	ctx: SerializableCtx;
@@ -666,7 +666,7 @@ async function handleInvoke(msg: InvokeMessage): Promise<void> {
 	try {
 		// ── (4) Dynamic-import the pack module through the module-import containment hook. ──
 		const mod = (await import(msg.url)) as Record<string, Record<string, unknown>>;
-		const group = msg.exportKind === "providers"
+		const group = msg.exportKind === "providers" || msg.exportKind === "hooks"
 			? ((mod.default as Record<string, unknown> | undefined) ?? mod)
 			: (mod[msg.exportKind] ?? (mod.default as Record<string, Record<string, unknown>> | undefined)?.[msg.exportKind]);
 		// Export-map validation now lives HERE (moved off the parent so the parent never
@@ -684,7 +684,7 @@ async function handleInvoke(msg: InvokeMessage): Promise<void> {
 			port!.postMessage({ kind: "result", ok: false, status: 404, error: `unknown ${msg.exportKind} member "${msg.member}"` });
 			return;
 		}
-		const ctx = msg.exportKind === "providers"
+		const ctx = msg.exportKind === "providers" || msg.exportKind === "hooks"
 			? { ...msg.ctx, host: buildHostProxy(msg.ctx), workingDir: msg.ctx.workingDir }
 			: {
 				host: buildHostProxy(msg.ctx),

--- a/src/server/extension-host/module-host-worker.ts
+++ b/src/server/extension-host/module-host-worker.ts
@@ -62,7 +62,7 @@ export interface InvokeRequest {
 	/** Snapshot of the dispatcher epoch at resolution (carried for audit/debug). */
 	epoch: number;
 	/** Which export group on the pack module holds the member. */
-	exportKind: "actions" | "routes" | "providers";
+	exportKind: "actions" | "routes" | "providers" | "hooks";
 	/** The member (action/route name) to invoke — pre-validated by the dispatcher. */
 	member: string;
 	/** The FULL handler context. Its `host` (a live ServerHostApi) stays in the
@@ -76,6 +76,9 @@ export interface InvokeRequest {
 	 *  `chdir`, so the bootstrap overrides `process.cwd` to this). Relative spawns +
 	 *  bare-relative fs paths resolve under it. Absent ⇒ the worker's real cwd. */
 	workingDir?: string;
+	/** Parent-owned cancellation. The signal is never cloned into pack code; abort
+	 * terminates the worker and fences any later result. */
+	signal?: AbortSignal;
 }
 
 /** Flag NAMES safe to forward to a `worker_threads.Worker` execArgv. Node rejects
@@ -181,8 +184,9 @@ export class ModuleHost {
 	 *     dispatcher passes its own per-call timeout).
 	 * The worker is ALWAYS terminated before this settles (no zombie threads).
 	 */
-	invoke(req: InvokeRequest, timeoutMs?: number): Promise<unknown> {
+	invoke(req: InvokeRequest, timeoutMs?: number, signal: AbortSignal | undefined = req.signal): Promise<unknown> {
 		if (this.disposed) return Promise.reject(new ActionError(500, "module host disposed"));
+		if (signal?.aborted) return Promise.reject(new ActionError(499, "pack server module invocation cancelled"));
 		const limit = timeoutMs ?? this.defaultTimeoutMs;
 		const host = (req.ctx as { host?: unknown } | undefined)?.host;
 		const capSrc = (host as { capabilities?: Record<string, unknown> } | undefined)?.capabilities;
@@ -194,7 +198,7 @@ export class ModuleHost {
 		// worker tier gets `capabilities.store === true`; `callRoute` is always false
 		// (a server module reaches its own routes directly).
 		const { host: _liveProviderHost, ...providerCtxNoHost } = providerCtx;
-		const serCtx = req.exportKind === "providers"
+		const serCtx = req.exportKind === "providers" || req.exportKind === "hooks"
 			? {
 				...providerCtxNoHost,
 				workingDir: providerCtx.workingDir ?? req.workingDir,
@@ -252,10 +256,13 @@ export class ModuleHost {
 
 		return new Promise<unknown>((resolve, reject) => {
 			let settled = false;
+			let timer: ReturnType<typeof setTimeout> | undefined;
+			let onAbort: () => void = () => undefined;
 			const finish = (fn: () => void): void => {
 				if (settled) return;
 				settled = true;
-				clearTimeout(timer);
+				if (timer) clearTimeout(timer);
+				signal?.removeEventListener("abort", onAbort);
 				this.live.delete(worker);
 				// True terminate-on-timeout (and unconditional teardown so a completed
 				// worker never lingers). terminate() is fire-and-forget.
@@ -268,9 +275,15 @@ export class ModuleHost {
 			};
 			// Wall-time termination IS the CPU-exhaustion control (a runaway
 			// while(1) is KILLED here; worker_threads has no per-core throttle).
-			const timer = setTimeout(() => {
+			timer = setTimeout(() => {
 				finish(() => reject(new ActionError(504, "pack server module timed out")));
 			}, limit);
+			onAbort = (): void => {
+				finish(() => reject(new ActionError(499, "pack server module invocation cancelled")));
+			};
+			signal?.addEventListener("abort", onAbort, { once: true });
+			if (signal?.aborted) onAbort();
+			if (settled) return;
 
 			worker.on("message", (msg: { kind?: string; ok?: boolean; value?: unknown; status?: number; error?: string; id?: number; path?: unknown; args?: unknown[]; pid?: number }) => {
 				if (msg?.kind === "result") {

--- a/src/server/extension-host/pack-contribution-registry.ts
+++ b/src/server/extension-host/pack-contribution-registry.ts
@@ -157,7 +157,7 @@ export class PackContributionRegistry implements PackContributionResolver {
 		const hook = this.getPack(projectId, packId)?.hooks.find(
 			(candidate) => candidate.id === contributionId && candidate.listName === listName && candidate.kind !== undefined,
 		);
-		return !!hook && requiredCapabilities.every((capability) => hook.capabilities.some((granted) => granted === capability));
+		return !!hook && requiredCapabilities.every((capability) => hook.capabilities.some((declared) => declared === capability));
 	}
 
 	list(projectId: string | undefined): PackContributions[] {
@@ -271,7 +271,7 @@ export class PackContributionRegistry implements PackContributionResolver {
 			}
 			// Legacy rows retain their metadata-only compatibility behavior. Explicit
 			// runtime rows additionally honor declaration config activation; none of
-			// these checks imports pack code or grants undeclared capabilities.
+			// these checks imports pack code or authorizes undeclared capabilities.
 			const disabledHooks = this.disabledHooks
 				? new Set(this.disabledHooks(e.scope, projectId, contrib.packName))
 				: undefined;

--- a/src/server/extension-host/pack-contribution-registry.ts
+++ b/src/server/extension-host/pack-contribution-registry.ts
@@ -38,7 +38,7 @@ export interface PackContributionResolver {
 	getEntrypoint(projectId: string | undefined, packId: string, entrypointId: string): EntrypointContribution | undefined;
 	/** List active provider contributions across all active packs. */
 	listProviders(projectId: string | undefined): ProviderContribution[];
-	/** List active inert hook metadata across all active packs. */
+	/** List active hook declarations; legacy rows remain inert to runtime consumers. */
 	listHooks(projectId: string | undefined): HookContribution[];
 	/** Resolve a channel handler within a pack. */
 	getChannel(projectId: string | undefined, packId: string, name: string): ChannelContribution | undefined;
@@ -96,6 +96,10 @@ const DEFAULT_KEY = "\u0000default";
 
 export class PackContributionRegistry implements PackContributionResolver {
 	private cache = new Map<string, IndexedScope>();
+	/** Monotonic process-local activation generation. Runtime hook settlement is
+	 * accepted only while it still matches this generation. */
+	private activationEpoch = 0;
+	private readonly invalidationListeners = new Set<() => void>();
 
 	/**
 	 * @param enumerate  Returns the installed market-pack entries for a project
@@ -111,9 +115,49 @@ export class PackContributionRegistry implements PackContributionResolver {
 		private readonly disabledHooks?: DisabledEntrypointsLookup,
 	) {}
 
-	/** Drop the per-project index cache (rebuilt lazily on next read). */
+	/** Drop the per-project index cache and fence every in-flight runtime hook. */
 	invalidate(): void {
 		this.cache = new Map();
+		this.activationEpoch++;
+		for (const listener of [...this.invalidationListeners]) listener();
+	}
+
+	onInvalidate(listener: () => void): () => void {
+		this.invalidationListeners.add(listener);
+		return () => { this.invalidationListeners.delete(listener); };
+	}
+
+	getActivationEpoch(): number {
+		return this.activationEpoch;
+	}
+
+	/** Live authority check used immediately before invocation and result apply. */
+	isProviderAuthorized(
+		projectId: string | undefined,
+		packId: string,
+		providerId: string,
+		listName: string,
+		epoch: number,
+	): boolean {
+		if (epoch !== this.activationEpoch) return false;
+		return !!this.getPack(projectId, packId)?.providers.some(
+			(provider) => provider.id === providerId && provider.listName === listName,
+		);
+	}
+
+	isHookAuthorized(
+		projectId: string | undefined,
+		packId: string,
+		contributionId: string,
+		listName: string,
+		epoch: number,
+		requiredCapabilities: readonly string[] = [],
+	): boolean {
+		if (epoch !== this.activationEpoch) return false;
+		const hook = this.getPack(projectId, packId)?.hooks.find(
+			(candidate) => candidate.id === contributionId && candidate.listName === listName && candidate.kind !== undefined,
+		);
+		return !!hook && requiredCapabilities.every((capability) => hook.capabilities.some((granted) => granted === capability));
 	}
 
 	list(projectId: string | undefined): PackContributions[] {
@@ -225,14 +269,17 @@ export class PackContributionRegistry implements PackContributionResolver {
 			if (resolvedProviders.length !== contrib.providers.length || resolvedProviders.some((p, i) => p !== contrib.providers[i])) {
 				contrib = { ...contrib, providers: resolvedProviders };
 			}
-			// Hook declarations remain inert metadata. Activation only filters their
-			// manifest listName; it never evaluates config or confers capabilities.
+			// Legacy rows retain their metadata-only compatibility behavior. Explicit
+			// runtime rows additionally honor declaration config activation; none of
+			// these checks imports pack code or grants undeclared capabilities.
 			const disabledHooks = this.disabledHooks
 				? new Set(this.disabledHooks(e.scope, projectId, contrib.packName))
 				: undefined;
-			if (disabledHooks && disabledHooks.size > 0) {
-				contrib = { ...contrib, hooks: contrib.hooks.filter((hook) => !disabledHooks.has(hook.listName)) };
-			}
+			const activeHooks = contrib.hooks.filter((hook) => {
+				if (disabledHooks?.has(hook.listName)) return false;
+				return hook.kind === undefined || hookActivationSatisfied(hook);
+			});
+			if (activeHooks.length !== contrib.hooks.length) contrib = { ...contrib, hooks: activeHooks };
 			const authorizedChannels = authorizeChannelCapabilities(e, contrib.channels);
 			if (authorizedChannels !== contrib.channels) contrib = { ...contrib, channels: authorizedChannels };
 			loaded.push(contrib);
@@ -327,6 +374,17 @@ function safeDiagnosticCode(diagnostic: unknown): string {
 	return typeof code === "string" && /^[A-Z0-9_]{1,80}$/.test(code)
 		? code
 		: "STORE_READ_UNAVAILABLE";
+}
+
+function hookActivationSatisfied(hook: HookContribution): boolean {
+	const required = hook.activation?.requiresConfig;
+	if (!required || required.length === 0) return true;
+	const config = hook.config ?? {};
+	return required.every((key) => {
+		const value = config[key];
+		if (value === undefined || value === null) return false;
+		return typeof value !== "string" || value.trim().length > 0;
+	});
 }
 
 function providerActivationSatisfied(provider: ProviderContribution): boolean {

--- a/src/server/extension-host/server-host-api.ts
+++ b/src/server/extension-host/server-host-api.ts
@@ -186,6 +186,12 @@ export interface CreateServerHostApiOptions {
 	 *  Own-session by construction — there is no parameter for another session. When
 	 *  absent (non-gateway context), the session reads throw a clear error. */
 	readOwnTranscript?: () => Promise<string | null>;
+	/** Optional live authority fence for a project-bound session host. The gateway
+	 *  derives this predicate from the expected project and current live + persisted
+	 *  session ownership. When supplied, every session/agents operation checks it
+	 *  before work and again after asynchronous settlement. Ordinary action/route
+	 *  hosts omit it and retain their existing authenticated-session semantics. */
+	isSessionAuthorized?: () => boolean;
 	/** SUB-GOAL A SEAM (orchestration-core §8.3): the gateway injects the shared
 	 *  OrchestrationCore so sub-goal C can implement the ambient `host.agents`
 	 *  capability (spawn/prompt/dismiss/list/read/status) over the SAME core that
@@ -227,6 +233,12 @@ export function createServerHostApi(opts: CreateServerHostApiOptions): ServerHos
 	// Slice B2: own-session transcript reader (header-bound session, supplied by the
 	// gateway). The reads below map its rows through the single contract adapter.
 	const readOwnTranscript = opts.readOwnTranscript;
+	const assertSessionAuthorized = (member: string): void => {
+		if (!opts.isSessionAuthorized) return;
+		let authorized = false;
+		try { authorized = opts.isSessionAuthorized(); } catch { /* fail closed */ }
+		if (!authorized) throw new Error(`host.${member} session authority is no longer valid`);
+	};
 	const requireReader = (member: string): (() => Promise<string | null>) => {
 		if (!readOwnTranscript) {
 			throw new Error(`host.session.${member} requires a gateway transcript reader`);
@@ -291,11 +303,15 @@ export function createServerHostApi(opts: CreateServerHostApiOptions): ServerHos
 	// lands the read bodies early purely to decouple the work.
 	const session: ServerHostSessionApi = {
 		readTranscript: async (sessionOpts) => {
+			assertSessionAuthorized("session.readTranscript");
 			const jsonl = await requireReader("readTranscript")();
+			assertSessionAuthorized("session.readTranscript");
 			return buildTranscriptEnvelope(transcriptToHostMessages(jsonl), sessionOpts);
 		},
 		readToolCall: async (toolUseId) => {
+			assertSessionAuthorized("session.readToolCall");
 			const jsonl = await requireReader("readToolCall")();
+			assertSessionAuthorized("session.readToolCall");
 			return transcriptToToolCall(jsonl, toolUseId);
 		},
 		// `postMessage` is intentionally NOT implemented on the server host (Fix B):
@@ -346,6 +362,7 @@ export function createServerHostApi(opts: CreateServerHostApiOptions): ServerHos
 	};
 	const agents: ServerHostAgentsApi = {
 		spawn: async (spawnOpts) => {
+			assertSessionAuthorized("agents.spawn");
 			const c = requireCore();
 			// Recursion denial reuses A's shared guard (no grandchildren), surfaced as a
 			// capability-specific message.
@@ -368,30 +385,56 @@ export function createServerHostApi(opts: CreateServerHostApiOptions): ServerHos
 				toolEnv: spawnOpts.toolEnv,
 				childKind: HOST_AGENTS_KIND,
 			});
+			try {
+				assertSessionAuthorized("agents.spawn");
+			} catch (error) {
+				// The core captures owner scope synchronously before its first await, so a
+				// concurrent move cannot mint in the destination project. Remove the now
+				// stale old-project child before denying settlement to the old handler.
+				try { await c.dismiss(ownerSessionId, handle.sessionId); } catch { /* best-effort containment */ }
+				throw error;
+			}
 			return { childSessionId: handle.sessionId };
 		},
 		prompt: async (childSessionId, message) => {
+			assertSessionAuthorized("agents.prompt");
 			requireOwnAgentsChild(childSessionId);
-			return requireCore().prompt(ownerSessionId, childSessionId, message);
+			const result = await requireCore().prompt(ownerSessionId, childSessionId, message);
+			assertSessionAuthorized("agents.prompt");
+			return result;
 		},
 		dismiss: async (childSessionId) => {
+			assertSessionAuthorized("agents.dismiss");
 			const c = requireCore();
 			const ownedKind = c.ownedChildKind(ownerSessionId, childSessionId);
 			if (ownedKind && ownedKind !== HOST_AGENTS_KIND) return hostAgentsNotOwned(childSessionId);
-			return c.dismiss(ownerSessionId, childSessionId);
+			const result = await c.dismiss(ownerSessionId, childSessionId);
+			assertSessionAuthorized("agents.dismiss");
+			return result;
 		},
-		list: async () => ownHostAgentsChildren().map((h) => ({
-			childSessionId: h.sessionId,
-			status: mapStatus(readChildStatus?.(h.sessionId)),
-			childKind: h.childKind,
-		})),
+		list: async () => {
+			assertSessionAuthorized("agents.list");
+			const result = ownHostAgentsChildren().map((h) => ({
+				childSessionId: h.sessionId,
+				status: mapStatus(readChildStatus?.(h.sessionId)),
+				childKind: h.childKind,
+			}));
+			assertSessionAuthorized("agents.list");
+			return result;
+		},
 		read: async (childSessionId, readOpts) => {
+			assertSessionAuthorized("agents.read");
 			requireOwnAgentsChild(childSessionId);
-			return requireCore().read(ownerSessionId, childSessionId, readOpts);
+			const result = await requireCore().read(ownerSessionId, childSessionId, readOpts);
+			assertSessionAuthorized("agents.read");
+			return result;
 		},
 		status: async (childSessionId) => {
+			assertSessionAuthorized("agents.status");
 			requireOwnAgentsChild(childSessionId);
-			return { status: mapStatus(readChildStatus?.(childSessionId)) };
+			const result = { status: mapStatus(readChildStatus?.(childSessionId)) };
+			assertSessionAuthorized("agents.status");
+			return result;
 		},
 	};
 

--- a/src/server/gate-status-broadcast.ts
+++ b/src/server/gate-status-broadcast.ts
@@ -1,4 +1,4 @@
-import type { GateStatus, GateStore } from "./agent/gate-store.js";
+import type { GateStatus, GateStatusCommit, GateStore } from "./agent/gate-store.js";
 import type { GoalStore } from "./agent/goal-store.js";
 import type { ServerMessage } from "./ws/protocol.js";
 
@@ -29,4 +29,12 @@ export function wireGateStatusGenerationInvalidation(
 	gateStore.onStatusChange = () => {
 		goalStore.bumpGeneration();
 	};
+}
+
+/** Wire the canonical post-persistence gate transition observer independently of legacy broadcasts. */
+export function wireGateStatusCommittedObserver(
+	gateStore: Pick<GateStore, "onStatusCommitted">,
+	observer: (commit: Readonly<GateStatusCommit>) => void,
+): void {
+	gateStore.onStatusCommitted = observer;
 }

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -4244,6 +4244,7 @@ export function createGateway(config: GatewayConfig, deps?: GatewayDeps) {
 	sessionManager.setHostNotificationPublisher(hostNotificationDispatcher as any);
 	sessionManager.setHostInterceptorPort({
 		dispatch: (name, input, context) => hostInterceptorRouter.dispatch(name as any, input as any, context as any),
+		requiresFailClosed: (name, projectId) => hostInterceptorRouter.requiresFailClosed(name as any, projectId),
 		hasAny: (names, projectId, goalId) => {
 			const explicit = normalizeHookContributions(packContributionRegistry, projectId)
 				.some(row => row.kind === "interceptor" && names.includes(row.name));

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -91,6 +91,7 @@ import { mintSurfaceToken, resolveSurfaceIdentity } from "./extension-host/surfa
 import type { StorePutOptions } from "../shared/extension-host/host-api.js";
 import { PackContributionRegistry, type ProviderConfigOverrideReadResult } from "./extension-host/pack-contribution-registry.js";
 import { HostInterceptorRouter } from "./extension-host/host-interceptor-router.js";
+import { hostInterceptorAuditSink } from "./extension-host/host-interceptor-audit.js";
 import {
 	HostNotificationDispatcher,
 	HostNotificationModuleAdapter,
@@ -2159,26 +2160,42 @@ export async function shutdownCpuDiagnostics(diagnostics: Pick<CpuDiagnostics, "
 	try { await diagnostics.shutdown(); } catch { /* best-effort */ }
 }
 
-type SettingsChangedIdentifier = "components" | "workflows" | "configDirectories" | "sandbox" | "sandboxTokens" | "packOrder" | "packActivation" | "commands" | "providers" | "models";
+type SettingsChangedIdentifier = "baseRef" | "commands" | "components" | "configDirectories" | "models" | "packActivation" | "packOrder" | "providers" | "sandbox" | "sandboxTokens" | "workflows" | "worktrees";
+
+/**
+ * Allowlist of public ProjectConfigStore families. Unknown flat keys are
+ * deliberately omitted: that namespace is extensible and may contain secrets.
+ */
+const SETTINGS_CHANGED_IDENTIFIERS = new Map<string, SettingsChangedIdentifier>([
+	["base_ref", "baseRef"],
+	["build_command", "commands"],
+	["components", "components"],
+	["config_directories", "configDirectories"],
+	["pack_activation", "packActivation"],
+	["pack_order", "packOrder"],
+	["sandbox", "sandbox"],
+	["sandbox_credentials", "sandbox"],
+	["sandbox_github_token", "sandbox"],
+	["sandbox_host_token_overrides", "sandbox"],
+	["sandbox_image", "sandbox"],
+	["sandbox_mounts", "sandbox"],
+	["sandbox_tokens", "sandboxTokens"],
+	["test_command", "commands"],
+	["test_e2e_command", "commands"],
+	["test_unit_command", "commands"],
+	["typecheck_command", "commands"],
+	["workflows", "workflows"],
+	["worktree_pool_size", "worktrees"],
+	["worktree_root", "worktrees"],
+	["worktree_setup_command", "commands"],
+	["worktree_setup_timeout_ms", "worktrees"],
+]);
 
 function settingsChangedIdentifiers(keys: readonly string[]): SettingsChangedIdentifier[] {
-	const mapped = keys.flatMap((key): SettingsChangedIdentifier[] => {
-		switch (key) {
-			case "components": return ["components"];
-			case "workflows": return ["workflows"];
-			case "config_directories": return ["configDirectories"];
-			case "sandbox_tokens": return ["sandboxTokens"];
-			case "pack_order": return ["packOrder"];
-			case "pack_activation": return ["packActivation"];
-			default:
-				if (key.includes("command")) return ["commands"];
-				if (key.includes("provider")) return ["providers"];
-				if (key.includes("model") || key.includes("thinking")) return ["models"];
-				if (key.startsWith("sandbox")) return ["sandbox"];
-				return [];
-		}
-	});
-	return [...new Set(mapped)].sort();
+	return [...new Set(keys.flatMap(key => {
+		const identifier = SETTINGS_CHANGED_IDENTIFIERS.get(key);
+		return identifier === undefined ? [] : [identifier];
+	}))].sort();
 }
 
 /**
@@ -4148,6 +4165,7 @@ export function createGateway(config: GatewayConfig, deps?: GatewayDeps) {
 
 	const hostInterceptorRouter = new HostInterceptorRouter({
 		registry: packContributionRegistry,
+		audit: hostInterceptorAuditSink,
 		moduleHost,
 		lifecycleHub: sessionManager.lifecycleHub,
 		createHostApi: ({ context, packId, contributionId, capabilities }) =>
@@ -4852,6 +4870,8 @@ export function createGateway(config: GatewayConfig, deps?: GatewayDeps) {
 		orchestrationCore,
 		bgProcessManager,
 		projectContextManager,
+		/** @internal Exposed for integration coverage of production hook wiring. */
+		hostInterceptorRouter,
 		get extensionChannels() { return extensionChannelServices; },
 		async start(): Promise<number> {
 			// Phase timer for the pre-listen critical path: everything awaited here

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -4156,6 +4156,16 @@ export function createGateway(config: GatewayConfig, deps?: GatewayDeps) {
 	// from compression in production either, so this is a strict win.
 	const wss = new WebSocketServer({ noServer: true, perMessageDeflate: false, maxPayload: WS_MAX_PAYLOAD_BYTES });
 
+	const resolveHostNotificationSessionProject = (sessionId: string): string | undefined => {
+		const liveProjectId = sessionManager.getSession(sessionId)?.projectId;
+		const persistedProjectId = sessionManager.getPersistedSession(sessionId)?.projectId;
+		// Both are host-owned authorities. Refuse an ambiguous transition rather than
+		// choosing a partition; a completed live reassignment may temporarily have no
+		// row in the destination store, in which case the live owner is authoritative.
+		if (liveProjectId && persistedProjectId && liveProjectId !== persistedProjectId) return undefined;
+		return liveProjectId ?? persistedProjectId;
+	};
+
 	const createHookHostApi = (
 		context: { projectId?: string; sessionId?: string; cwd: string },
 		packId: string,
@@ -4163,12 +4173,17 @@ export function createGateway(config: GatewayConfig, deps?: GatewayDeps) {
 		capabilities: readonly string[],
 	) => {
 		const localDataDirectory = resolveDeclaredPackLocalData(context.projectId, packId);
+		const isSessionAuthorized = context.sessionId
+			? () => typeof context.projectId === "string"
+				&& resolveHostNotificationSessionProject(context.sessionId!) === context.projectId
+			: undefined;
 		return createServerHostApi({
 			sessionId: context.sessionId ?? `project:${context.projectId ?? "unbound"}`,
 			packId,
 			contributionId,
 			packStore: getPackStore(),
 			...(localDataDirectory ? { localDataDirectory } : {}),
+			...(isSessionAuthorized ? { isSessionAuthorized } : {}),
 			capabilityMask: {
 				store: capabilities.includes("store"),
 				session: capabilities.includes("session") && context.sessionId !== undefined,
@@ -4177,10 +4192,12 @@ export function createGateway(config: GatewayConfig, deps?: GatewayDeps) {
 			},
 			...(context.sessionId ? {
 				readOwnTranscript: async () => {
+					if (isSessionAuthorized && !isSessionAuthorized()) throw new Error("host.session authority is no longer valid");
 					const persisted = sessionManager.getPersistedSession(context.sessionId!);
 					if (!persisted?.agentSessionFile) return null;
 					const fsContext = sessionFsContextForAgentFile(persisted, persisted.agentSessionFile);
 					const jsonl = await sessionFileRead(fsContext, persisted.agentSessionFile, sandboxManager);
+					if (isSessionAuthorized && !isSessionAuthorized()) throw new Error("host.session authority is no longer valid");
 					return projectOwnTranscriptJsonl(context.sessionId!, jsonl);
 				},
 				orchestrationCore,
@@ -4252,6 +4269,8 @@ export function createGateway(config: GatewayConfig, deps?: GatewayDeps) {
 		isAuthorized: (handler, notification) => {
 			const contribution = (handler as RuntimeNotificationHandler).contribution;
 			return handler.projectId === notification.projectId
+				&& (!notification.sessionId
+					|| resolveHostNotificationSessionProject(notification.sessionId) === notification.projectId)
 				&& packContributionRegistry.isHookAuthorized(
 					notification.projectId,
 					contribution.packId,
@@ -4263,6 +4282,10 @@ export function createGateway(config: GatewayConfig, deps?: GatewayDeps) {
 		},
 		invoke: (handler, notification, signal) => {
 			const contribution = (handler as RuntimeNotificationHandler).contribution;
+			if (notification.sessionId
+				&& resolveHostNotificationSessionProject(notification.sessionId) !== notification.projectId) {
+				throw new Error("notification session authority is no longer valid");
+			}
 			const persisted = notification.sessionId
 				? sessionManager.getPersistedSession(notification.sessionId)
 				: undefined;
@@ -4295,15 +4318,6 @@ export function createGateway(config: GatewayConfig, deps?: GatewayDeps) {
 			}, handler.timeoutMs, signal);
 		},
 	});
-	const resolveHostNotificationSessionProject = (sessionId: string): string | undefined => {
-		const liveProjectId = sessionManager.getSession(sessionId)?.projectId;
-		const persistedProjectId = sessionManager.getPersistedSession(sessionId)?.projectId;
-		// Both are host-owned authorities. Refuse an ambiguous transition rather than
-		// choosing a partition; a completed live reassignment may temporarily have no
-		// row in the destination store, in which case the live owner is authoritative.
-		if (liveProjectId && persistedProjectId && liveProjectId !== persistedProjectId) return undefined;
-		return liveProjectId ?? persistedProjectId;
-	};
 	const hostNotificationDispatcher = new HostNotificationDispatcher({
 		adapters: [
 			new HostNotificationSocketRouter(() => wss.clients, {

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -9221,17 +9221,11 @@ async function handleApiRoute(
 				maxConcurrentChildren: effMaxConcurrentChildren,
 				metadata,
 				worktree: explicitWorktree,
-				...(body?.team !== false ? { team: true } : {}),
+				// `team: false` historically means "standalone until manually
+				// started". Give createGoal the final shape so goalCreated is the only
+				// fact for this create and no existing record is silently rewritten.
+				team: body?.team !== false,
 			});
-			// `team: false` historically meant "do not auto-enable yet", not a
-			// durable prohibition on a later manual start. GoalManager defaults new
-			// goals to team mode, so remove that default from this explicit legacy
-			// shape while retaining `team: true` as archive-retry evidence for goals
-			// that were actually enabled at creation.
-			if (body?.team === false) {
-				delete goal.team;
-				targetCtx.goalStore.put(goal);
-			}
 			// Set projectId from the explicit request scope.
 			if (targetProjectId) {
 				targetGoalManager.updateGoal(goal.id, { projectId: targetProjectId });
@@ -13892,10 +13886,9 @@ async function handleApiRoute(
 			// preserve team worktree/branch evidence after TeamStore is reconciled.
 			if (startGoal.team === undefined) {
 				const startContext = projectContextManager.getContextForGoal(goalId);
-				if (!startContext?.goalStore.update(goalId, { team: true })) {
+				if (!startContext || !(await startContext.goalStore.updateStrict(goalId, { team: true }))) {
 					throw new Error(`Unable to enable team mode for goal ${goalId}`);
 				}
-				await startContext.goalStore.flush();
 			}
 			// REST retries are idempotent even after the first paused request has
 			// resumed the goal. Resume authority remains limited to the paused

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -4295,13 +4295,24 @@ export function createGateway(config: GatewayConfig, deps?: GatewayDeps) {
 			}, handler.timeoutMs, signal);
 		},
 	});
+	const resolveHostNotificationSessionProject = (sessionId: string): string | undefined => {
+		const liveProjectId = sessionManager.getSession(sessionId)?.projectId;
+		const persistedProjectId = sessionManager.getPersistedSession(sessionId)?.projectId;
+		// Both are host-owned authorities. Refuse an ambiguous transition rather than
+		// choosing a partition; a completed live reassignment may temporarily have no
+		// row in the destination store, in which case the live owner is authoritative.
+		if (liveProjectId && persistedProjectId && liveProjectId !== persistedProjectId) return undefined;
+		return liveProjectId ?? persistedProjectId;
+	};
 	const hostNotificationDispatcher = new HostNotificationDispatcher({
 		adapters: [
-			new HostNotificationSocketRouter(() => wss.clients),
+			new HostNotificationSocketRouter(() => wss.clients, {
+				resolveSessionProject: resolveHostNotificationSessionProject,
+			}),
 			notificationModuleAdapter,
 			notificationStaffDispatcher,
 		],
-		resolveSessionProject: (sessionId) => sessionManager.getPersistedSession(sessionId)?.projectId,
+		resolveSessionProject: resolveHostNotificationSessionProject,
 	});
 	projectContextManager.setHostNotificationDispatcher(hostNotificationDispatcher);
 	sessionManager.setHostNotificationPublisher(hostNotificationDispatcher as any);

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -632,9 +632,10 @@ import { StaffManager } from "./agent/staff-manager.js";
 import { buildStaffSystemPrompt } from "./agent/role-prompt.js";
 import { TriggerEngine } from "./agent/staff-trigger-engine.js";
 import { GoalTriggerDispatcher } from "./agent/goal-trigger-dispatcher.js";
-import { InboxManager, type InboxEntry } from "./agent/inbox-manager.js";
+import { InboxManager, type InboxEntry, type InboxLiveAddress, type InboxLiveEvent } from "./agent/inbox-manager.js";
 import { InboxNudger } from "./agent/inbox-nudger.js";
 import { NotificationStaffDispatcher } from "./agent/notification-staff-dispatcher.js";
+import { runWithStaffNotificationTurnContext } from "./agent/staff-notification-causation.js";
 import type { InboxStore } from "./agent/inbox-store.js";
 import { PreferencesStore } from "./agent/preferences-store.js";
 import { ProjectConfigLoadError, ProjectConfigStore, type PackOrderScope } from "./agent/project-config-store.js";
@@ -3159,7 +3160,7 @@ export function createGateway(config: GatewayConfig, deps?: GatewayDeps) {
 	//   - Wiring order: construct InboxManager → construct InboxNudger →
 	//     inboxManager.setNudger(inboxNudger) → staffManager.setInboxManager(
 	//     inboxManager) → sessionManager.setInboxNudger(inboxNudger) → start.
-	const inboxManager = new InboxManager(projectContextManager, staffManager, (event) => broadcastToAll(event));
+	const inboxManager = new InboxManager(projectContextManager, staffManager, broadcastInboxLive);
 	const crossProjectInboxStore: InboxStore = {
 		listPending: (staffId: string): InboxEntry[] => {
 			for (const ctx of projectContextManager.all()) {
@@ -3188,7 +3189,11 @@ export function createGateway(config: GatewayConfig, deps?: GatewayDeps) {
 		projectContextManager,
 		staffManager,
 		inboxManager,
-		{ clock: gatewayDeps.clock },
+		{
+			clock: gatewayDeps.clock,
+			isTurnContextCurrent: (context) => !!context
+				&& sessionManager.getStaffNotificationTurnContext(context.sessionId) === context,
+		},
 	);
 
 	// One-shot migration: heal sessions that lost their `staffId` association
@@ -4010,7 +4015,16 @@ export function createGateway(config: GatewayConfig, deps?: GatewayDeps) {
 			// Enable via BOBBIT_TIMING_LOG=1 to print "[timing] METHOD path ms" for each API call.
 			const _timingEnabled = process.env.BOBBIT_TIMING_LOG === "1";
 			const _timingStart = _timingEnabled ? performance.now() : 0;
-			await handleApiRoute(url, req, res, sessionManager, config, colorStore, prStatusStore, teamManager, orchestrationCore, roleManager, toolManager, projectContextManager, bgProcessManager, staffManager, verificationHarness, preferencesStore, projectConfigStore, groupPolicyStore, broadcastToGoal, broadcastToAll, broadcastToUi, sandboxManager, projectRegistry, configCascade, sandboxScope, sandboxTokenStore, reviewAnnotationStore, broadcastToSession, roleStore, inboxManager, marketplaceSourceStore, marketplaceInstaller, cookieStore, actionDispatcher, routeDispatcher, routeRegistry, packContributionRegistry, extensionChannelServices, gatewayDeps.fetchImpl, gatewayDeps.commandRunner, gatewayDeps.fsImpl, gatewayDeps.clock, withPreviewSessionOperation, reviewPayloadOperations, oauthCancellationRetryState, remoteStateRoutes, hostInterceptorRouter);
+			const rawSessionSecret = req.headers["x-bobbit-session-secret"];
+			const sessionSecret = Array.isArray(rawSessionSecret) ? rawSessionSecret[0] : rawSessionSecret;
+			const authenticSessionId = sessionManager.sessionSecretStore.resolveSessionIdBySecret(sessionSecret);
+			const causalTurn = authenticSessionId
+				&& (!sandboxScope || (sandboxScope.sessionIds.has(authenticSessionId) && sandboxScope.projectId === sessionManager.getSession(authenticSessionId)?.projectId))
+				? sessionManager.getStaffNotificationTurnContext(authenticSessionId)
+				: undefined;
+			const routeOperation = () => handleApiRoute(url, req, res, sessionManager, config, colorStore, prStatusStore, teamManager, orchestrationCore, roleManager, toolManager, projectContextManager, bgProcessManager, staffManager, verificationHarness, preferencesStore, projectConfigStore, groupPolicyStore, broadcastToGoal, broadcastToAll, broadcastToUi, sandboxManager, projectRegistry, configCascade, sandboxScope, sandboxTokenStore, reviewAnnotationStore, broadcastToSession, roleStore, inboxManager, marketplaceSourceStore, marketplaceInstaller, cookieStore, actionDispatcher, routeDispatcher, routeRegistry, packContributionRegistry, extensionChannelServices, gatewayDeps.fetchImpl, gatewayDeps.commandRunner, gatewayDeps.fsImpl, gatewayDeps.clock, withPreviewSessionOperation, reviewPayloadOperations, oauthCancellationRetryState, remoteStateRoutes, hostInterceptorRouter);
+			if (causalTurn) await runWithStaffNotificationTurnContext(causalTurn, routeOperation);
+			else await routeOperation();
 			if (_timingEnabled) {
 				const dur = performance.now() - _timingStart;
 				if (dur >= 100) console.log(`[timing] ${req.method} ${url.pathname}${url.search} ${dur.toFixed(1)}ms`);
@@ -4388,6 +4402,34 @@ export function createGateway(config: GatewayConfig, deps?: GatewayDeps) {
 			stringifyMs,
 			sendMs: performance.now() - sendStart,
 		});
+	}
+
+	/** Publish a bounded inbox invalidation only to the exact owning staff UI
+	 * session. Project, staff, live/persisted session, viewer, unbound, and sandbox
+	 * authority are all checked server-side; clients never filter for isolation. */
+	function broadcastInboxLive(event: InboxLiveEvent, address?: InboxLiveAddress): void {
+		if (!address) return;
+		const staff = staffManager.getStaff(address.staffId);
+		if (!staff
+			|| staff.projectId !== address.projectId
+			|| staff.currentSessionId !== address.staffSessionId) return;
+		const session = sessionManager.getSession(address.staffSessionId);
+		const persisted = sessionManager.getPersistedSession(address.staffSessionId);
+		if (!session
+			|| !persisted
+			|| session.staffId !== address.staffId
+			|| persisted.staffId !== address.staffId
+			|| session.projectId !== address.projectId
+			|| persisted.projectId !== address.projectId) return;
+		const data = JSON.stringify(event);
+		for (const ws of session.clients) {
+			if ((ws as any).authenticated !== true
+				|| (ws as any).isViewer === true
+				|| (ws as any).sessionId !== address.staffSessionId
+				|| !hasUiWebSocketPrincipal(ws)
+				|| !isSocketSendable(ws)) continue;
+			ws.send(data);
+		}
 	}
 
 	/** Broadcast to ALL authenticated WebSocket clients (regardless of session/goal). */

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -8153,32 +8153,54 @@ async function handleApiRoute(
 			json({ error: "Invalid bounded tool hook body" }, 400);
 			return;
 		}
+		const claim = isBefore
+			? await sessionManager.claimToolCallBefore(sessionId, body.toolCallId, body.toolName)
+			: sessionManager.claimToolCallAfter(sessionId, body.toolCallId, body.toolName);
+		if (!claim) {
+			json({ error: "Tool callback provenance unavailable" }, 409);
+			return;
+		}
 		try {
 			if (isBefore) {
-				const routed = await sessionManager.dispatchHostInterceptor(sessionId, "beforeToolCall", {
-					toolCallId: body.toolCallId,
-					toolName: body.toolName,
+				const routed = await sessionManager.dispatchClaimedToolInterceptor(claim, {
 					args: body.args as Record<string, any>,
 				});
 				const terminal = routed?.terminal as any;
-				if (terminal?.action === "block") { json(terminal); return; }
+				if (terminal?.action === "block") {
+					if (!sessionManager.settleToolCallBefore(claim, false)) {
+						json({ error: "Tool callback provenance unavailable" }, 409);
+						return;
+					}
+					json(terminal);
+					return;
+				}
 				const args = (routed?.value as any)?.args;
-				sessionManager.markToolCallAdmitted(sessionId, body.toolCallId, body.toolName);
+				if (!sessionManager.settleToolCallBefore(claim, true)) {
+					json({ error: "Tool callback provenance unavailable" }, 409);
+					return;
+				}
 				json({ action: "replaceArgs", args });
 			} else {
-				const routed = await sessionManager.dispatchHostInterceptor(sessionId, "afterToolResult", {
-					toolCallId: body.toolCallId,
-					toolName: body.toolName,
+				const routed = await sessionManager.dispatchClaimedToolInterceptor(claim, {
 					result: body.result as any,
 				});
 				const terminal = routed?.terminal as any;
+				if (!sessionManager.settleToolCallAfter(claim)) {
+					json({ error: "Tool callback provenance unavailable" }, 409);
+					return;
+				}
 				if (terminal?.action === "syntheticError") { json(terminal); return; }
 				json({ action: "replaceResult", result: (routed?.value as any)?.result });
 			}
 		} catch (err: any) {
 			if (!isBefore) {
+				if (!sessionManager.settleToolCallAfter(claim)) {
+					json({ error: "Tool callback provenance unavailable" }, 409);
+					return;
+				}
 				json({ action: "syntheticError", code: "handler_error" });
 			} else {
+				sessionManager.cancelToolCallInterceptorClaim(claim);
 				jsonError(err instanceof TypeError ? 400 : 500, err);
 			}
 		}

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -16,7 +16,8 @@ import path from "node:path";
 
 import os from "node:os";
 import { parse as parseYaml } from "yaml";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { Value } from "@sinclair/typebox/value";
 import {
 	bobbitStateDir,
 	serverSecretsDir,
@@ -80,7 +81,7 @@ import { RoleManager } from "./agent/role-manager.js";
 import { ToolManager, copyToolGroupWithSharedDependencies, __resetToolScanCache, type MarketToolRoot, type PiExtensionExternalTool, type ScopedToolContext } from "./agent/tool-manager.js";
 import { ActionDispatcher, ActionError, resolveActionToolManager } from "./extension-host/action-dispatcher.js";
 import { RouteDispatcher, RouteRegistry } from "./extension-host/route-dispatcher.js";
-import { ModuleHost } from "./extension-host/module-host-worker.js";
+import { ModuleHost, type InvokeRequest } from "./extension-host/module-host-worker.js";
 import { authorizeActionRequest, authorizeScopedRequest, transcriptHasToolUse, type ActionGuardSession } from "./extension-host/action-guard.js";
 import { getPackStore, withStoreTimeout, PackStoreTimeoutError, PackStoreQuotaError } from "./extension-host/pack-store.js";
 import { createServerHostApi } from "./extension-host/server-host-api.js";
@@ -89,6 +90,17 @@ import { resolvePackIdentityForTool } from "./extension-host/pack-identity.js";
 import { mintSurfaceToken, resolveSurfaceIdentity } from "./extension-host/surface-binding.js";
 import type { StorePutOptions } from "../shared/extension-host/host-api.js";
 import { PackContributionRegistry, type ProviderConfigOverrideReadResult } from "./extension-host/pack-contribution-registry.js";
+import { HostInterceptorRouter } from "./extension-host/host-interceptor-router.js";
+import {
+	HostNotificationDispatcher,
+	HostNotificationModuleAdapter,
+	type HostNotificationModuleHandler,
+} from "./extension-host/host-notification-dispatcher.js";
+import { HostNotificationSocketRouter } from "./extension-host/host-notification-socket-router.js";
+import {
+	normalizeHookContributions,
+	type NormalizedNotificationContribution,
+} from "./extension-host/host-hook-contributions.js";
 import { loadPackContributions, providerConfigStoreKey, PROVIDER_CONFIG_KEY_PREFIX } from "./agent/pack-contributions.js";
 import { loadPiExtensionContributions, loadPiExtensionContributionsWithDiscoverySync } from "./agent/pi-extension-contributions.js";
 import { LifecycleHub, type HookCtx } from "./agent/lifecycle-hub.js";
@@ -622,6 +634,7 @@ import { TriggerEngine } from "./agent/staff-trigger-engine.js";
 import { GoalTriggerDispatcher } from "./agent/goal-trigger-dispatcher.js";
 import { InboxManager, type InboxEntry } from "./agent/inbox-manager.js";
 import { InboxNudger } from "./agent/inbox-nudger.js";
+import { NotificationStaffDispatcher } from "./agent/notification-staff-dispatcher.js";
 import type { InboxStore } from "./agent/inbox-store.js";
 import { PreferencesStore } from "./agent/preferences-store.js";
 import { ProjectConfigLoadError, ProjectConfigStore, type PackOrderScope } from "./agent/project-config-store.js";
@@ -2145,6 +2158,79 @@ export async function shutdownCpuDiagnostics(diagnostics: Pick<CpuDiagnostics, "
 	try { await diagnostics.shutdown(); } catch { /* best-effort */ }
 }
 
+type SettingsChangedIdentifier = "components" | "workflows" | "configDirectories" | "sandbox" | "sandboxTokens" | "packOrder" | "packActivation" | "commands" | "providers" | "models";
+
+function settingsChangedIdentifiers(keys: readonly string[]): SettingsChangedIdentifier[] {
+	const mapped = keys.flatMap((key): SettingsChangedIdentifier[] => {
+		switch (key) {
+			case "components": return ["components"];
+			case "workflows": return ["workflows"];
+			case "config_directories": return ["configDirectories"];
+			case "sandbox_tokens": return ["sandboxTokens"];
+			case "pack_order": return ["packOrder"];
+			case "pack_activation": return ["packActivation"];
+			default:
+				if (key.includes("command")) return ["commands"];
+				if (key.includes("provider")) return ["providers"];
+				if (key.includes("model") || key.includes("thinking")) return ["models"];
+				if (key.startsWith("sandbox")) return ["sandbox"];
+				return [];
+		}
+	});
+	return [...new Set(mapped)].sort();
+}
+
+/**
+ * Bind project-owned post-commit callbacks to the canonical dispatcher seam.
+ * Legacy index, broadcast, and trigger callbacks remain independently owned.
+ */
+export function wireProjectHostNotificationBoundaries(ctx: ProjectContext): void {
+	ctx.goalStore.onHostNotification = (fact) => {
+		switch (fact.name) {
+			case "goalCreated": ctx.publishHostNotification("goalCreated", { aggregateId: fact.payload.goalId, aggregateRevision: fact.revision, payload: fact.payload }); break;
+			case "goalUpdated": ctx.publishHostNotification("goalUpdated", { aggregateId: fact.payload.goalId, aggregateRevision: fact.revision, payload: { ...fact.payload, changedFields: [...fact.payload.changedFields] } }); break;
+			case "goalCompleted": ctx.publishHostNotification("goalCompleted", { aggregateId: fact.payload.goalId, aggregateRevision: fact.revision, payload: fact.payload }); break;
+			case "goalArchived": ctx.publishHostNotification("goalArchived", { aggregateId: fact.payload.goalId, aggregateRevision: fact.revision, payload: fact.payload }); break;
+		}
+	};
+	ctx.taskStore.onCommittedFact = (fact) => {
+		switch (fact.kind) {
+			case "taskCreated":
+				ctx.publishHostNotification("taskCreated", { aggregateId: fact.taskId, aggregateRevision: fact.revision, payload: {
+					taskId: fact.taskId, goalId: fact.goalId, type: fact.type, state: fact.state,
+					...(fact.parentTaskId ? { parentTaskId: fact.parentTaskId } : {}),
+				} });
+				break;
+			case "taskUpdated":
+				ctx.publishHostNotification("taskUpdated", { aggregateId: fact.taskId, aggregateRevision: fact.revision, payload: {
+					taskId: fact.taskId, goalId: fact.goalId, state: fact.state, changedFields: fact.changedFields,
+				} });
+				break;
+			case "taskStateChanged":
+				ctx.publishHostNotification("taskStateChanged", { aggregateId: fact.taskId, aggregateRevision: fact.revision, payload: {
+					taskId: fact.taskId, goalId: fact.goalId, previousState: fact.previousState, state: fact.state,
+				} });
+				break;
+		}
+	};
+	ctx.gateStore.onStatusCommitted = (fact) => {
+		ctx.publishHostNotification("gateStatusChanged", {
+			aggregateId: `${fact.goalId}:${fact.gateId}`,
+			aggregateRevision: fact.revision,
+			payload: { gateId: fact.gateId, goalId: fact.goalId, previousStatus: fact.previousStatus, status: fact.status },
+		});
+	};
+	ctx.projectConfigStore.onSettingsChanged = (fact) => {
+		const changedKeys = settingsChangedIdentifiers(fact.payload.changedKeys);
+		if (changedKeys.length === 0) return;
+		ctx.publishHostNotification("settingsChanged", {
+			aggregateId: ctx.project.id,
+			aggregateRevision: fact.revision,
+			payload: { target: fact.payload.target, changedKeys },
+		});
+	};
+}
+
 interface ShutdownWorktreePool {
 	stop(): Promise<void>;
 	drain(): Promise<void>;
@@ -2793,6 +2879,7 @@ export function createGateway(config: GatewayConfig, deps?: GatewayDeps) {
 				}
 			});
 		}
+		wireProjectHostNotificationBoundaries(ctx);
 	});
 
 	// pack-schema-v1 §6.7: resolve the pack_activation store for a scope+project.
@@ -3097,6 +3184,12 @@ export function createGateway(config: GatewayConfig, deps?: GatewayDeps) {
 	inboxManager.setNudger(inboxNudger);
 	staffManager.setInboxManager(inboxManager);
 	sessionManager.setInboxNudger(inboxNudger);
+	const notificationStaffDispatcher = new NotificationStaffDispatcher(
+		projectContextManager,
+		staffManager,
+		inboxManager,
+		{ clock: gatewayDeps.clock },
+	);
 
 	// One-shot migration: heal sessions that lost their `staffId` association
 	// before the staffId-persistence fix landed. Idempotent — sessions that
@@ -3601,6 +3694,7 @@ export function createGateway(config: GatewayConfig, deps?: GatewayDeps) {
 		invalidatePrSnapshot,
 	};
 	inboxNudger.start();
+	notificationStaffDispatcher.start();
 
 	// Push-based dispatcher for `goal_created` / `goal_archived` staff triggers.
 	// Distinct from `TriggerEngine` (which polls schedule/git) — fired
@@ -3916,7 +4010,7 @@ export function createGateway(config: GatewayConfig, deps?: GatewayDeps) {
 			// Enable via BOBBIT_TIMING_LOG=1 to print "[timing] METHOD path ms" for each API call.
 			const _timingEnabled = process.env.BOBBIT_TIMING_LOG === "1";
 			const _timingStart = _timingEnabled ? performance.now() : 0;
-			await handleApiRoute(url, req, res, sessionManager, config, colorStore, prStatusStore, teamManager, orchestrationCore, roleManager, toolManager, projectContextManager, bgProcessManager, staffManager, verificationHarness, preferencesStore, projectConfigStore, groupPolicyStore, broadcastToGoal, broadcastToAll, broadcastToUi, sandboxManager, projectRegistry, configCascade, sandboxScope, sandboxTokenStore, reviewAnnotationStore, broadcastToSession, roleStore, inboxManager, marketplaceSourceStore, marketplaceInstaller, cookieStore, actionDispatcher, routeDispatcher, routeRegistry, packContributionRegistry, extensionChannelServices, gatewayDeps.fetchImpl, gatewayDeps.commandRunner, gatewayDeps.fsImpl, gatewayDeps.clock, withPreviewSessionOperation, reviewPayloadOperations, oauthCancellationRetryState, remoteStateRoutes);
+			await handleApiRoute(url, req, res, sessionManager, config, colorStore, prStatusStore, teamManager, orchestrationCore, roleManager, toolManager, projectContextManager, bgProcessManager, staffManager, verificationHarness, preferencesStore, projectConfigStore, groupPolicyStore, broadcastToGoal, broadcastToAll, broadcastToUi, sandboxManager, projectRegistry, configCascade, sandboxScope, sandboxTokenStore, reviewAnnotationStore, broadcastToSession, roleStore, inboxManager, marketplaceSourceStore, marketplaceInstaller, cookieStore, actionDispatcher, routeDispatcher, routeRegistry, packContributionRegistry, extensionChannelServices, gatewayDeps.fetchImpl, gatewayDeps.commandRunner, gatewayDeps.fsImpl, gatewayDeps.clock, withPreviewSessionOperation, reviewPayloadOperations, oauthCancellationRetryState, remoteStateRoutes, hostInterceptorRouter);
 			if (_timingEnabled) {
 				const dur = performance.now() - _timingStart;
 				if (dur >= 100) console.log(`[timing] ${req.method} ${url.pathname}${url.search} ${dur.toFixed(1)}ms`);
@@ -3990,6 +4084,142 @@ export function createGateway(config: GatewayConfig, deps?: GatewayDeps) {
 	// during high-volume mock-agent event bursts. Loopback never benefits
 	// from compression in production either, so this is a strict win.
 	const wss = new WebSocketServer({ noServer: true, perMessageDeflate: false, maxPayload: WS_MAX_PAYLOAD_BYTES });
+
+	const createHookHostApi = (
+		context: { projectId?: string; sessionId?: string; cwd: string },
+		packId: string,
+		contributionId: string,
+		capabilities: readonly string[],
+	) => createServerHostApi({
+		sessionId: context.sessionId ?? `project:${context.projectId ?? "unbound"}`,
+		packId,
+		contributionId,
+		packStore: getPackStore(),
+		capabilityMask: {
+			store: capabilities.includes("store"),
+			session: capabilities.includes("session") && context.sessionId !== undefined,
+			agents: capabilities.includes("agents") && context.sessionId !== undefined,
+		},
+		...(context.sessionId ? {
+			readOwnTranscript: async () => {
+				const persisted = sessionManager.getPersistedSession(context.sessionId!);
+				if (!persisted?.agentSessionFile) return null;
+				const fsContext = sessionFsContextForAgentFile(persisted, persisted.agentSessionFile);
+				const jsonl = await sessionFileRead(fsContext, persisted.agentSessionFile, sandboxManager);
+				return projectOwnTranscriptJsonl(context.sessionId!, jsonl);
+			},
+			orchestrationCore,
+			readChildStatus: (sessionId: string) => sessionManager.getSession(sessionId)?.status,
+		} : {}),
+	});
+
+	const hostInterceptorRouter = new HostInterceptorRouter({
+		registry: packContributionRegistry,
+		moduleHost,
+		lifecycleHub: sessionManager.lifecycleHub,
+		createHostApi: ({ context, packId, contributionId, capabilities }) =>
+			createHookHostApi(context, packId, contributionId, capabilities),
+		validateToolArgs: (toolName, args) => {
+			try {
+				if (!args || typeof args !== "object" || Array.isArray(args)) return false;
+				const piTool = toolManager.resolveScopedPiExtensionTools().find(tool =>
+					(tool.runtimeName ?? tool.name).toLowerCase() === toolName.toLowerCase(),
+				);
+				if (piTool?.inputSchema) return Value.Check(piTool.inputSchema as never, args);
+				const params = toolManager.getToolByName(toolName)?.params;
+				if (!params) return Object.keys(args).length === 0;
+				const allowed = new Set(params.map(param => param.replace(/\?$/, "")));
+				const required = params.filter(param => !param.endsWith("?")).map(param => param.replace(/\?$/, ""));
+				return Object.keys(args).every(key => allowed.has(key))
+					&& required.every(key => Object.prototype.hasOwnProperty.call(args, key));
+			} catch { return false; }
+		},
+		validateToolResult: () => true,
+	});
+
+	type RuntimeNotificationHandler = HostNotificationModuleHandler & {
+		readonly contribution: NormalizedNotificationContribution;
+	};
+	const notificationModuleAdapter = new HostNotificationModuleAdapter({
+		resolve: (notification) => normalizeHookContributions(packContributionRegistry, notification.projectId)
+			.filter((row): row is NormalizedNotificationContribution => row.kind === "notification")
+			.filter((row) => row.selector.scope === notification.scope && row.selector.name === notification.name)
+			.map((contribution): RuntimeNotificationHandler => ({
+				projectId: notification.projectId,
+				packId: contribution.packId,
+				contributionId: contribution.contributionId,
+				scope: contribution.selector.scope,
+				name: contribution.selector.name,
+				timeoutMs: contribution.budget.declaredTimeoutMs ?? contribution.budget.timeoutMs,
+				contribution,
+			})),
+		isAuthorized: (handler, notification) => {
+			const contribution = (handler as RuntimeNotificationHandler).contribution;
+			return handler.projectId === notification.projectId
+				&& packContributionRegistry.isHookAuthorized(
+					notification.projectId,
+					contribution.packId,
+					contribution.contributionId,
+					contribution.listName,
+					contribution.activationEpoch,
+					contribution.capabilities,
+				);
+		},
+		invoke: (handler, notification, signal) => {
+			const contribution = (handler as RuntimeNotificationHandler).contribution;
+			const persisted = notification.sessionId
+				? sessionManager.getPersistedSession(notification.sessionId)
+				: undefined;
+			const cwd = persisted?.cwd ?? projectRegistry.get(notification.projectId)?.rootPath;
+			if (!cwd) throw new Error("notification project is no longer registered");
+			const host = createHookHostApi({
+				projectId: notification.projectId,
+				...(notification.sessionId ? { sessionId: notification.sessionId } : {}),
+				cwd,
+			}, contribution.packId, contribution.contributionId, contribution.capabilities);
+			const url = `${pathToFileURL(path.resolve(path.dirname(contribution.sourceFile), contribution.module)).href}?e=${contribution.activationEpoch}`;
+			return moduleHost.invoke({
+				url,
+				packRoot: contribution.packRoot,
+				epoch: contribution.activationEpoch,
+				exportKind: "hooks",
+				member: notification.name,
+				ctx: {
+					host,
+					sessionId: notification.sessionId ?? `project:${notification.projectId}`,
+					projectId: notification.projectId,
+					tool: `host-notification:${notification.name}`,
+					workingDir: cwd,
+					config: contribution.config,
+					correlationId: notification.correlationId,
+				} as unknown as InvokeRequest["ctx"],
+				arg: notification,
+				workingDir: cwd,
+				signal,
+			}, handler.timeoutMs, signal);
+		},
+	});
+	const hostNotificationDispatcher = new HostNotificationDispatcher({
+		adapters: [
+			new HostNotificationSocketRouter(() => wss.clients),
+			notificationModuleAdapter,
+			notificationStaffDispatcher,
+		],
+		resolveSessionProject: (sessionId) => sessionManager.getPersistedSession(sessionId)?.projectId,
+	});
+	projectContextManager.setHostNotificationDispatcher(hostNotificationDispatcher);
+	sessionManager.setHostNotificationPublisher(hostNotificationDispatcher as any);
+	sessionManager.setHostInterceptorPort(hostInterceptorRouter as any);
+	staffManager.setStaffNotificationPublisher(hostNotificationDispatcher);
+	prStatusStore.onPullRequestStatusChanged = (fact) => {
+		const ctx = projectContextManager.getContextForGoal(fact.goalId);
+		ctx?.publishHostNotification("pullRequestStatusChanged", {
+			aggregateId: fact.goalId,
+			aggregateRevision: fact.revision,
+			payload: fact.payload,
+		});
+	};
+
 	const rejectUnavailableWebSocket = (req: http.IncomingMessage, socket: import("node:stream").Duplex, head: Buffer, code: "SERVER_STARTING" | "SERVER_SATURATED", retryAfterMs: number) => {
 		// The rejected socket is briefly live while its retry frame drains. Keep
 		// no-op listeners until it closes so a reset/malformed peer cannot turn
@@ -4305,10 +4535,32 @@ export function createGateway(config: GatewayConfig, deps?: GatewayDeps) {
 	}
 
 	teamManager.setBroadcastToGoal(broadcastToGoal);
+	const sessionKind = (session: SessionInfo): "general" | "assistant" | "goal" | "team" | "delegate" | "staff" | "child" => {
+		if (session.staffId) return "staff";
+		if (session.delegateOf) return "delegate";
+		if (session.childKind || session.parentSessionId) return "child";
+		if (session.teamGoalId || session.teamLeadSessionId) return "team";
+		if (session.goalId) return "goal";
+		if (session.assistantType) return "assistant";
+		return "general";
+	};
 	// Push session creation to ALL clients so session navigation refreshes promptly
 	// for visible sessions created through REST, UI, or host.agents full-lifecycle paths.
 	sessionManager.addCreationListener((session) => {
 		try {
+			const persisted = sessionManager.getPersistedSession(session.id);
+			if (session.projectId && persisted?.projectId === session.projectId) {
+				hostNotificationDispatcher.publish("sessionCreated", {
+					projectId: session.projectId,
+					aggregateId: session.id,
+					aggregateRevision: Math.max(persisted.createdAt, persisted.lastActivity),
+					payload: {
+						sessionId: session.id,
+						kind: sessionKind(session),
+						...(session.goalId ? { goalId: session.goalId } : {}),
+					},
+				});
+			}
 			broadcastToAll({ type: "session_created", sessionId: session.id, projectId: session.projectId });
 		} catch (err) {
 			console.error(`[broadcast] session_created failed for ${session.id}:`, err);
@@ -4320,6 +4572,25 @@ export function createGateway(config: GatewayConfig, deps?: GatewayDeps) {
 	// after another tab archived the session).
 	sessionManager.addTerminationListener(async (sessionId, info) => {
 		try {
+			const persisted = sessionManager.getPersistedSession(sessionId);
+			if (info.reason !== "purged" && info.projectId && persisted?.projectId === info.projectId && persisted.archivedAt !== undefined) {
+				const goalId = persisted.goalId ?? persisted.teamGoalId;
+				const goalArchived = goalId
+					? projectContextManager.getContextForGoal(goalId)?.goalStore.get(goalId)?.archived === true
+					: false;
+				const staffRetired = persisted.staffId ? staffManager.getStaff(persisted.staffId)?.state === "retired" : false;
+				const reason = !projectRegistry.get(info.projectId)
+					? "project_deleted" as const
+					: goalArchived ? "goal_archived" as const
+						: staffRetired ? "retired" as const
+							: "user" as const;
+				hostNotificationDispatcher.publish("sessionArchived", {
+					projectId: info.projectId,
+					aggregateId: sessionId,
+					aggregateRevision: persisted.archivedAt,
+					payload: { sessionId, reason },
+				});
+			}
 			broadcastToAll({ type: "session_removed", sessionId, projectId: info.projectId, reason: info.reason });
 		} catch (err) {
 			console.error(`[broadcast] session_removed failed for ${sessionId}:`, err);
@@ -4997,6 +5268,7 @@ export function createGateway(config: GatewayConfig, deps?: GatewayDeps) {
 				gatewayDeps.clock.clearInterval(cleanupInterval);
 				triggerEngine.stop();
 				inboxNudger.stop();
+				notificationStaffDispatcher.stop();
 				wss.close();
 				// Pi's Anthropic callback and exchange outlive the HTTP server. Abort
 				// and await them before tearing down stores or allowing restart.
@@ -5268,6 +5540,7 @@ async function handleApiRoute(
 	reviewPayloadOperations: ReviewPayloadSessionCoordinator = createReviewPayloadSessionCoordinator(),
 	oauthCancellationRetryState: { anthropicFlowId?: string } = {},
 	remoteStateRoutes?: any,
+	hostInterceptorRouter?: HostInterceptorRouter,
 ) {
 	// These are always wired by the sole caller; the optional markers are only to avoid
 	// touching every existing signature site.
@@ -6669,6 +6942,26 @@ async function handleApiRoute(
 			// Wire the goal-manager pool resolver for the new project (Phase 3 — goals via pool).
 			if (newCtx) {
 				wireGoalManagerResolvers(newCtx, { sessionManager, projectContextManager, projectRegistry });
+			}
+			// Await the post-commit initialization boundary, but never compensate or
+			// hide the already-registered project when an extension fails.
+			if (newCtx && hostInterceptorRouter) {
+				try {
+					await hostInterceptorRouter.dispatch("projectImported", {
+						projectId: project.id,
+						components: newCtx.projectConfigStore.getComponents().map(component => ({
+							name: component.name,
+							repo: component.repo,
+							...(component.relativePath ? { relativePath: component.relativePath } : {}),
+						})),
+					}, {
+						projectId: project.id,
+						cwd: project.rootPath,
+						signal: new AbortController().signal,
+					});
+				} catch {
+					console.warn(`[host-hooks] projectImported failed for ${project.id} (non-fatal)`);
+				}
 			}
 			json(project, 201);
 		} catch (err: any) {
@@ -14805,6 +15098,19 @@ async function handleApiRoute(
 					)
 					: await launchFork();
 				if (ps.staffId) (launched.fork as SessionInfo).staffId = ps.staffId;
+				const persistedFork = sessionManager.getPersistedSession(launched.fork.id);
+				if (persistedFork?.projectId === launched.projectId) {
+					projectContextManager.getOrCreate(launched.projectId)?.publishHostNotification("sessionForked", {
+						aggregateId: launched.fork.id,
+						aggregateRevision: Math.max(persistedFork.createdAt, persistedFork.lastActivity),
+						payload: {
+							sourceSessionId: sourceId,
+							sessionId: launched.fork.id,
+							...(hasEntryId ? { cutEntryId: entryId as string } : {}),
+							forkMode: hasEntryId ? "history" : "whole",
+						},
+					});
+				}
 				json({
 					id: launched.fork.id,
 					cwd: launched.fork.cwd,

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -632,7 +632,7 @@ import { StaffManager } from "./agent/staff-manager.js";
 import { buildStaffSystemPrompt } from "./agent/role-prompt.js";
 import { TriggerEngine } from "./agent/staff-trigger-engine.js";
 import { GoalTriggerDispatcher } from "./agent/goal-trigger-dispatcher.js";
-import { InboxManager, type InboxEntry, type InboxLiveAddress, type InboxLiveEvent } from "./agent/inbox-manager.js";
+import { InboxManager, toInboxLiveEntry, type InboxEntry, type InboxLiveAddress, type InboxLiveEvent } from "./agent/inbox-manager.js";
 import { InboxNudger } from "./agent/inbox-nudger.js";
 import { NotificationStaffDispatcher } from "./agent/notification-staff-dispatcher.js";
 import { runWithStaffNotificationTurnContext } from "./agent/staff-notification-causation.js";
@@ -19253,6 +19253,27 @@ async function handleApiRoute(
 	// (see docs/design/staff-inbox.md §7.2). UI/external integrations now hit
 	// `POST /api/staff/:id/inbox` with `source.type = "manual_ui" | "manual_api"`.
 
+	/** Resolve the one live staff session that owns this inbox from its host-issued
+	 * capability secret. Public session ids, request bodies, bearer/cookie auth,
+	 * and client project claims never establish notification-inbox authority. */
+	const resolveExactInboxOwner = (staff: { id: string; projectId?: string; currentSessionId?: string }): SessionInfo | undefined => {
+		if (!staff.projectId || !staff.currentSessionId) return undefined;
+		const rawSecret = req.headers["x-bobbit-session-secret"];
+		const secret = Array.isArray(rawSecret) ? rawSecret[0] : rawSecret;
+		const callerSessionId = sessionManager.sessionSecretStore.resolveSessionIdBySecret(secret);
+		if (!callerSessionId || callerSessionId !== staff.currentSessionId) return undefined;
+		const live = sessionManager.getSession(callerSessionId);
+		const persisted = sessionManager.getPersistedSession(callerSessionId);
+		if (!live || live.dormant === true || live.status === "terminated" || !persisted) return undefined;
+		if (live.id !== callerSessionId
+			|| persisted.id !== callerSessionId
+			|| live.staffId !== staff.id
+			|| persisted.staffId !== staff.id
+			|| live.projectId !== staff.projectId
+			|| persisted.projectId !== staff.projectId) return undefined;
+		return live;
+	};
+
 	// GET /api/staff/:id/inbox?state=pending&limit=50
 	const staffInboxListMatch = url.pathname.match(/^\/api\/staff\/([^/]+)\/inbox$/);
 	if (staffInboxListMatch && req.method === "GET") {
@@ -19267,7 +19288,10 @@ async function handleApiRoute(
 			: undefined;
 		const limitRaw = url.searchParams.get("limit");
 		const limit = limitRaw != null ? Math.max(0, parseInt(limitRaw, 10) || 0) : undefined;
-		const entries = inboxManager.listForStaff(id, state, limit);
+		const storedEntries = inboxManager.listForStaff(id, state, limit);
+		const entries = resolveExactInboxOwner(staff)
+			? storedEntries
+			: storedEntries.map(toInboxLiveEntry);
 		json({ entries });
 		return;
 	}
@@ -19312,24 +19336,31 @@ async function handleApiRoute(
 		if (!inboxManager) { json({ error: "Inbox not initialised" }, 500); return; }
 		const staff = staffManager.getStaff(id);
 		if (!staff) { json({ error: "Staff agent not found" }, 404); return; }
-		const body = await readBody(req);
-		if (!body || typeof body.sessionId !== "string" || !body.sessionId) {
-			json({ error: "Missing sessionId" }, 400);
-			return;
-		}
-		const session = sessionManager.getSession(body.sessionId);
-		if (!session || session.staffId !== id) {
-			json({ error: "Forbidden: session does not belong to this staff" }, 403);
-			return;
-		}
 		const existing = inboxManager.listForStaff(id).find(e => e.id === entryId);
 		if (!existing) { json({ error: "Inbox entry not found" }, 404); return; }
+		const body = await readBody(req);
+		if (existing.source.type === "notification") {
+			if (!resolveExactInboxOwner(staff)) {
+				json({ error: "Forbidden: exact owning staff session required" }, 403);
+				return;
+			}
+		} else {
+			if (!body || typeof body.sessionId !== "string" || !body.sessionId) {
+				json({ error: "Missing sessionId" }, 400);
+				return;
+			}
+			const session = sessionManager.getSession(body.sessionId);
+			if (!session || session.staffId !== id) {
+				json({ error: "Forbidden: session does not belong to this staff" }, 403);
+				return;
+			}
+		}
 		if (existing.state !== "pending") {
 			json({ error: `Inbox entry ${entryId} is ${existing.state}, expected pending` }, 409);
 			return;
 		}
 		try {
-			const entry = inboxManager.transitionToCompleted(id, entryId, typeof body.summary === "string" ? body.summary : undefined);
+			const entry = inboxManager.transitionToCompleted(id, entryId, typeof body?.summary === "string" ? body.summary : undefined);
 			json({ entry });
 		} catch (err) {
 			jsonError(400, err);
@@ -19344,17 +19375,26 @@ async function handleApiRoute(
 		if (!inboxManager) { json({ error: "Inbox not initialised" }, 500); return; }
 		const staff = staffManager.getStaff(id);
 		if (!staff) { json({ error: "Staff agent not found" }, 404); return; }
+		const existing = inboxManager.listForStaff(id).find(e => e.id === entryId);
+		if (!existing) { json({ error: "Inbox entry not found" }, 404); return; }
 		const body = await readBody(req);
-		if (!body || typeof body.sessionId !== "string" || !body.sessionId) {
-			json({ error: "Missing sessionId" }, 400);
-			return;
+		if (existing.source.type === "notification") {
+			if (!resolveExactInboxOwner(staff)) {
+				json({ error: "Forbidden: exact owning staff session required" }, 403);
+				return;
+			}
+		} else {
+			if (!body || typeof body.sessionId !== "string" || !body.sessionId) {
+				json({ error: "Missing sessionId" }, 400);
+				return;
+			}
+			const session = sessionManager.getSession(body.sessionId);
+			if (!session || session.staffId !== id) {
+				json({ error: "Forbidden: session does not belong to this staff" }, 403);
+				return;
+			}
 		}
-		const session = sessionManager.getSession(body.sessionId);
-		if (!session || session.staffId !== id) {
-			json({ error: "Forbidden: session does not belong to this staff" }, 403);
-			return;
-		}
-		if (body.outcome !== "failed" && body.outcome !== "cancelled") {
+		if (body?.outcome !== "failed" && body?.outcome !== "cancelled") {
 			json({ error: "outcome must be 'failed' or 'cancelled'" }, 400);
 			return;
 		}
@@ -19362,8 +19402,6 @@ async function handleApiRoute(
 			json({ error: "Missing reason" }, 400);
 			return;
 		}
-		const existing = inboxManager.listForStaff(id).find(e => e.id === entryId);
-		if (!existing) { json({ error: "Inbox entry not found" }, 404); return; }
 		if (existing.state !== "pending") {
 			json({ error: `Inbox entry ${entryId} is ${existing.state}, expected pending` }, 409);
 			return;
@@ -19384,6 +19422,12 @@ async function handleApiRoute(
 		if (!inboxManager) { json({ error: "Inbox not initialised" }, 500); return; }
 		const staff = staffManager.getStaff(id);
 		if (!staff) { json({ error: "Staff agent not found" }, 404); return; }
+		const existing = inboxManager.listForStaff(id).find(e => e.id === entryId);
+		if (!existing) { json({ error: "Inbox entry not found" }, 404); return; }
+		if (existing.source.type === "notification" && !resolveExactInboxOwner(staff)) {
+			json({ error: "Forbidden: exact owning staff session required" }, 403);
+			return;
+		}
 		const ok = inboxManager.remove(id, entryId);
 		if (!ok) { json({ error: "Inbox entry not found" }, 404); return; }
 		json({ ok: true });

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -103,10 +103,10 @@ import {
 } from "./extension-host/host-hook-contributions.js";
 import { loadPackContributions, providerConfigStoreKey, PROVIDER_CONFIG_KEY_PREFIX } from "./agent/pack-contributions.js";
 import { loadPiExtensionContributions, loadPiExtensionContributionsWithDiscoverySync } from "./agent/pi-extension-contributions.js";
-import { LifecycleHub, type HookCtx } from "./agent/lifecycle-hub.js";
+import { LifecycleHub } from "./agent/lifecycle-hub.js";
 import { resolveConfiguredComponent, resolveHookScopeContext } from "./agent/hook-scope-context.js";
 import { ContextTraceStore } from "./agent/context-trace-store.js";
-import { fenceBlock } from "./agent/context-blocks.js";
+import { estimateTokens, fenceBlock, type ContextBlock } from "./agent/context-blocks.js";
 import { DYNAMIC_CONTEXT_START, DYNAMIC_CONTEXT_END } from "./agent/provider-bridge-extension.js";
 import { isPackPathWithinRoot } from "./extension-host/path-guard.js";
 import { buildGateStatusSummary, projectGateForList } from "./gate-status-summary.js";
@@ -4113,6 +4113,25 @@ export function createGateway(config: GatewayConfig, deps?: GatewayDeps) {
 		} : {}),
 	});
 
+	const validateBoundedToolResult = (toolName: string, result: unknown): boolean => {
+		const knownTool = toolManager.resolveScopedPiExtensionTools().some(tool =>
+			(tool.runtimeName ?? tool.name).toLowerCase() === toolName.toLowerCase(),
+		) || toolManager.getToolByName(toolName) !== undefined;
+		if (!knownTool) return false;
+		let nodes = 0;
+		const visit = (value: unknown, depth: number): boolean => {
+			if (++nodes > 1_024 || depth > 8) return false;
+			if (value === null || typeof value === "boolean" || typeof value === "string") return typeof value !== "string" || value.length <= 8_192;
+			if (typeof value === "number") return Number.isFinite(value);
+			if (Array.isArray(value)) return value.length <= 64 && value.every(item => visit(item, depth + 1));
+			if (!value || typeof value !== "object" || Object.getPrototypeOf(value) !== Object.prototype) return false;
+			const entries = Object.entries(value as Record<string, unknown>);
+			return entries.length <= 64 && entries.every(([key, item]) => /^[A-Za-z][A-Za-z0-9._-]*$/.test(key) && key.length <= 128 && visit(item, depth + 1));
+		};
+		if (!visit(result, 0)) return false;
+		try { return Buffer.byteLength(JSON.stringify(result), "utf8") <= 128 * 1_024; } catch { return false; }
+	};
+
 	const hostInterceptorRouter = new HostInterceptorRouter({
 		registry: packContributionRegistry,
 		moduleHost,
@@ -4134,7 +4153,7 @@ export function createGateway(config: GatewayConfig, deps?: GatewayDeps) {
 					&& required.every(key => Object.prototype.hasOwnProperty.call(args, key));
 			} catch { return false; }
 		},
-		validateToolResult: () => true,
+		validateToolResult: validateBoundedToolResult,
 	});
 
 	type RuntimeNotificationHandler = HostNotificationModuleHandler & {
@@ -4209,7 +4228,18 @@ export function createGateway(config: GatewayConfig, deps?: GatewayDeps) {
 	});
 	projectContextManager.setHostNotificationDispatcher(hostNotificationDispatcher);
 	sessionManager.setHostNotificationPublisher(hostNotificationDispatcher as any);
-	sessionManager.setHostInterceptorPort(hostInterceptorRouter as any);
+	sessionManager.setHostInterceptorPort({
+		dispatch: (name, input, context) => hostInterceptorRouter.dispatch(name as any, input as any, context as any),
+		hasAny: (names, projectId, goalId) => {
+			const explicit = normalizeHookContributions(packContributionRegistry, projectId)
+				.some(row => row.kind === "interceptor" && names.includes(row.name));
+			if (explicit) return true;
+			const legacy = names.filter((name): name is "sessionSetup" | "beforePrompt" | "beforeCompact" | "sessionShutdown" =>
+				name === "sessionSetup" || name === "beforePrompt" || name === "beforeCompact" || name === "sessionShutdown",
+			);
+			return legacy.length > 0 && sessionManager.lifecycleHub?.hasProvidersForHooks(projectId, legacy, goalId) === true;
+		},
+	});
 	staffManager.setStaffNotificationPublisher(hostNotificationDispatcher);
 	prStatusStore.onPullRequestStatusChanged = (fact) => {
 		const ctx = projectContextManager.getContextForGoal(fact.goalId);
@@ -7839,95 +7869,59 @@ async function handleApiRoute(
 		return;
 	}
 
-	// ── Provider per-turn lifecycle hooks (EP G1.4) ──
-	// These endpoints are called only by the Bobbit-generated provider-bridge pi
-	// extension (before-prompt / before-compact) and the context-trace inspector.
-	// They inherit the admin-bearer gate enforced before handleApiRoute, exactly
-	// like POST /api/sessions/:id/tool-grant-request above. afterTurn /
-	// sessionShutdown are gateway-internal dispatches and intentionally have NO
-	// public endpoint.
-	//
-	// Resolve a session's lifecycle dispatch context from live or persisted state.
-	// Returns undefined when the session is unknown (→ 404 for the hook endpoints).
-	const resolveHookCtx = (id: string): {
-		base: Omit<HookCtx, "budget" | "config" | "gateway" | "scopeContext">;
-		scopeInput: {
-			projectId?: string;
-			goalId?: string;
-			roleName?: string;
-			cwd: string;
-			worktreePath?: string;
-			repoPath?: string;
-			repoWorktrees?: Readonly<Record<string, string>>;
-		};
-	} | undefined => {
-		const live = sessionManager.getSession(id);
-		const persisted = sessionManager.getPersistedSession(id);
-		const source = live ?? persisted;
-		if (!source) return undefined;
-		const projectId = source.projectId;
-		const goalId = source.goalId ?? source.teamGoalId;
-		const repoWorktrees = Array.isArray(source.repoWorktrees)
-			? Object.fromEntries(source.repoWorktrees.map(({ repo, worktreePath }) => [repo, worktreePath]))
-			: source.repoWorktrees;
-		const base = {
-			sessionId: id,
-			projectId,
-			scope: projectId ? "project" as const : "global" as const,
-			cwd: source.cwd ?? process.cwd(),
-			// Effective goal: team members, delegates, and reviewers carry the goal
-			// only in teamGoalId, so fall back to it before persisted state. Without
-			// this, disabled-provider filtering would not apply at the provider hook
-			// endpoints (beforePrompt / beforeCompact) for non-lead sessions.
-			goalId,
-			roleName: source.role,
-		};
-		return {
-			base,
-			scopeInput: {
-				projectId,
-				goalId,
-				roleName: source.role,
-				cwd: source.cwd ?? process.cwd(),
-				worktreePath: source.worktreePath,
-				repoPath: source.repoPath,
-				repoWorktrees,
-			},
-		};
+	// ── Pi-owned interceptor lifecycle routes ──
+	// The global bearer gate authenticates the process; the per-session secret
+	// below binds authority to the exact URL session before any body is accepted.
+	const resolveAuthenticatedHookSession = (rawSessionId: string): string | undefined => {
+		let sessionId: string;
+		try { sessionId = decodeURIComponent(rawSessionId); } catch { return undefined; }
+		const rawSecret = req.headers["x-bobbit-session-secret"];
+		const secret = Array.isArray(rawSecret) ? rawSecret[0] : rawSecret;
+		const authenticatedSessionId = sessionManager.sessionSecretStore.resolveSessionIdBySecret(
+			typeof secret === "string" && secret.trim() ? secret.trim() : undefined,
+		);
+		return authenticatedSessionId === sessionId ? sessionId : undefined;
 	};
+	const isStrictHookBody = (body: unknown, keys: readonly string[]): body is Record<string, unknown> => {
+		if (!body || typeof body !== "object" || Array.isArray(body)) return false;
+		return Object.keys(body).every(key => keys.includes(key));
+	};
+	const hookTurnIndex = (sessionId: string): number =>
+		Math.max(0, (sessionManager.getSession(sessionId)?.completedTurnCount ?? 0) + 1);
 
-	// POST /api/sessions/:id/provider-hooks/before-prompt — per-turn dynamic context.
+	// The generated Pi bridges call these four exact-session routes. The router is
+	// the sole lifecycle dispatcher; its legacy adapter already normalizes providers.
 	const beforePromptMatch = url.pathname.match(/^\/api\/sessions\/([^/]+)\/provider-hooks\/before-prompt$/);
 	if (beforePromptMatch && req.method === "POST") {
-		const sessionId = beforePromptMatch[1];
-		const body = await readBody(req).catch(() => ({} as any));
-		if (body && body.prompt !== undefined && typeof body.prompt !== "string") {
-			json({ error: "prompt must be a string" }, 400);
+		const sessionId = resolveAuthenticatedHookSession(beforePromptMatch[1]);
+		if (!sessionId) { json({ error: "Exact session authentication required" }, 403); return; }
+		const body = await readBody(req).catch(() => undefined);
+		if (!isStrictHookBody(body, ["prompt"]) || typeof body.prompt !== "string" || body.prompt.length > 16_384) {
+			json({ error: "Invalid bounded beforePrompt body" }, 400);
 			return;
 		}
-		const hookContext = resolveHookCtx(sessionId);
-		if (!hookContext) {
-			json({ error: "Session not found" }, 404);
-			return;
-		}
-		const hub = sessionManager.lifecycleHub;
-		if (!hub) {
-			json({ content: "", tail: "", blocks: [] });
-			return;
-		}
+		const session = sessionManager.getSession(sessionId);
+		if (!session) { json({ error: "Session not found" }, 404); return; }
 		try {
-			const turnIndex = body?.turn?.index;
-			const { blocks } = await hub.dispatch("beforePrompt", {
-				...hookContext.base,
-				prompt: typeof body?.prompt === "string" ? body.prompt : undefined,
-				turn: typeof turnIndex === "number" && Number.isFinite(turnIndex) ? { index: turnIndex } : undefined,
-			}, hookContext.scopeInput);
+			const routed = await sessionManager.dispatchHostInterceptor(sessionId, "beforePrompt", {
+				sessionId,
+				turnIndex: hookTurnIndex(sessionId),
+				source: session.lastPromptSource ?? "user",
+				userText: body.prompt,
+			});
+			const contributions = Array.isArray((routed?.value as any)?.context) ? (routed.value as any).context : [];
+			const blocks: ContextBlock[] = contributions.map((block: any) => ({
+				id: block.id,
+				title: block.title,
+				providerId: "host-hooks",
+				authority: block.authority,
+				content: block.content,
+				reason: block.reason,
+				priority: block.priority,
+				tokenEstimate: estimateTokens(block.content),
+			}));
 			const content = blocks.length ? blocks.map(fenceBlock).join("\n\n") : "";
-			// Temporary back-compat for generated bridges from the system-prompt-tail era.
-			// New bridges consume `content` only and must never return systemPrompt.
 			const tail = content ? `\n${DYNAMIC_CONTEXT_START}\n${content}\n${DYNAMIC_CONTEXT_END}` : "";
-			// Best-effort: refresh the persisted prompt-sections snapshot so the
-			// inspector reflects this turn's dynamic-context blocks. Non-fatal.
 			try {
 				const parts = sessionManager.getPromptParts(sessionId);
 				if (parts) {
@@ -7937,52 +7931,82 @@ async function handleApiRoute(
 			} catch (err) {
 				console.debug(`[provider-hooks] prompt-sections refresh skipped for ${sessionId}:`, err);
 			}
-			json({
-				content,
-				tail,
-				blocks: blocks.map((b) => ({ id: b.id, providerId: b.providerId, title: b.title, tokenEstimate: b.tokenEstimate })),
-			});
+			json({ content, tail, blocks: blocks.map(({ id, providerId, title, tokenEstimate }) => ({ id, providerId, title, tokenEstimate })) });
 		} catch (err: any) {
-			jsonError(500, err);
+			jsonError(err instanceof TypeError ? 400 : 500, err);
 		}
 		return;
 	}
 
-	// POST /api/sessions/:id/provider-hooks/before-compact — notify providers before compaction.
 	const beforeCompactMatch = url.pathname.match(/^\/api\/sessions\/([^/]+)\/provider-hooks\/before-compact$/);
 	if (beforeCompactMatch && req.method === "POST") {
-		const sessionId = beforeCompactMatch[1];
-		// The bridge forwards the about-to-be-lost span (and optionally a precomputed
-		// summary) from the pi session_before_compact payload. Validate both as strings
-		// so a malformed body is rejected rather than silently dispatched empty.
-		const body = await readBody(req).catch(() => ({} as any));
-		if (body && body.span !== undefined && typeof body.span !== "string") {
-			json({ error: "span must be a string" }, 400);
+		const sessionId = resolveAuthenticatedHookSession(beforeCompactMatch[1]);
+		if (!sessionId) { json({ error: "Exact session authentication required" }, 403); return; }
+		const body = await readBody(req).catch(() => undefined);
+		if (!isStrictHookBody(body, ["span", "summary"])
+			|| (body.span !== undefined && typeof body.span !== "string")
+			|| (body.summary !== undefined && typeof body.summary !== "string")
+			|| (typeof body.span === "string" && body.span.length > 16_384)
+			|| (typeof body.summary === "string" && body.summary.length > 16_384)) {
+			json({ error: "Invalid bounded beforeCompact body" }, 400);
 			return;
 		}
-		if (body && body.summary !== undefined && typeof body.summary !== "string") {
-			json({ error: "summary must be a string" }, 400);
-			return;
-		}
-		const hookContext = resolveHookCtx(sessionId);
-		if (!hookContext) {
-			json({ error: "Session not found" }, 404);
-			return;
-		}
-		const hub = sessionManager.lifecycleHub;
-		if (!hub) {
+		if (!sessionManager.getSession(sessionId)) { json({ error: "Session not found" }, 404); return; }
+		try {
+			await sessionManager.dispatchHostInterceptor(sessionId, "beforeCompact", {
+				sessionId,
+				turnIndex: hookTurnIndex(sessionId),
+				span: typeof body.span === "string" ? body.span : "",
+				...(typeof body.summary === "string" ? { summary: body.summary } : {}),
+			});
 			json({});
+		} catch (err: any) {
+			jsonError(err instanceof TypeError ? 400 : 500, err);
+		}
+		return;
+	}
+
+	const toolHookMatch = url.pathname.match(/^\/api\/sessions\/([^/]+)\/host-hooks\/(before-tool-call|after-tool-result)$/);
+	if (toolHookMatch && req.method === "POST") {
+		const sessionId = resolveAuthenticatedHookSession(toolHookMatch[1]);
+		if (!sessionId) { json({ error: "Exact session authentication required" }, 403); return; }
+		const body = await readBody(req).catch(() => undefined);
+		const isBefore = toolHookMatch[2] === "before-tool-call";
+		const keys = isBefore ? ["toolCallId", "toolName", "args"] : ["toolCallId", "toolName", "result"];
+		if (!isStrictHookBody(body, keys)
+			|| typeof body.toolCallId !== "string"
+			|| typeof body.toolName !== "string") {
+			json({ error: "Invalid bounded tool hook body" }, 400);
 			return;
 		}
 		try {
-			await hub.dispatch("beforeCompact", {
-				...hookContext.base,
-				span: typeof body?.span === "string" ? body.span : undefined,
-				summary: typeof body?.summary === "string" ? body.summary : undefined,
-			}, hookContext.scopeInput);
-			json({});
+			if (isBefore) {
+				const routed = await sessionManager.dispatchHostInterceptor(sessionId, "beforeToolCall", {
+					toolCallId: body.toolCallId,
+					toolName: body.toolName,
+					args: body.args as Record<string, any>,
+				});
+				const terminal = routed?.terminal as any;
+				if (terminal?.action === "block") { json(terminal); return; }
+				const args = (routed?.value as any)?.args;
+				sessionManager.markToolCallAdmitted(sessionId, body.toolCallId, body.toolName);
+				json({ action: "replaceArgs", args });
+			} else {
+				const routed = await sessionManager.dispatchHostInterceptor(sessionId, "afterToolResult", {
+					toolCallId: body.toolCallId,
+					toolName: body.toolName,
+					result: body.result as any,
+				});
+				const terminal = routed?.terminal as any;
+				if (terminal?.action === "syntheticError") { json(terminal); return; }
+				json({ action: "replaceResult", result: (routed?.value as any)?.result });
+			}
 		} catch (err: any) {
-			jsonError(500, err);
+			if (!isBefore) {
+				json({ action: "syntheticError", code: "handler_error" });
+			} else {
+				jsonError(err instanceof TypeError ? 400 : 500, err);
+			}
 		}
 		return;
 	}

--- a/src/server/ws/handler.ts
+++ b/src/server/ws/handler.ts
@@ -57,6 +57,7 @@ import {
 	SessionCommandSerialiser,
 } from "./session-command-serialiser.js";
 import { isSocketSendable } from "./socket-sendability.js";
+import { bindHostNotificationSocket, unbindHostNotificationSocket } from "../extension-host/host-notification-socket-router.js";
 
 /**
  * Stamp `_order` on every message in a snapshot for the unified message
@@ -989,6 +990,13 @@ export function handleWebSocketConnection(
 				if (archived) {
 					(ws as any).sessionId = sessionId;
 					(ws as any).isArchived = true;
+					const persistedArchivedProjectId = sessionManager.getPersistedSession(sessionId)?.projectId;
+					const archivedProjectId = persistedArchivedProjectId && archived.projectId && persistedArchivedProjectId !== archived.projectId
+						? undefined
+						: persistedArchivedProjectId ?? archived.projectId;
+					if (authMsg.clientKind === "app" && archivedProjectId) {
+						bindHostNotificationSocket(ws, { sessionId, projectId: archivedProjectId });
+					}
 					send(ws, { type: "auth_ok", ...(assistantStreamDeltaCapable ? { capabilities: { assistantStreamDelta: 1 as const } } : {}) });
 					sendSessionCostUpdate(ws, sessionManager, sessionId);
 					send(ws, { type: "session_status", status: "archived", statusVersion: 0, archivedAt: archived.archivedAt });
@@ -1011,6 +1019,17 @@ export function handleWebSocketConnection(
 			// dashboard events.
 			(ws as any).sessionId = sessionId;
 			sessionManager.addClient(sessionId, ws);
+
+			// Canonical Host notifications use a separate exact server-owned binding.
+			// Fail closed if live and persisted project ownership disagree; product
+			// metadata selects the UI transport but never supplies either authority ID.
+			const persistedProjectId = sessionManager.getPersistedSession(sessionId)?.projectId;
+			const exactProjectId = persistedProjectId && session.projectId && persistedProjectId !== session.projectId
+				? undefined
+				: persistedProjectId ?? session.projectId;
+			if (authMsg.clientKind === "app" && exactProjectId) {
+				bindHostNotificationSocket(ws, { sessionId, projectId: exactProjectId });
+			}
 
 			// Pack-bound surface-token minting uses an app-connection protocol key so
 			// sanctioned Host API calls bind to this authenticated session and an active
@@ -2490,6 +2509,7 @@ export function handleWebSocketConnection(
 
 	ws.on("close", () => {
 		clearTimeout(authTimeout);
+		unbindHostNotificationSocket(ws);
 		if (channelRegistry && attachedExtChannels.size > 0) {
 			for (const [channelId, attached] of attachedExtChannels) {
 				void Promise.resolve(channelRegistry.detach({ sessionId: attached.sessionId, packId: attached.packId, channelId, clientId })).catch((err) => {

--- a/src/server/ws/handler.ts
+++ b/src/server/ws/handler.ts
@@ -57,7 +57,15 @@ import {
 	SessionCommandSerialiser,
 } from "./session-command-serialiser.js";
 import { isSocketSendable } from "./socket-sendability.js";
+import {
+	hasUiWebSocketPrincipal,
+	type PrincipalTaggedWebSocket,
+	type WebSocketAuthPrincipal,
+} from "./ui-principal.js";
 import { bindHostNotificationSocket, unbindHostNotificationSocket } from "../extension-host/host-notification-socket-router.js";
+
+export { hasUiWebSocketPrincipal } from "./ui-principal.js";
+export type { WebSocketAuthPrincipal } from "./ui-principal.js";
 
 /**
  * Stamp `_order` on every message in a snapshot for the unified message
@@ -735,24 +743,6 @@ function isHostChannelFrame(frame: unknown): frame is HostChannelFrame {
 		|| (f.kind === "json" && Object.prototype.hasOwnProperty.call(f, "data") && f.data !== undefined);
 }
 
-export type WebSocketAuthPrincipal = Readonly<{
-	kind: "admin" | "sandbox" | "localhost";
-}>;
-
-type PrincipalTaggedWebSocket = WebSocket & {
-	authPrincipal?: WebSocketAuthPrincipal;
-};
-
-/**
- * Sidebar/global UI payloads are restricted to server-authenticated user
- * principals. Product metadata such as clientKind is intentionally ignored:
- * sandbox bearer tokens must never acquire global UI broadcast authority.
- */
-export function hasUiWebSocketPrincipal(ws: WebSocket): boolean {
-	const kind = (ws as PrincipalTaggedWebSocket).authPrincipal?.kind;
-	return kind === "admin" || kind === "localhost";
-}
-
 export function handleWebSocketConnection(
 	ws: WebSocket,
 	sessionId: string,
@@ -994,8 +984,10 @@ export function handleWebSocketConnection(
 					const archivedProjectId = persistedArchivedProjectId && archived.projectId && persistedArchivedProjectId !== archived.projectId
 						? undefined
 						: persistedArchivedProjectId ?? archived.projectId;
-					if (authMsg.clientKind === "app" && archivedProjectId) {
+					if (authMsg.clientKind === "app" && archivedProjectId && hasUiWebSocketPrincipal(ws)) {
 						bindHostNotificationSocket(ws, { sessionId, projectId: archivedProjectId });
+					} else {
+						unbindHostNotificationSocket(ws);
 					}
 					send(ws, { type: "auth_ok", ...(assistantStreamDeltaCapable ? { capabilities: { assistantStreamDelta: 1 as const } } : {}) });
 					sendSessionCostUpdate(ws, sessionManager, sessionId);
@@ -1027,8 +1019,10 @@ export function handleWebSocketConnection(
 			const exactProjectId = persistedProjectId && session.projectId && persistedProjectId !== session.projectId
 				? undefined
 				: persistedProjectId ?? session.projectId;
-			if (authMsg.clientKind === "app" && exactProjectId) {
+			if (authMsg.clientKind === "app" && exactProjectId && hasUiWebSocketPrincipal(ws)) {
 				bindHostNotificationSocket(ws, { sessionId, projectId: exactProjectId });
+			} else {
+				unbindHostNotificationSocket(ws);
 			}
 
 			// Pack-bound surface-token minting uses an app-connection protocol key so

--- a/src/server/ws/protocol.ts
+++ b/src/server/ws/protocol.ts
@@ -1,4 +1,4 @@
-import type { InboxEntry } from "../agent/inbox-store.js";
+import type { InboxLiveEntry } from "../agent/inbox-manager.js";
 import type { MessageAuthor } from "../../shared/message-author.js";
 import type { PromptSource } from "../../shared/prompt-source.js";
 import type { VerificationTimeoutInfo } from "../agent/gate-store.js";
@@ -378,8 +378,8 @@ export type ServerMessage =
 	| { type: "team_agent_spawned"; goalId: string; sessionId: string; role: string; name: string }
 	| { type: "team_agent_dismissed"; goalId: string; sessionId: string; role: string; name: string }
 	| { type: "team_agent_finished"; goalId: string; sessionId: string; role: string; name: string }
-	| { type: "inbox.entry.added"; staffId: string; entry: InboxEntry }
-	| { type: "inbox.entry.updated"; staffId: string; entry: InboxEntry }
+	| { type: "inbox.entry.added"; staffId: string; entry: InboxLiveEntry }
+	| { type: "inbox.entry.updated"; staffId: string; entry: InboxLiveEntry }
 	| { type: "inbox.entry.removed"; staffId: string; entryId: string }
 	| RemoteStateSnapshotMessage
 	| { type: "pr_status_changed"; goalId: string }

--- a/src/server/ws/protocol.ts
+++ b/src/server/ws/protocol.ts
@@ -4,6 +4,7 @@ import type { PromptSource } from "../../shared/prompt-source.js";
 import type { VerificationTimeoutInfo } from "../agent/gate-store.js";
 import type { GoalState } from "../agent/goal-store.js";
 import type { SidePanelWorkspace } from "../../shared/side-panel-workspace.js";
+import type { HostHookScope, HostNotification } from "../../shared/extension-host/host-hooks.js";
 
 export interface GateResetReopenOutcome {
 	reopened: boolean;
@@ -299,6 +300,8 @@ export interface RemoteStateSnapshotMessage {
 /** Server → Client messages over WebSocket */
 export type ServerMessage =
 	| { type: "auth_ok"; surfaceTokenKey?: string; capabilities?: SessionStreamCapabilities }
+	| { type: "host_notification"; notification: HostNotification; stream: { epoch: string; sequence: number } }
+	| { type: "host_notifications_refresh_required"; scope: HostHookScope; epoch: string; sequence: number }
 	| { type: "ext_surface_token_result"; requestId: string; ok: boolean; token?: string; error?: string }
 	| { type: "ext_channel_open_grant_result"; requestId: string; ok: boolean; openGrant?: string; error?: string }
 	| { type: "ext_channel_result"; requestId: string; ok: boolean; channel?: ChannelInfo; channels?: ChannelInfo[]; error?: string; message?: string; status?: number }

--- a/src/server/ws/ui-principal.ts
+++ b/src/server/ws/ui-principal.ts
@@ -1,0 +1,18 @@
+import type { WebSocket } from "ws";
+
+export type WebSocketAuthPrincipal = Readonly<{
+	kind: "admin" | "sandbox" | "localhost";
+}>;
+
+export type PrincipalTaggedWebSocket = WebSocket & {
+	authPrincipal?: WebSocketAuthPrincipal;
+};
+
+/**
+ * Canonical authority predicate for browser/UI-only WebSocket egress.
+ * Caller-controlled product metadata such as clientKind is never consulted.
+ */
+export function hasUiWebSocketPrincipal(ws: WebSocket): boolean {
+	const kind = (ws as PrincipalTaggedWebSocket).authPrincipal?.kind;
+	return kind === "admin" || kind === "localhost";
+}

--- a/src/shared/extension-host/host-api.ts
+++ b/src/shared/extension-host/host-api.ts
@@ -41,7 +41,15 @@ export const HOST_API_VERSION = 1 as const;
 // side-panel tab identity. Packs feature-detect via `host.contractVersion >= 3` and
 // fall back to host-derived singleton/allowlisted param identity. See PanelTarget.
 // v4 (additive): added generic host.channels data contracts.
-export const HOST_CONTRACT_VERSION = 4 as const;
+// v5 (additive): added canonical scoped session/project notification contracts.
+export const HOST_CONTRACT_VERSION = 5 as const;
+
+import type {
+	HostNotification,
+	HostNotificationName,
+	ProjectNotificationName,
+	SessionNotificationName,
+} from "./host-hooks.js";
 
 /**
  * The single, versioned, capability-scoped object through which ALL extension code
@@ -111,8 +119,11 @@ export interface HostApi {
 	 */
 	callRoute<TResult = unknown>(name: string, init?: HostRouteInit): Promise<TResult>;
 
-	/** Transcript + message capabilities. PHASE 2 (frozen, not implemented). */
+	/** Transcript, legacy events, and canonical session notifications. */
 	readonly session: HostSessionApi;
+
+	/** Current-project canonical notifications, bound by the host. */
+	readonly project: HostProjectApi;
 
 	/** UI surface capabilities. PHASE 2 (frozen, not implemented). */
 	readonly ui: HostUiApi;
@@ -146,6 +157,10 @@ export interface HostCapabilities {
 	readonly store: boolean;
 	/** Long-lived pack-scoped framed channels. False/absent until the host wires the bridge. */
 	readonly channels?: boolean;
+	/** Canonical facts bound to the current session. */
+	readonly sessionNotifications?: boolean;
+	/** Canonical facts bound to the current session's server-resolved project. */
+	readonly projectNotifications?: boolean;
 	/** Convenience: feature-detect by name; returns the flag, or false for unknown names. */
 	has(name: string): boolean;
 }
@@ -165,6 +180,16 @@ export interface HostRouteInit {
 /** PHASE 2 — frozen, not implemented. Read/post the current session's transcript.
  *  All shapes returned/accepted here are Host-API-OWNED contract types (below), produced
  *  by the internal→contract adapter — never Bobbit's internal wire format. */
+export interface HostNotificationSubscriptionApi<N extends HostNotificationName> {
+	/** Observe a committed canonical fact. The host owns scope and identity binding. */
+	subscribe<E extends N>(
+		name: E,
+		handler: (event: HostNotification<E>) => void,
+	): () => void;
+	/** Refresh the authoritative projection after mount, reconnect, or a stream gap. */
+	onRefreshRequired(handler: () => void): () => void;
+}
+
 export interface HostSessionApi {
 	/** Read the current session's transcript (paginated envelope of HostMessages). */
 	readTranscript(opts?: ReadTranscriptOpts): Promise<TranscriptEnvelope>;
@@ -178,6 +203,13 @@ export interface HostSessionApi {
 		event: E,
 		cb: (payload: HostSessionEventMap[E]) => void,
 	): () => void;
+	/** Privacy-bounded committed facts for this host's current session. */
+	readonly notifications: HostNotificationSubscriptionApi<SessionNotificationName>;
+}
+
+export interface HostProjectApi {
+	/** Privacy-bounded committed facts for the host's server-resolved project. */
+	readonly notifications: HostNotificationSubscriptionApi<ProjectNotificationName>;
 }
 
 /** PHASE 2 — frozen, not implemented. Drive non-chat UI surfaces. Targets are STRUCTURED

--- a/src/shared/extension-host/host-hooks.ts
+++ b/src/shared/extension-host/host-hooks.ts
@@ -1,0 +1,719 @@
+import { Type, type Static, type TSchema } from "@sinclair/typebox";
+import { Value } from "@sinclair/typebox/value";
+
+/** Runtime and type-level source of truth for Extension Host lifecycle hooks. */
+
+export const HOST_HOOK_LIMITS = Object.freeze({
+	identifierLength: 256,
+	nameLength: 128,
+	shortTextLength: 512,
+	textLength: 16_384,
+	jsonStringLength: 8_192,
+	arrayItems: 64,
+	contextContributions: 16,
+	changedIdentifiers: 16,
+	objectProperties: 64,
+	jsonDepth: 8,
+	jsonNodes: 1_024,
+	payloadBytes: 32 * 1_024,
+	interceptorBytes: 128 * 1_024,
+	filterFields: 8,
+	filterBytes: 2 * 1_024,
+} as const);
+
+export type HostHookScope = "session" | "project";
+export type HostConsumerKind = "browser" | "module" | "staff" | "diagnostic";
+export type HostNotificationPrivacy = "public-metadata" | "project-metadata";
+export type HostInterceptorFailurePolicy = "failOpen" | "failClosed" | "nonFatal";
+
+const IDENTIFIER_PATTERN = "^[A-Za-z0-9][A-Za-z0-9._:/@+\\-]*$";
+const SAFE_KEY_PATTERN = "^[A-Za-z][A-Za-z0-9._-]*$";
+const RELATIVE_COORDINATE_PATTERN = "^(?![A-Za-z]:[\\\\/])(?![\\\\/])(?!.*(?:^|[\\\\/])\\.\\.(?:[\\\\/]|$))[^\\u0000]+$";
+
+const IdentifierSchema = Type.String({
+	minLength: 1,
+	maxLength: HOST_HOOK_LIMITS.identifierLength,
+	pattern: IDENTIFIER_PATTERN,
+});
+const NameSchema = Type.String({
+	minLength: 1,
+	maxLength: HOST_HOOK_LIMITS.nameLength,
+	pattern: SAFE_KEY_PATTERN,
+});
+const ShortTextSchema = Type.String({ maxLength: HOST_HOOK_LIMITS.shortTextLength });
+const TextSchema = Type.String({ maxLength: HOST_HOOK_LIMITS.textLength });
+const NonNegativeIntegerSchema = Type.Integer({ minimum: 0, maximum: Number.MAX_SAFE_INTEGER });
+const NonNegativeNumberSchema = Type.Number({ minimum: 0, maximum: Number.MAX_SAFE_INTEGER });
+const RevisionSchema = Type.Union([
+	Type.String({ minLength: 1, maxLength: HOST_HOOK_LIMITS.identifierLength }),
+	NonNegativeNumberSchema,
+]);
+
+function literals<const V extends readonly [string, ...string[]]>(values: V) {
+	return Type.Union(values.map((value) => Type.Literal(value)) as [ReturnType<typeof Type.Literal>, ...ReturnType<typeof Type.Literal>[]]);
+}
+
+const SessionStatusSchema = literals(["starting", "preparing", "idle", "streaming", "aborting", "terminated"] as const);
+const PromptSourceSchema = literals([
+	"user",
+	"auto-nudge",
+	"task-notification",
+	"verification",
+	"system",
+	"agent",
+	"child-complete",
+	"extension",
+] as const);
+const GoalStateSchema = literals(["todo", "in-progress", "complete", "shelved", "blocked"] as const);
+const TaskStateSchema = literals(["todo", "in-progress", "blocked", "complete", "skipped"] as const);
+const GateStatusSchema = literals(["pending", "passed", "failed", "bypassed"] as const);
+const StaffStateSchema = literals(["active", "paused", "retired"] as const);
+const MessageRoleSchema = literals(["user", "assistant", "system"] as const);
+const ContentBlockKindSchema = literals(["text", "tool_use", "tool_result"] as const);
+const ToolCallStatusSchema = literals(["succeeded", "errored"] as const);
+const ToolErrorStatusSchema = literals(["timeout", "denied", "handler_error", "invalid_result", "cancelled"] as const);
+const TurnOutcomeSchema = literals(["succeeded", "errored", "aborted"] as const);
+const SessionKindSchema = literals(["general", "assistant", "goal", "team", "delegate", "staff", "child"] as const);
+const SessionArchiveReasonSchema = literals(["user", "goal_archived", "project_deleted", "retired", "cleanup"] as const);
+const ForkModeSchema = literals(["whole", "history"] as const);
+const PullRequestStateSchema = literals(["OPEN", "CLOSED", "MERGED"] as const);
+const ReviewDecisionSchema = literals(["APPROVED", "CHANGES_REQUESTED", "REVIEW_REQUIRED"] as const);
+const MergeabilitySchema = literals(["MERGEABLE", "CONFLICTING", "UNKNOWN"] as const);
+const SettingsTargetSchema = literals(["project", "component", "workflow", "pack", "sandbox", "provider"] as const);
+
+function strictObject<P extends Record<string, TSchema>>(properties: P) {
+	return Type.Object(properties, { additionalProperties: false });
+}
+
+function sortedUniqueArray<T extends TSchema>(items: T, maxItems: number = HOST_HOOK_LIMITS.changedIdentifiers) {
+	return Type.Array(items, { maxItems, uniqueItems: true });
+}
+
+const StaffChangedFieldSchema = literals([
+	"name", "description", "systemPrompt", "state", "triggers", "roleId", "accessory", "contextPolicy",
+] as const);
+const GoalChangedFieldSchema = literals([
+	"title", "spec", "state", "workflow", "metadata", "team", "paused", "divergencePolicy", "maxConcurrentChildren",
+] as const);
+const TaskChangedFieldSchema = literals([
+	"title", "type", "assignedSessionId", "spec", "parentTaskId", "dependsOn", "workflowGateId", "inputGateIds", "resultSummary", "headSha",
+] as const);
+const SettingsChangedKeySchema = literals([
+	"components", "workflows", "configDirectories", "sandbox", "sandboxTokens", "packOrder", "packActivation", "commands", "providers", "models",
+] as const);
+
+const StatusChangedPayloadSchema = strictObject({
+	previousStatus: SessionStatusSchema,
+	status: SessionStatusSchema,
+	statusVersion: NonNegativeIntegerSchema,
+});
+const TurnStartedPayloadSchema = strictObject({
+	turnIndex: NonNegativeIntegerSchema,
+	source: PromptSourceSchema,
+});
+const TurnCompletedPayloadSchema = strictObject({
+	turnIndex: NonNegativeIntegerSchema,
+	outcome: TurnOutcomeSchema,
+	durationMs: NonNegativeNumberSchema,
+	hadToolCalls: Type.Boolean(),
+});
+const MessageAppendedPayloadSchema = strictObject({
+	messageId: IdentifierSchema,
+	cursor: RevisionSchema,
+	role: MessageRoleSchema,
+	blockKinds: sortedUniqueArray(ContentBlockKindSchema, 8),
+});
+const ToolCallStartedPayloadSchema = strictObject({
+	toolCallId: IdentifierSchema,
+	toolName: NameSchema,
+	turnIndex: NonNegativeIntegerSchema,
+});
+const ToolCallCompletedPayloadSchema = strictObject({
+	toolCallId: IdentifierSchema,
+	toolName: NameSchema,
+	status: ToolCallStatusSchema,
+	durationMs: NonNegativeNumberSchema,
+	errorStatus: Type.Optional(ToolErrorStatusSchema),
+});
+const SessionCreatedPayloadSchema = strictObject({
+	sessionId: IdentifierSchema,
+	kind: SessionKindSchema,
+	goalId: Type.Optional(IdentifierSchema),
+});
+const SessionArchivedPayloadSchema = strictObject({
+	sessionId: IdentifierSchema,
+	reason: SessionArchiveReasonSchema,
+});
+const SessionForkedPayloadSchema = strictObject({
+	sourceSessionId: IdentifierSchema,
+	sessionId: IdentifierSchema,
+	cutEntryId: Type.Optional(IdentifierSchema),
+	forkMode: ForkModeSchema,
+});
+const SessionStatusChangedPayloadSchema = strictObject({
+	sessionId: IdentifierSchema,
+	previousStatus: SessionStatusSchema,
+	status: SessionStatusSchema,
+	statusVersion: NonNegativeIntegerSchema,
+});
+const StaffCreatedPayloadSchema = strictObject({
+	staffId: IdentifierSchema,
+	state: StaffStateSchema,
+	sessionId: Type.Optional(IdentifierSchema),
+});
+const StaffConfigChangedPayloadSchema = strictObject({
+	staffId: IdentifierSchema,
+	changedFields: sortedUniqueArray(StaffChangedFieldSchema),
+});
+const StaffRetiredPayloadSchema = strictObject({ staffId: IdentifierSchema });
+const StaffSessionChangedPayloadSchema = strictObject({
+	staffId: IdentifierSchema,
+	previousSessionId: Type.Optional(IdentifierSchema),
+	sessionId: Type.Optional(IdentifierSchema),
+});
+const GoalCreatedPayloadSchema = strictObject({
+	goalId: IdentifierSchema,
+	parentGoalId: Type.Optional(IdentifierSchema),
+	state: GoalStateSchema,
+});
+const GoalUpdatedPayloadSchema = strictObject({
+	goalId: IdentifierSchema,
+	state: GoalStateSchema,
+	changedFields: sortedUniqueArray(GoalChangedFieldSchema),
+});
+const GoalCompletedPayloadSchema = strictObject({
+	goalId: IdentifierSchema,
+	parentGoalId: Type.Optional(IdentifierSchema),
+});
+const GoalArchivedPayloadSchema = strictObject({ goalId: IdentifierSchema });
+const TaskCreatedPayloadSchema = strictObject({
+	taskId: IdentifierSchema,
+	goalId: IdentifierSchema,
+	type: NameSchema,
+	state: TaskStateSchema,
+	parentTaskId: Type.Optional(IdentifierSchema),
+});
+const TaskUpdatedPayloadSchema = strictObject({
+	taskId: IdentifierSchema,
+	goalId: IdentifierSchema,
+	state: TaskStateSchema,
+	changedFields: sortedUniqueArray(TaskChangedFieldSchema),
+});
+const TaskStateChangedPayloadSchema = strictObject({
+	taskId: IdentifierSchema,
+	goalId: IdentifierSchema,
+	previousState: TaskStateSchema,
+	state: TaskStateSchema,
+});
+const GateStatusChangedPayloadSchema = strictObject({
+	gateId: IdentifierSchema,
+	goalId: IdentifierSchema,
+	previousStatus: GateStatusSchema,
+	status: GateStatusSchema,
+});
+const PullRequestStatusChangedPayloadSchema = strictObject({
+	goalId: IdentifierSchema,
+	number: Type.Optional(Type.Integer({ minimum: 1, maximum: Number.MAX_SAFE_INTEGER })),
+	state: PullRequestStateSchema,
+	reviewDecision: Type.Optional(ReviewDecisionSchema),
+	mergeability: Type.Optional(MergeabilitySchema),
+});
+const SettingsChangedPayloadSchema = strictObject({
+	target: SettingsTargetSchema,
+	changedKeys: sortedUniqueArray(SettingsChangedKeySchema),
+});
+
+export interface HostNotificationDefinition<
+	N extends string,
+	S extends HostHookScope,
+	P extends TSchema,
+	K extends string = string,
+> {
+	readonly name: N;
+	readonly scope: S;
+	readonly payloadVersion: 1;
+	readonly payloadSchema: P;
+	readonly boundary: string;
+	readonly aggregateKind: K;
+	readonly revisionSource: string;
+	readonly filterFields: Readonly<Record<string, TSchema>>;
+	readonly consumers: ReadonlySet<HostConsumerKind>;
+	readonly privacy: HostNotificationPrivacy;
+	readonly delivery: Readonly<{
+		browser: "live" | "none";
+		module: "live" | "none";
+		staff: "durable-intent" | "none";
+	}>;
+}
+
+const ALL_CONSUMERS: ReadonlySet<HostConsumerKind> = new Set(["browser", "module", "staff", "diagnostic"]);
+const STANDARD_DELIVERY = Object.freeze({ browser: "live", module: "live", staff: "durable-intent" } as const);
+
+function notificationDefinition<
+	const N extends string,
+	const S extends HostHookScope,
+	const P extends TSchema,
+	const K extends string,
+>(definition: HostNotificationDefinition<N, S, P, K>): HostNotificationDefinition<N, S, P, K> {
+	return Object.freeze(definition);
+}
+
+function notification<
+	const N extends string,
+	const S extends HostHookScope,
+	const P extends TSchema,
+	const K extends string,
+>(options: {
+	name: N;
+	scope: S;
+	payloadSchema: P;
+	boundary: string;
+	aggregateKind: K;
+	revisionSource: string;
+	filterFields?: Readonly<Record<string, TSchema>>;
+	privacy?: HostNotificationPrivacy;
+}): HostNotificationDefinition<N, S, P, K> {
+	return notificationDefinition({
+		...options,
+		payloadVersion: 1,
+		filterFields: Object.freeze({ ...(options.filterFields ?? {}) }),
+		consumers: ALL_CONSUMERS,
+		privacy: options.privacy ?? "project-metadata",
+		delivery: STANDARD_DELIVERY,
+	});
+}
+
+export const HOST_NOTIFICATION_CATALOGUE = Object.freeze({
+	statusChanged: notification({ name: "statusChanged", scope: "session", payloadSchema: StatusChangedPayloadSchema, boundary: "session-status.broadcastStatus.afterLegacyFrameQueued", aggregateKind: "session", revisionSource: "statusVersion", filterFields: { status: SessionStatusSchema } }),
+	turnStarted: notification({ name: "turnStarted", scope: "session", payloadSchema: TurnStartedPayloadSchema, boundary: "session-manager.handleAgentLifecycle.canonicalAgentStart", aggregateKind: "turn", revisionSource: "turnIndex", filterFields: { source: PromptSourceSchema } }),
+	turnCompleted: notification({ name: "turnCompleted", scope: "session", payloadSchema: TurnCompletedPayloadSchema, boundary: "session-manager.handleAgentLifecycle.finalAgentEnd", aggregateKind: "turn", revisionSource: "completedTurnIndex", filterFields: { outcome: TurnOutcomeSchema, hadToolCalls: Type.Boolean() } }),
+	messageAppended: notification({ name: "messageAppended", scope: "session", payloadSchema: MessageAppendedPayloadSchema, boundary: "session-manager.emitSessionEvent.acceptedMessageEnd", aggregateKind: "message", revisionSource: "eventBufferCursor", filterFields: { role: MessageRoleSchema } }),
+	toolCallStarted: notification({ name: "toolCallStarted", scope: "session", payloadSchema: ToolCallStartedPayloadSchema, boundary: "session-manager.toolExecutionStart.afterAdmission", aggregateKind: "toolCall", revisionSource: "toolCallStartCursor", filterFields: { toolName: NameSchema } }),
+	toolCallCompleted: notification({ name: "toolCallCompleted", scope: "session", payloadSchema: ToolCallCompletedPayloadSchema, boundary: "session-manager.acceptedToolResultMessageEnd", aggregateKind: "toolCall", revisionSource: "resultMessageCursor", filterFields: { toolName: NameSchema, status: ToolCallStatusSchema, errorStatus: ToolErrorStatusSchema } }),
+	sessionCreated: notification({ name: "sessionCreated", scope: "project", payloadSchema: SessionCreatedPayloadSchema, boundary: "session-manager.notifySessionCreated.afterStrictPersistence", aggregateKind: "session", revisionSource: "session.updatedAt", filterFields: { kind: SessionKindSchema } }),
+	sessionArchived: notification({ name: "sessionArchived", scope: "project", payloadSchema: SessionArchivedPayloadSchema, boundary: "session-store.archiveAsync.afterCommit", aggregateKind: "session", revisionSource: "session.archivedAt", filterFields: { reason: SessionArchiveReasonSchema } }),
+	sessionForked: notification({ name: "sessionForked", scope: "project", payloadSchema: SessionForkedPayloadSchema, boundary: "server.historyFork.afterMaterialisation", aggregateKind: "session", revisionSource: "destinationSession.updatedAt", filterFields: { forkMode: ForkModeSchema } }),
+	sessionStatusChanged: notification({ name: "sessionStatusChanged", scope: "project", payloadSchema: SessionStatusChangedPayloadSchema, boundary: "session-status.broadcastStatus.afterLegacyFrameQueued", aggregateKind: "session", revisionSource: "statusVersion", filterFields: { status: SessionStatusSchema } }),
+	staffCreated: notification({ name: "staffCreated", scope: "project", payloadSchema: StaffCreatedPayloadSchema, boundary: "staff-manager.createStaff.afterDurableAcceptance", aggregateKind: "staff", revisionSource: "staff.updatedAt", filterFields: { state: StaffStateSchema } }),
+	staffConfigChanged: notification({ name: "staffConfigChanged", scope: "project", payloadSchema: StaffConfigChangedPayloadSchema, boundary: "staff-manager.updateStaff.afterStrictCommit", aggregateKind: "staff", revisionSource: "staff.updatedAt" }),
+	staffRetired: notification({ name: "staffRetired", scope: "project", payloadSchema: StaffRetiredPayloadSchema, boundary: "staff-manager.retire.afterStrictCommit", aggregateKind: "staff", revisionSource: "staff.updatedAt" }),
+	staffSessionChanged: notification({ name: "staffSessionChanged", scope: "project", payloadSchema: StaffSessionChangedPayloadSchema, boundary: "staff-manager.commitCurrentSession.afterStrictCommit", aggregateKind: "staff", revisionSource: "staff.updatedAt" }),
+	goalCreated: notification({ name: "goalCreated", scope: "project", payloadSchema: GoalCreatedPayloadSchema, boundary: "goal-store.create.afterStrictPublication", aggregateKind: "goal", revisionSource: "goal.updatedAt", filterFields: { state: GoalStateSchema } }),
+	goalUpdated: notification({ name: "goalUpdated", scope: "project", payloadSchema: GoalUpdatedPayloadSchema, boundary: "goal-store.updateStrict.afterPublication", aggregateKind: "goal", revisionSource: "goal.updatedAt", filterFields: { state: GoalStateSchema } }),
+	goalCompleted: notification({ name: "goalCompleted", scope: "project", payloadSchema: GoalCompletedPayloadSchema, boundary: "goal-manager.complete.afterStrictPublication", aggregateKind: "goal", revisionSource: "goal.updatedAt" }),
+	goalArchived: notification({ name: "goalArchived", scope: "project", payloadSchema: GoalArchivedPayloadSchema, boundary: "goal-store.archiveStrict.afterPublication", aggregateKind: "goal", revisionSource: "goal.archivedAt" }),
+	taskCreated: notification({ name: "taskCreated", scope: "project", payloadSchema: TaskCreatedPayloadSchema, boundary: "task-manager.createTask.afterStrictPublication", aggregateKind: "task", revisionSource: "task.updatedAt", filterFields: { type: NameSchema, state: TaskStateSchema } }),
+	taskUpdated: notification({ name: "taskUpdated", scope: "project", payloadSchema: TaskUpdatedPayloadSchema, boundary: "task-manager.updateTask.afterStrictPublication", aggregateKind: "task", revisionSource: "task.updatedAt", filterFields: { state: TaskStateSchema } }),
+	taskStateChanged: notification({ name: "taskStateChanged", scope: "project", payloadSchema: TaskStateChangedPayloadSchema, boundary: "task-manager.stateTransition.afterStrictPublication", aggregateKind: "task", revisionSource: "task.updatedAt", filterFields: { previousState: TaskStateSchema, state: TaskStateSchema } }),
+	gateStatusChanged: notification({ name: "gateStatusChanged", scope: "project", payloadSchema: GateStatusChangedPayloadSchema, boundary: "gate-store.statusSummary.afterStrictPersistence", aggregateKind: "gate", revisionSource: "gate.statusRevision", filterFields: { status: GateStatusSchema } }),
+	pullRequestStatusChanged: notification({ name: "pullRequestStatusChanged", scope: "project", payloadSchema: PullRequestStatusChangedPayloadSchema, boundary: "pr-status-store.set.afterAtomicPersistence", aggregateKind: "pullRequest", revisionSource: "provider.updatedAt|safeProjectionSha256", filterFields: { state: PullRequestStateSchema, reviewDecision: ReviewDecisionSchema, mergeability: MergeabilitySchema } }),
+	settingsChanged: notification({ name: "settingsChanged", scope: "project", payloadSchema: SettingsChangedPayloadSchema, boundary: "project-config-store.mutate.afterAtomicRename", aggregateKind: "settings", revisionSource: "committedConfigSha256", filterFields: { target: SettingsTargetSchema } }),
+} as const);
+
+export type HostNotificationName = keyof typeof HOST_NOTIFICATION_CATALOGUE;
+export type HostNotificationScope<N extends HostNotificationName> = (typeof HOST_NOTIFICATION_CATALOGUE)[N]["scope"];
+export type HostNotificationAggregateKind<N extends HostNotificationName> = (typeof HOST_NOTIFICATION_CATALOGUE)[N]["aggregateKind"];
+export type HostNotificationPayload<N extends HostNotificationName> = Static<(typeof HOST_NOTIFICATION_CATALOGUE)[N]["payloadSchema"]>;
+export type SessionNotificationName = {
+	[N in HostNotificationName]: HostNotificationScope<N> extends "session" ? N : never;
+}[HostNotificationName];
+export type ProjectNotificationName = {
+	[N in HostNotificationName]: HostNotificationScope<N> extends "project" ? N : never;
+}[HostNotificationName];
+
+export interface HostNotification<N extends HostNotificationName = HostNotificationName> {
+	readonly id: string;
+	readonly scope: HostNotificationScope<N>;
+	readonly name: N;
+	readonly payloadVersion: number;
+	readonly occurredAt: number;
+	readonly projectId: string;
+	readonly sessionId?: string;
+	readonly aggregate: Readonly<{
+		kind: HostNotificationAggregateKind<N>;
+		id: string;
+		revision?: string | number;
+	}>;
+	readonly correlationId?: string;
+	readonly causationId?: string;
+	readonly payload: Readonly<HostNotificationPayload<N>>;
+}
+
+export interface HostNotificationBuildInput<N extends HostNotificationName> {
+	readonly id: string;
+	readonly occurredAt: number;
+	readonly projectId: string;
+	readonly sessionId?: string;
+	readonly aggregateId: string;
+	readonly aggregateRevision: string | number;
+	readonly correlationId?: string;
+	readonly causationId?: string;
+	readonly payload: HostNotificationPayload<N>;
+}
+
+export type HostNotificationFilter = Readonly<Record<string, string | number | boolean>>;
+export type HostNotificationFilterValidation =
+	| { ok: true; filter: HostNotificationFilter }
+	| { ok: false; code: "UNKNOWN_NOTIFICATION" | "INELIGIBLE_CONSUMER" | "UNKNOWN_FILTER_FIELD" | "INVALID_FILTER_VALUE" | "FILTER_TOO_LARGE" };
+
+export function isHostNotificationName(value: unknown): value is HostNotificationName {
+	return typeof value === "string" && Object.prototype.hasOwnProperty.call(HOST_NOTIFICATION_CATALOGUE, value);
+}
+
+export function getHostNotificationDefinition(name: string): (typeof HOST_NOTIFICATION_CATALOGUE)[HostNotificationName] | undefined {
+	return isHostNotificationName(name) ? HOST_NOTIFICATION_CATALOGUE[name] : undefined;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+	if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+	const prototype = Object.getPrototypeOf(value);
+	return prototype === Object.prototype || prototype === null;
+}
+
+function jsonByteLength(value: unknown): number {
+	try {
+		return new TextEncoder().encode(JSON.stringify(value)).byteLength;
+	} catch {
+		return Number.POSITIVE_INFINITY;
+	}
+}
+
+function isStructurallyBounded(value: unknown, maxBytes: number): boolean {
+	if (jsonByteLength(value) > maxBytes) return false;
+	let nodes = 0;
+	const ancestors = new Set<object>();
+	const visit = (current: unknown, depth: number): boolean => {
+		nodes += 1;
+		if (nodes > HOST_HOOK_LIMITS.jsonNodes || depth > HOST_HOOK_LIMITS.jsonDepth) return false;
+		if (current === null || typeof current === "boolean") return true;
+		if (typeof current === "number") return Number.isFinite(current);
+		if (typeof current === "string") return current.length <= HOST_HOOK_LIMITS.textLength;
+		if (typeof current !== "object") return false;
+		if (ancestors.has(current)) return false;
+		ancestors.add(current);
+		let valid = true;
+		if (Array.isArray(current)) {
+			valid = current.length <= HOST_HOOK_LIMITS.arrayItems && current.every((item) => visit(item, depth + 1));
+		} else if (isPlainObject(current)) {
+			const entries = Object.entries(current);
+			valid = entries.length <= HOST_HOOK_LIMITS.objectProperties
+				&& entries.every(([key, item]) => key.length <= HOST_HOOK_LIMITS.nameLength && visit(item, depth + 1));
+		} else {
+			valid = false;
+		}
+		ancestors.delete(current);
+		return valid;
+	};
+	return visit(value, 0);
+}
+
+function isSortedUniqueStrings(value: unknown): boolean {
+	if (!Array.isArray(value)) return false;
+	for (let index = 0; index < value.length; index += 1) {
+		if (typeof value[index] !== "string") return false;
+		if (index > 0 && value[index - 1] >= value[index]) return false;
+	}
+	return true;
+}
+
+function hasPayloadInvariants(name: HostNotificationName, payload: Record<string, unknown>): boolean {
+	if ("changedFields" in payload && !isSortedUniqueStrings(payload.changedFields)) return false;
+	if ("changedKeys" in payload && !isSortedUniqueStrings(payload.changedKeys)) return false;
+	if (name === "toolCallCompleted") {
+		if (payload.status === "succeeded" && payload.errorStatus !== undefined) return false;
+		if (payload.status === "errored" && payload.errorStatus === undefined) return false;
+	}
+	if (name === "staffSessionChanged" && payload.previousSessionId === undefined && payload.sessionId === undefined) return false;
+	return true;
+}
+
+export function validateNotificationPayload<N extends HostNotificationName>(
+	name: N,
+	value: unknown,
+): value is HostNotificationPayload<N> {
+	return isStructurallyBounded(value, HOST_HOOK_LIMITS.payloadBytes)
+		&& Value.Check(HOST_NOTIFICATION_CATALOGUE[name].payloadSchema, value)
+		&& isPlainObject(value)
+		&& hasPayloadInvariants(name, value);
+}
+
+export function validateNotificationFilter(
+	scope: HostHookScope,
+	name: string,
+	value: unknown,
+): HostNotificationFilterValidation {
+	const definition = getHostNotificationDefinition(name);
+	if (!definition || definition.scope !== scope) return { ok: false, code: "UNKNOWN_NOTIFICATION" };
+	if (!definition.consumers.has("staff")) return { ok: false, code: "INELIGIBLE_CONSUMER" };
+	if (!isPlainObject(value)) return { ok: false, code: "INVALID_FILTER_VALUE" };
+	const entries = Object.entries(value);
+	if (entries.length > HOST_HOOK_LIMITS.filterFields || jsonByteLength(value) > HOST_HOOK_LIMITS.filterBytes) {
+		return { ok: false, code: "FILTER_TOO_LARGE" };
+	}
+	for (const [field, fieldValue] of entries) {
+		const schema = definition.filterFields[field];
+		if (!schema) return { ok: false, code: "UNKNOWN_FILTER_FIELD" };
+		if ((typeof fieldValue !== "string" && typeof fieldValue !== "number" && typeof fieldValue !== "boolean")
+			|| !Value.Check(schema, fieldValue)) {
+			return { ok: false, code: "INVALID_FILTER_VALUE" };
+		}
+	}
+	return { ok: true, filter: Object.freeze(Object.fromEntries(entries)) as HostNotificationFilter };
+}
+
+export function notificationMatchesFilter<N extends HostNotificationName>(
+	notification: HostNotification<N>,
+	filter: HostNotificationFilter,
+): boolean {
+	const validated = validateNotificationFilter(notification.scope, notification.name, filter);
+	if (!validated.ok || !validateHostNotification(notification)) return false;
+	const payload = notification.payload as Record<string, unknown>;
+	return Object.entries(validated.filter).every(([field, expected]) => payload[field] === expected);
+}
+
+function notificationEnvelopeSchema<N extends HostNotificationName>(name: N): TSchema {
+	const definition = HOST_NOTIFICATION_CATALOGUE[name];
+	return strictObject({
+		id: IdentifierSchema,
+		scope: Type.Literal(definition.scope),
+		name: Type.Literal(name),
+		payloadVersion: Type.Literal(definition.payloadVersion),
+		occurredAt: NonNegativeIntegerSchema,
+		projectId: IdentifierSchema,
+		...(definition.scope === "session" ? { sessionId: IdentifierSchema } : {}),
+		aggregate: strictObject({
+			kind: Type.Literal(definition.aggregateKind),
+			id: IdentifierSchema,
+			revision: RevisionSchema,
+		}),
+		correlationId: Type.Optional(IdentifierSchema),
+		causationId: Type.Optional(IdentifierSchema),
+		payload: definition.payloadSchema,
+	});
+}
+
+export const HOST_NOTIFICATION_ENVELOPE_SCHEMAS: Readonly<Record<HostNotificationName, TSchema>> = Object.freeze(
+	Object.fromEntries((Object.keys(HOST_NOTIFICATION_CATALOGUE) as HostNotificationName[]).map((name) => [name, notificationEnvelopeSchema(name)])) as Record<HostNotificationName, TSchema>,
+);
+
+export function validateHostNotification(value: unknown): value is HostNotification {
+	if (!isPlainObject(value) || !isHostNotificationName(value.name)) return false;
+	if (!isStructurallyBounded(value, HOST_HOOK_LIMITS.payloadBytes)) return false;
+	if (!Value.Check(HOST_NOTIFICATION_ENVELOPE_SCHEMAS[value.name], value)) return false;
+	return validateNotificationPayload(value.name, value.payload);
+}
+
+function cloneHostValue<T>(value: T): T {
+	if (Array.isArray(value)) return value.map((item) => cloneHostValue(item)) as T;
+	if (isPlainObject(value)) {
+		return Object.fromEntries(Object.entries(value).map(([key, item]) => [key, cloneHostValue(item)])) as T;
+	}
+	return value;
+}
+
+export function deepFreezeHostValue<T>(value: T): Readonly<T> {
+	if (value && typeof value === "object" && !Object.isFrozen(value)) {
+		for (const child of Object.values(value as Record<string, unknown>)) deepFreezeHostValue(child);
+		Object.freeze(value);
+	}
+	return value as Readonly<T>;
+}
+
+/** Host-only constructor. It copies, validates, and deeply freezes the canonical projection. */
+export function buildHostNotification<N extends HostNotificationName>(
+	name: N,
+	input: HostNotificationBuildInput<N>,
+): HostNotification<N> {
+	const definition = HOST_NOTIFICATION_CATALOGUE[name];
+	const candidate = cloneHostValue({
+		id: input.id,
+		scope: definition.scope,
+		name,
+		payloadVersion: definition.payloadVersion,
+		occurredAt: input.occurredAt,
+		projectId: input.projectId,
+		...(input.sessionId === undefined ? {} : { sessionId: input.sessionId }),
+		aggregate: {
+			kind: definition.aggregateKind,
+			id: input.aggregateId,
+			revision: input.aggregateRevision,
+		},
+		...(input.correlationId === undefined ? {} : { correlationId: input.correlationId }),
+		...(input.causationId === undefined ? {} : { causationId: input.causationId }),
+		payload: input.payload,
+	});
+	if (!validateHostNotification(candidate)) throw new TypeError("Invalid host notification projection");
+	return deepFreezeHostValue(candidate) as HostNotification<N>;
+}
+
+// Interceptor contracts -----------------------------------------------------
+
+const BoundedJsonValueSchema = Type.Recursive((This) => Type.Union([
+	Type.Null(),
+	Type.Boolean(),
+	Type.Number(),
+	Type.String({ maxLength: HOST_HOOK_LIMITS.jsonStringLength }),
+	Type.Array(This, { maxItems: HOST_HOOK_LIMITS.arrayItems }),
+	Type.Record(
+		Type.String({ minLength: 1, maxLength: HOST_HOOK_LIMITS.nameLength, pattern: SAFE_KEY_PATTERN }),
+		This,
+		{ maxProperties: HOST_HOOK_LIMITS.objectProperties },
+	),
+]));
+const BoundedJsonObjectSchema = Type.Record(
+	Type.String({ minLength: 1, maxLength: HOST_HOOK_LIMITS.nameLength, pattern: SAFE_KEY_PATTERN }),
+	BoundedJsonValueSchema,
+	{ maxProperties: HOST_HOOK_LIMITS.objectProperties },
+);
+const ContextContributionSchema = strictObject({
+	id: IdentifierSchema,
+	title: Type.String({ minLength: 1, maxLength: HOST_HOOK_LIMITS.shortTextLength }),
+	authority: literals(["memory", "skill", "tool", "workflow", "role", "generic"] as const),
+	content: TextSchema,
+	reason: ShortTextSchema,
+	priority: Type.Number({ minimum: -1_000, maximum: 1_000 }),
+});
+const ContextResultSchema = strictObject({
+	context: Type.Array(ContextContributionSchema, { maxItems: HOST_HOOK_LIMITS.contextContributions }),
+});
+const SessionSetupRequestSchema = strictObject({
+	sessionId: IdentifierSchema,
+	projectId: Type.Optional(IdentifierSchema),
+	goalId: Type.Optional(IdentifierSchema),
+	scope: literals(["project", "global"] as const),
+	roleName: Type.Optional(NameSchema),
+	component: Type.Optional(strictObject({ name: NameSchema })),
+});
+const BeforePromptRequestSchema = strictObject({
+	sessionId: IdentifierSchema,
+	turnIndex: NonNegativeIntegerSchema,
+	source: PromptSourceSchema,
+	userText: TextSchema,
+});
+const BeforeToolCallRequestSchema = strictObject({
+	toolCallId: IdentifierSchema,
+	toolName: NameSchema,
+	args: BoundedJsonObjectSchema,
+});
+const BeforeToolCallResultSchema = Type.Union([
+	strictObject({ action: Type.Literal("allow") }),
+	strictObject({ action: Type.Literal("block"), reasonCode: literals(["denied", "invalid_request", "not_permitted"] as const) }),
+	strictObject({ action: Type.Literal("replaceArgs"), args: BoundedJsonObjectSchema }),
+]);
+const AfterToolResultRequestSchema = strictObject({
+	toolCallId: IdentifierSchema,
+	toolName: NameSchema,
+	result: BoundedJsonValueSchema,
+});
+const AfterToolResultResultSchema = Type.Union([
+	strictObject({ action: Type.Literal("allow") }),
+	strictObject({ action: Type.Literal("replaceResult"), result: BoundedJsonValueSchema }),
+	strictObject({ action: Type.Literal("syntheticError"), code: literals(["policy_denied", "invalid_result", "handler_error"] as const) }),
+]);
+const BeforeCompactRequestSchema = strictObject({
+	sessionId: IdentifierSchema,
+	turnIndex: NonNegativeIntegerSchema,
+	span: TextSchema,
+	summary: Type.Optional(TextSchema),
+});
+const BeforeCompactResultSchema = strictObject({
+	context: Type.Optional(Type.Array(ContextContributionSchema, { maxItems: HOST_HOOK_LIMITS.contextContributions })),
+	flush: Type.Optional(Type.Literal("complete")),
+});
+const SessionShutdownRequestSchema = strictObject({
+	sessionId: IdentifierSchema,
+	projectId: Type.Optional(IdentifierSchema),
+	reason: literals(["completed", "archived", "terminated", "restarted", "failed"] as const),
+});
+const FlushResultSchema = strictObject({ flush: Type.Optional(Type.Literal("complete")) });
+const ProjectImportedRequestSchema = strictObject({
+	projectId: IdentifierSchema,
+	components: Type.Array(strictObject({
+		name: NameSchema,
+		repo: Type.String({ minLength: 1, maxLength: HOST_HOOK_LIMITS.identifierLength, pattern: RELATIVE_COORDINATE_PATTERN }),
+		relativePath: Type.Optional(Type.String({ minLength: 1, maxLength: HOST_HOOK_LIMITS.identifierLength, pattern: RELATIVE_COORDINATE_PATTERN })),
+	}), { maxItems: HOST_HOOK_LIMITS.arrayItems }),
+});
+const ProjectImportedResultSchema = strictObject({ initialised: Type.Optional(Type.Literal(true)) });
+
+export interface HostInterceptorAuditProjection {
+	readonly proposal: "none" | "received";
+}
+
+export interface HostInterceptorDefinition<N extends string, RQ extends TSchema, RS extends TSchema> {
+	readonly name: N;
+	readonly requestSchema: RQ;
+	readonly resultSchema: RS;
+	readonly defaultTimeoutMs: number;
+	readonly maxTimeoutMs: number;
+	readonly dispatchDeadlineMs: number;
+	readonly defaultFailurePolicy: HostInterceptorFailurePolicy;
+	readonly allowedFailurePolicies: ReadonlySet<HostInterceptorFailurePolicy>;
+	readonly requiredGrants: readonly string[];
+	readonly cancellation: Readonly<{
+		abortWorker: true;
+		discardLateResult: true;
+		operationAtDeadline: "continue" | "apply-failure-policy";
+	}>;
+	readonly auditProjector: (request: unknown, result: unknown) => HostInterceptorAuditProjection;
+}
+
+const FAIL_OPEN = new Set<HostInterceptorFailurePolicy>(["failOpen"]);
+const FAIL_CLOSED_OR_OPEN = new Set<HostInterceptorFailurePolicy>(["failOpen", "failClosed"]);
+const NON_FATAL = new Set<HostInterceptorFailurePolicy>(["nonFatal"]);
+const NO_GRANTS = Object.freeze([]) as readonly string[];
+const AUDIT_NONE = Object.freeze({ proposal: "none" } as const);
+const AUDIT_RECEIVED = Object.freeze({ proposal: "received" } as const);
+
+function interceptor<const N extends string, const RQ extends TSchema, const RS extends TSchema>(options: {
+	name: N;
+	requestSchema: RQ;
+	resultSchema: RS;
+	defaultTimeoutMs: number;
+	maxTimeoutMs: number;
+	dispatchDeadlineMs: number;
+	defaultFailurePolicy: HostInterceptorFailurePolicy;
+	allowedFailurePolicies: ReadonlySet<HostInterceptorFailurePolicy>;
+	operationAtDeadline: "continue" | "apply-failure-policy";
+}): HostInterceptorDefinition<N, RQ, RS> {
+	return Object.freeze({
+		...options,
+		requiredGrants: NO_GRANTS,
+		cancellation: Object.freeze({ abortWorker: true, discardLateResult: true, operationAtDeadline: options.operationAtDeadline }),
+		auditProjector: (_request: unknown, result: unknown) => result === undefined ? AUDIT_NONE : AUDIT_RECEIVED,
+	});
+}
+
+export const HOST_INTERCEPTOR_CATALOGUE = Object.freeze({
+	sessionSetup: interceptor({ name: "sessionSetup", requestSchema: SessionSetupRequestSchema, resultSchema: ContextResultSchema, defaultTimeoutMs: 1_500, maxTimeoutMs: 3_000, dispatchDeadlineMs: 5_000, defaultFailurePolicy: "failOpen", allowedFailurePolicies: FAIL_OPEN, operationAtDeadline: "continue" }),
+	beforePrompt: interceptor({ name: "beforePrompt", requestSchema: BeforePromptRequestSchema, resultSchema: ContextResultSchema, defaultTimeoutMs: 500, maxTimeoutMs: 1_000, dispatchDeadlineMs: 1_500, defaultFailurePolicy: "failOpen", allowedFailurePolicies: FAIL_OPEN, operationAtDeadline: "continue" }),
+	beforeToolCall: interceptor({ name: "beforeToolCall", requestSchema: BeforeToolCallRequestSchema, resultSchema: BeforeToolCallResultSchema, defaultTimeoutMs: 750, maxTimeoutMs: 1_500, dispatchDeadlineMs: 2_000, defaultFailurePolicy: "failOpen", allowedFailurePolicies: FAIL_CLOSED_OR_OPEN, operationAtDeadline: "apply-failure-policy" }),
+	afterToolResult: interceptor({ name: "afterToolResult", requestSchema: AfterToolResultRequestSchema, resultSchema: AfterToolResultResultSchema, defaultTimeoutMs: 750, maxTimeoutMs: 1_500, dispatchDeadlineMs: 2_000, defaultFailurePolicy: "failClosed", allowedFailurePolicies: FAIL_CLOSED_OR_OPEN, operationAtDeadline: "apply-failure-policy" }),
+	beforeCompact: interceptor({ name: "beforeCompact", requestSchema: BeforeCompactRequestSchema, resultSchema: BeforeCompactResultSchema, defaultTimeoutMs: 1_500, maxTimeoutMs: 3_000, dispatchDeadlineMs: 5_000, defaultFailurePolicy: "failOpen", allowedFailurePolicies: FAIL_OPEN, operationAtDeadline: "continue" }),
+	sessionShutdown: interceptor({ name: "sessionShutdown", requestSchema: SessionShutdownRequestSchema, resultSchema: FlushResultSchema, defaultTimeoutMs: 1_000, maxTimeoutMs: 2_000, dispatchDeadlineMs: 3_000, defaultFailurePolicy: "nonFatal", allowedFailurePolicies: NON_FATAL, operationAtDeadline: "continue" }),
+	projectImported: interceptor({ name: "projectImported", requestSchema: ProjectImportedRequestSchema, resultSchema: ProjectImportedResultSchema, defaultTimeoutMs: 2_000, maxTimeoutMs: 5_000, dispatchDeadlineMs: 8_000, defaultFailurePolicy: "nonFatal", allowedFailurePolicies: NON_FATAL, operationAtDeadline: "continue" }),
+} as const);
+
+export type HostInterceptorName = keyof typeof HOST_INTERCEPTOR_CATALOGUE;
+export type HostInterceptorRequest<N extends HostInterceptorName> = Static<(typeof HOST_INTERCEPTOR_CATALOGUE)[N]["requestSchema"]>;
+export type HostInterceptorResult<N extends HostInterceptorName> = Static<(typeof HOST_INTERCEPTOR_CATALOGUE)[N]["resultSchema"]>;
+
+export function isHostInterceptorName(value: unknown): value is HostInterceptorName {
+	return typeof value === "string" && Object.prototype.hasOwnProperty.call(HOST_INTERCEPTOR_CATALOGUE, value);
+}
+
+export function validateInterceptorRequest<N extends HostInterceptorName>(
+	name: N,
+	value: unknown,
+): value is HostInterceptorRequest<N> {
+	return isStructurallyBounded(value, HOST_HOOK_LIMITS.interceptorBytes)
+		&& Value.Check(HOST_INTERCEPTOR_CATALOGUE[name].requestSchema, value);
+}
+
+export function validateInterceptorResult<N extends HostInterceptorName>(
+	name: N,
+	value: unknown,
+): value is HostInterceptorResult<N> {
+	return isStructurallyBounded(value, HOST_HOOK_LIMITS.interceptorBytes)
+		&& Value.Check(HOST_INTERCEPTOR_CATALOGUE[name].resultSchema, value);
+}

--- a/src/shared/extension-host/host-hooks.ts
+++ b/src/shared/extension-host/host-hooks.ts
@@ -99,7 +99,7 @@ const TaskChangedFieldSchema = literals([
 	"title", "type", "assignedSessionId", "spec", "parentTaskId", "dependsOn", "workflowGateId", "inputGateIds", "resultSummary", "headSha",
 ] as const);
 const SettingsChangedKeySchema = literals([
-	"components", "workflows", "configDirectories", "sandbox", "sandboxTokens", "packOrder", "packActivation", "commands", "providers", "models",
+	"baseRef", "commands", "components", "configDirectories", "models", "packActivation", "packOrder", "providers", "sandbox", "sandboxTokens", "workflows", "worktrees",
 ] as const);
 
 const StatusChangedPayloadSchema = strictObject({

--- a/src/shared/extension-host/host-hooks.ts
+++ b/src/shared/extension-host/host-hooks.ts
@@ -649,7 +649,7 @@ export interface HostInterceptorDefinition<N extends string, RQ extends TSchema,
 	readonly dispatchDeadlineMs: number;
 	readonly defaultFailurePolicy: HostInterceptorFailurePolicy;
 	readonly allowedFailurePolicies: ReadonlySet<HostInterceptorFailurePolicy>;
-	readonly requiredGrants: readonly string[];
+	readonly requiredCapabilities: readonly string[];
 	readonly cancellation: Readonly<{
 		abortWorker: true;
 		discardLateResult: true;
@@ -661,7 +661,7 @@ export interface HostInterceptorDefinition<N extends string, RQ extends TSchema,
 const FAIL_OPEN = new Set<HostInterceptorFailurePolicy>(["failOpen"]);
 const FAIL_CLOSED_OR_OPEN = new Set<HostInterceptorFailurePolicy>(["failOpen", "failClosed"]);
 const NON_FATAL = new Set<HostInterceptorFailurePolicy>(["nonFatal"]);
-const NO_GRANTS = Object.freeze([]) as readonly string[];
+const NO_REQUIRED_CAPABILITIES = Object.freeze([]) as readonly string[];
 const AUDIT_NONE = Object.freeze({ proposal: "none" } as const);
 const AUDIT_RECEIVED = Object.freeze({ proposal: "received" } as const);
 
@@ -678,7 +678,7 @@ function interceptor<const N extends string, const RQ extends TSchema, const RS 
 }): HostInterceptorDefinition<N, RQ, RS> {
 	return Object.freeze({
 		...options,
-		requiredGrants: NO_GRANTS,
+		requiredCapabilities: NO_REQUIRED_CAPABILITIES,
 		cancellation: Object.freeze({ abortWorker: true, discardLateResult: true, operationAtDeadline: options.operationAtDeadline }),
 		auditProjector: (_request: unknown, result: unknown) => result === undefined ? AUDIT_NONE : AUDIT_RECEIVED,
 	});

--- a/tests/e2e/host-notifications.spec.ts
+++ b/tests/e2e/host-notifications.spec.ts
@@ -297,6 +297,29 @@ test.describe.serial("canonical host notification E2E", () => {
 				.update(`${staff.id}|goal-created-notification|${originalNotification.id}`)
 				.digest("hex"));
 
+			// Seed the exact host-only turn authority a notification wake owns. It is
+			// deliberately live-only: a real restart must neither restore this context
+			// nor accept the old process's per-session capability secret.
+			if (!staffSessionId) throw new Error("notification staff fixture did not create a permanent session");
+			const liveSession = gateway.sessionManager?.getSession(staffSessionId);
+			if (!liveSession) throw new Error(`notification staff session ${staffSessionId} is not live`);
+			expect(liveSession.staffId).toBe(staff.id);
+			const preRestartSecret = gateway.sessionManager.sessionSecretStore.getOrCreateSecret(staffSessionId);
+			liveSession.staffNotificationTurnContext = Object.freeze({
+				sessionId: staffSessionId,
+				projectId: project.id,
+				staffId: staff.id,
+				triggerId: "goal-created-notification",
+				notificationId: originalNotification.id,
+				rootCorrelationId: accepted.row.deliveryId,
+				causationDepth: 1,
+				lifecycleGeneration: liveSession.lifecycleGeneration ?? 0,
+			});
+			expect(gateway.sessionManager.getStaffNotificationTurnContext(staffSessionId)).toMatchObject({
+				notificationId: originalNotification.id,
+				rootCorrelationId: accepted.row.deliveryId,
+			});
+
 			// Model the exact durable crash checkpoint: InboxStore.putStrict has
 			// committed the deterministic entry, but the outbox lease ACK did not.
 			await gateway.crash();
@@ -313,6 +336,8 @@ test.describe.serial("canonical host notification E2E", () => {
 			await gateway.restart();
 			serverOnline = true;
 			await waitForHealth(20_000);
+			expect(gateway.sessionManager?.getStaffNotificationTurnContext(staffSessionId!)).toBeUndefined();
+			expect(gateway.sessionManager?.sessionSecretStore.resolveSessionIdBySecret(preRestartSecret)).toBeUndefined();
 
 			const reconciled = await pollUntil(() => {
 				const rows = JSON.parse(readFileSync(deliveryFile, "utf8")) as DeliveryRow[];

--- a/tests/e2e/host-notifications.spec.ts
+++ b/tests/e2e/host-notifications.spec.ts
@@ -1,0 +1,338 @@
+import { createHash } from "node:crypto";
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import WebSocket from "ws";
+import { expect, test, type GatewayInfo } from "./gateway-harness.js";
+import {
+	agentEndPredicate,
+	apiFetch,
+	createGoal,
+	createSession,
+	projectStateDirForRoot,
+	readE2ETokenAsync,
+	registerProject,
+	waitForHealth,
+	waitForSessionStatus,
+	type WsMsg,
+} from "./e2e-setup.js";
+import { awaitableRm, pollUntil } from "./test-utils/cleanup.js";
+
+type SocketHarness = {
+	messages: WsMsg[];
+	messageCount(): number;
+	send(message: Record<string, unknown>): void;
+	waitForFrom(index: number, predicate: (message: WsMsg) => boolean, timeoutMs?: number): Promise<WsMsg>;
+	close(): void;
+};
+
+type DeliveryRow = {
+	deliveryId: string;
+	state: "pending" | "leased" | "accepted" | "cancelled" | "failed";
+	attempt: number;
+	leaseId?: string;
+	leaseUntil?: number;
+	updatedAt: number;
+	notification: Record<string, any>;
+};
+
+type InboxFile = {
+	staffId: string;
+	entries: Array<{
+		id: string;
+		source: { type: string; triggerId?: string };
+		notificationInput?: { notification: Record<string, any> };
+	}>;
+};
+
+function notificationFor(message: WsMsg, name: string, aggregateId?: string): boolean {
+	return message.type === "host_notification"
+		&& message.notification?.name === name
+		&& (aggregateId === undefined || message.notification?.aggregate?.id === aggregateId);
+}
+
+async function connectSocket(
+	gateway: GatewayInfo,
+	sessionId: string,
+	clientKind: "app" | undefined,
+): Promise<SocketHarness> {
+	const token = await readE2ETokenAsync();
+	const ws = new WebSocket(`${gateway.wsBase}/ws/${sessionId}`);
+	const messages: WsMsg[] = [];
+	const waiters: Array<{
+		index: number;
+		predicate: (message: WsMsg) => boolean;
+		resolve: (message: WsMsg) => void;
+		reject: (error: Error) => void;
+		timer: ReturnType<typeof setTimeout>;
+	}> = [];
+
+	ws.on("message", raw => {
+		const message = JSON.parse(raw.toString()) as WsMsg;
+		messages.push(message);
+		for (let i = waiters.length - 1; i >= 0; i--) {
+			const waiter = waiters[i]!;
+			if (messages.length - 1 >= waiter.index && waiter.predicate(message)) {
+				clearTimeout(waiter.timer);
+				waiters.splice(i, 1);
+				waiter.resolve(message);
+			}
+		}
+	});
+
+	const opened = new Promise<void>((resolve, reject) => {
+		ws.once("open", resolve);
+		ws.once("error", reject);
+	});
+	await opened;
+	ws.send(JSON.stringify({ type: "auth", token, ...(clientKind ? { clientKind } : {}) }));
+
+	const harness: SocketHarness = {
+		messages,
+		messageCount: () => messages.length,
+		send: message => ws.send(JSON.stringify(message)),
+		waitForFrom(index, predicate, timeoutMs = 15_000) {
+			const existing = messages.slice(index).find(predicate);
+			if (existing) return Promise.resolve(existing);
+			return new Promise((resolve, reject) => {
+				const timer = setTimeout(() => {
+					const waiterIndex = waiters.findIndex(waiter => waiter.timer === timer);
+					if (waiterIndex >= 0) waiters.splice(waiterIndex, 1);
+					reject(new Error(`host notification WS wait timed out after ${timeoutMs}ms`));
+				}, timeoutMs);
+				waiters.push({ index, predicate, resolve, reject, timer });
+			});
+		},
+		close: () => ws.close(),
+	};
+
+	await harness.waitForFrom(0, message => message.type === "auth_ok", 10_000);
+	return harness;
+}
+
+async function assertSocketBarrierHasNoNotification(
+	socket: SocketHarness,
+	cursor: number,
+	barrier: "state" | "pong",
+	name: string,
+	aggregateId: string,
+): Promise<void> {
+	socket.send(barrier === "state" ? { type: "get_state" } : { type: "ping" });
+	await socket.waitForFrom(cursor, message => message.type === barrier);
+	expect(
+		socket.messages.slice(cursor).filter(message => notificationFor(message, name, aggregateId)),
+		`${name} for ${aggregateId} must not cross this socket's authoritative binding`,
+	).toHaveLength(0);
+}
+
+async function deleteProject(projectId: string | undefined): Promise<void> {
+	if (!projectId) return;
+	await apiFetch(`/api/projects/${encodeURIComponent(projectId)}`, { method: "DELETE" }).catch(() => undefined);
+}
+
+async function restartGateway(gateway: GatewayInfo): Promise<void> {
+	await gateway.crash();
+	await gateway.restart();
+	await waitForHealth(20_000);
+}
+
+test.describe.serial("canonical host notification E2E", () => {
+	test("routes sessionForked only to app sockets bound to the exact project", async ({ gateway }) => {
+		test.setTimeout(120_000);
+		const root = mkdtempSync(join(tmpdir(), "bobbit-e2e-host-notification-routing-"));
+		const projectARoot = join(root, "project-a");
+		const projectBRoot = join(root, "project-b");
+		mkdirSync(projectARoot, { recursive: true });
+		mkdirSync(projectBRoot, { recursive: true });
+		let projectAId: string | undefined;
+		let projectBId: string | undefined;
+		let sourceId: string | undefined;
+		let peerId: string | undefined;
+		let foreignId: string | undefined;
+		let forkId: string | undefined;
+		const sockets: SocketHarness[] = [];
+
+		try {
+			const projectA = await registerProject({ name: `host-notification-a-${Date.now()}`, rootPath: projectARoot });
+			const projectB = await registerProject({ name: `host-notification-b-${Date.now()}`, rootPath: projectBRoot });
+			projectAId = projectA.id;
+			projectBId = projectB.id;
+			sourceId = await createSession({ projectId: projectA.id, cwd: projectARoot });
+			peerId = await createSession({ projectId: projectA.id, cwd: projectARoot });
+			foreignId = await createSession({ projectId: projectB.id, cwd: projectBRoot });
+			await Promise.all([
+				waitForSessionStatus(sourceId, "idle", 20_000),
+				waitForSessionStatus(peerId, "idle", 20_000),
+				waitForSessionStatus(foreignId, "idle", 20_000),
+			]);
+
+			const sourceApp = await connectSocket(gateway, sourceId, "app");
+			const projectPeerApp = await connectSocket(gateway, peerId, "app");
+			const foreignApp = await connectSocket(gateway, foreignId, "app");
+			const unboundSource = await connectSocket(gateway, sourceId, undefined);
+			const viewer = await connectSocket(gateway, "__viewer__", "app");
+			sockets.push(sourceApp, projectPeerApp, foreignApp, unboundSource, viewer);
+
+			// Give the fork route a real persisted transcript, then begin every
+			// routing assertion after that unrelated turn has completed.
+			const turnCursor = sourceApp.messageCount();
+			sourceApp.send({ type: "prompt", text: "HOST_NOTIFICATION_FORK_SOURCE" });
+			await sourceApp.waitForFrom(turnCursor, agentEndPredicate(), 20_000);
+
+			const sourceCursor = sourceApp.messageCount();
+			const peerCursor = projectPeerApp.messageCount();
+			const foreignCursor = foreignApp.messageCount();
+			const unboundCursor = unboundSource.messageCount();
+			const viewerCursor = viewer.messageCount();
+			const forkResponse = await apiFetch(`/api/sessions/${encodeURIComponent(sourceId)}/fork`, {
+				method: "POST",
+				body: JSON.stringify({ newWorktree: false }),
+			});
+			const forkText = await forkResponse.text();
+			expect(forkResponse.status, `fork should succeed: ${forkText}`).toBe(201);
+			const fork = JSON.parse(forkText) as { id: string; projectId: string };
+			forkId = fork.id;
+
+			const [sourceFrame, peerFrame] = await Promise.all([
+				sourceApp.waitForFrom(sourceCursor, message => notificationFor(message, "sessionForked", fork.id)),
+				projectPeerApp.waitForFrom(peerCursor, message => notificationFor(message, "sessionForked", fork.id)),
+			]);
+			for (const frame of [sourceFrame, peerFrame]) {
+				expect(frame.notification).toMatchObject({
+					scope: "project",
+					name: "sessionForked",
+					payloadVersion: 1,
+					projectId: projectA.id,
+					aggregate: { kind: "session", id: fork.id },
+					payload: { sourceSessionId: sourceId, sessionId: fork.id, forkMode: "whole" },
+				});
+				expect(frame.notification.aggregate.revision).toBeDefined();
+			}
+
+			// Receipt proves the publication boundary is after durable destination
+			// creation: the authoritative REST owner must already expose the fork.
+			const persistedResponse = await apiFetch(`/api/sessions/${encodeURIComponent(fork.id)}`);
+			expect(persistedResponse.status, await persistedResponse.clone().text()).toBe(200);
+			expect(await persistedResponse.json()).toMatchObject({ id: fork.id, projectId: projectA.id });
+
+			// Per-connection barriers make the negative assertions event-driven. Any
+			// incorrectly queued notification precedes the subsequent state/pong frame.
+			await Promise.all([
+				assertSocketBarrierHasNoNotification(foreignApp, foreignCursor, "state", "sessionForked", fork.id),
+				assertSocketBarrierHasNoNotification(unboundSource, unboundCursor, "state", "sessionForked", fork.id),
+				assertSocketBarrierHasNoNotification(viewer, viewerCursor, "pong", "sessionForked", fork.id),
+			]);
+			expect(sourceApp.messages.slice(sourceCursor).filter(message => notificationFor(message, "sessionForked", fork.id))).toHaveLength(1);
+			expect(projectPeerApp.messages.slice(peerCursor).filter(message => notificationFor(message, "sessionForked", fork.id))).toHaveLength(1);
+		} finally {
+			for (const socket of sockets) socket.close();
+			for (const sessionId of [forkId, sourceId, peerId, foreignId]) {
+				if (sessionId) await apiFetch(`/api/sessions/${encodeURIComponent(sessionId)}?purge=true`, { method: "DELETE" }).catch(() => undefined);
+			}
+			await deleteProject(projectBId);
+			await deleteProject(projectAId);
+			await awaitableRm(root, { maxAttempts: 5, backoffMs: 100 });
+		}
+	});
+
+	test("reconciles the inbox-commit/outbox-ack crash window after a real restart without duplicates", async ({ gateway }) => {
+		test.setTimeout(120_000);
+		const root = mkdtempSync(join(tmpdir(), "bobbit-e2e-host-notification-staff-"));
+		let projectId: string | undefined;
+		let staffId: string | undefined;
+		let staffSessionId: string | undefined;
+		let goalId: string | undefined;
+		let serverOnline = true;
+
+		try {
+			const project = await registerProject({ name: `host-notification-staff-${Date.now()}`, rootPath: root });
+			projectId = project.id;
+			const staffResponse = await apiFetch("/api/staff", {
+				method: "POST",
+				body: JSON.stringify({
+					name: `Host notification observer ${Date.now()}`,
+					systemPrompt: "Observe canonical host notifications.",
+					cwd: root,
+					projectId: project.id,
+					worktree: false,
+					sandboxed: false,
+					triggers: [{
+						id: "goal-created-notification",
+						type: "notification",
+						notification: { scope: "project", name: "goalCreated" },
+						filter: { state: "todo" },
+						enabled: true,
+					}],
+				}),
+			});
+			const staffText = await staffResponse.text();
+			expect(staffResponse.status, `staff creation should succeed: ${staffText}`).toBe(201);
+			const staff = JSON.parse(staffText) as { id: string; currentSessionId?: string };
+			staffId = staff.id;
+			staffSessionId = staff.currentSessionId;
+
+			const goal = await createGoal({
+				title: `Host notification durable intent ${Date.now()}`,
+				spec: "Exercise durable notification staff delivery through the real gateway restart boundary.",
+				cwd: root,
+				projectId: project.id,
+				worktree: false,
+			});
+			goalId = goal.id;
+
+			const stateDir = projectStateDirForRoot(root);
+			const deliveryFile = join(stateDir, "notification-deliveries.json");
+			const inboxFile = join(stateDir, "inbox", `${staff.id}.json`);
+			const accepted = await pollUntil(() => {
+				const rows = JSON.parse(readFileSync(deliveryFile, "utf8")) as DeliveryRow[];
+				const inbox = JSON.parse(readFileSync(inboxFile, "utf8")) as InboxFile;
+				const row = rows.find(candidate => candidate.notification?.name === "goalCreated" && candidate.notification?.aggregate?.id === goal.id);
+				const entries = row ? inbox.entries.filter(entry => entry.id === row.deliveryId) : [];
+				return row?.state === "accepted" && entries.length === 1 ? { rows, row, inbox } : null;
+			}, { timeoutMs: 20_000, label: "accepted goalCreated staff delivery" });
+
+			const originalNotification = structuredClone(accepted.row.notification);
+			expect(accepted.inbox.entries.find(entry => entry.id === accepted.row.deliveryId)?.notificationInput?.notification).toEqual(originalNotification);
+			expect(accepted.row.deliveryId).toBe(createHash("sha256")
+				.update(`${staff.id}|goal-created-notification|${originalNotification.id}`)
+				.digest("hex"));
+
+			// Model the exact durable crash checkpoint: InboxStore.putStrict has
+			// committed the deterministic entry, but the outbox lease ACK did not.
+			await gateway.crash();
+			serverOnline = false;
+			const crashRows = JSON.parse(readFileSync(deliveryFile, "utf8")) as DeliveryRow[];
+			const crashRow = crashRows.find(row => row.deliveryId === accepted.row.deliveryId)!;
+			crashRow.state = "leased";
+			crashRow.attempt = Math.max(1, crashRow.attempt);
+			crashRow.leaseId = "e2e-crash-after-inbox-commit";
+			crashRow.leaseUntil = 0;
+			crashRow.updatedAt = 0;
+			writeFileSync(deliveryFile, JSON.stringify(crashRows, null, 2), "utf8");
+
+			await gateway.restart();
+			serverOnline = true;
+			await waitForHealth(20_000);
+
+			const reconciled = await pollUntil(() => {
+				const rows = JSON.parse(readFileSync(deliveryFile, "utf8")) as DeliveryRow[];
+				const row = rows.find(candidate => candidate.deliveryId === accepted.row.deliveryId);
+				return row?.state === "accepted" ? row : null;
+			}, { timeoutMs: 20_000, label: "restart reconciliation accepts expired staff lease" });
+			const restartedInbox = JSON.parse(readFileSync(inboxFile, "utf8")) as InboxFile;
+			const matchingEntries = restartedInbox.entries.filter(entry => entry.id === accepted.row.deliveryId);
+			expect(matchingEntries, "idempotent inbox acceptance must retain exactly one entry").toHaveLength(1);
+			expect(reconciled.notification, "restart must preserve the complete canonical notification").toEqual(originalNotification);
+			expect(matchingEntries[0]?.notificationInput?.notification).toEqual(originalNotification);
+		} finally {
+			if (!serverOnline) {
+				await restartGateway(gateway).then(() => { serverOnline = true; }).catch(() => undefined);
+			}
+			if (goalId) await apiFetch(`/api/goals/${encodeURIComponent(goalId)}?cascade=true`, { method: "DELETE" }).catch(() => undefined);
+			if (staffId) await apiFetch(`/api/staff/${encodeURIComponent(staffId)}`, { method: "DELETE" }).catch(() => undefined);
+			if (staffSessionId) await apiFetch(`/api/sessions/${encodeURIComponent(staffSessionId)}?purge=true`, { method: "DELETE" }).catch(() => undefined);
+			await deleteProject(projectId);
+			await awaitableRm(root, { maxAttempts: 5, backoffMs: 100 });
+		}
+	});
+});

--- a/tests2/browser/fixtures/host-notifications/host-notifications-fixture/entrypoints/host-notifications-route.yaml
+++ b/tests2/browser/fixtures/host-notifications/host-notifications-fixture/entrypoints/host-notifications-route.yaml
@@ -1,0 +1,6 @@
+id: host-notifications.route
+kind: route
+routeId: host-notifications-fixture
+target:
+  panelId: host-notifications.panel
+paramKeys: []

--- a/tests2/browser/fixtures/host-notifications/host-notifications-fixture/lib/panel.js
+++ b/tests2/browser/fixtures/host-notifications/host-notifications-fixture/lib/panel.js
@@ -1,0 +1,120 @@
+// Marketplace panel fixture for the canonical scoped notification Host APIs.
+// It refreshes from authoritative Host API projections on initial mount,
+// reconnect/gap invalidation, and reload; notifications are never treated as a
+// historical state store.
+export default function createPanel({ html }) {
+	const bySession = new Map();
+
+	function repaint(host) {
+		try { host?.requestRender?.(); } catch { /* fixture remains usable while detached */ }
+	}
+
+	function stateFor(sessionId) {
+		let state = bySession.get(sessionId);
+		if (!state) {
+			state = {
+				mounted: false,
+				suspended: false,
+				generation: 0,
+				refreshScheduled: false,
+				refreshCount: 0,
+				refreshError: "",
+				transcriptTotal: 0,
+				snapshotSessionId: "",
+				snapshotWorkingDir: "",
+				sessionEvents: [],
+				projectEvents: [],
+				unsubscribers: [],
+			};
+			bySession.set(sessionId, state);
+		}
+		return state;
+	}
+
+	function queueSnapshot(state, host, generation) {
+		if (state.refreshScheduled || !state.mounted || generation !== state.generation) return;
+		state.refreshScheduled = true;
+		queueMicrotask(async () => {
+			state.refreshScheduled = false;
+			if (!state.mounted || generation !== state.generation) return;
+			try {
+				const [transcript, projection] = await Promise.all([
+					host.session.readTranscript({ offset: 0, limit: 100 }),
+					host.callRoute("snapshot"),
+				]);
+				if (!state.mounted || generation !== state.generation) return;
+				state.transcriptTotal = Number(transcript?.total ?? 0);
+				state.snapshotSessionId = String(projection?.sessionId ?? "");
+				state.snapshotWorkingDir = String(projection?.workingDir ?? "");
+				state.refreshCount += 1;
+				state.refreshError = "";
+			} catch (error) {
+				if (!state.mounted || generation !== state.generation) return;
+				state.refreshError = error instanceof Error ? error.message : String(error);
+			}
+			repaint(host);
+		});
+	}
+
+	function mount(state, host) {
+		if (state.mounted) return;
+		state.mounted = true;
+		state.suspended = false;
+		const generation = ++state.generation;
+		const sessionEvent = host.session.notifications.subscribe("messageAppended", (event) => {
+			if (!state.mounted || generation !== state.generation) return;
+			state.sessionEvents.push({ id: event.id, messageId: event.payload.messageId });
+			repaint(host);
+		});
+		const projectEvent = host.project.notifications.subscribe("goalCreated", (event) => {
+			if (!state.mounted || generation !== state.generation) return;
+			state.projectEvents.push({ id: event.id, goalId: event.payload.goalId });
+			repaint(host);
+		});
+		const sessionRefresh = host.session.notifications.onRefreshRequired(() => queueSnapshot(state, host, generation));
+		const projectRefresh = host.project.notifications.onRefreshRequired(() => queueSnapshot(state, host, generation));
+		state.unsubscribers = [sessionEvent, projectEvent, sessionRefresh, projectRefresh];
+	}
+
+	function unsubscribe(state, host) {
+		if (!state.mounted) return;
+		state.mounted = false;
+		state.suspended = true;
+		state.generation += 1;
+		const unsubscribers = state.unsubscribers.splice(0);
+		for (const stop of unsubscribers) {
+			stop();
+			stop(); // contract: unsubscribe is idempotent
+		}
+		repaint(host);
+	}
+
+	return {
+		render(params, host) {
+			const sessionId = String(params?.__sessionId ?? "unbound");
+			const state = stateFor(sessionId);
+			if (host && !state.mounted && !state.suspended) mount(state, host);
+			return html`
+				<section data-testid="host-notifications-fixture-panel" style="padding:1rem;display:grid;gap:.75rem;color:var(--foreground);background:var(--background)">
+					<header><strong>Host Notifications Fixture</strong></header>
+					<div data-testid="fixture-subscription-state">${state.mounted ? "mounted" : "unsubscribed"}</div>
+					<div>Snapshots: <span data-testid="fixture-snapshot-count">${state.refreshCount}</span></div>
+					<div>Transcript total: <span data-testid="fixture-transcript-total">${state.transcriptTotal}</span></div>
+					<div>Snapshot session: <span data-testid="fixture-snapshot-session">${state.snapshotSessionId}</span></div>
+					<div data-testid="fixture-snapshot-working-dir">${state.snapshotWorkingDir}</div>
+					<div data-testid="fixture-refresh-error">${state.refreshError}</div>
+					<button data-testid="fixture-unsubscribe" type="button" @click=${() => unsubscribe(state, host)}>Unsubscribe twice</button>
+					<button data-testid="fixture-remount" type="button" @click=${() => { mount(state, host); repaint(host); }}>Remount</button>
+					<h3>Session notifications</h3>
+					<ul data-testid="fixture-session-events">
+						${state.sessionEvents.map((event) => html`<li data-notification-id=${event.id} data-message-id=${event.messageId}>messageAppended ${event.messageId}</li>`)}
+					</ul>
+					<h3>Project notifications</h3>
+					<ul data-testid="fixture-project-events">
+						${state.projectEvents.map((event) => html`<li data-notification-id=${event.id} data-goal-id=${event.goalId}>goalCreated ${event.goalId}</li>`)}
+					</ul>
+				</section>
+			`;
+		},
+	};
+}

--- a/tests2/browser/fixtures/host-notifications/host-notifications-fixture/lib/routes.mjs
+++ b/tests2/browser/fixtures/host-notifications/host-notifications-fixture/lib/routes.mjs
@@ -1,0 +1,9 @@
+// Authoritative fixture projection reached only through this pack's scoped Host API.
+export const routes = {
+	async snapshot(ctx) {
+		return {
+			sessionId: ctx.sessionId,
+			workingDir: ctx.workingDir,
+		};
+	},
+};

--- a/tests2/browser/fixtures/host-notifications/host-notifications-fixture/pack.yaml
+++ b/tests2/browser/fixtures/host-notifications/host-notifications-fixture/pack.yaml
@@ -1,0 +1,12 @@
+name: host-notifications-fixture
+schema: 2
+description: Browser journey fixture for scoped canonical Host API notifications.
+version: 1.0.0
+contents:
+  roles: []
+  tools: []
+  skills: []
+  entrypoints: [host-notifications-route]
+routes:
+  module: lib/routes.mjs
+  names: [snapshot]

--- a/tests2/browser/fixtures/host-notifications/host-notifications-fixture/panels/host-notifications-panel.yaml
+++ b/tests2/browser/fixtures/host-notifications/host-notifications-fixture/panels/host-notifications-panel.yaml
@@ -1,0 +1,4 @@
+id: host-notifications.panel
+title: Host Notifications Fixture
+entry: ../lib/panel.js
+instanceMode: singleton

--- a/tests2/browser/journeys/host-notifications.journey.spec.ts
+++ b/tests2/browser/journeys/host-notifications.journey.spec.ts
@@ -1,0 +1,218 @@
+/**
+ * Journey: a real project-scoped marketplace panel consumes canonical session
+ * and project notifications, while snapshots remain authoritative across load,
+ * reload, stream gaps, unsubscribe/remount, and foreign-project mutations.
+ */
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+	apiFetch,
+	createGoal,
+	createSession,
+	deleteGoal,
+	deleteSession,
+	expect,
+	navigateToHash,
+	openApp,
+	registerProject,
+	test,
+	waitForSessionStatus,
+} from "../_helpers/journey-fixture.js";
+
+const SOURCE_DIR = fileURLToPath(new URL("../fixtures/host-notifications", import.meta.url));
+const PACK_NAME = "host-notifications-fixture";
+const PANEL = '[data-testid="host-notifications-fixture-panel"]';
+
+async function responseText(response: Response): Promise<string> {
+	return response.clone().text().catch(() => "");
+}
+
+async function addFixtureSource(): Promise<string> {
+	const response = await apiFetch("/api/marketplace/sources", {
+		method: "POST",
+		body: JSON.stringify({ url: SOURCE_DIR }),
+	});
+	if (response.status === 409) {
+		const list = await apiFetch("/api/marketplace/sources");
+		const source = ((await list.json()).sources ?? []).find((item: { id: string; url: string }) => item.url === SOURCE_DIR);
+		expect(source, "the existing fixture source should be discoverable after a conflict").toBeTruthy();
+		return source.id;
+	}
+	expect(response.status, `fixture source registration failed: ${await responseText(response)}`).toBe(201);
+	return (await response.json()).source.id;
+}
+
+async function installFixturePack(sourceId: string, projectId: string): Promise<void> {
+	const response = await apiFetch("/api/marketplace/install", {
+		method: "POST",
+		body: JSON.stringify({ sourceId, dirName: PACK_NAME, scope: "project", projectId }),
+	});
+	expect(response.status, `fixture pack installation failed: ${await responseText(response)}`).toBe(201);
+}
+
+async function uninstallFixturePack(projectId: string): Promise<void> {
+	await apiFetch("/api/marketplace/installed", {
+		method: "DELETE",
+		body: JSON.stringify({ scope: "project", projectId, packName: PACK_NAME }),
+	}).catch(() => {});
+}
+
+async function deleteProject(projectId: string | undefined): Promise<void> {
+	if (projectId) await apiFetch(`/api/projects/${encodeURIComponent(projectId)}`, { method: "DELETE" }).catch(() => {});
+}
+
+async function numericText(page: import("@playwright/test").Page, testId: string): Promise<number> {
+	return Number(await page.getByTestId(testId).textContent());
+}
+
+async function injectCoalescedTransportGap(
+	page: import("@playwright/test").Page,
+	sessionId: string,
+	projectId: string,
+): Promise<void> {
+	await page.evaluate(({ sessionId, projectId }) => {
+		const socket = (window as any).__bobbitState?.remoteAgent?.ws as WebSocket | undefined;
+		if (!socket?.onmessage) throw new Error("active session WebSocket was not available for the gap fixture");
+		const deliver = (message: unknown) => socket.onmessage?.call(socket, new MessageEvent("message", {
+			data: JSON.stringify(message),
+		}));
+		const occurredAt = Date.now();
+		deliver({
+			type: "host_notification",
+			stream: { epoch: "fixture-gap-epoch", sequence: 41 },
+			notification: {
+				id: "fixture-gap-session",
+				scope: "session",
+				name: "messageAppended",
+				payloadVersion: 1,
+				occurredAt,
+				projectId,
+				sessionId,
+				aggregate: { kind: "session", id: sessionId, revision: 41 },
+				payload: { messageId: "must-be-dropped", cursor: 41, role: "user", blockKinds: ["text"] },
+			},
+		});
+		deliver({
+			type: "host_notification",
+			stream: { epoch: "fixture-gap-epoch", sequence: 73 },
+			notification: {
+				id: "fixture-gap-project",
+				scope: "project",
+				name: "goalCreated",
+				payloadVersion: 1,
+				occurredAt,
+				projectId,
+				aggregate: { kind: "goal", id: "must-be-dropped", revision: 73 },
+				payload: { goalId: "must-be-dropped", state: "in-progress" },
+			},
+		});
+		deliver({ type: "host_notifications_refresh_required", scope: "session", epoch: "fixture-gap-epoch", sequence: 42 });
+		deliver({ type: "host_notifications_refresh_required", scope: "project", epoch: "fixture-gap-epoch", sequence: 74 });
+	}, { sessionId, projectId });
+}
+
+test.describe("Journey: scoped Host notifications marketplace panel", () => {
+	test("loads snapshots first, observes scoped live facts, recovers gaps, and remounts without leaks", async ({ page, gateway }) => {
+		test.setTimeout(120_000);
+		const firstRoot = mkdtempSync(join(tmpdir(), "bobbit-host-notifications-a-"));
+		const secondRoot = mkdtempSync(join(tmpdir(), "bobbit-host-notifications-b-"));
+		let firstProjectId: string | undefined;
+		let secondProjectId: string | undefined;
+		let sessionId: string | undefined;
+		let sourceId: string | undefined;
+		const goals: string[] = [];
+
+		try {
+			firstProjectId = (await registerProject({
+				name: `host-notifications-a-${Date.now()}`,
+				rootPath: firstRoot,
+				seedWorkflows: false,
+			})).id;
+			secondProjectId = (await registerProject({
+				name: `host-notifications-b-${Date.now()}`,
+				rootPath: secondRoot,
+				seedWorkflows: false,
+			})).id;
+			sourceId = await addFixtureSource();
+			await installFixturePack(sourceId, firstProjectId);
+			sessionId = await createSession({ projectId: firstProjectId, cwd: firstRoot });
+			await waitForSessionStatus(sessionId, "idle", 30_000);
+
+			await openApp(page);
+			await navigateToHash(page, `#/session/${sessionId}`);
+			await expect(page.locator("message-editor textarea").first()).toBeVisible({ timeout: 20_000 });
+			await navigateToHash(page, "#/ext/host-notifications-fixture");
+			await expect(page.locator(PANEL)).toBeVisible({ timeout: 20_000 });
+			await expect(page.getByTestId("fixture-subscription-state")).toHaveText("mounted");
+			await expect(page.getByTestId("fixture-refresh-error")).toHaveText("");
+			await expect(page.getByTestId("fixture-snapshot-count"), "session + project mount invalidations must coalesce into one snapshot").toHaveText("1", { timeout: 20_000 });
+			await expect(page.getByTestId("fixture-snapshot-session")).toHaveText(sessionId);
+			const initialTranscriptTotal = await numericText(page, "fixture-transcript-total");
+
+			const prompt = "HOST_NOTIFICATION_BROWSER_LIVE_MESSAGE";
+			const promptResult = await gateway.sessionManager.enqueuePrompt(sessionId, prompt);
+			expect(promptResult.status).toBe("dispatched");
+			await waitForSessionStatus(sessionId, "idle", 30_000);
+			await expect(page.getByTestId("fixture-session-events").locator("li").first(), "the panel should observe a live session fact").toBeVisible({ timeout: 20_000 });
+			await expect(page.getByTestId("fixture-session-events")).toContainText("messageAppended");
+
+			const ownGoal = await createGoal({ title: "Host notification own-project fact", projectId: firstProjectId, cwd: firstRoot });
+			goals.push(ownGoal.id);
+			await expect(page.locator(`[data-testid="fixture-project-events"] li[data-goal-id="${ownGoal.id}"]`), "the panel should observe its bound project's fact").toHaveCount(1, { timeout: 20_000 });
+			const ownProjectEventCount = await page.getByTestId("fixture-project-events").locator("li").count();
+
+			const foreignGoal = await createGoal({ title: "Host notification foreign-project fact", projectId: secondProjectId, cwd: secondRoot });
+			goals.push(foreignGoal.id);
+			await page.waitForTimeout(500);
+			expect(await page.getByTestId("fixture-project-events").locator("li").count(), "a second project's fact must stay silent").toBe(ownProjectEventCount);
+			await expect(page.locator(`[data-testid="fixture-project-events"] li[data-goal-id="${foreignGoal.id}"]`)).toHaveCount(0);
+
+			await page.reload();
+			await navigateToHash(page, `#/session/${sessionId}`);
+			await expect(page.locator("message-editor textarea").first()).toBeVisible({ timeout: 20_000 });
+			await navigateToHash(page, "#/ext/host-notifications-fixture");
+			await expect(page.locator(PANEL), "the marketplace panel should remount after reload").toBeVisible({ timeout: 25_000 });
+			await expect(page.getByTestId("fixture-snapshot-count"), "reload must re-read one coalesced authoritative snapshot").toHaveText("1", { timeout: 20_000 });
+			await expect(page.getByTestId("fixture-snapshot-session")).toHaveText(sessionId);
+			await expect.poll(() => numericText(page, "fixture-transcript-total"), {
+				timeout: 20_000,
+				message: "the reload snapshot should contain the authoritative post-prompt transcript",
+			}).toBeGreaterThan(initialTranscriptTotal);
+			await expect(page.getByTestId("fixture-session-events").locator("li"), "reload does not replay live deltas").toHaveCount(0);
+			await expect(page.getByTestId("fixture-project-events").locator("li"), "reload does not rebuild project state from deltas").toHaveCount(0);
+
+			await page.getByTestId("fixture-unsubscribe").click();
+			await expect(page.getByTestId("fixture-subscription-state")).toHaveText("unsubscribed");
+			const mutedGoal = await createGoal({ title: "Host notification while unsubscribed", projectId: firstProjectId, cwd: firstRoot });
+			goals.push(mutedGoal.id);
+			await page.waitForTimeout(500);
+			await expect(page.getByTestId("fixture-project-events").locator("li"), "idempotent unsubscribe must fence stale callbacks").toHaveCount(0);
+
+			await page.getByTestId("fixture-remount").click();
+			await expect(page.getByTestId("fixture-subscription-state")).toHaveText("mounted");
+			await expect(page.getByTestId("fixture-snapshot-count"), "remount should perform one new snapshot despite two scoped invalidations").toHaveText("2", { timeout: 20_000 });
+			const remountedGoal = await createGoal({ title: "Host notification after remount", projectId: firstProjectId, cwd: firstRoot });
+			goals.push(remountedGoal.id);
+			await expect(page.locator(`[data-testid="fixture-project-events"] li[data-goal-id="${remountedGoal.id}"]`), "remount should install exactly one live handler").toHaveCount(1, { timeout: 20_000 });
+			await expect(page.getByTestId("fixture-project-events").locator("li")).toHaveCount(1);
+
+			const snapshotsBeforeGap = await numericText(page, "fixture-snapshot-count");
+			await injectCoalescedTransportGap(page, sessionId, firstProjectId);
+			await expect(page.getByTestId("fixture-snapshot-count"), "session/project gap burst must coalesce into one authoritative refresh").toHaveText(String(snapshotsBeforeGap + 1), { timeout: 20_000 });
+			await expect(page.getByTestId("fixture-session-events")).not.toContainText("must-be-dropped");
+			await expect(page.getByTestId("fixture-project-events")).not.toContainText("must-be-dropped");
+		} finally {
+			await page.getByTestId("fixture-unsubscribe").click({ timeout: 1_000 }).catch(() => {});
+			for (const goalId of goals.reverse()) await deleteGoal(goalId).catch(() => {});
+			if (sessionId) await deleteSession(sessionId).catch(() => {});
+			if (firstProjectId) await uninstallFixturePack(firstProjectId);
+			if (sourceId) await apiFetch(`/api/marketplace/sources/${encodeURIComponent(sourceId)}`, { method: "DELETE" }).catch(() => {});
+			await deleteProject(secondProjectId);
+			await deleteProject(firstProjectId);
+			rmSync(firstRoot, { recursive: true, force: true });
+			rmSync(secondRoot, { recursive: true, force: true });
+		}
+	});
+});

--- a/tests2/browser/journeys/scheduler-recovery.journey.spec.ts
+++ b/tests2/browser/journeys/scheduler-recovery.journey.spec.ts
@@ -76,6 +76,17 @@ test.describe("Journey: Scheduler recovery controls", () => {
 			expect(childResponse.status, `spawn scheduler recovery child: ${await childResponse.clone().text()}`).toBe(201);
 			childId = (await childResponse.json()).id as string;
 
+			// spawn-child returns while its scheduler-owned auto-start is still
+			// finishing. Wait for TeamManager.startTeam's durable transition before
+			// injecting recovery that the scheduler success continuation may clear.
+			await expect.poll(
+				() => goalStoreFor(gateway, childId).get(childId)?.state,
+				{
+					message: "child auto-start reaches its durable in-progress state",
+					timeout: 20_000,
+				},
+			).toBe("in-progress");
+
 			const rootRecovery: SchedulerRecovery = {
 				kind: "root",
 				code: "SCHEDULER_CIRCUIT_OPEN",

--- a/tests2/core/affected-reader-inventory.test.ts
+++ b/tests2/core/affected-reader-inventory.test.ts
@@ -305,17 +305,17 @@ describe("affected repository reader inventory", () => {
 	it("pins the exact dynamic-operation and computed-scan inventories", () => {
 		const audit = DYNAMIC_EXECUTABLE_CONSUMER_AUDIT as readonly DynamicAuditEntry[];
 		const observedOperations = graph.meta.dynamicExecutableConsumerAudit.actual as Map<string, Map<string, number>>;
-		expect(audit).toHaveLength(46);
-		expect(audit.reduce((count, entry) => count + entry.operations.length, 0)).toBe(61);
+		expect(audit).toHaveLength(47);
+		expect(audit.reduce((count, entry) => count + entry.operations.length, 0)).toBe(62);
 		expect([...observedOperations.values()].reduce(
 			(count, operations) => count + [...operations.values()].reduce((sum, occurrences) => sum + occurrences, 0),
 			0,
-		)).toBe(66);
+		)).toBe(67);
 		expect(REPOSITORY_SCAN_RULES).toHaveLength(17);
 		expect(REPOSITORY_SCAN_RULES.map((rule: { id: string }) => rule.id)).toEqual(REPOSITORY_SCAN_RULE_IDS);
 		expect(graph.meta.dynamicExecutableConsumerAudit.issues).toEqual([]);
-		expect(observedOperations.size).toBe(46);
-		expect(graph.meta.dynamicExecutableConsumerAudit.auditedConsumers.size).toBe(46);
+		expect(observedOperations.size).toBe(47);
+		expect(graph.meta.dynamicExecutableConsumerAudit.auditedConsumers.size).toBe(47);
 		expect(graph.meta.repositoryScanValidation.issues).toEqual([]);
 		for (const entry of audit) {
 			for (const operation of entry.operations) {

--- a/tests2/core/bobbit-tool-credentials.test.ts
+++ b/tests2/core/bobbit-tool-credentials.test.ts
@@ -16,6 +16,7 @@ function clearCreds() {
 	delete process.env.BOBBIT_TOKEN;
 	delete process.env.BOBBIT_GATEWAY_URL;
 	delete process.env.BOBBIT_DIR;
+	delete process.env.BOBBIT_SESSION_SECRET;
 }
 
 afterEach(() => {
@@ -65,5 +66,82 @@ describe("bobbit extension — credential resolution", () => {
 		const calls = stubFetch();
 		await tools.get("bobbit_read")!.execute("id", { operation: "health" });
 		expect(calls[0].url).toBe("https://gw.test/api/health");
+	});
+
+	it("binds goal, task, gate, and settings mutations to the host-issued session secret", async () => {
+		clearCreds();
+		process.env.BOBBIT_TOKEN = "tok";
+		process.env.BOBBIT_GATEWAY_URL = "https://gw.test";
+		process.env.BOBBIT_SESSION_SECRET = "host-issued-secret";
+		const tools = loadBobbitTools();
+		const calls = stubFetch();
+		for (const toolName of ["bobbit_orchestrate", "bobbit_admin"]) {
+			const properties = tools.get(toolName)!.parameters?.properties ?? {};
+			expect(properties).not.toHaveProperty("rootCorrelationId");
+			expect(properties).not.toHaveProperty("causationDepth");
+			expect(properties).not.toHaveProperty("correlationId");
+		}
+		const forgedControls = {
+			rootCorrelationId: "caller-root",
+			causationDepth: 999,
+			correlationId: "caller-correlation",
+		};
+
+		await tools.get("bobbit_orchestrate")!.execute("id", {
+			operation: "update_goal",
+			goalId: "goal-1",
+			body: { title: "Renamed" },
+			...forgedControls,
+		});
+		await tools.get("bobbit_orchestrate")!.execute("id", {
+			operation: "transition_task",
+			taskId: "task-1",
+			state: "complete",
+			...forgedControls,
+		});
+		await tools.get("bobbit_orchestrate")!.execute("id", {
+			operation: "signal_gate",
+			goalId: "goal-1",
+			gateId: "gate-1",
+			body: { content: "ready" },
+			...forgedControls,
+		});
+		await tools.get("bobbit_admin")!.execute("id", {
+			operation: "update_project_config",
+			projectId: "project-1",
+			config: { sandbox: "docker" },
+			...forgedControls,
+		});
+
+		expect(calls).toHaveLength(4);
+		expect(calls.map((call) => call.body)).toEqual([
+			{ title: "Renamed" },
+			{ state: "complete" },
+			{ content: "ready" },
+			{ sandbox: "docker" },
+		]);
+		for (const call of calls) {
+			expect(call.headers["X-Bobbit-Session-Secret"]).toBe("host-issued-secret");
+			expect(call.headers).not.toHaveProperty("X-Bobbit-Correlation-Id");
+			expect(call.headers).not.toHaveProperty("X-Bobbit-Causation-Depth");
+			expect(call.headers).not.toHaveProperty("X-Bobbit-Causation-Root");
+		}
+	});
+
+	it("preserves external no-secret requests without a session identity header", async () => {
+		clearCreds();
+		process.env.BOBBIT_TOKEN = "tok";
+		process.env.BOBBIT_GATEWAY_URL = "https://gw.test";
+		const tools = loadBobbitTools();
+		const calls = stubFetch();
+
+		await tools.get("bobbit_admin")!.execute("id", {
+			operation: "update_project_config",
+			projectId: "project-1",
+			config: { sandbox: "docker" },
+		});
+
+		expect(calls).toHaveLength(1);
+		expect(calls[0].headers).not.toHaveProperty("X-Bobbit-Session-Secret");
 	});
 });

--- a/tests2/core/extension-host-channel-contract.test.ts
+++ b/tests2/core/extension-host-channel-contract.test.ts
@@ -22,7 +22,7 @@ const hostApiSource = () => fs.readFileSync(path.join(process.cwd(), "src", "sha
 describe("host.channels — public Host API contract", () => {
 	it("keeps the Host API version stable and bumps only the owned contract version", () => {
 		assert.equal(HOST_API_VERSION, 1, "host.channels is additive; HOST_API_VERSION must remain v1");
-		assert.equal(HOST_CONTRACT_VERSION, 4, "host.channels adds owned frame/channel contracts; HOST_CONTRACT_VERSION must be 4");
+		assert.equal(HOST_CONTRACT_VERSION, 5, "host notifications are additive; HOST_CONTRACT_VERSION must be 5");
 	});
 
 	it("declares a generic text/json channel API with no terminal-specific core method", () => {

--- a/tests2/core/extension-host-module-isolation.test.ts
+++ b/tests2/core/extension-host-module-isolation.test.ts
@@ -38,7 +38,7 @@ enableTsWorkerResolver();
  * Fixtures are `.mjs` ESM modules under a temp dir (the worker dynamic-imports
  * them by file:// URL, exactly as the dispatcher builds it).
  */
-import { describe, it, beforeAll, afterAll } from "vitest";
+import { describe, it, beforeAll, afterAll, expect } from "vitest";
 import assert from "node:assert/strict";
 import fs from "node:fs";
 import path from "node:path";
@@ -618,6 +618,40 @@ describe.concurrent("ModuleHost — host.agents proxy (Sub-goal C)", () => {
 			assert.equal(result, "caught:host.agents.spawn is not permitted for a child session");
 		} finally {
 			mh.dispose();
+		}
+	});
+});
+
+describe("ModuleHost — hooks execution", () => {
+	it("resolves canonical members from the default hooks export", async () => {
+		const url = writeModule("export default { beforePrompt: async (_ctx, request) => ({ context: [{ id: request.sessionId, title: 't', authority: 'memory', content: 'c', reason: 'r', priority: 1 }] }) };\n");
+		const host = new ModuleHost({ timeoutMs: 30_000 });
+		try {
+			const value = await host.invoke({
+				url, packRoot: tmp, epoch: 0, exportKind: "hooks", member: "beforePrompt",
+				ctx: { sessionId: "session-1", tool: "hook", host: {} } as any,
+				arg: { sessionId: "session-1" }, workingDir: tmp,
+			});
+			expect(value).toMatchObject({ context: [{ id: "session-1" }] });
+		} finally {
+			host.dispose();
+		}
+	});
+
+	it("terminates a worker when the host cancellation signal aborts", async () => {
+		const url = writeModule("export default { beforePrompt: async () => new Promise(() => {}) };\n");
+		const host = new ModuleHost({ timeoutMs: 10_000 });
+		const controller = new AbortController();
+		try {
+			const invocation = host.invoke({
+				url, packRoot: tmp, epoch: 0, exportKind: "hooks", member: "beforePrompt",
+				ctx: { sessionId: "session-1", tool: "hook", host: {} } as any,
+				arg: {}, workingDir: tmp, signal: controller.signal,
+			});
+			setTimeout(() => controller.abort(), 25);
+			await expect(invocation).rejects.toMatchObject({ status: 499 });
+		} finally {
+			host.dispose();
 		}
 	});
 });

--- a/tests2/core/extension-host-module-isolation.test.ts
+++ b/tests2/core/extension-host-module-isolation.test.ts
@@ -91,10 +91,11 @@ function trySymlink(target: string, linkPath: string): boolean {
 }
 
 beforeAll(() => {
-	// v2-core reuses forks with isolate:false; another file's env restoration can
-	// run after collection, so restore the worker resolver at this file boundary.
-	enableTsWorkerResolver();
 	tmp = makeTmpDir("ext-host-iso-");
+	// v2-core reuses forks with isolate:false. Re-assert the supported worker
+	// resolver immediately before this file spawns real ModuleHost workers, after
+	// any sibling env guard may have restored NODE_OPTIONS following collection.
+	enableTsWorkerResolver();
 });
 afterAll(() => {
 	try { fs.rmSync(tmp, { recursive: true, force: true }); } catch { /* best effort */ }

--- a/tests2/core/extension-host-server-host-api.test.ts
+++ b/tests2/core/extension-host-server-host-api.test.ts
@@ -261,6 +261,85 @@ describe("createServerHostApi — capabilityMask (least-privilege provider hosts
 	});
 });
 
+describe("createServerHostApi — live project authority fences", () => {
+	const fencedCore = {
+		assertCanSpawn: () => {},
+		spawn: async () => ({ sessionId: "child-1" }),
+		list: () => [{ sessionId: "child-1", childKind: "host-agents" }],
+		ownedChildKind: () => "host-agents",
+		prompt: async () => ({ status: "dispatched" }),
+		dismiss: async () => ({ ok: true, status: "dismissed", sessionId: "child-1", message: "dismissed", retryable: false }),
+		read: async () => ({ output: "private" }),
+	};
+
+	it("fails closed before every session and agents operation when ownership is missing or mismatched", async () => {
+		let transcriptReads = 0;
+		const host = createServerHostApi({
+			sessionId: "session-a", packId: "pack-a", contributionId: "hooks/a",
+			readOwnTranscript: async () => { transcriptReads++; return ""; },
+			orchestrationCore: fencedCore,
+			isSessionAuthorized: () => false,
+			capabilityMask: { session: true, agents: true },
+		});
+
+		assert.equal(host.capabilities.session, true, "the live fence must not remove a declared capability");
+		assert.equal(host.capabilities.agents, true, "the live fence must not remove a declared capability");
+		await assert.rejects(() => host.session.readTranscript(), /session authority is no longer valid/);
+		await assert.rejects(() => host.session.readToolCall("tool-1"), /session authority is no longer valid/);
+		await assert.rejects(() => host.agents.spawn({ instructions: "no" }), /session authority is no longer valid/);
+		await assert.rejects(() => host.agents.prompt("child-1", "no"), /session authority is no longer valid/);
+		await assert.rejects(() => host.agents.dismiss("child-1"), /session authority is no longer valid/);
+		await assert.rejects(() => host.agents.list(), /session authority is no longer valid/);
+		await assert.rejects(() => host.agents.read("child-1"), /session authority is no longer valid/);
+		await assert.rejects(() => host.agents.status("child-1"), /session authority is no longer valid/);
+		assert.equal(transcriptReads, 0, "an unauthorized read must not reach the transcript source");
+	});
+
+	it("rechecks authority after an in-flight transcript read and withholds the settled projection", async () => {
+		let authorized = true;
+		let release!: (value: string) => void;
+		const source = new Promise<string>(resolve => { release = resolve; });
+		const host = createServerHostApi({
+			sessionId: "session-a", packId: "pack-a", contributionId: "hooks/a",
+			readOwnTranscript: () => source,
+			isSessionAuthorized: () => authorized,
+			capabilityMask: { session: true },
+		});
+
+		const read = host.session.readTranscript();
+		authorized = false;
+		release(JSON.stringify({ type: "message", message: { role: "assistant", content: "project-b-sentinel" } }));
+		await assert.rejects(() => read, /session authority is no longer valid/);
+	});
+
+	it("contains a spawn whose authority is lost while the core is in flight", async () => {
+		let authorized = true;
+		let release!: () => void;
+		const spawnGate = new Promise<void>(resolve => { release = resolve; });
+		const dismissed: string[] = [];
+		const core = {
+			...fencedCore,
+			spawn: async () => { await spawnGate; return { sessionId: "stale-child" }; },
+			dismiss: async (_owner: string, child: string) => {
+				dismissed.push(child);
+				return { ok: true, status: "dismissed", sessionId: child, message: "dismissed", retryable: false };
+			},
+		};
+		const host = createServerHostApi({
+			sessionId: "session-a", packId: "pack-a", contributionId: "hooks/a",
+			orchestrationCore: core,
+			isSessionAuthorized: () => authorized,
+			capabilityMask: { agents: true },
+		});
+
+		const spawn = host.agents.spawn({ instructions: "private" });
+		authorized = false;
+		release();
+		await assert.rejects(() => spawn, /session authority is no longer valid/);
+		assert.deepEqual(dismissed, ["stale-child"]);
+	});
+});
+
 describe("createServerHostApi — Slice B2 own-session reads (contract adapter)", () => {
 	const jsonl = [
 		JSON.stringify({ type: "message", id: "e1", message: { role: "assistant", content: [

--- a/tests2/core/helpers/bobbit-harness.ts
+++ b/tests2/core/helpers/bobbit-harness.ts
@@ -38,6 +38,7 @@ export function loadBobbitTools(): Map<string, CapturedTool> {
 export interface FetchCall {
 	url: string;
 	method: string;
+	headers: Record<string, string>;
 	body: any;
 }
 
@@ -57,8 +58,9 @@ export function stubFetch(impl?: (url: string, init: any) => StubResponse): Fetc
 	const calls: FetchCall[] = [];
 	globalThis.fetch = (async (url: any, init: any) => {
 		const method = init?.method ?? "GET";
+		const headers = { ...(init?.headers ?? {}) } as Record<string, string>;
 		const body = typeof init?.body === "string" ? JSON.parse(init.body) : init?.body;
-		calls.push({ url: String(url), method, body });
+		calls.push({ url: String(url), method, headers, body });
 		const r = impl ? impl(String(url), init) : {};
 		const status = r.status ?? 200;
 		const text = r.text !== undefined ? r.text : r.body !== undefined ? JSON.stringify(r.body) : JSON.stringify({ ok: true });

--- a/tests2/core/host-goal-notifications.test.ts
+++ b/tests2/core/host-goal-notifications.test.ts
@@ -6,6 +6,8 @@ import {
 	type GoalStoreNotification,
 	type PersistedGoal,
 } from "../../src/server/agent/goal-store.js";
+import { HostNotificationDispatcher } from "../../src/server/extension-host/host-notification-dispatcher.js";
+import type { HostNotification } from "../../src/shared/extension-host/host-hooks.js";
 import { createMemFs, type MemFs } from "../harness/mem-fs.js";
 
 const stores: GoalStore[] = [];
@@ -42,6 +44,42 @@ function goal(id: string, overrides: Partial<PersistedGoal> = {}): PersistedGoal
 function durableGoal(memfs: MemFs, stateDir: string, id: string): PersistedGoal | undefined {
 	const rows = JSON.parse(memfs.readFileSync(path.join(stateDir, "goals.json"), "utf-8")) as PersistedGoal[];
 	return rows.find(row => row.id === id);
+}
+
+function captureDispatchedGoals(store: GoalStore): {
+	notifications: HostNotification[];
+	dispatcher: HostNotificationDispatcher;
+} {
+	const notifications: HostNotification[] = [];
+	let nextId = 0;
+	const dispatcher = new HostNotificationDispatcher({
+		idGenerator: () => `goal-notification-${++nextId}`,
+		now: () => 1_000,
+	});
+	store.onHostNotification = fact => {
+		const common = { projectId: "project-a", aggregateRevision: fact.revision };
+		let notification: HostNotification | undefined;
+		switch (fact.name) {
+			case "goalCreated":
+				notification = dispatcher.publish("goalCreated", { ...common, aggregateId: fact.payload.goalId, payload: fact.payload });
+				break;
+			case "goalUpdated":
+				notification = dispatcher.publish("goalUpdated", {
+					...common,
+					aggregateId: fact.payload.goalId,
+					payload: { ...fact.payload, changedFields: [...fact.payload.changedFields] },
+				});
+				break;
+			case "goalCompleted":
+				notification = dispatcher.publish("goalCompleted", { ...common, aggregateId: fact.payload.goalId, payload: fact.payload });
+				break;
+			case "goalArchived":
+				notification = dispatcher.publish("goalArchived", { ...common, aggregateId: fact.payload.goalId, payload: fact.payload });
+				break;
+		}
+		if (notification) notifications.push(notification);
+	};
+	return { notifications, dispatcher };
 }
 
 describe("authoritative goal host notifications", () => {
@@ -99,6 +137,27 @@ describe("authoritative goal host notifications", () => {
 			revision: 502,
 			payload: { goalId: "child", parentGoalId: "parent" },
 		});
+	});
+
+	it("omits internal setup metadata while the real dispatcher accepts the committed update", async () => {
+		const { store } = fixture("public-projection");
+		await store.putStrict(goal("goal-1"));
+		const { notifications, dispatcher } = captureDispatchedGoals(store);
+
+		await store.transitionSetupStrict("goal-1", "retrying", { branch: "private-checkout-branch" });
+		await store.updateStrict("goal-1", {
+			title: "Public title",
+			metadata: { "example.enabled": true },
+			setupStatus: "ready",
+		});
+
+		expect(notifications.map(notification => notification.payload)).toEqual([
+			{ goalId: "goal-1", state: "todo", changedFields: [] },
+			{ goalId: "goal-1", state: "todo", changedFields: ["metadata", "title"] },
+		]);
+		expect(JSON.stringify(notifications)).not.toContain("setupStatus");
+		expect(JSON.stringify(notifications)).not.toContain("private-checkout-branch");
+		expect(dispatcher.getDiagnostics().filter(row => row.code === "invalid_payload")).toEqual([]);
 	});
 
 	it("keeps completion distinct from archive and suppresses duplicate archive publication", async () => {

--- a/tests2/core/host-goal-notifications.test.ts
+++ b/tests2/core/host-goal-notifications.test.ts
@@ -1,0 +1,144 @@
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { GoalManager } from "../../src/server/agent/goal-manager.js";
+import {
+	GoalStore,
+	type GoalStoreNotification,
+	type PersistedGoal,
+} from "../../src/server/agent/goal-store.js";
+import { createMemFs, type MemFs } from "../harness/mem-fs.js";
+
+const stores: GoalStore[] = [];
+
+afterEach(async () => {
+	vi.restoreAllMocks();
+	await Promise.allSettled(stores.splice(0).map(store => store.close()));
+});
+
+function fixture(suffix: string): { memfs: MemFs; stateDir: string; store: GoalStore; manager: GoalManager } {
+	const memfs = createMemFs();
+	const stateDir = path.resolve("/memfs/host-goal-notifications", suffix);
+	memfs.mkdirSync(stateDir, { recursive: true });
+	const store = new GoalStore(stateDir, memfs, { persistence: "json" });
+	stores.push(store);
+	return { memfs, stateDir, store, manager: new GoalManager(store, undefined, stateDir) };
+}
+
+function goal(id: string, overrides: Partial<PersistedGoal> = {}): PersistedGoal {
+	return {
+		id,
+		title: `Goal ${id}`,
+		cwd: `/work/${id}`,
+		state: "todo",
+		spec: "",
+		createdAt: 100,
+		updatedAt: 100,
+		setupStatus: "ready",
+		projectId: "project-a",
+		...overrides,
+	};
+}
+
+function durableGoal(memfs: MemFs, stateDir: string, id: string): PersistedGoal | undefined {
+	const rows = JSON.parse(memfs.readFileSync(path.join(stateDir, "goals.json"), "utf-8")) as PersistedGoal[];
+	return rows.find(row => row.id === id);
+}
+
+describe("authoritative goal host notifications", () => {
+	it("publishes create only after the strict record commit while legacy callbacks remain independent", async () => {
+		const { memfs, stateDir, store, manager } = fixture("create");
+		const hostFacts: GoalStoreNotification[] = [];
+		const legacy: string[] = [];
+		store.onIndexUpdate = () => { legacy.push("index"); };
+		store.onGoalCreated = () => { legacy.push("goal-created"); };
+		store.onHostNotification = fact => {
+			hostFacts.push(fact);
+			expect(durableGoal(memfs, stateDir, fact.payload.goalId)?.updatedAt).toBe(fact.revision);
+		};
+
+		const created = await manager.createGoal("Strict create", "/workspace", {
+			projectId: "headquarters",
+			worktree: false,
+		});
+
+		expect(hostFacts).toEqual([{
+			name: "goalCreated",
+			revision: created.updatedAt,
+			payload: { goalId: created.id, state: "todo" },
+		}]);
+		expect(legacy).toEqual(["index", "goal-created"]);
+	});
+
+	it("suppresses no-ops and emits monotonic update then genuine completion facts", async () => {
+		const { memfs, stateDir, store, manager } = fixture("update-complete");
+		await store.putStrict(goal("child", { parentGoalId: "parent", updatedAt: 500 }));
+		const facts: GoalStoreNotification[] = [];
+		store.onHostNotification = fact => {
+			facts.push(fact);
+			expect(durableGoal(memfs, stateDir, "child")?.updatedAt).toBeGreaterThanOrEqual(fact.revision);
+		};
+		vi.spyOn(Date, "now").mockReturnValue(100);
+
+		expect(await manager.updateGoal("child", { title: "Changed", spec: "private body" })).toBe(true);
+		const firstRevision = store.get("child")!.updatedAt;
+		expect(firstRevision).toBe(501);
+		expect(await manager.updateGoal("child", { title: "Changed", spec: "private body" })).toBe(true);
+		expect(store.get("child")!.updatedAt).toBe(firstRevision);
+		expect(await manager.updateGoal("child", { state: "complete" })).toBe(true);
+		expect(await manager.updateGoal("child", { state: "complete" })).toBe(true);
+
+		expect(facts.map(fact => fact.name)).toEqual(["goalUpdated", "goalUpdated", "goalCompleted"]);
+		expect(facts[0]).toMatchObject({
+			revision: 501,
+			payload: { goalId: "child", state: "todo", changedFields: ["spec", "title"] },
+		});
+		expect(JSON.stringify(facts)).not.toContain("private body");
+		expect(facts[1].revision).toBe(502);
+		expect(facts[2]).toEqual({
+			name: "goalCompleted",
+			revision: 502,
+			payload: { goalId: "child", parentGoalId: "parent" },
+		});
+	});
+
+	it("keeps completion distinct from archive and suppresses duplicate archive publication", async () => {
+		const { memfs, stateDir, store, manager } = fixture("archive");
+		await store.putStrict(goal("goal-1"));
+		const facts: GoalStoreNotification[] = [];
+		let legacyArchives = 0;
+		store.onHostNotification = fact => { facts.push(fact); };
+		store.onGoalArchived = () => { legacyArchives++; };
+
+		await manager.updateGoal("goal-1", { state: "complete" });
+		await store.archiveStrict("goal-1");
+		const archivedRevision = store.get("goal-1")!.updatedAt;
+		await store.archiveStrict("goal-1");
+
+		expect(facts.map(fact => fact.name)).toEqual(["goalUpdated", "goalCompleted", "goalArchived"]);
+		expect(facts[2]).toEqual({ name: "goalArchived", revision: archivedRevision, payload: { goalId: "goal-1" } });
+		expect(store.get("goal-1")?.archivedAt).toBe(archivedRevision);
+		expect(durableGoal(memfs, stateDir, "goal-1")?.updatedAt).toBe(archivedRevision);
+		expect(legacyArchives).toBe(1);
+	});
+
+	it("isolates host consumer failures after commit and emits nothing for a failed strict commit", async () => {
+		const { memfs, stateDir, store, manager } = fixture("failures");
+		await store.putStrict(goal("goal-1"));
+		const warning = vi.spyOn(console, "warn").mockImplementation(() => {});
+		store.onHostNotification = () => { throw new Error("consumer failed"); };
+		expect(await manager.updateGoal("goal-1", { title: "Committed" })).toBe(true);
+		expect(durableGoal(memfs, stateDir, "goal-1")?.title).toBe("Committed");
+		expect(warning).toHaveBeenCalledWith(expect.stringContaining("non-fatal"));
+
+		const delivered: GoalStoreNotification[] = [];
+		store.onHostNotification = fact => { delivered.push(fact); };
+		const originalRename = memfs.promises.rename.bind(memfs.promises);
+		(memfs.promises as typeof memfs.promises & { rename: typeof originalRename }).rename = async (from, to) => {
+			if (String(to).endsWith("goals.json")) throw new Error("injected goal publication failure");
+			return originalRename(from, to);
+		};
+		await expect(manager.updateGoal("goal-1", { title: "Rejected" })).rejects.toThrow(/injected goal publication failure/);
+		expect(delivered).toEqual([]);
+		expect(store.get("goal-1")?.title).toBe("Committed");
+	});
+});

--- a/tests2/core/host-hook-contributions.test.ts
+++ b/tests2/core/host-hook-contributions.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { normalizeHookContributions } from "../../src/server/extension-host/host-hook-contributions.ts";
+import { loadHooks, type PackContributions } from "../../src/server/agent/pack-contributions.ts";
+import type { PackContributionRegistry } from "../../src/server/extension-host/pack-contribution-registry.ts";
+
+function pack(packId: string, providers: any[] = [], hooks: any[] = []): PackContributions {
+	return {
+		packId,
+		packName: packId,
+		packRoot: `/packs/${packId}`,
+		panels: [],
+		entrypoints: [],
+		providers,
+		channels: [],
+		hooks,
+	};
+}
+
+function base(id: string, listName = id): any {
+	return {
+		id,
+		listName,
+		module: "../lib/hooks.mjs",
+		sourceFile: `/packs/p/hooks/${listName}.yaml`,
+		packRoot: "/packs/p",
+		budget: { maxTokens: 1000, timeoutMs: 500 },
+		capabilities: [],
+	};
+}
+
+describe("explicit hook declarations", () => {
+	it("parses explicit kinds against the canonical catalogues while retaining legacy rows as inert", () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "host-hook-contrib-"));
+		try {
+			fs.mkdirSync(path.join(root, "hooks"), { recursive: true });
+			fs.mkdirSync(path.join(root, "lib"), { recursive: true });
+			fs.writeFileSync(path.join(root, "lib", "hooks.mjs"), "export default {};\n");
+			fs.writeFileSync(path.join(root, "hooks", "policy.yaml"), [
+				"id: policy.tools", "module: ../lib/hooks.mjs", "kind: interceptor",
+				"interceptors: [beforeToolCall, afterToolResult]", "failurePolicy: failClosed",
+				"capabilities: [store]", "budget: { timeoutMs: 900 }",
+			].join("\n"));
+			fs.writeFileSync(path.join(root, "hooks", "audit.yaml"), [
+				"id: audit.goals", "module: ../lib/hooks.mjs", "kind: notification",
+				"notifications:", "  - { scope: project, name: goalUpdated }",
+				"capabilities: []",
+			].join("\n"));
+			fs.writeFileSync(path.join(root, "hooks", "legacy.yaml"), [
+				"id: old.metadata", "module: ../lib/hooks.mjs",
+				"events: [beforePrompt]", "mode: observe", "capabilities: []",
+			].join("\n"));
+			const hooks = loadHooks(root, {
+				name: "p", description: "", version: "1", schema: 2,
+				contents: { roles: [], tools: [], skills: [], entrypoints: [], hooks: ["policy", "audit", "legacy"] },
+			});
+			expect(hooks).toMatchObject([
+				{ id: "policy.tools", kind: "interceptor", interceptors: ["beforeToolCall", "afterToolResult"], failurePolicy: "failClosed" },
+				{ id: "audit.goals", kind: "notification", notifications: [{ scope: "project", name: "goalUpdated" }] },
+				{ id: "old.metadata", events: ["beforePrompt"], mode: "observe" },
+			]);
+			expect(hooks[2].kind).toBeUndefined();
+		} finally { fs.rmSync(root, { recursive: true, force: true }); }
+	});
+});
+
+describe("normalizeHookContributions", () => {
+	it("orders winning packs, providers, declarations, and declared names deterministically", () => {
+		const provider = {
+			...base("memory"),
+			kind: "memory",
+			hooks: ["beforePrompt", "afterTurn", "sessionSetup"],
+		};
+		const inert = { ...base("old"), events: ["beforePrompt"], mode: "observe" };
+		const explicit = {
+			...base("policy"),
+			kind: "interceptor",
+			interceptors: ["beforeToolCall", "afterToolResult"],
+			failurePolicy: "failClosed",
+		};
+		const notification = {
+			...base("observe"),
+			kind: "notification",
+			notifications: [{ scope: "project", name: "goalUpdated" }],
+		};
+		const packs = [pack("p", [provider], [inert, explicit, notification]), pack("q", [], [{
+			...base("q-policy"),
+			packRoot: "/packs/q",
+			sourceFile: "/packs/q/hooks/q-policy.yaml",
+			kind: "interceptor",
+			interceptors: ["beforePrompt"],
+		}])];
+		const registry = {
+			list: () => packs,
+			listHooks: () => packs.flatMap((row) => row.hooks),
+			listProviders: () => packs.flatMap((row) => row.providers),
+			getActivationEpoch: () => 17,
+		} as unknown as PackContributionRegistry;
+
+		const rows = normalizeHookContributions(registry, "project-1");
+		expect(rows.map((row) => row.kind === "notification"
+			? `${row.packId}:notification:${row.selector.name}`
+			: `${row.packId}:${row.kind}:${row.name}`)).toEqual([
+			"p:legacy-provider:beforePrompt",
+			"p:legacy-provider:sessionSetup",
+			"p:interceptor:beforeToolCall",
+			"p:interceptor:afterToolResult",
+			"p:notification:goalUpdated",
+			"q:interceptor:beforePrompt",
+		]);
+		expect(rows.every((row, index) => row.activationEpoch === 17 && row.order === index)).toBe(true);
+		expect(rows.some((row) => row.contributionId === "old")).toBe(false);
+	});
+
+	it("returns an immutable row list without mutating declarations", () => {
+		const declaration = {
+			...base("policy"),
+			kind: "interceptor",
+			interceptors: ["beforePrompt"],
+			config: { enabled: true },
+		};
+		const registry = {
+			list: () => [pack("p", [], [declaration])],
+			listHooks: () => [declaration],
+			listProviders: () => [],
+			getActivationEpoch: () => 2,
+		} as unknown as PackContributionRegistry;
+		const rows = normalizeHookContributions(registry, undefined);
+		expect(Object.isFrozen(rows)).toBe(true);
+		expect(rows[0]).toMatchObject({ packId: "p", contributionId: "policy", config: { enabled: true } });
+		expect(declaration).not.toHaveProperty("packId");
+	});
+});

--- a/tests2/core/host-hooks-catalogue.test.ts
+++ b/tests2/core/host-hooks-catalogue.test.ts
@@ -1,0 +1,228 @@
+// v2-native — unified Extension Host hook catalogue contract.
+import { describe, expect, it } from "vitest";
+import { Value } from "@sinclair/typebox/value";
+
+import {
+	HOST_HOOK_LIMITS,
+	HOST_INTERCEPTOR_CATALOGUE,
+	HOST_NOTIFICATION_CATALOGUE,
+	HOST_NOTIFICATION_ENVELOPE_SCHEMAS,
+	buildHostNotification,
+	notificationMatchesFilter,
+	validateHostNotification,
+	validateInterceptorRequest,
+	validateInterceptorResult,
+	validateNotificationFilter,
+	validateNotificationPayload,
+	type HostInterceptorName,
+	type HostNotificationName,
+} from "../../src/shared/extension-host/host-hooks.ts";
+
+const payloads: Record<HostNotificationName, unknown> = {
+	statusChanged: { previousStatus: "starting", status: "idle", statusVersion: 1 },
+	turnStarted: { turnIndex: 2, source: "user" },
+	turnCompleted: { turnIndex: 2, outcome: "succeeded", durationMs: 25, hadToolCalls: true },
+	messageAppended: { messageId: "message-1", cursor: 4, role: "assistant", blockKinds: ["text", "tool_use"] },
+	toolCallStarted: { toolCallId: "tool-call-1", toolName: "read", turnIndex: 2 },
+	toolCallCompleted: { toolCallId: "tool-call-1", toolName: "read", status: "errored", durationMs: 5, errorStatus: "denied" },
+	sessionCreated: { sessionId: "session-1", kind: "general" },
+	sessionArchived: { sessionId: "session-1", reason: "user" },
+	sessionForked: { sourceSessionId: "session-1", sessionId: "session-2", cutEntryId: "entry-1", forkMode: "history" },
+	sessionStatusChanged: { sessionId: "session-1", previousStatus: "starting", status: "idle", statusVersion: 1 },
+	staffCreated: { staffId: "staff-1", state: "active", sessionId: "session-1" },
+	staffConfigChanged: { staffId: "staff-1", changedFields: ["description", "name"] },
+	staffRetired: { staffId: "staff-1" },
+	staffSessionChanged: { staffId: "staff-1", previousSessionId: "session-1", sessionId: "session-2" },
+	goalCreated: { goalId: "goal-1", state: "todo" },
+	goalUpdated: { goalId: "goal-1", state: "in-progress", changedFields: ["spec", "state"] },
+	goalCompleted: { goalId: "goal-1" },
+	goalArchived: { goalId: "goal-1" },
+	taskCreated: { taskId: "task-1", goalId: "goal-1", type: "implementation", state: "todo" },
+	taskUpdated: { taskId: "task-1", goalId: "goal-1", state: "in-progress", changedFields: ["assignedSessionId", "title"] },
+	taskStateChanged: { taskId: "task-1", goalId: "goal-1", previousState: "todo", state: "in-progress" },
+	gateStatusChanged: { gateId: "implementation", goalId: "goal-1", previousStatus: "pending", status: "passed" },
+	pullRequestStatusChanged: { goalId: "goal-1", number: 42, state: "OPEN", reviewDecision: "APPROVED", mergeability: "MERGEABLE" },
+	settingsChanged: { target: "project", changedKeys: ["components", "workflows"] },
+};
+
+const interceptorRequests: Record<HostInterceptorName, unknown> = {
+	sessionSetup: { sessionId: "session-1", projectId: "project-1", scope: "project", roleName: "coder", component: { name: "app" } },
+	beforePrompt: { sessionId: "session-1", turnIndex: 1, source: "user", userText: "hello" },
+	beforeToolCall: { toolCallId: "tool-call-1", toolName: "read", args: { path: "README.md", options: [1, true, null] } },
+	afterToolResult: { toolCallId: "tool-call-1", toolName: "read", result: { ok: true } },
+	beforeCompact: { sessionId: "session-1", turnIndex: 1, span: "old messages", summary: "summary" },
+	sessionShutdown: { sessionId: "session-1", projectId: "project-1", reason: "terminated" },
+	projectImported: { projectId: "project-1", components: [{ name: "app", repo: "." }, { name: "web", repo: "packages/web", relativePath: "src" }] },
+};
+
+const interceptorResults: Record<HostInterceptorName, unknown> = {
+	sessionSetup: { context: [{ id: "context-1", title: "Memory", authority: "memory", content: "bounded", reason: "relevant", priority: 10 }] },
+	beforePrompt: { context: [] },
+	beforeToolCall: { action: "replaceArgs", args: { path: "safe.txt" } },
+	afterToolResult: { action: "syntheticError", code: "policy_denied" },
+	beforeCompact: { context: [], flush: "complete" },
+	sessionShutdown: { flush: "complete" },
+	projectImported: { initialised: true },
+};
+
+describe("host notification catalogue", () => {
+	it("contains every canonical name once with unique scope/name identity and complete metadata", () => {
+		expect(Object.keys(HOST_NOTIFICATION_CATALOGUE)).toEqual(Object.keys(payloads));
+		const identities = Object.values(HOST_NOTIFICATION_CATALOGUE).map((definition) => `${definition.scope}:${definition.name}`);
+		expect(new Set(identities).size).toBe(identities.length);
+		for (const [key, definition] of Object.entries(HOST_NOTIFICATION_CATALOGUE)) {
+			expect(definition.name).toBe(key);
+			expect(definition.payloadVersion).toBe(1);
+			expect(definition.boundary.length).toBeGreaterThan(10);
+			expect(definition.aggregateKind.length).toBeGreaterThan(0);
+			expect(definition.revisionSource.length).toBeGreaterThan(0);
+			expect([...definition.consumers]).toEqual(["browser", "module", "staff", "diagnostic"]);
+			expect(definition.privacy).toBe("project-metadata");
+			expect(definition.delivery).toEqual({ browser: "live", module: "live", staff: "durable-intent" });
+		}
+	});
+
+	it("validates every v1 payload through the catalogue TypeBox schema and helper", () => {
+		for (const name of Object.keys(payloads) as HostNotificationName[]) {
+			expect(Value.Check(HOST_NOTIFICATION_CATALOGUE[name].payloadSchema, payloads[name]), name).toBe(true);
+			expect(validateNotificationPayload(name, payloads[name]), name).toBe(true);
+		}
+	});
+
+	it("rejects unknown fields, invalid enums, non-finite values, and unsorted or duplicate change identifiers", () => {
+		expect(validateNotificationPayload("goalCreated", { ...payloads.goalCreated as object, rawPrompt: "DO_NOT_LEAK" })).toBe(false);
+		expect(validateNotificationPayload("turnCompleted", { turnIndex: 1, outcome: "retrying", durationMs: 1, hadToolCalls: false })).toBe(false);
+		expect(validateNotificationPayload("turnCompleted", { turnIndex: 1, outcome: "errored", durationMs: Number.NaN, hadToolCalls: false })).toBe(false);
+		expect(validateNotificationPayload("goalUpdated", { goalId: "goal-1", state: "todo", changedFields: ["state", "spec"] })).toBe(false);
+		expect(validateNotificationPayload("goalUpdated", { goalId: "goal-1", state: "todo", changedFields: ["state", "state"] })).toBe(false);
+		expect(validateNotificationPayload("settingsChanged", { target: "project", changedKeys: ["secretValue"] })).toBe(false);
+		expect(validateNotificationPayload("toolCallCompleted", { toolCallId: "t", toolName: "read", status: "succeeded", durationMs: 1, errorStatus: "denied" })).toBe(false);
+		expect(validateNotificationPayload("toolCallCompleted", { toolCallId: "t", toolName: "read", status: "errored", durationMs: 1 })).toBe(false);
+	});
+
+	it("enforces catalogue-owned flat staff filters and exact scope", () => {
+		expect(validateNotificationFilter("session", "toolCallCompleted", { toolName: "read", status: "succeeded" })).toEqual({
+			ok: true,
+			filter: { toolName: "read", status: "succeeded" },
+		});
+		expect(validateNotificationFilter("project", "toolCallCompleted", {})).toEqual({ ok: false, code: "UNKNOWN_NOTIFICATION" });
+		expect(validateNotificationFilter("project", "missing", {})).toEqual({ ok: false, code: "UNKNOWN_NOTIFICATION" });
+		expect(validateNotificationFilter("project", "goalUpdated", { goalId: "goal-1" })).toEqual({ ok: false, code: "UNKNOWN_FILTER_FIELD" });
+		expect(validateNotificationFilter("project", "goalUpdated", { state: "not-a-state" })).toEqual({ ok: false, code: "INVALID_FILTER_VALUE" });
+		expect(validateNotificationFilter("project", "goalUpdated", { state: { nested: true } })).toEqual({ ok: false, code: "INVALID_FILTER_VALUE" });
+		expect(validateNotificationFilter("session", "toolCallStarted", { toolName: "x".repeat(HOST_HOOK_LIMITS.filterBytes) })).toEqual({ ok: false, code: "FILTER_TOO_LARGE" });
+	});
+});
+
+describe("canonical host notification envelope", () => {
+	it("builds a strict, revisioned, deeply frozen copy", () => {
+		const mutable = { goalId: "goal-1", state: "todo" };
+		const event = buildHostNotification("goalCreated", {
+			id: "notification-1",
+			occurredAt: 100,
+			projectId: "project-1",
+			aggregateId: "goal-1",
+			aggregateRevision: 7,
+			correlationId: "correlation-1",
+			payload: mutable,
+		});
+		mutable.state = "blocked";
+		expect(event).toEqual({
+			id: "notification-1",
+			scope: "project",
+			name: "goalCreated",
+			payloadVersion: 1,
+			occurredAt: 100,
+			projectId: "project-1",
+			aggregate: { kind: "goal", id: "goal-1", revision: 7 },
+			correlationId: "correlation-1",
+			payload: { goalId: "goal-1", state: "todo" },
+		});
+		expect(validateHostNotification(event)).toBe(true);
+		expect(Value.Check(HOST_NOTIFICATION_ENVELOPE_SCHEMAS.goalCreated, event)).toBe(true);
+		expect(Object.isFrozen(event)).toBe(true);
+		expect(Object.isFrozen(event.aggregate)).toBe(true);
+		expect(Object.isFrozen(event.payload)).toBe(true);
+		expect(notificationMatchesFilter(event, { state: "todo" })).toBe(true);
+		expect(notificationMatchesFilter(event, { state: "complete" })).toBe(false);
+	});
+
+	it("requires session binding only at session scope and rejects forged metadata or privacy fields", () => {
+		expect(() => buildHostNotification("turnStarted", {
+			id: "notification-1", occurredAt: 1, projectId: "project-1", aggregateId: "turn-1", aggregateRevision: 1,
+			payload: payloads.turnStarted as never,
+		})).toThrow("Invalid host notification projection");
+		expect(() => buildHostNotification("goalCreated", {
+			id: "notification-1", occurredAt: 1, projectId: "project-1", sessionId: "session-1", aggregateId: "goal-1", aggregateRevision: 1,
+			payload: payloads.goalCreated as never,
+		})).toThrow("Invalid host notification projection");
+
+		const valid = buildHostNotification("turnStarted", {
+			id: "notification-1", occurredAt: 1, projectId: "project-1", sessionId: "session-1", aggregateId: "turn-1", aggregateRevision: 1,
+			payload: payloads.turnStarted as never,
+		});
+		for (const forbidden of [
+			{ ...valid, payloadVersion: 2 },
+			{ ...valid, scope: "project" },
+			{ ...valid, aggregate: { ...valid.aggregate, kind: "goal" } },
+			{ ...valid, rawPrompt: "DO_NOT_LEAK" },
+			{ ...valid, payload: { ...valid.payload, toolResultBody: "DO_NOT_LEAK" } },
+			{ ...valid, aggregate: { ...valid.aggregate, revision: Number.POSITIVE_INFINITY } },
+		]) expect(validateHostNotification(forbidden), JSON.stringify(forbidden)).toBe(false);
+	});
+});
+
+describe("host interceptor catalogue", () => {
+	it("contains all seven contracts with the specified timing and failure metadata", () => {
+		expect(Object.keys(HOST_INTERCEPTOR_CATALOGUE)).toEqual([
+			"sessionSetup", "beforePrompt", "beforeToolCall", "afterToolResult", "beforeCompact", "sessionShutdown", "projectImported",
+		]);
+		expect(Object.fromEntries(Object.entries(HOST_INTERCEPTOR_CATALOGUE).map(([name, definition]) => [name, [definition.defaultTimeoutMs, definition.maxTimeoutMs, definition.dispatchDeadlineMs]]))).toEqual({
+			sessionSetup: [1500, 3000, 5000],
+			beforePrompt: [500, 1000, 1500],
+			beforeToolCall: [750, 1500, 2000],
+			afterToolResult: [750, 1500, 2000],
+			beforeCompact: [1500, 3000, 5000],
+			sessionShutdown: [1000, 2000, 3000],
+			projectImported: [2000, 5000, 8000],
+		});
+		expect(HOST_INTERCEPTOR_CATALOGUE.beforePrompt.defaultFailurePolicy).toBe("failOpen");
+		expect(HOST_INTERCEPTOR_CATALOGUE.beforeToolCall.allowedFailurePolicies.has("failClosed")).toBe(true);
+		expect(HOST_INTERCEPTOR_CATALOGUE.afterToolResult.defaultFailurePolicy).toBe("failClosed");
+		expect(HOST_INTERCEPTOR_CATALOGUE.projectImported.defaultFailurePolicy).toBe("nonFatal");
+		for (const definition of Object.values(HOST_INTERCEPTOR_CATALOGUE)) {
+			expect(definition.maxTimeoutMs).toBeLessThanOrEqual(definition.dispatchDeadlineMs);
+			expect(definition.cancellation).toEqual(expect.objectContaining({ abortWorker: true, discardLateResult: true }));
+			expect(definition.requiredGrants).toEqual([]);
+		}
+	});
+
+	it("validates every request/result and rejects unknown fields and malformed decisions", () => {
+		for (const name of Object.keys(HOST_INTERCEPTOR_CATALOGUE) as HostInterceptorName[]) {
+			expect(Value.Check(HOST_INTERCEPTOR_CATALOGUE[name].requestSchema, interceptorRequests[name]), `${name} request schema`).toBe(true);
+			expect(validateInterceptorRequest(name, interceptorRequests[name]), `${name} request`).toBe(true);
+			expect(Value.Check(HOST_INTERCEPTOR_CATALOGUE[name].resultSchema, interceptorResults[name]), `${name} result schema`).toBe(true);
+			expect(validateInterceptorResult(name, interceptorResults[name]), `${name} result`).toBe(true);
+		}
+		expect(validateInterceptorRequest("beforeToolCall", { ...interceptorRequests.beforeToolCall as object, cwd: "/secret" })).toBe(false);
+		expect(validateInterceptorResult("beforeToolCall", { action: "block", reason: "raw provider error" })).toBe(false);
+		expect(validateInterceptorResult("afterToolResult", { action: "syntheticError", code: "raw_stack_trace" })).toBe(false);
+		expect(validateInterceptorRequest("projectImported", { projectId: "p", components: [{ name: "app", repo: "/absolute" }] })).toBe(false);
+		expect(validateInterceptorRequest("projectImported", { projectId: "p", components: [{ name: "app", repo: "../outside" }] })).toBe(false);
+	});
+
+	it("bounds structured inputs and emits body-free audit projections", () => {
+		let nested: unknown = "leaf";
+		for (let index = 0; index < HOST_HOOK_LIMITS.jsonDepth + 2; index += 1) nested = { child: nested };
+		expect(validateInterceptorRequest("beforeToolCall", { toolCallId: "t", toolName: "read", args: { nested } })).toBe(false);
+		expect(validateInterceptorRequest("beforeToolCall", { toolCallId: "t", toolName: "read", args: { n: Number.NaN } })).toBe(false);
+		expect(validateInterceptorRequest("beforePrompt", { sessionId: "s", turnIndex: 1, source: "user", userText: "x".repeat(HOST_HOOK_LIMITS.textLength + 1) })).toBe(false);
+
+		const audit = HOST_INTERCEPTOR_CATALOGUE.afterToolResult.auditProjector(
+			{ toolCallId: "t", toolName: "read", result: { secret: "DO_NOT_LEAK" } },
+			{ action: "replaceResult", result: { secret: "DO_NOT_LEAK" } },
+		);
+		expect(audit).toEqual({ proposal: "received" });
+		expect(JSON.stringify(audit)).not.toContain("DO_NOT_LEAK");
+	});
+});

--- a/tests2/core/host-hooks-catalogue.test.ts
+++ b/tests2/core/host-hooks-catalogue.test.ts
@@ -193,7 +193,7 @@ describe("host interceptor catalogue", () => {
 		for (const definition of Object.values(HOST_INTERCEPTOR_CATALOGUE)) {
 			expect(definition.maxTimeoutMs).toBeLessThanOrEqual(definition.dispatchDeadlineMs);
 			expect(definition.cancellation).toEqual(expect.objectContaining({ abortWorker: true, discardLateResult: true }));
-			expect(definition.requiredGrants).toEqual([]);
+			expect(definition.requiredCapabilities).toEqual([]);
 		}
 	});
 

--- a/tests2/core/host-interceptor-router.test.ts
+++ b/tests2/core/host-interceptor-router.test.ts
@@ -1,16 +1,9 @@
-import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
-import { guardProcessEnv } from "./helpers/env-guard.js";
-import { enableTsWorkerResolver } from "./helpers/enable-ts-worker.js";
-guardProcessEnv();
-enableTsWorkerResolver();
-import fs from "node:fs";
-import os from "node:os";
+import { describe, expect, it, vi } from "vitest";
 import path from "node:path";
-import { pathToFileURL } from "node:url";
 import { ActionError } from "../../src/server/extension-host/action-dispatcher.ts";
 import { hostInterceptorAuditSink } from "../../src/server/extension-host/host-interceptor-audit.ts";
 import { HostInterceptorRouter } from "../../src/server/extension-host/host-interceptor-router.ts";
-import { ModuleHost, type InvokeRequest } from "../../src/server/extension-host/module-host-worker.ts";
+import type { InvokeRequest, ModuleHost } from "../../src/server/extension-host/module-host-worker.ts";
 import type { PackContributions } from "../../src/server/agent/pack-contributions.ts";
 import type { PackContributionRegistry } from "../../src/server/extension-host/pack-contribution-registry.ts";
 
@@ -216,49 +209,5 @@ describe("HostInterceptorRouter", () => {
 		expect((result.value as any).context).toEqual([{
 			id: "memory-1", title: "Memory", authority: "memory", content: "safe", reason: "relevant", priority: 1,
 		}]);
-	});
-});
-
-let tmp = "";
-beforeAll(() => {
-	// Establish the resolver for normal file execution. Each worker-spawning test
-	// reasserts it again at invoke time because isolate:false sibling env guards
-	// can restore NODE_OPTIONS after this hook has run.
-	enableTsWorkerResolver();
-	tmp = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "host-hook-module-")));
-});
-afterAll(() => { fs.rmSync(tmp, { recursive: true, force: true }); });
-
-describe("ModuleHost hooks execution", () => {
-	it("resolves canonical members from the default hooks export", async () => {
-		const file = path.join(tmp, "hooks.mjs");
-		fs.writeFileSync(file, "export default { beforePrompt: async (_ctx, request) => ({ context: [{ id: request.sessionId, title: 't', authority: 'memory', content: 'c', reason: 'r', priority: 1 }] }) };\n");
-		const host = new ModuleHost({ timeoutMs: 30_000 });
-		try {
-			enableTsWorkerResolver();
-			const value = await host.invoke({
-				url: pathToFileURL(file).href, packRoot: tmp, epoch: 0, exportKind: "hooks", member: "beforePrompt",
-				ctx: { sessionId: "session-1", tool: "hook", host: {} } as any,
-				arg: { sessionId: "session-1" }, workingDir: tmp,
-			});
-			expect(value).toMatchObject({ context: [{ id: "session-1" }] });
-		} finally { host.dispose(); }
-	});
-
-	it("terminates a worker when the host cancellation signal aborts", async () => {
-		const file = path.join(tmp, "hanging.mjs");
-		fs.writeFileSync(file, "export default { beforePrompt: async () => new Promise(() => {}) };\n");
-		const host = new ModuleHost({ timeoutMs: 10_000 });
-		const controller = new AbortController();
-		try {
-			enableTsWorkerResolver();
-			const invocation = host.invoke({
-				url: pathToFileURL(file).href, packRoot: tmp, epoch: 0, exportKind: "hooks", member: "beforePrompt",
-				ctx: { sessionId: "session-1", tool: "hook", host: {} } as any,
-				arg: {}, workingDir: tmp, signal: controller.signal,
-			});
-			setTimeout(() => controller.abort(), 25);
-			await expect(invocation).rejects.toMatchObject({ status: 499 });
-		} finally { host.dispose(); }
 	});
 });

--- a/tests2/core/host-interceptor-router.test.ts
+++ b/tests2/core/host-interceptor-router.test.ts
@@ -221,9 +221,9 @@ describe("HostInterceptorRouter", () => {
 
 let tmp = "";
 beforeAll(() => {
-	// v2-core reuses forks with isolate:false. Re-assert the supported worker
-	// bootstrap resolver immediately before this file spawns real ModuleHost
-	// workers, after any sibling env guard may have restored NODE_OPTIONS.
+	// Establish the resolver for normal file execution. Each worker-spawning test
+	// reasserts it again at invoke time because isolate:false sibling env guards
+	// can restore NODE_OPTIONS after this hook has run.
 	enableTsWorkerResolver();
 	tmp = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "host-hook-module-")));
 });
@@ -235,6 +235,7 @@ describe("ModuleHost hooks execution", () => {
 		fs.writeFileSync(file, "export default { beforePrompt: async (_ctx, request) => ({ context: [{ id: request.sessionId, title: 't', authority: 'memory', content: 'c', reason: 'r', priority: 1 }] }) };\n");
 		const host = new ModuleHost({ timeoutMs: 30_000 });
 		try {
+			enableTsWorkerResolver();
 			const value = await host.invoke({
 				url: pathToFileURL(file).href, packRoot: tmp, epoch: 0, exportKind: "hooks", member: "beforePrompt",
 				ctx: { sessionId: "session-1", tool: "hook", host: {} } as any,
@@ -250,6 +251,7 @@ describe("ModuleHost hooks execution", () => {
 		const host = new ModuleHost({ timeoutMs: 10_000 });
 		const controller = new AbortController();
 		try {
+			enableTsWorkerResolver();
 			const invocation = host.invoke({
 				url: pathToFileURL(file).href, packRoot: tmp, epoch: 0, exportKind: "hooks", member: "beforePrompt",
 				ctx: { sessionId: "session-1", tool: "hook", host: {} } as any,

--- a/tests2/core/host-interceptor-router.test.ts
+++ b/tests2/core/host-interceptor-router.test.ts
@@ -8,6 +8,7 @@ import os from "node:os";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { ActionError } from "../../src/server/extension-host/action-dispatcher.ts";
+import { hostInterceptorAuditSink } from "../../src/server/extension-host/host-interceptor-audit.ts";
 import { HostInterceptorRouter } from "../../src/server/extension-host/host-interceptor-router.ts";
 import { ModuleHost, type InvokeRequest } from "../../src/server/extension-host/module-host-worker.ts";
 import type { PackContributions } from "../../src/server/agent/pack-contributions.ts";
@@ -144,6 +145,34 @@ describe("HostInterceptorRouter", () => {
 		}, context());
 		expect(result.value.args).toEqual({ original: true });
 		expect(result.decisions[0].outcome).toBe("cancelled");
+	});
+
+	it("records the production diagnostic projection once and keeps sink failures non-fatal", async () => {
+		const { registry } = registryFor(pack([explicit("audited")]));
+		const moduleHost = {
+			invoke: vi.fn(async () => ({ action: "allow" })),
+		} as unknown as ModuleHost;
+		const log = vi.spyOn(console, "log").mockImplementation(() => {});
+		const router = new HostInterceptorRouter({ registry, moduleHost, audit: hostInterceptorAuditSink });
+		const result = await router.dispatch("beforeToolCall", {
+			toolCallId: "call-sensitive", toolName: "demo", args: { secret: "forbidden args" },
+		}, context());
+		expect(result.decisions).toHaveLength(1);
+		expect(log).toHaveBeenCalledOnce();
+		expect(log.mock.calls[0]?.[0]).toBe("[host-interceptor-audit] %s");
+		const diagnostic = JSON.parse(String(log.mock.calls[0]?.[1]));
+		expect(diagnostic).toMatchObject({
+			hook: "beforeToolCall", projectId: "project-1", sessionId: "session-1",
+			packId: "p", contributionId: "audited", outcome: "applied",
+			proposalReceived: true, valid: true, applied: true, timedOut: false, cancelled: false,
+		});
+		expect(JSON.stringify(diagnostic)).not.toMatch(/call-sensitive|forbidden|args|prompt|result|error|path/i);
+
+		log.mockImplementation(() => { throw new Error("diagnostic sink unavailable"); });
+		await expect(router.dispatch("beforeToolCall", {
+			toolCallId: "call-2", toolName: "demo", args: {},
+		}, context())).resolves.toMatchObject({ decisions: [{ outcome: "applied" }] });
+		log.mockRestore();
 	});
 
 	it("applies a constant fail-closed decision without exposing worker errors", async () => {

--- a/tests2/core/host-interceptor-router.test.ts
+++ b/tests2/core/host-interceptor-router.test.ts
@@ -61,6 +61,20 @@ const context = () => ({
 });
 
 describe("HostInterceptorRouter", () => {
+	it("derives the protected transport snapshot only from live authorized fail-closed contributions", () => {
+		const authority = registryFor(pack([
+			explicit("ordinary", "failOpen"),
+			explicit("protected", "failClosed"),
+		]));
+		const router = new HostInterceptorRouter({
+			registry: authority.registry,
+			moduleHost: {} as ModuleHost,
+		});
+		expect(router.requiresFailClosed("beforeToolCall", "project-1")).toBe(true);
+		authority.setInactive();
+		expect(router.requiresFailClosed("beforeToolCall", "project-1")).toBe(false);
+	});
+
 	it("validates and folds explicit mutations sequentially in normalized order", async () => {
 		const declarations = [explicit("first"), explicit("second")];
 		const { registry } = registryFor(pack(declarations));

--- a/tests2/core/host-interceptor-router.test.ts
+++ b/tests2/core/host-interceptor-router.test.ts
@@ -1,0 +1,211 @@
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { enableTsWorkerResolver } from "./helpers/enable-ts-worker.ts";
+enableTsWorkerResolver();
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { ActionError } from "../../src/server/extension-host/action-dispatcher.ts";
+import { HostInterceptorRouter } from "../../src/server/extension-host/host-interceptor-router.ts";
+import { ModuleHost, type InvokeRequest } from "../../src/server/extension-host/module-host-worker.ts";
+import type { PackContributions } from "../../src/server/agent/pack-contributions.ts";
+import type { PackContributionRegistry } from "../../src/server/extension-host/pack-contribution-registry.ts";
+
+function explicit(id: string, failurePolicy: "failOpen" | "failClosed" = "failOpen"): any {
+	return {
+		id,
+		kind: "interceptor",
+		interceptors: ["beforeToolCall"],
+		failurePolicy,
+		module: `../lib/${id}.mjs`,
+		capabilities: [],
+		budget: { maxTokens: 1000, timeoutMs: 500 },
+		listName: id,
+		sourceFile: `/packs/p/hooks/${id}.yaml`,
+		packRoot: "/packs/p",
+	};
+}
+
+function pack(hooks: any[] = [], providers: any[] = []): PackContributions {
+	return {
+		packId: "p", packName: "p", packRoot: "/packs/p",
+		panels: [], entrypoints: [], channels: [], hooks, providers,
+	};
+}
+
+function registryFor(p: PackContributions) {
+	let active = true;
+	let epoch = 3;
+	const listeners = new Set<() => void>();
+	const registry = {
+		list: () => [p],
+		listHooks: () => p.hooks,
+		listProviders: () => p.providers,
+		getActivationEpoch: () => epoch,
+		onInvalidate: (listener: () => void) => { listeners.add(listener); return () => listeners.delete(listener); },
+		isHookAuthorized: () => active,
+		isProviderAuthorized: () => active,
+	} as unknown as PackContributionRegistry;
+	return {
+		registry,
+		disable: () => { active = false; epoch++; for (const listener of listeners) listener(); },
+		setInactive: () => { active = false; },
+	};
+}
+
+const context = () => ({
+	projectId: "project-1",
+	sessionId: "session-1",
+	cwd: process.cwd(),
+	signal: new AbortController().signal,
+});
+
+describe("HostInterceptorRouter", () => {
+	it("validates and folds explicit mutations sequentially in normalized order", async () => {
+		const declarations = [explicit("first"), explicit("second")];
+		const { registry } = registryFor(pack(declarations));
+		const calls: InvokeRequest[] = [];
+		const moduleHost = {
+			invoke: vi.fn(async (request: InvokeRequest) => {
+				calls.push(request);
+				return calls.length === 1 ? { action: "replaceArgs", args: { changed: true } } : { action: "allow" };
+			}),
+		} as unknown as ModuleHost;
+		const router = new HostInterceptorRouter({
+			registry,
+			moduleHost,
+			validateToolArgs: (_tool, args) => !!args && (args as any).changed === true,
+		});
+		const result = await router.dispatch("beforeToolCall", {
+			toolCallId: "call-1", toolName: "demo", args: { original: true },
+		}, context());
+		expect(result.value.args).toEqual({ changed: true });
+		expect(calls.map((call) => path.basename(new URL(call.url).pathname).split(".")[0])).toEqual(["first", "second"]);
+		expect(calls[1].arg).toMatchObject({ args: { changed: true } });
+		expect(result.decisions.map((row) => row.outcome)).toEqual(["applied", "applied"]);
+		expect(result.decisions.every((row) => !Object.keys(row).some((key) => /args|result|error|path|prompt/i.test(key)))).toBe(true);
+	});
+
+	it("rechecks live authority immediately before application and discards a late result", async () => {
+		const authority = registryFor(pack([explicit("late")]));
+		const moduleHost = {
+			invoke: vi.fn(async () => {
+				authority.setInactive();
+				return { action: "replaceArgs", args: { forbidden: true } };
+			}),
+		} as unknown as ModuleHost;
+		const router = new HostInterceptorRouter({
+			registry: authority.registry,
+			moduleHost,
+			validateToolArgs: () => true,
+		});
+		const result = await router.dispatch("beforeToolCall", {
+			toolCallId: "call-1", toolName: "demo", args: { original: true },
+		}, context());
+		expect(result.value.args).toEqual({ original: true });
+		expect(result.decisions[0]).toMatchObject({ outcome: "cancelled", cancelled: true, applied: false, proposalReceived: true });
+	});
+
+	it("rechecks capability grants before applying a settled proposal", async () => {
+		const declaration = explicit("granted");
+		declaration.capabilities = ["store"];
+		const { registry } = registryFor(pack([declaration]));
+		let granted = true;
+		const moduleHost = {
+			invoke: vi.fn(async () => {
+				granted = false;
+				return { action: "replaceArgs", args: { forbidden: true } };
+			}),
+		} as unknown as ModuleHost;
+		const router = new HostInterceptorRouter({
+			registry,
+			moduleHost,
+			validateToolArgs: () => true,
+			isCapabilityGranted: () => granted,
+		});
+		const result = await router.dispatch("beforeToolCall", {
+			toolCallId: "call-1", toolName: "demo", args: { original: true },
+		}, context());
+		expect(result.value.args).toEqual({ original: true });
+		expect(result.decisions[0].outcome).toBe("cancelled");
+	});
+
+	it("applies a constant fail-closed decision without exposing worker errors", async () => {
+		const { registry } = registryFor(pack([explicit("protected", "failClosed")]));
+		const moduleHost = {
+			invoke: vi.fn(async () => { throw new ActionError(504, "sensitive extension failure"); }),
+		} as unknown as ModuleHost;
+		const audit = vi.fn();
+		const router = new HostInterceptorRouter({ registry, moduleHost, audit });
+		const result = await router.dispatch("beforeToolCall", {
+			toolCallId: "call-1", toolName: "demo", args: {},
+		}, context());
+		expect(result.terminal).toEqual({ action: "block", reasonCode: "not_permitted" });
+		expect(result.decisions[0]).toMatchObject({ outcome: "failed-closed", timedOut: true, applied: false });
+		expect(JSON.stringify(audit.mock.calls)).not.toContain("sensitive");
+	});
+
+	it("uses LifecycleHub's selective provider adapter and projects canonical context fields", async () => {
+		const provider = {
+			id: "memory", kind: "memory", module: "../lib/provider.mjs",
+			hooks: ["beforePrompt"], budget: { maxTokens: 1000, timeoutMs: 500 },
+			listName: "memory", sourceFile: "/packs/p/providers/memory.yaml", packRoot: "/packs/p",
+		};
+		const { registry } = registryFor(pack([], [provider]));
+		const dispatchProvider = vi.fn(async () => ({
+			blocks: [{
+				id: "memory-1", title: "Memory", authority: "memory", content: "safe",
+				reason: "relevant", priority: 1, providerId: "memory", tokenEstimate: 1,
+			}],
+			diagnostics: [],
+		}));
+		const router = new HostInterceptorRouter({
+			registry,
+			moduleHost: {} as ModuleHost,
+			lifecycleHub: { dispatchProvider } as any,
+		});
+		const result = await router.dispatch("beforePrompt", {
+			sessionId: "session-1", turnIndex: 1, source: "user", userText: "hello",
+		}, context());
+		expect(dispatchProvider).toHaveBeenCalledOnce();
+		expect((result.value as any).context).toEqual([{
+			id: "memory-1", title: "Memory", authority: "memory", content: "safe", reason: "relevant", priority: 1,
+		}]);
+	});
+});
+
+let tmp = "";
+beforeAll(() => { tmp = fs.mkdtempSync(path.join(os.tmpdir(), "host-hook-module-")); });
+afterAll(() => { fs.rmSync(tmp, { recursive: true, force: true }); });
+
+describe("ModuleHost hooks execution", () => {
+	it("resolves canonical members from the default hooks export", async () => {
+		const file = path.join(tmp, "hooks.mjs");
+		fs.writeFileSync(file, "export default { beforePrompt: async (_ctx, request) => ({ context: [{ id: request.sessionId, title: 't', authority: 'memory', content: 'c', reason: 'r', priority: 1 }] }) };\n");
+		const host = new ModuleHost({ timeoutMs: 5_000 });
+		try {
+			const value = await host.invoke({
+				url: pathToFileURL(file).href, packRoot: tmp, epoch: 0, exportKind: "hooks", member: "beforePrompt",
+				ctx: { sessionId: "session-1", tool: "hook", host: {} } as any,
+				arg: { sessionId: "session-1" }, workingDir: tmp,
+			});
+			expect(value).toMatchObject({ context: [{ id: "session-1" }] });
+		} finally { host.dispose(); }
+	});
+
+	it("terminates a worker when the host cancellation signal aborts", async () => {
+		const file = path.join(tmp, "hanging.mjs");
+		fs.writeFileSync(file, "export default { beforePrompt: async () => new Promise(() => {}) };\n");
+		const host = new ModuleHost({ timeoutMs: 10_000 });
+		const controller = new AbortController();
+		try {
+			const invocation = host.invoke({
+				url: pathToFileURL(file).href, packRoot: tmp, epoch: 0, exportKind: "hooks", member: "beforePrompt",
+				ctx: { sessionId: "session-1", tool: "hook", host: {} } as any,
+				arg: {}, workingDir: tmp, signal: controller.signal,
+			});
+			setTimeout(() => controller.abort(), 25);
+			await expect(invocation).rejects.toMatchObject({ status: 499 });
+		} finally { host.dispose(); }
+	});
+});

--- a/tests2/core/host-interceptor-router.test.ts
+++ b/tests2/core/host-interceptor-router.test.ts
@@ -1,5 +1,7 @@
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
-import { enableTsWorkerResolver } from "./helpers/enable-ts-worker.ts";
+import { guardProcessEnv } from "./helpers/env-guard.js";
+import { enableTsWorkerResolver } from "./helpers/enable-ts-worker.js";
+guardProcessEnv();
 enableTsWorkerResolver();
 import fs from "node:fs";
 import os from "node:os";
@@ -120,14 +122,14 @@ describe("HostInterceptorRouter", () => {
 		expect(result.decisions[0]).toMatchObject({ outcome: "cancelled", cancelled: true, applied: false, proposalReceived: true });
 	});
 
-	it("rechecks capability grants before applying a settled proposal", async () => {
-		const declaration = explicit("granted");
+	it("rechecks capability authorization before applying a settled proposal", async () => {
+		const declaration = explicit("authorized");
 		declaration.capabilities = ["store"];
 		const { registry } = registryFor(pack([declaration]));
-		let granted = true;
+		let authorized = true;
 		const moduleHost = {
 			invoke: vi.fn(async () => {
-				granted = false;
+				authorized = false;
 				return { action: "replaceArgs", args: { forbidden: true } };
 			}),
 		} as unknown as ModuleHost;
@@ -135,7 +137,7 @@ describe("HostInterceptorRouter", () => {
 			registry,
 			moduleHost,
 			validateToolArgs: () => true,
-			isCapabilityGranted: () => granted,
+			isCapabilityAuthorized: () => authorized,
 		});
 		const result = await router.dispatch("beforeToolCall", {
 			toolCallId: "call-1", toolName: "demo", args: { original: true },
@@ -189,14 +191,20 @@ describe("HostInterceptorRouter", () => {
 });
 
 let tmp = "";
-beforeAll(() => { tmp = fs.mkdtempSync(path.join(os.tmpdir(), "host-hook-module-")); });
+beforeAll(() => {
+	// v2-core reuses forks with isolate:false. Re-assert the supported worker
+	// bootstrap resolver immediately before this file spawns real ModuleHost
+	// workers, after any sibling env guard may have restored NODE_OPTIONS.
+	enableTsWorkerResolver();
+	tmp = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "host-hook-module-")));
+});
 afterAll(() => { fs.rmSync(tmp, { recursive: true, force: true }); });
 
 describe("ModuleHost hooks execution", () => {
 	it("resolves canonical members from the default hooks export", async () => {
 		const file = path.join(tmp, "hooks.mjs");
 		fs.writeFileSync(file, "export default { beforePrompt: async (_ctx, request) => ({ context: [{ id: request.sessionId, title: 't', authority: 'memory', content: 'c', reason: 'r', priority: 1 }] }) };\n");
-		const host = new ModuleHost({ timeoutMs: 5_000 });
+		const host = new ModuleHost({ timeoutMs: 30_000 });
 		try {
 			const value = await host.invoke({
 				url: pathToFileURL(file).href, packRoot: tmp, epoch: 0, exportKind: "hooks", member: "beforePrompt",

--- a/tests2/core/host-notification-dispatcher.test.ts
+++ b/tests2/core/host-notification-dispatcher.test.ts
@@ -124,6 +124,52 @@ describe("HostNotificationDispatcher", () => {
 			expect.objectContaining({ code: "consumer_failure", consumer: "browser" }),
 		]));
 	});
+
+	it("admits every durable staff event in order beyond bounded live capacity", async () => {
+		const browserDelivered: string[] = [];
+		const refreshes: string[] = [];
+		const staffAdmitted: string[] = [];
+		let nextId = 0;
+		const dispatcher = new HostNotificationDispatcher({
+			queueCapacity: 1,
+			idGenerator: () => `notification-${++nextId}`,
+			now: () => 103,
+			adapters: [
+				{
+					consumer: "browser",
+					deliver(notification) { browserDelivered.push(notification.id); },
+					refreshRequired(notification) { refreshes.push(notification.id); },
+				},
+				{
+					consumer: "staff",
+					admission: "durable-subscriber",
+					deliver(notification) { staffAdmitted.push(notification.id); },
+				},
+			],
+		});
+
+		for (let revision = 1; revision <= 4; revision++) {
+			dispatcher.publish("goalUpdated", {
+				...goalPublication(),
+				aggregateRevision: revision,
+			});
+		}
+		await settleFanout();
+
+		expect(browserDelivered).toEqual(["notification-1"]);
+		expect(refreshes).toEqual(["notification-2", "notification-3", "notification-4"]);
+		expect(staffAdmitted).toEqual([
+			"notification-1",
+			"notification-2",
+			"notification-3",
+			"notification-4",
+		]);
+		expect(dispatcher.getDiagnostics().filter(row => row.code === "queue_overflow")).toEqual([
+			expect.objectContaining({ consumer: "browser" }),
+			expect.objectContaining({ consumer: "browser" }),
+			expect.objectContaining({ consumer: "browser" }),
+		]);
+	});
 });
 
 describe("HostNotificationModuleAdapter", () => {

--- a/tests2/core/host-notification-dispatcher.test.ts
+++ b/tests2/core/host-notification-dispatcher.test.ts
@@ -1,0 +1,206 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+	HostNotificationDispatcher,
+	HostNotificationModuleAdapter,
+	type HostNotificationDeliveryAdapter,
+	type HostNotificationModuleHandler,
+} from "../../src/server/extension-host/host-notification-dispatcher.js";
+import { buildHostNotification, type HostNotification } from "../../src/shared/extension-host/host-hooks.js";
+
+async function settleFanout(): Promise<void> {
+	await new Promise<void>(resolve => setImmediate(resolve));
+}
+
+function goalPublication() {
+	return {
+		projectId: "project-a",
+		aggregateId: "goal-1",
+		aggregateRevision: 7,
+		correlationId: "correlation-1",
+		payload: { goalId: "goal-1", state: "in-progress" as const, changedFields: ["title" as const] },
+	};
+}
+
+function goalEvent(): HostNotification<"goalUpdated"> {
+	return buildHostNotification("goalUpdated", {
+		id: "notification-1",
+		occurredAt: 100,
+		projectId: "project-a",
+		aggregateId: "goal-1",
+		aggregateRevision: 7,
+		correlationId: "correlation-1",
+		payload: { goalId: "goal-1", state: "in-progress", changedFields: ["title"] },
+	});
+}
+
+afterEach(() => {
+	vi.useRealTimers();
+	vi.restoreAllMocks();
+});
+
+describe("HostNotificationDispatcher", () => {
+	it("fans the exact frozen canonical envelope to every eligible consumer without retaining mutable input", async () => {
+		const received = new Map<string, HostNotification>();
+		const adapters: HostNotificationDeliveryAdapter[] = (["browser", "module", "staff"] as const).map(consumer => ({
+			consumer,
+			deliver(notification) { received.set(consumer, notification); },
+		}));
+		const dispatcher = new HostNotificationDispatcher({
+			adapters,
+			idGenerator: () => "notification-1",
+			now: () => 100,
+		});
+		const publication = goalPublication();
+
+		const published = dispatcher.publish("goalUpdated", publication);
+		publication.payload.goalId = "mutated-after-publication";
+		await settleFanout();
+
+		expect(published).toBeDefined();
+		expect(Object.isFrozen(published)).toBe(true);
+		expect(Object.isFrozen(published!.aggregate)).toBe(true);
+		expect(Object.isFrozen(published!.payload)).toBe(true);
+		expect(published!.payload.goalId).toBe("goal-1");
+		expect([...received.values()]).toHaveLength(3);
+		for (const notification of received.values()) expect(notification).toBe(published);
+	});
+
+	it("fails closed on non-catalogue payload fields and keeps privacy sentinels out of bounded diagnostics", async () => {
+		const delivered = vi.fn();
+		const diagnostic = vi.fn();
+		const dispatcher = new HostNotificationDispatcher({
+			adapters: [{ consumer: "browser", deliver: delivered }],
+			now: () => 101,
+			onDiagnostic: diagnostic,
+		});
+		const tainted = {
+			...goalPublication(),
+			payload: { ...goalPublication().payload, rawPrompt: "FORBIDDEN_SENTINEL" },
+		};
+
+		expect(dispatcher.publish("goalUpdated", tainted as never)).toBeUndefined();
+		await settleFanout();
+
+		expect(delivered).not.toHaveBeenCalled();
+		expect(dispatcher.getDiagnostics()).toEqual([
+			expect.objectContaining({ code: "invalid_payload", projectId: "project-a", name: "goalUpdated" }),
+		]);
+		expect(JSON.stringify(dispatcher.getDiagnostics())).not.toContain("FORBIDDEN_SENTINEL");
+		expect(JSON.stringify(diagnostic.mock.calls)).not.toContain("FORBIDDEN_SENTINEL");
+	});
+
+	it("bounds each consumer queue, requests refresh after overflow, and isolates adapter failures", async () => {
+		const browserDelivered: string[] = [];
+		const refreshes: string[] = [];
+		const moduleDelivered: string[] = [];
+		let nextId = 0;
+		const dispatcher = new HostNotificationDispatcher({
+			queueCapacity: 1,
+			idGenerator: () => `notification-${++nextId}`,
+			now: () => 102,
+			adapters: [
+				{
+					consumer: "browser",
+					deliver(notification) {
+						browserDelivered.push(notification.id);
+						throw new Error("browser transport failed");
+					},
+					refreshRequired(notification) { refreshes.push(notification.id); },
+				},
+				{ consumer: "module", deliver(notification) { moduleDelivered.push(notification.id); } },
+			],
+		});
+
+		expect(dispatcher.publish("goalUpdated", goalPublication())?.id).toBe("notification-1");
+		expect(dispatcher.publish("goalUpdated", goalPublication())?.id).toBe("notification-2");
+		await settleFanout();
+
+		expect(browserDelivered).toEqual(["notification-1"]);
+		expect(refreshes).toEqual(["notification-2"]);
+		expect(moduleDelivered).toEqual(["notification-1"]);
+		expect(dispatcher.getDiagnostics()).toEqual(expect.arrayContaining([
+			expect.objectContaining({ code: "queue_overflow", consumer: "browser" }),
+			expect.objectContaining({ code: "queue_overflow", consumer: "module" }),
+			expect.objectContaining({ code: "consumer_failure", consumer: "browser" }),
+		]));
+	});
+});
+
+describe("HostNotificationModuleAdapter", () => {
+	const handler = (contributionId: string, overrides: Partial<HostNotificationModuleHandler> = {}): HostNotificationModuleHandler => ({
+		projectId: "project-a",
+		packId: "pack-a",
+		contributionId,
+		scope: "project",
+		name: "goalUpdated",
+		...overrides,
+	});
+
+	it("preserves resolver order and performs live authority checks before invocation and after settlement", async () => {
+		const notification = goalEvent();
+		const invoked: string[] = [];
+		const authorityChecks: string[] = [];
+		const diagnostics: Array<{ code: string; contributionId: string }> = [];
+		const authorization = new Map([[
+			"revoked-before", false,
+		], ["revoked-after", true], ["second", true]]);
+		const adapter = new HostNotificationModuleAdapter({
+			resolve: () => [
+				handler("revoked-before"),
+				handler("foreign", { projectId: "project-b" }),
+				handler("revoked-after"),
+				handler("second"),
+			],
+			isAuthorized(current) {
+				authorityChecks.push(current.contributionId);
+				return authorization.get(current.contributionId) ?? false;
+			},
+			invoke(current, received) {
+				expect(received).toBe(notification);
+				invoked.push(current.contributionId);
+				if (current.contributionId === "revoked-after") authorization.set("revoked-after", false);
+			},
+			onDiagnostic(row) { diagnostics.push(row); },
+		});
+
+		await adapter.deliver(notification);
+
+		expect(invoked).toEqual(["revoked-after", "second"]);
+		expect(authorityChecks).toEqual(["revoked-before", "revoked-after", "revoked-after", "second", "second"]);
+		expect(diagnostics).toEqual([
+			expect.objectContaining({ code: "handler_revoked", contributionId: "revoked-before" }),
+			expect.objectContaining({ code: "handler_revoked", contributionId: "revoked-after" }),
+		]);
+	});
+
+	it("enforces host deadlines and continues deterministically after timeout and handler failure", async () => {
+		vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+		const notification = goalEvent();
+		const invoked: string[] = [];
+		const aborted: string[] = [];
+		const diagnostics: Array<{ code: string; contributionId: string }> = [];
+		const adapter = new HostNotificationModuleAdapter({
+			resolve: () => [handler("slow", { timeoutMs: 10 }), handler("throws"), handler("last")],
+			isAuthorized: () => true,
+			invoke(current, _received, signal) {
+				invoked.push(current.contributionId);
+				signal.addEventListener("abort", () => aborted.push(current.contributionId), { once: true });
+				if (current.contributionId === "slow") return new Promise(() => {});
+				if (current.contributionId === "throws") throw new Error("isolated failure");
+			},
+			onDiagnostic(row) { diagnostics.push(row); },
+		});
+
+		const delivery = adapter.deliver(notification);
+		await Promise.resolve();
+		await vi.advanceTimersByTimeAsync(10);
+		await delivery;
+
+		expect(invoked).toEqual(["slow", "throws", "last"]);
+		expect(aborted).toEqual(["slow", "throws", "last"]);
+		expect(diagnostics).toEqual([
+			expect.objectContaining({ code: "handler_timeout", contributionId: "slow" }),
+			expect.objectContaining({ code: "handler_failure", contributionId: "throws" }),
+		]);
+	});
+});

--- a/tests2/core/host-pr-settings-notifications.test.ts
+++ b/tests2/core/host-pr-settings-notifications.test.ts
@@ -1,0 +1,201 @@
+import { createHash } from "node:crypto";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+	PrStatusPersistenceError,
+	PrStatusStore,
+	type PrStatusChangedFact,
+} from "../../src/server/agent/pr-status-store.js";
+import {
+	ProjectConfigPersistenceError,
+	ProjectConfigStore,
+	type ProjectSettingsChangedFact,
+} from "../../src/server/agent/project-config-store.js";
+import { createMemFs, type MemFs } from "../harness/mem-fs.js";
+
+function siblingTemp(file: string, candidate: string): boolean {
+	return path.dirname(candidate) === path.dirname(file)
+		&& candidate !== file
+		&& path.basename(candidate).startsWith(`${path.basename(file)}.`);
+}
+
+function text(fs: MemFs, file: string): string {
+	return String(fs.readFileSync(file, "utf-8"));
+}
+
+describe("authoritative PR and settings notification facts", () => {
+	it("publishes a bounded PR projection only after atomic commit and suppresses safe no-ops", () => {
+		const fs = createMemFs();
+		const stateDir = path.resolve("/memfs/host-pr-facts");
+		const storeFile = path.join(stateDir, "pr-status-cache.json");
+		const store = new PrStatusStore(stateDir, fs);
+		const facts: PrStatusChangedFact[] = [];
+		let committed = false;
+		const originalRename = fs.renameSync.bind(fs);
+		(fs as any).renameSync = (from: string, to: string) => {
+			originalRename(from, to);
+			if (to === storeFile) committed = true;
+		};
+		store.onPullRequestStatusChanged = fact => {
+			expect(committed).toBe(true);
+			facts.push(fact);
+		};
+
+		store.set("goal-1", {
+			state: "OPEN",
+			number: 42,
+			reviewDecision: "APPROVED",
+			mergeable: "MERGEABLE",
+			updatedAt: "2027-03-04T05:06:07.000Z",
+			url: "https://user:PR_URL_SECRET@example.invalid/pull/42",
+			title: "PR_TITLE_SECRET",
+			headRefName: "PR_BRANCH_SECRET",
+			viewerIsAdmin: true,
+		});
+
+		expect(facts).toEqual([{
+			goalId: "goal-1",
+			revision: "2027-03-04T05:06:07.000Z",
+			payload: {
+				goalId: "goal-1",
+				number: 42,
+				state: "OPEN",
+				reviewDecision: "APPROVED",
+				mergeability: "MERGEABLE",
+			},
+		}]);
+		expect(JSON.stringify(facts)).not.toMatch(/PR_URL_SECRET|PR_TITLE_SECRET|PR_BRANCH_SECRET|viewerIsAdmin|url|title/);
+
+		committed = false;
+		store.set("goal-1", {
+			...store.get("goal-1")!,
+			url: "https://example.invalid/pull/changed-sensitive-cache-field",
+			title: "changed sensitive cache field",
+			updatedAt: "2027-03-04T05:07:00.000Z",
+		});
+		expect(committed).toBe(true);
+		expect(facts).toHaveLength(1);
+		expect(store.get("goal-1")?.title).toBe("changed sensitive cache field");
+	});
+
+	it("uses a stable SHA-256 revision of the canonical safe PR projection without provider updatedAt", () => {
+		const fs = createMemFs();
+		const store = new PrStatusStore(path.resolve("/memfs/host-pr-hash"), fs);
+		let fact: PrStatusChangedFact | undefined;
+		store.onPullRequestStatusChanged = value => { fact = value; };
+
+		store.set("goal-hash", { state: "CLOSED", number: 9, mergeable: "UNKNOWN", title: "not hashed" });
+
+		const payload = { goalId: "goal-hash", number: 9, state: "CLOSED", mergeability: "UNKNOWN" };
+		const expected = createHash("sha256").update(JSON.stringify(payload)).digest("hex");
+		expect(fact).toEqual({ goalId: "goal-hash", revision: expected, payload });
+		expect(fact?.revision).toMatch(/^[a-f0-9]{64}$/);
+	});
+
+	it("fails PR persistence loudly without changing cache or publishing a fact", () => {
+		const fs = createMemFs();
+		const stateDir = path.resolve("/memfs/host-pr-failure");
+		const storeFile = path.join(stateDir, "pr-status-cache.json");
+		const store = new PrStatusStore(stateDir, fs);
+		store.set("goal-1", { state: "OPEN" });
+		const beforeBytes = text(fs, storeFile);
+		const facts: PrStatusChangedFact[] = [];
+		store.onPullRequestStatusChanged = fact => facts.push(fact);
+		const originalRename = fs.renameSync.bind(fs);
+		(fs as any).renameSync = (from: string, to: string) => {
+			if (to === storeFile) throw new Error("PR_PERSISTENCE_SECRET");
+			return originalRename(from, to);
+		};
+
+		expect(() => store.set("goal-1", { state: "MERGED" })).toThrow(PrStatusPersistenceError);
+		expect(store.get("goal-1")).toEqual({ state: "OPEN" });
+		expect(text(fs, storeFile)).toBe(beforeBytes);
+		expect(facts).toEqual([]);
+		expect([...fs.files.keys()].filter(file => siblingTemp(storeFile, file))).toEqual([]);
+	});
+
+	it("publishes sorted setting identifiers and the exact committed-byte hash after rename", () => {
+		const fs = createMemFs();
+		const configDir = path.resolve("/memfs/host-settings-facts");
+		const configFile = path.join(configDir, "project.yaml");
+		const store = new ProjectConfigStore(configDir, fs);
+		const facts: ProjectSettingsChangedFact[] = [];
+		let committed = false;
+		const originalRename = fs.renameSync.bind(fs);
+		(fs as any).renameSync = (from: string, to: string) => {
+			originalRename(from, to);
+			if (to === configFile) committed = true;
+		};
+		store.onSettingsChanged = fact => {
+			expect(committed).toBe(true);
+			facts.push(fact);
+		};
+
+		store.mutate(draft => {
+			draft.set("test_command", "SETTINGS_VALUE_SECRET");
+			draft.set("build_command", "BUILD_VALUE_SECRET");
+			draft.setSandboxTokens([{ key: "DEPLOY_TOKEN", enabled: true, value: "TOKEN_VALUE_SECRET" }]);
+		});
+
+		const committedBytes = text(fs, configFile);
+		expect(facts).toEqual([{
+			revision: createHash("sha256").update(committedBytes).digest("hex"),
+			payload: {
+				target: "project",
+				changedKeys: ["build_command", "sandbox_tokens", "test_command"],
+			},
+		}]);
+		expect(JSON.stringify(facts)).not.toMatch(/SETTINGS_VALUE_SECRET|BUILD_VALUE_SECRET|TOKEN_VALUE_SECRET/);
+		expect(committedBytes).not.toContain("TOKEN_VALUE_SECRET");
+	});
+
+	it("suppresses settings no-ops and changes to non-durable secret values", () => {
+		const fs = createMemFs();
+		const store = new ProjectConfigStore(path.resolve("/memfs/host-settings-noop"), fs);
+		const facts: ProjectSettingsChangedFact[] = [];
+		store.onSettingsChanged = fact => facts.push(fact);
+		store.set("build_command", "npm run build");
+		store.setSandboxTokens([{ key: "DEPLOY_TOKEN", enabled: true, value: "first secret" }]);
+		expect(facts).toHaveLength(2);
+
+		store.set("build_command", "npm run build");
+		store.setSandboxTokens([{ key: "DEPLOY_TOKEN", enabled: true, value: "second secret" }]);
+
+		expect(facts).toHaveLength(2);
+	});
+
+	it("does not publish settings when the atomic commit fails", () => {
+		const fs = createMemFs();
+		const configDir = path.resolve("/memfs/host-settings-failure");
+		const configFile = path.join(configDir, "project.yaml");
+		const store = new ProjectConfigStore(configDir, fs);
+		store.set("build_command", "before");
+		const beforeBytes = text(fs, configFile);
+		const facts: ProjectSettingsChangedFact[] = [];
+		store.onSettingsChanged = fact => facts.push(fact);
+		const originalRename = fs.renameSync.bind(fs);
+		(fs as any).renameSync = (from: string, to: string) => {
+			if (to === configFile) throw new Error("SETTINGS_PERSISTENCE_SECRET");
+			return originalRename(from, to);
+		};
+
+		expect(() => store.set("build_command", "after")).toThrow(ProjectConfigPersistenceError);
+		expect(store.get("build_command")).toBe("before");
+		expect(text(fs, configFile)).toBe(beforeBytes);
+		expect(facts).toEqual([]);
+		expect([...fs.files.keys()].filter(file => siblingTemp(configFile, file))).toEqual([]);
+	});
+
+	it("isolates post-commit observer failures from both authoritative stores", () => {
+		const fs = createMemFs();
+		const prStore = new PrStatusStore(path.resolve("/memfs/host-pr-observer-failure"), fs);
+		const configStore = new ProjectConfigStore(path.resolve("/memfs/host-settings-observer-failure"), fs);
+		prStore.onPullRequestStatusChanged = () => { throw new Error("observer failed"); };
+		configStore.onSettingsChanged = () => { throw new Error("observer failed"); };
+
+		expect(() => prStore.set("goal-1", { state: "OPEN" })).not.toThrow();
+		expect(() => configStore.set("build_command", "npm run committed")).not.toThrow();
+		expect(prStore.get("goal-1")).toEqual({ state: "OPEN" });
+		expect(configStore.get("build_command")).toBe("npm run committed");
+	});
+});

--- a/tests2/core/host-session-notifications.test.ts
+++ b/tests2/core/host-session-notifications.test.ts
@@ -18,6 +18,13 @@ const { HostNotificationDispatcher } = await import("../../src/server/extension-
 
 const managers: any[] = [];
 
+function deferred<T = void>() {
+	let resolve!: (value: T | PromiseLike<T>) => void;
+	let reject!: (reason?: unknown) => void;
+	const promise = new Promise<T>((res, rej) => { resolve = res; reject = rej; });
+	return { promise, resolve, reject };
+}
+
 afterEach(() => {
 	for (const manager of managers.splice(0)) {
 		if (manager._statusHeartbeatTimer) clearInterval(manager._statusHeartbeatTimer);
@@ -70,6 +77,38 @@ function makeHarness() {
 }
 
 describe("authoritative session host notifications", () => {
+	it("fences session creation listeners on successful initial persistence", async () => {
+		const manager: any = new SessionManager();
+		managers.push(manager);
+		const publication = deferred<void>();
+		const calls: string[] = [];
+		manager.addCreationListener((session: any) => calls.push(session.id));
+		const session = { id: "created-after-commit" } as any;
+		const notifying = manager.notifySessionCreated(session, {
+			flushAsync: () => publication.promise,
+		} as any);
+
+		await Promise.resolve();
+		assert.deepEqual(calls, [], "listeners must remain silent before the store barrier settles");
+		publication.resolve();
+		await notifying;
+		assert.deepEqual(calls, [session.id]);
+	});
+
+	it("keeps session creation listeners silent when initial persistence fails", async () => {
+		const manager: any = new SessionManager();
+		managers.push(manager);
+		const calls: string[] = [];
+		manager.addCreationListener((session: any) => calls.push(session.id));
+		await assert.rejects(
+			manager.notifySessionCreated({ id: "failed-creation" } as any, {
+				flushAsync: async () => { throw new Error("injected initial persistence failure"); },
+			} as any),
+			/injected initial persistence failure/,
+		);
+		assert.deepEqual(calls, []);
+	});
+
 	it("publishes status only after the legacy frame and suppresses unchanged status", () => {
 		const { session, facts, sent } = makeHarness();
 		broadcastStatus(session, "streaming", { streamingStartedAt: 10 });
@@ -118,10 +157,15 @@ describe("authoritative session host notifications", () => {
 		assert.equal(JSON.stringify(facts).includes("PRIVATE_PROVIDER_BODY"), false);
 	});
 
-	it("fences tool completion on accepted tool-result message metadata", () => {
+	it("publishes tool lifecycle facts without an installed interceptor and fences completion on the accepted result", () => {
 		const { manager, session, facts, dispatcher } = makeHarness();
+		assert.equal(manager.hostInterceptors, undefined, "precondition: lifecycle observation is not interceptor-gated");
 		manager.handleAgentLifecycle(session, { type: "agent_start" });
+		assert.equal(manager.dispatchHostInterceptor(session.id, "beforeToolCall", {
+			toolCallId: "call-1", toolName: "read", args: {},
+		}), undefined);
 		manager.markToolCallAdmitted(session.id, "call-1", "read");
+		assert.equal(facts.filter((fact) => fact.name === "toolCallStarted").length, 1);
 		manager.handleAgentLifecycle(session, {
 			type: "tool_execution_end",
 			toolCallId: "call-1",
@@ -144,6 +188,8 @@ describe("authoritative session host notifications", () => {
 		});
 
 		assert.deepEqual(facts.slice(-2).map((fact) => fact.name), ["messageAppended", "toolCallCompleted"]);
+		assert.equal(facts.filter((fact) => fact.name === "toolCallStarted").length, 1);
+		assert.equal(facts.filter((fact) => fact.name === "toolCallCompleted").length, 1);
 		assert.deepEqual(facts.at(-1)?.publication.payload, {
 			toolCallId: "call-1",
 			toolName: "read",

--- a/tests2/core/host-session-notifications.test.ts
+++ b/tests2/core/host-session-notifications.test.ts
@@ -14,6 +14,7 @@ const { SessionManager, emitSessionEvent } = await import("../../src/server/agen
 const { broadcastStatus } = await import("../../src/server/agent/session-status.ts");
 const { PromptQueue } = await import("../../src/server/agent/prompt-queue.ts");
 const { EventBuffer } = await import("../../src/server/agent/event-buffer.ts");
+const { HostNotificationDispatcher } = await import("../../src/server/extension-host/host-notification-dispatcher.ts");
 
 const managers: any[] = [];
 
@@ -27,9 +28,14 @@ afterEach(() => {
 function makeHarness() {
 	const facts: Array<{ name: string; publication: any; frameCount: number }> = [];
 	const sent: any[] = [];
+	const dispatcher = new HostNotificationDispatcher({
+		resolveSessionProject: (sessionId) => sessionId === "session-a" ? "project-a" : undefined,
+	});
 	const publisher = {
 		publish(name: string, publication: any) {
-			facts.push({ name, publication, frameCount: sent.length });
+			const validated = dispatcher.publish(name as any, publication);
+			if (validated) facts.push({ name, publication: validated, frameCount: sent.length });
+			return validated;
 		},
 	};
 	const manager: any = new SessionManager({ hostNotificationPublisher: publisher });
@@ -60,7 +66,7 @@ function makeHarness() {
 	};
 	manager.sessions.set(session.id, session);
 	manager.setHostNotificationPublisher(publisher);
-	return { manager, session, facts, sent };
+	return { manager, session, facts, sent, dispatcher };
 }
 
 describe("authoritative session host notifications", () => {
@@ -113,7 +119,7 @@ describe("authoritative session host notifications", () => {
 	});
 
 	it("fences tool completion on accepted tool-result message metadata", () => {
-		const { manager, session, facts } = makeHarness();
+		const { manager, session, facts, dispatcher } = makeHarness();
 		manager.handleAgentLifecycle(session, { type: "agent_start" });
 		manager.markToolCallAdmitted(session.id, "call-1", "read");
 		manager.handleAgentLifecycle(session, {
@@ -141,11 +147,12 @@ describe("authoritative session host notifications", () => {
 		assert.deepEqual(facts.at(-1)?.publication.payload, {
 			toolCallId: "call-1",
 			toolName: "read",
-			status: "failed",
+			status: "errored",
 			durationMs: facts.at(-1)?.publication.payload.durationMs,
-			errorStatus: "tool_error",
+			errorStatus: "handler_error",
 		});
 		assert.equal(JSON.stringify(facts).includes("PRIVATE_TOOL_BODY"), false);
+		assert.deepEqual(dispatcher.getDiagnostics(), [], "session facts must satisfy the canonical dispatcher schema");
 		assert.equal(session.hostToolCallLifecycle.size, 0);
 	});
 });

--- a/tests2/core/host-session-notifications.test.ts
+++ b/tests2/core/host-session-notifications.test.ts
@@ -33,6 +33,12 @@ afterEach(() => {
 	}
 });
 
+function acceptToolStart(manager: any, session: any, toolCallId: string, toolName: string): void {
+	const start = { type: "tool_execution_start", toolCallId, toolName };
+	manager.handleAgentLifecycle(session, start);
+	emitSessionEvent(session, start);
+}
+
 function makeHarness() {
 	const facts: Array<{ name: string; publication: any; frameCount: number }> = [];
 	const sent: any[] = [];
@@ -175,15 +181,25 @@ describe("authoritative session host notifications", () => {
 		assert.equal(JSON.stringify(facts).includes("PRIVATE_PROVIDER_BODY"), false);
 	});
 
-	it("publishes tool lifecycle facts without an installed interceptor and fences completion on the accepted result", () => {
+	it("publishes one private-safe tool completion only after an accepted Pi start, both policy claims, and the persisted result", async () => {
 		const { manager, session, facts, dispatcher } = makeHarness();
 		assert.equal(manager.hostInterceptors, undefined, "precondition: lifecycle observation is not interceptor-gated");
 		manager.handleAgentLifecycle(session, { type: "agent_start" });
-		assert.equal(manager.dispatchHostInterceptor(session.id, "beforeToolCall", {
-			toolCallId: "call-1", toolName: "read", args: {},
-		}), undefined);
-		manager.markToolCallAdmitted(session.id, "call-1", "read");
+		acceptToolStart(manager, session, "call-1", "read");
+
+		const beforeClaim = await manager.claimToolCallBefore(session.id, "call-1", "read");
+		assert.ok(beforeClaim, "the exact accepted Pi start must mint one before-call claim");
+		assert.equal(manager.dispatchClaimedToolInterceptor(beforeClaim, { args: {} }), undefined);
+		assert.equal(manager.settleToolCallBefore(beforeClaim, true), true);
+		assert.equal(manager.settleToolCallBefore(beforeClaim, true), false, "a settled claim cannot be replayed");
 		assert.equal(facts.filter((fact) => fact.name === "toolCallStarted").length, 1);
+
+		const afterClaim = manager.claimToolCallAfter(session.id, "call-1", "read");
+		assert.ok(afterClaim, "only the admitted exact call can enter after-result policy");
+		assert.equal(manager.dispatchClaimedToolInterceptor(afterClaim, { result: { isError: true } }), undefined);
+		assert.equal(manager.settleToolCallAfter(afterClaim), true);
+		assert.equal(manager.claimToolCallAfter(session.id, "call-1", "read"), undefined, "after-result admission is single-use");
+
 		manager.handleAgentLifecycle(session, {
 			type: "tool_execution_end",
 			toolCallId: "call-1",
@@ -193,7 +209,7 @@ describe("authoritative session host notifications", () => {
 		});
 		assert.equal(facts.filter((fact) => fact.name === "toolCallCompleted").length, 0);
 
-		emitSessionEvent(session, {
+		const persistedResult = {
 			type: "message_end",
 			message: {
 				id: "result-message",
@@ -203,20 +219,61 @@ describe("authoritative session host notifications", () => {
 				isError: true,
 				content: [{ type: "text", text: "PRIVATE_TOOL_BODY" }],
 			},
-		});
+		};
+		emitSessionEvent(session, persistedResult);
+		emitSessionEvent(session, persistedResult);
 
-		assert.deepEqual(facts.slice(-2).map((fact) => fact.name), ["messageAppended", "toolCallCompleted"]);
+		assert.deepEqual(facts.slice(-3).map((fact) => fact.name), ["messageAppended", "toolCallCompleted", "messageAppended"]);
 		assert.equal(facts.filter((fact) => fact.name === "toolCallStarted").length, 1);
 		assert.equal(facts.filter((fact) => fact.name === "toolCallCompleted").length, 1);
-		assert.deepEqual(facts.at(-1)?.publication.payload, {
+		const completion = facts.find((fact) => fact.name === "toolCallCompleted")!;
+		assert.deepEqual(completion.publication.payload, {
 			toolCallId: "call-1",
 			toolName: "read",
 			status: "errored",
-			durationMs: facts.at(-1)?.publication.payload.durationMs,
+			durationMs: completion.publication.payload.durationMs,
 			errorStatus: "handler_error",
 		});
 		assert.equal(JSON.stringify(facts).includes("PRIVATE_TOOL_BODY"), false);
 		assert.deepEqual(dispatcher.getDiagnostics(), [], "session facts must satisfy the canonical dispatcher schema");
 		assert.equal(session.hostToolCallLifecycle.size, 0);
+	});
+
+	it("rejects forged, mismatched, duplicate, stale-generation, and terminal callbacks before facts are published", async () => {
+		const forged = makeHarness();
+		const forgedClaim = forged.manager.claimToolCallBefore(forged.session.id, "forged-call", "read");
+		await new Promise((resolve) => setTimeout(resolve, 110));
+		assert.equal(await forgedClaim, undefined, "a callback cannot create its own Pi provenance");
+		assert.equal(forged.session.hostToolCallLifecycle, undefined);
+		assert.equal(forged.facts.some((fact) => fact.name.startsWith("toolCall")), false);
+
+		const preArrival = makeHarness();
+		const waitingClaim = preArrival.manager.claimToolCallBefore(preArrival.session.id, "racing-call", "read");
+		acceptToolStart(preArrival.manager, preArrival.session, "racing-call", "read");
+		const claimedAfterAcceptance = await waitingClaim;
+		assert.ok(claimedAfterAcceptance, "HTTP may arrive first only while waiting for the real accepted Pi cursor");
+		assert.equal(preArrival.manager.settleToolCallBefore(claimedAfterAcceptance, true), true);
+		assert.equal(await preArrival.manager.claimToolCallBefore(preArrival.session.id, "racing-call", "read"), undefined);
+		assert.equal(preArrival.manager.claimToolCallAfter(preArrival.session.id, "racing-call", "other-tool"), undefined);
+		assert.equal(preArrival.facts.filter((fact) => fact.name === "toolCallStarted").length, 1);
+
+		const stale = makeHarness();
+		acceptToolStart(stale.manager, stale.session, "stale-call", "read");
+		const staleClaim = await stale.manager.claimToolCallBefore(stale.session.id, "stale-call", "read");
+		assert.ok(staleClaim);
+		stale.manager._sessionRespawnGenerations.set(stale.session.id, 1);
+		assert.equal(stale.manager.settleToolCallBefore(staleClaim, true), false, "generation replacement invalidates an in-flight claim");
+		assert.equal(await stale.manager.claimToolCallBefore(stale.session.id, "stale-call", "read"), undefined);
+		assert.equal(stale.facts.some((fact) => fact.name.startsWith("toolCall")), false);
+
+		const terminal = makeHarness();
+		acceptToolStart(terminal.manager, terminal.session, "terminal-call", "read");
+		const terminalClaim = await terminal.manager.claimToolCallBefore(terminal.session.id, "terminal-call", "read");
+		assert.ok(terminalClaim);
+		assert.equal(terminal.manager.settleToolCallBefore(terminalClaim, true), true);
+		terminal.manager.handleAgentLifecycle(terminal.session, { type: "agent_end", willRetry: false, messages: [] });
+		assert.equal(terminal.session.hostToolCallLifecycle.size, 0, "terminal turn cleanup removes admitted provenance");
+		assert.equal(terminal.manager.claimToolCallAfter(terminal.session.id, "terminal-call", "read"), undefined);
+		assert.equal(terminal.facts.filter((fact) => fact.name === "toolCallCompleted").length, 0);
 	});
 });

--- a/tests2/core/host-session-notifications.test.ts
+++ b/tests2/core/host-session-notifications.test.ts
@@ -11,6 +11,7 @@ const root = fs.mkdtempSync(path.join(os.tmpdir(), "host-session-notifications-"
 process.env.BOBBIT_DIR = root;
 
 const { SessionManager, emitSessionEvent } = await import("../../src/server/agent/session-manager.ts");
+const { SessionStore } = await import("../../src/server/agent/session-store.ts");
 const { broadcastStatus } = await import("../../src/server/agent/session-status.ts");
 const { PromptQueue } = await import("../../src/server/agent/prompt-queue.ts");
 const { EventBuffer } = await import("../../src/server/agent/event-buffer.ts");
@@ -95,18 +96,35 @@ describe("authoritative session host notifications", () => {
 		assert.deepEqual(calls, [session.id]);
 	});
 
-	it("keeps session creation listeners silent when initial persistence fails", async () => {
+	it("treats a synchronous injected recording store as an already-committed seam", async () => {
 		const manager: any = new SessionManager();
 		managers.push(manager);
 		const calls: string[] = [];
 		manager.addCreationListener((session: any) => calls.push(session.id));
-		await assert.rejects(
-			manager.notifySessionCreated({ id: "failed-creation" } as any, {
-				flushAsync: async () => { throw new Error("injected initial persistence failure"); },
-			} as any),
-			/injected initial persistence failure/,
-		);
-		assert.deepEqual(calls, []);
+		await manager.notifySessionCreated({ id: "sync-fixture-creation" } as any, {
+			put: () => {},
+			update: () => {},
+		} as any);
+		assert.deepEqual(calls, ["sync-fixture-creation"]);
+	});
+
+	it("keeps session creation listeners silent when a real store's atomic flush fails", async () => {
+		const manager: any = new SessionManager();
+		managers.push(manager);
+		const calls: string[] = [];
+		manager.addCreationListener((session: any) => calls.push(session.id));
+		const store = manager._testStore;
+		assert.ok(store instanceof SessionStore, "fixture must exercise the production SessionStore fence");
+		const flush = vi.spyOn(store, "flushAsync").mockRejectedValueOnce(new Error("injected initial persistence failure"));
+		try {
+			await assert.rejects(
+				manager.notifySessionCreated({ id: "failed-creation" } as any, store),
+				/injected initial persistence failure/,
+			);
+			assert.deepEqual(calls, []);
+		} finally {
+			flush.mockRestore();
+		}
 	});
 
 	it("publishes status only after the legacy frame and suppresses unchanged status", () => {

--- a/tests2/core/host-session-notifications.test.ts
+++ b/tests2/core/host-session-notifications.test.ts
@@ -1,0 +1,151 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, it, vi } from "vitest";
+
+import { guardProcessEnv } from "./helpers/env-guard.js";
+
+guardProcessEnv();
+const root = fs.mkdtempSync(path.join(os.tmpdir(), "host-session-notifications-"));
+process.env.BOBBIT_DIR = root;
+
+const { SessionManager, emitSessionEvent } = await import("../../src/server/agent/session-manager.ts");
+const { broadcastStatus } = await import("../../src/server/agent/session-status.ts");
+const { PromptQueue } = await import("../../src/server/agent/prompt-queue.ts");
+const { EventBuffer } = await import("../../src/server/agent/event-buffer.ts");
+
+const managers: any[] = [];
+
+afterEach(() => {
+	for (const manager of managers.splice(0)) {
+		if (manager._statusHeartbeatTimer) clearInterval(manager._statusHeartbeatTimer);
+		manager.sessions.clear();
+	}
+});
+
+function makeHarness() {
+	const facts: Array<{ name: string; publication: any; frameCount: number }> = [];
+	const sent: any[] = [];
+	const publisher = {
+		publish(name: string, publication: any) {
+			facts.push({ name, publication, frameCount: sent.length });
+		},
+	};
+	const manager: any = new SessionManager({ hostNotificationPublisher: publisher });
+	managers.push(manager);
+	manager._testStore = { update: vi.fn(), get: vi.fn(() => undefined) };
+	const client = {
+		readyState: 1,
+		bufferedAmount: 0,
+		send(data: string) { sent.push(JSON.parse(data)); },
+	};
+	const session: any = {
+		id: "session-a",
+		projectId: "project-a",
+		title: "Session A",
+		cwd: root,
+		status: "idle",
+		statusVersion: 0,
+		createdAt: Date.now(),
+		lastActivity: Date.now(),
+		clients: new Set([client]),
+		rpcClient: { prompt: vi.fn(), getState: vi.fn(async () => ({ success: true, data: {} })) },
+		eventBuffer: new EventBuffer(),
+		promptQueue: new PromptQueue(),
+		unsubscribe: () => {},
+		isCompacting: false,
+		setupComplete: true,
+		lastPromptSource: "user",
+	};
+	manager.sessions.set(session.id, session);
+	manager.setHostNotificationPublisher(publisher);
+	return { manager, session, facts, sent };
+}
+
+describe("authoritative session host notifications", () => {
+	it("publishes status only after the legacy frame and suppresses unchanged status", () => {
+		const { session, facts, sent } = makeHarness();
+		broadcastStatus(session, "streaming", { streamingStartedAt: 10 });
+
+		assert.equal(sent.length, 1);
+		assert.deepEqual(facts.map((fact) => fact.name), ["statusChanged", "sessionStatusChanged"]);
+		assert.ok(facts.every((fact) => fact.frameCount === 1), "fact must follow legacy frame queueing");
+		assert.deepEqual(facts[0].publication.payload, {
+			previousStatus: "idle",
+			status: "streaming",
+			statusVersion: 1,
+		});
+
+		broadcastStatus(session, "streaming", { streamingStartedAt: 10 });
+		assert.equal(sent.length, 2, "legacy same-status compatibility frame remains");
+		assert.equal(facts.length, 2, "same-status write is not a committed transition fact");
+	});
+
+	it("reuses final-turn fences and reports explicit success, error, and abort outcomes once", () => {
+		const { manager, session, facts } = makeHarness();
+		manager.handleAgentLifecycle(session, { type: "agent_start" });
+		manager.handleAgentLifecycle(session, { type: "agent_start" });
+		manager.handleAgentLifecycle(session, { type: "agent_end", willRetry: true, messages: [] });
+		assert.equal(facts.filter((fact) => fact.name === "turnStarted").length, 1);
+		assert.equal(facts.filter((fact) => fact.name === "turnCompleted").length, 0);
+
+		manager.handleAgentLifecycle(session, { type: "agent_end", willRetry: false, messages: [] });
+		manager.handleAgentLifecycle(session, { type: "agent_end", willRetry: false, messages: [] });
+		const completed = facts.filter((fact) => fact.name === "turnCompleted");
+		assert.equal(completed.length, 1);
+		assert.equal(completed[0].publication.payload.outcome, "succeeded");
+		assert.equal(session.completedTurnCount, 1);
+
+		manager.handleAgentLifecycle(session, { type: "agent_start" });
+		manager.handleAgentLifecycle(session, {
+			type: "message_end",
+			message: { id: "assistant-error", role: "assistant", stopReason: "error", errorMessage: "PRIVATE_PROVIDER_BODY" },
+		});
+		manager.handleAgentLifecycle(session, { type: "agent_end", willRetry: false, messages: [] });
+		assert.equal(facts.filter((fact) => fact.name === "turnCompleted").at(-1)?.publication.payload.outcome, "errored");
+
+		manager.handleAgentLifecycle(session, { type: "agent_start" });
+		broadcastStatus(session, "aborting");
+		manager.handleAgentLifecycle(session, { type: "agent_end", willRetry: false, messages: [] });
+		assert.equal(facts.filter((fact) => fact.name === "turnCompleted").at(-1)?.publication.payload.outcome, "aborted");
+		assert.equal(JSON.stringify(facts).includes("PRIVATE_PROVIDER_BODY"), false);
+	});
+
+	it("fences tool completion on accepted tool-result message metadata", () => {
+		const { manager, session, facts } = makeHarness();
+		manager.handleAgentLifecycle(session, { type: "agent_start" });
+		manager.markToolCallAdmitted(session.id, "call-1", "read");
+		manager.handleAgentLifecycle(session, {
+			type: "tool_execution_end",
+			toolCallId: "call-1",
+			toolName: "read",
+			isError: true,
+			result: { content: [{ type: "text", text: "PRIVATE_TOOL_BODY" }] },
+		});
+		assert.equal(facts.filter((fact) => fact.name === "toolCallCompleted").length, 0);
+
+		emitSessionEvent(session, {
+			type: "message_end",
+			message: {
+				id: "result-message",
+				role: "toolResult",
+				toolCallId: "call-1",
+				toolName: "read",
+				isError: true,
+				content: [{ type: "text", text: "PRIVATE_TOOL_BODY" }],
+			},
+		});
+
+		assert.deepEqual(facts.slice(-2).map((fact) => fact.name), ["messageAppended", "toolCallCompleted"]);
+		assert.deepEqual(facts.at(-1)?.publication.payload, {
+			toolCallId: "call-1",
+			toolName: "read",
+			status: "failed",
+			durationMs: facts.at(-1)?.publication.payload.durationMs,
+			errorStatus: "tool_error",
+		});
+		assert.equal(JSON.stringify(facts).includes("PRIVATE_TOOL_BODY"), false);
+		assert.equal(session.hostToolCallLifecycle.size, 0);
+	});
+});

--- a/tests2/core/host-task-gate-notifications.test.ts
+++ b/tests2/core/host-task-gate-notifications.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, it, vi } from "vitest";
+import path from "node:path";
+import { GateStore, type GateStatusCommit } from "../../src/server/agent/gate-store.js";
+import { TaskManager } from "../../src/server/agent/task-manager.js";
+import {
+	TaskStore,
+	type PersistedTask,
+	type TaskCommittedFact,
+} from "../../src/server/agent/task-store.js";
+import type { Workflow } from "../../src/server/agent/workflow-store.js";
+import { createMemFs } from "../harness/mem-fs.js";
+
+function workflow(): Workflow {
+	return {
+		id: "workflow",
+		name: "Workflow",
+		description: "",
+		createdAt: 0,
+		updatedAt: 0,
+		gates: [
+			{ id: "root", name: "Root", dependsOn: [] },
+			{ id: "child", name: "Child", dependsOn: ["root"] },
+		],
+	};
+}
+
+describe("task committed facts", () => {
+	it("publishes bounded facts after persistence, suppresses no-ops, and reports automatic parent transitions", async () => {
+		const memfs = createMemFs();
+		const stateDir = path.resolve("/memfs/host-task-facts");
+		memfs.mkdirSync(stateDir, { recursive: true });
+		const store = new TaskStore(stateDir, memfs, { persistence: "json" });
+		const manager = new TaskManager(store);
+		const facts: TaskCommittedFact[] = [];
+		store.onCommittedFact = fact => facts.push(fact as TaskCommittedFact);
+
+		const parent = manager.createTask("goal-1", "Parent", "implementation");
+		const child = manager.createTask("goal-1", "Child", "testing", { parentTaskId: parent.id });
+		expect(facts).toEqual([]);
+		await store.flush();
+		expect(facts.map(fact => fact.kind)).toEqual(["taskCreated", "taskCreated"]);
+
+		facts.length = 0;
+		const parentRevisionBefore = parent.updatedAt;
+		const childRevisionBefore = child.updatedAt;
+		expect(manager.updateTask(parent.id, { title: parent.title, state: parent.state })).toBe(true);
+		expect(parent.updatedAt).toBe(parentRevisionBefore);
+		manager.assignTask(child.id, "session-1");
+		expect(facts).toEqual([]);
+		await store.flush();
+
+		expect(facts).toEqual([
+			expect.objectContaining({
+				kind: "taskUpdated", taskId: child.id, goalId: "goal-1",
+				state: "in-progress", changedFields: ["assignedSessionId"],
+			}),
+			expect.objectContaining({
+				kind: "taskStateChanged", taskId: child.id, previousState: "todo", state: "in-progress",
+			}),
+			expect.objectContaining({
+				kind: "taskStateChanged", taskId: parent.id, previousState: "todo", state: "in-progress",
+			}),
+		]);
+		expect(child.updatedAt).toBeGreaterThan(childRevisionBefore);
+		expect(parent.updatedAt).toBeGreaterThan(parentRevisionBefore);
+		expect(facts.every(fact => fact.revision === (fact.taskId === child.id ? child.updatedAt : parent.updatedAt))).toBe(true);
+
+		facts.length = 0;
+		manager.assignTask(child.id, "session-1");
+		await store.flush();
+		expect(facts).toEqual([]);
+	});
+
+	it("does not report a fact when the strict publication fails", async () => {
+		const memfs = createMemFs();
+		const stateDir = path.resolve("/memfs/host-task-fact-failure");
+		memfs.mkdirSync(stateDir, { recursive: true });
+		const store = new TaskStore(stateDir, memfs, { persistence: "json" });
+		const facts: TaskCommittedFact[] = [];
+		store.onCommittedFact = fact => facts.push(fact as TaskCommittedFact);
+		const task: PersistedTask = {
+			id: "task-1", goalId: "goal-1", title: "Task", type: "testing", state: "todo",
+			createdAt: 1, updatedAt: 1,
+		};
+		const originalRename = memfs.promises.rename.bind(memfs.promises);
+		(memfs.promises as typeof memfs.promises & { rename: typeof memfs.promises.rename }).rename = vi.fn(async () => {
+			throw new Error("TASK_FACT_PERSISTENCE_FAILED");
+		});
+		const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+		await expect(store.putCommitted(task, [{
+			kind: "taskCreated", taskId: task.id, goalId: task.goalId,
+			type: task.type, state: task.state, revision: task.updatedAt,
+		}])).rejects.toThrow("TASK_FACT_PERSISTENCE_FAILED");
+		expect(facts).toEqual([]);
+		expect(errorSpy).toHaveBeenCalled();
+		errorSpy.mockRestore();
+		(memfs.promises as typeof memfs.promises & { rename: typeof memfs.promises.rename }).rename = originalRename;
+	});
+});
+
+describe("gate committed status facts", () => {
+	it("centralizes real persisted transitions with a stable monotonic revision", async () => {
+		const memfs = createMemFs();
+		const stateDir = path.resolve("/memfs/host-gate-facts");
+		memfs.mkdirSync(stateDir, { recursive: true });
+		const store = new GateStore(stateDir, memfs, { persistence: "json" });
+		const commits: GateStatusCommit[] = [];
+		store.onStatusCommitted = commit => commits.push(commit as GateStatusCommit);
+		store.initGatesForGoal("goal-1", ["root", "child"]);
+		await store.flush();
+
+		store.recordSignal({
+			id: "signal-1", gateId: "root", goalId: "goal-1", sessionId: "session-1",
+			timestamp: 1, commitSha: "abc", verification: { status: "running", steps: [] },
+		});
+		store.updateGateStatus("goal-1", "root", "passed");
+		expect(commits).toEqual([]);
+		await store.flush();
+		expect(commits).toEqual([{
+			goalId: "goal-1", gateId: "root", previousStatus: "pending", status: "passed", revision: 1,
+		}]);
+
+		store.updateGateStatus("goal-1", "root", "passed");
+		await store.flush();
+		expect(commits).toHaveLength(1);
+
+		store.updateGateStatus("goal-1", "child", "passed");
+		await store.flush();
+		store.cascadeReset("goal-1", "root", workflow());
+		await store.flush();
+		expect(commits.at(-1)).toEqual({
+			goalId: "goal-1", gateId: "child", previousStatus: "passed", status: "pending", revision: 2,
+		});
+
+		store.bypassGate("goal-1", "root", { whyBypassed: "approved", whoAmI: "reviewer" });
+		await store.flush();
+		expect(commits.at(-1)).toEqual({
+			goalId: "goal-1", gateId: "root", previousStatus: "passed", status: "bypassed", revision: 2,
+		});
+
+		store.reconcileGatesForGoal("goal-1", ["root", "child"], ["root"]);
+		await store.flush();
+		expect(commits.at(-1)).toEqual({
+			goalId: "goal-1", gateId: "root", previousStatus: "bypassed", status: "pending", revision: 3,
+		});
+
+		const reopened = new GateStore(stateDir, memfs, { persistence: "json" });
+		expect(reopened.getGate("goal-1", "root")?.statusRevision).toBe(3);
+		expect(reopened.getGate("goal-1", "child")?.statusRevision).toBe(2);
+	});
+
+	it("holds restored in-memory reset facts until the strict recovery fence commits", async () => {
+		const memfs = createMemFs();
+		const stateDir = path.resolve("/memfs/host-gate-reset-facts");
+		memfs.mkdirSync(stateDir, { recursive: true });
+		const store = new GateStore(stateDir, memfs, { persistence: "json" });
+		const commits: GateStatusCommit[] = [];
+		store.onStatusCommitted = commit => commits.push(commit as GateStatusCommit);
+		store.initGatesForGoal("goal-1", ["root", "child"]);
+		store.updateGateStatus("goal-1", "root", "passed");
+		store.updateGateStatus("goal-1", "child", "passed");
+		await store.flush();
+		commits.length = 0;
+
+		await store.resetGateAndDependentsInMemory("goal-1", "root", workflow());
+		expect(commits).toEqual([]);
+		await store.resetGateAndDependentsStrict("goal-1", "root", workflow());
+		expect(commits).toEqual([
+			{ goalId: "goal-1", gateId: "root", previousStatus: "passed", status: "pending", revision: 2 },
+			{ goalId: "goal-1", gateId: "child", previousStatus: "passed", status: "pending", revision: 2 },
+		]);
+	});
+});

--- a/tests2/core/host-task-gate-notifications.test.ts
+++ b/tests2/core/host-task-gate-notifications.test.ts
@@ -8,7 +8,58 @@ import {
 	type TaskCommittedFact,
 } from "../../src/server/agent/task-store.js";
 import type { Workflow } from "../../src/server/agent/workflow-store.js";
+import { HostNotificationDispatcher } from "../../src/server/extension-host/host-notification-dispatcher.js";
+import type { HostNotification } from "../../src/shared/extension-host/host-hooks.js";
 import { createMemFs } from "../harness/mem-fs.js";
+
+function captureDispatchedTasks(store: TaskStore): {
+	notifications: HostNotification[];
+	dispatcher: HostNotificationDispatcher;
+} {
+	const notifications: HostNotification[] = [];
+	let nextId = 0;
+	const dispatcher = new HostNotificationDispatcher({
+		idGenerator: () => `task-notification-${++nextId}`,
+		now: () => 1_000,
+	});
+	store.onCommittedFact = fact => {
+		const common = {
+			projectId: "project-a",
+			aggregateId: fact.taskId,
+			aggregateRevision: fact.revision,
+		};
+		let notification: HostNotification | undefined;
+		switch (fact.kind) {
+			case "taskCreated":
+				notification = dispatcher.publish("taskCreated", { ...common, payload: {
+					taskId: fact.taskId,
+					goalId: fact.goalId,
+					type: fact.type,
+					state: fact.state,
+					...(fact.parentTaskId ? { parentTaskId: fact.parentTaskId } : {}),
+				} });
+				break;
+			case "taskUpdated":
+				notification = dispatcher.publish("taskUpdated", { ...common, payload: {
+					taskId: fact.taskId,
+					goalId: fact.goalId,
+					state: fact.state,
+					changedFields: fact.changedFields,
+				} });
+				break;
+			case "taskStateChanged":
+				notification = dispatcher.publish("taskStateChanged", { ...common, payload: {
+					taskId: fact.taskId,
+					goalId: fact.goalId,
+					previousState: fact.previousState,
+					state: fact.state,
+				} });
+				break;
+		}
+		if (notification) notifications.push(notification);
+	};
+	return { notifications, dispatcher };
+}
 
 function workflow(): Workflow {
 	return {
@@ -69,6 +120,42 @@ describe("task committed facts", () => {
 		manager.assignTask(child.id, "session-1");
 		await store.flush();
 		expect(facts).toEqual([]);
+	});
+
+	it("omits baseSha and branch while the real dispatcher accepts internal-only task updates", async () => {
+		const memfs = createMemFs();
+		const stateDir = path.resolve("/memfs/host-task-public-projection");
+		memfs.mkdirSync(stateDir, { recursive: true });
+		const store = new TaskStore(stateDir, memfs, { persistence: "json" });
+		const manager = new TaskManager(store);
+		const { notifications, dispatcher } = captureDispatchedTasks(store);
+		const task = manager.createTask("goal-1", "Task", "implementation");
+		await store.flush();
+		notifications.length = 0;
+
+		manager.updateTask(task.id, {
+			title: "Public title",
+			spec: "private task body",
+			baseSha: "private-base-sha",
+			branch: "private-checkout-branch",
+			headSha: "public-head-sha",
+		});
+		await store.flush();
+		manager.updateTask(task.id, {
+			baseSha: "next-private-base-sha",
+			branch: "next-private-checkout-branch",
+		});
+		await store.flush();
+
+		expect(notifications.map(notification => notification.payload)).toEqual([
+			{ taskId: task.id, goalId: "goal-1", state: "todo", changedFields: ["headSha", "spec", "title"] },
+			{ taskId: task.id, goalId: "goal-1", state: "todo", changedFields: [] },
+		]);
+		expect(JSON.stringify(notifications)).not.toContain("baseSha");
+		expect(JSON.stringify(notifications)).not.toContain("branch");
+		expect(JSON.stringify(notifications)).not.toContain("private-checkout");
+		expect(JSON.stringify(notifications)).not.toContain("private task body");
+		expect(dispatcher.getDiagnostics().filter(row => row.code === "invalid_payload")).toEqual([]);
 	});
 
 	it("does not report a fact when the strict publication fails", async () => {

--- a/tests2/core/host-task-gate-notifications.test.ts
+++ b/tests2/core/host-task-gate-notifications.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it, vi } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
+import Database from "better-sqlite3";
 import { GateStore, type GateStatusCommit } from "../../src/server/agent/gate-store.js";
 import { TaskManager } from "../../src/server/agent/task-manager.js";
 import {
@@ -76,6 +79,89 @@ function workflow(): Workflow {
 }
 
 describe("task committed facts", () => {
+	it.each(["json", "sqlite"] as const)("coalesces a create+update burst to the exact %s durable snapshot", async persistence => {
+		const memfs = persistence === "json" ? createMemFs() : undefined;
+		const stateDir = persistence === "json"
+			? path.resolve("/memfs/host-task-create-update-burst")
+			: fs.mkdtempSync(path.join(os.tmpdir(), "bobbit-host-task-burst-"));
+		memfs?.mkdirSync(stateDir, { recursive: true });
+		const store = new TaskStore(stateDir, memfs, { persistence });
+		try {
+			const manager = new TaskManager(store);
+			const facts: TaskCommittedFact[] = [];
+			store.onCommittedFact = fact => facts.push(fact as TaskCommittedFact);
+
+			const task = manager.createTask("goal-1", "Initial", "implementation");
+			manager.updateTask(task.id, { title: "Final", state: "in-progress" });
+			await store.flush();
+
+			const durable = persistence === "json"
+				? (JSON.parse(memfs!.readFileSync(path.join(stateDir, "tasks.json"), "utf-8")) as PersistedTask[]).find(row => row.id === task.id)
+				: (() => {
+					const db = new Database(path.join(stateDir, "tasks.sqlite"), { readonly: true });
+					try {
+						const row = db.prepare("SELECT payload FROM task_records WHERE id = ?").get(task.id) as { payload: string };
+						return JSON.parse(row.payload) as PersistedTask;
+					} finally { db.close(); }
+				})();
+			expect(durable).toMatchObject({ id: task.id, title: "Final", state: "in-progress", updatedAt: task.updatedAt });
+			expect(facts).toEqual([{
+				kind: "taskCreated", taskId: task.id, goalId: "goal-1", type: "implementation",
+				state: "in-progress", parentTaskId: undefined, revision: task.updatedAt,
+			}]);
+		} finally {
+			await store.close();
+			if (persistence === "sqlite") fs.rmSync(stateDir, { recursive: true, force: true });
+		}
+	});
+
+	it.each(["json", "sqlite"] as const)("keeps the %s task baseline behind a failed publication and reports the retry once", async persistence => {
+		const memfs = persistence === "json" ? createMemFs() : undefined;
+		const stateDir = persistence === "json"
+			? path.resolve("/memfs/host-task-failed-retry")
+			: fs.mkdtempSync(path.join(os.tmpdir(), "bobbit-host-task-retry-"));
+		memfs?.mkdirSync(stateDir, { recursive: true });
+		const store = new TaskStore(stateDir, memfs, { persistence });
+		const facts: TaskCommittedFact[] = [];
+		store.onCommittedFact = fact => facts.push(fact as TaskCommittedFact);
+		const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+		let restoreFailure: () => void;
+		if (persistence === "json") {
+			const promises = memfs!.promises;
+			const rename = promises.rename.bind(promises);
+			(promises as typeof promises & { rename: typeof promises.rename }).rename = vi.fn(async () => {
+				throw new Error("TASK_FACT_PERSISTENCE_FAILED");
+			});
+			restoreFailure = () => {
+				(promises as typeof promises & { rename: typeof promises.rename }).rename = rename;
+			};
+		} else {
+			const db = new Database(path.join(stateDir, "tasks.sqlite"));
+			db.exec("CREATE TRIGGER fail_task_fact BEFORE INSERT ON task_records BEGIN SELECT RAISE(ABORT, 'TASK_FACT_PERSISTENCE_FAILED'); END;");
+			db.close();
+			restoreFailure = () => {
+				const retryDb = new Database(path.join(stateDir, "tasks.sqlite"));
+				retryDb.exec("DROP TRIGGER fail_task_fact");
+				retryDb.close();
+			};
+		}
+		try {
+			const manager = new TaskManager(store);
+			const task = manager.createTask("goal-1", "Retry", "testing");
+			await expect(store.flush()).rejects.toThrow("TASK_FACT_PERSISTENCE_FAILED");
+			expect(facts).toEqual([]);
+			restoreFailure();
+			await store.flush();
+			expect(facts).toEqual([expect.objectContaining({
+				kind: "taskCreated", taskId: task.id, state: "todo", revision: task.updatedAt,
+			})]);
+		} finally {
+			errorSpy.mockRestore();
+			await store.close();
+			if (persistence === "sqlite") fs.rmSync(stateDir, { recursive: true, force: true });
+		}
+	});
+
 	it("publishes bounded facts after persistence, suppresses no-ops, and reports automatic parent transitions", async () => {
 		const memfs = createMemFs();
 		const stateDir = path.resolve("/memfs/host-task-facts");
@@ -187,6 +273,92 @@ describe("task committed facts", () => {
 });
 
 describe("gate committed status facts", () => {
+	it.each(["json", "sqlite"] as const)("coalesces a multi-transition burst to the final %s durable delta", async persistence => {
+		const memfs = persistence === "json" ? createMemFs() : undefined;
+		const stateDir = persistence === "json"
+			? path.resolve("/memfs/host-gate-transition-burst")
+			: fs.mkdtempSync(path.join(os.tmpdir(), "bobbit-host-gate-burst-"));
+		memfs?.mkdirSync(stateDir, { recursive: true });
+		const store = new GateStore(stateDir, memfs, { persistence });
+		try {
+			const commits: GateStatusCommit[] = [];
+			store.onStatusCommitted = commit => commits.push(commit as GateStatusCommit);
+			store.initGatesForGoal("goal-1", ["implementation"]);
+			await store.flush();
+
+			store.updateGateStatus("goal-1", "implementation", "passed");
+			store.updateGateStatus("goal-1", "implementation", "failed");
+			await store.flush();
+
+			const durable = persistence === "json"
+				? (JSON.parse(memfs!.readFileSync(path.join(stateDir, "gates.json"), "utf-8")) as Array<{ status: string; statusRevision: number }>)[0]
+				: (() => {
+					const db = new Database(path.join(stateDir, "gates.sqlite"), { readonly: true });
+					try {
+						const row = db.prepare("SELECT payload FROM gate_records WHERE goal_id = ? AND gate_id = ?")
+							.get("goal-1", "implementation") as { payload: string };
+						return JSON.parse(row.payload) as { status: string; statusRevision: number };
+					} finally { db.close(); }
+				})();
+			expect(durable).toMatchObject({ status: "failed", statusRevision: 2 });
+			expect(commits).toEqual([{
+				goalId: "goal-1", gateId: "implementation", previousStatus: "pending", status: "failed", revision: 2,
+			}]);
+		} finally {
+			await store.close();
+			if (persistence === "sqlite") fs.rmSync(stateDir, { recursive: true, force: true });
+		}
+	});
+
+	it.each(["json", "sqlite"] as const)("does not advance the %s gate baseline on failure and reports the retried final delta", async persistence => {
+		const memfs = persistence === "json" ? createMemFs() : undefined;
+		const stateDir = persistence === "json"
+			? path.resolve("/memfs/host-gate-failed-retry")
+			: fs.mkdtempSync(path.join(os.tmpdir(), "bobbit-host-gate-retry-"));
+		memfs?.mkdirSync(stateDir, { recursive: true });
+		const store = new GateStore(stateDir, memfs, { persistence });
+		const commits: GateStatusCommit[] = [];
+		store.onStatusCommitted = commit => commits.push(commit as GateStatusCommit);
+		store.initGatesForGoal("goal-1", ["implementation"]);
+		await store.flush();
+		const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+		let restoreFailure: () => void;
+		if (persistence === "json") {
+			const promises = memfs!.promises;
+			const rename = promises.rename.bind(promises);
+			(promises as typeof promises & { rename: typeof promises.rename }).rename = vi.fn(async () => {
+				throw new Error("GATE_FACT_PERSISTENCE_FAILED");
+			});
+			restoreFailure = () => {
+				(promises as typeof promises & { rename: typeof promises.rename }).rename = rename;
+			};
+		} else {
+			const db = new Database(path.join(stateDir, "gates.sqlite"));
+			db.exec("CREATE TRIGGER fail_gate_fact BEFORE UPDATE ON gate_records BEGIN SELECT RAISE(ABORT, 'GATE_FACT_PERSISTENCE_FAILED'); END;");
+			db.close();
+			restoreFailure = () => {
+				const retryDb = new Database(path.join(stateDir, "gates.sqlite"));
+				retryDb.exec("DROP TRIGGER fail_gate_fact");
+				retryDb.close();
+			};
+		}
+		try {
+			store.updateGateStatus("goal-1", "implementation", "passed");
+			store.updateGateStatus("goal-1", "implementation", "failed");
+			await expect(store.flush()).rejects.toThrow("GATE_FACT_PERSISTENCE_FAILED");
+			expect(commits).toEqual([]);
+			restoreFailure();
+			await store.flush();
+			expect(commits).toEqual([{
+				goalId: "goal-1", gateId: "implementation", previousStatus: "pending", status: "failed", revision: 2,
+			}]);
+		} finally {
+			errorSpy.mockRestore();
+			await store.close();
+			if (persistence === "sqlite") fs.rmSync(stateDir, { recursive: true, force: true });
+		}
+	});
+
 	it("centralizes real persisted transitions with a stable monotonic revision", async () => {
 		const memfs = createMemFs();
 		const stateDir = path.resolve("/memfs/host-gate-facts");

--- a/tests2/core/host-tool-interceptor-order.test.ts
+++ b/tests2/core/host-tool-interceptor-order.test.ts
@@ -17,7 +17,9 @@ const originalEnv = {
 	session: process.env.BOBBIT_SESSION_ID,
 	token: process.env.BOBBIT_TOKEN,
 	hooks: process.env.BOBBIT_HOST_HOOKS_ENABLED,
+	sessionSecret: process.env.BOBBIT_SESSION_SECRET,
 	beforeFailClosed: process.env.BOBBIT_HOST_BEFORE_TOOL_CALL_FAIL_CLOSED,
+	afterFailClosed: process.env.BOBBIT_HOST_AFTER_TOOL_RESULT_FAIL_CLOSED,
 };
 
 afterEach(() => {
@@ -27,7 +29,9 @@ afterEach(() => {
 		BOBBIT_SESSION_ID: originalEnv.session,
 		BOBBIT_TOKEN: originalEnv.token,
 		BOBBIT_HOST_HOOKS_ENABLED: originalEnv.hooks,
+		BOBBIT_SESSION_SECRET: originalEnv.sessionSecret,
 		BOBBIT_HOST_BEFORE_TOOL_CALL_FAIL_CLOSED: originalEnv.beforeFailClosed,
+		BOBBIT_HOST_AFTER_TOOL_RESULT_FAIL_CLOSED: originalEnv.afterFailClosed,
 	})) {
 		if (value === undefined) delete process.env[key];
 		else process.env[key] = value;
@@ -63,6 +67,7 @@ function installHostEnv(): void {
 	process.env.BOBBIT_GATEWAY_URL = "http://host-hooks.test";
 	process.env.BOBBIT_SESSION_ID = "session-tool-order";
 	process.env.BOBBIT_TOKEN = "token";
+	process.env.BOBBIT_SESSION_SECRET = "current-session-secret";
 	process.env.BOBBIT_HOST_HOOKS_ENABLED = "1";
 	process.env.BOBBIT_HOST_BEFORE_TOOL_CALL_FAIL_CLOSED = "0";
 }
@@ -73,6 +78,8 @@ describe("Pi host tool interceptor ordering", () => {
 		const order: string[] = [];
 		globalThis.fetch = (async (url: string | URL | Request, init?: RequestInit) => {
 			const pathname = new URL(String(url)).pathname;
+			const headers = new Headers(init?.headers);
+			assert.equal(headers.get("X-Bobbit-Session-Secret"), "current-session-secret", "the bridge must bind callbacks to the owning session secret");
 			const body = JSON.parse(String(init?.body));
 			if (pathname.endsWith("/before-tool-call")) {
 				order.push("beforeToolCall");
@@ -137,6 +144,7 @@ describe("Pi host tool interceptor ordering", () => {
 			{ name: "disabled", configure: () => { delete process.env.BOBBIT_HOST_HOOKS_ENABLED; } },
 			{ name: "missing gateway", configure: () => { delete process.env.BOBBIT_GATEWAY_URL; } },
 			{ name: "forbidden", configure: () => { globalThis.fetch = (async () => new Response(null, { status: 403 })) as typeof fetch; } },
+			{ name: "missing provenance", configure: () => { globalThis.fetch = (async () => new Response(null, { status: 409 })) as typeof fetch; } },
 			{ name: "non-2xx", configure: () => { globalThis.fetch = (async () => new Response(null, { status: 503 })) as typeof fetch; } },
 			{ name: "malformed", configure: () => { globalThis.fetch = (async () => Response.json({ unexpected: true })) as typeof fetch; } },
 			{ name: "unavailable", configure: () => { globalThis.fetch = (async () => { throw new Error("PRIVATE_TRANSPORT_FAILURE"); }) as typeof fetch; } },

--- a/tests2/core/host-tool-interceptor-order.test.ts
+++ b/tests2/core/host-tool-interceptor-order.test.ts
@@ -1,0 +1,157 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { afterEach, describe, it } from "vitest";
+
+import { guardProcessEnv } from "./helpers/env-guard.js";
+import { generateToolResultErrorBridgeExtension } from "../../src/server/agent/tool-result-error-bridge-extension.ts";
+
+guardProcessEnv();
+
+const roots: string[] = [];
+const originalFetch = globalThis.fetch;
+const originalEnv = {
+	gateway: process.env.BOBBIT_GATEWAY_URL,
+	session: process.env.BOBBIT_SESSION_ID,
+	token: process.env.BOBBIT_TOKEN,
+	hooks: process.env.BOBBIT_HOST_HOOKS_ENABLED,
+};
+
+afterEach(() => {
+	globalThis.fetch = originalFetch;
+	for (const [key, value] of Object.entries({
+		BOBBIT_GATEWAY_URL: originalEnv.gateway,
+		BOBBIT_SESSION_ID: originalEnv.session,
+		BOBBIT_TOKEN: originalEnv.token,
+		BOBBIT_HOST_HOOKS_ENABLED: originalEnv.hooks,
+	})) {
+		if (value === undefined) delete process.env[key];
+		else process.env[key] = value;
+	}
+	for (const root of roots.splice(0)) fs.rmSync(root, { recursive: true, force: true });
+});
+
+async function loadBridge(): Promise<(pi: any) => void> {
+	const root = fs.mkdtempSync(path.join(os.tmpdir(), "host-tool-order-"));
+	roots.push(root);
+	const file = path.join(root, "bridge.mjs");
+	fs.writeFileSync(file, generateToolResultErrorBridgeExtension(), "utf8");
+	return (await import(`${pathToFileURL(file).href}?${Date.now()}-${Math.random()}`)).default;
+}
+
+function makePi() {
+	const listeners = new Map<string, Array<(event: any) => any>>();
+	const handlers = new Map<string, Function>();
+	const pi: any = {
+		on(name: string, handler: (event: any) => any) {
+			const rows = listeners.get(name) ?? [];
+			rows.push(handler);
+			listeners.set(name, rows);
+		},
+		tool(spec: any, handler?: Function) {
+			handlers.set(typeof spec === "string" ? spec : spec.name, handler ?? spec.handler ?? spec.execute);
+		},
+	};
+	return { pi, listeners, handlers };
+}
+
+function installHostEnv(): void {
+	process.env.BOBBIT_GATEWAY_URL = "http://host-hooks.test";
+	process.env.BOBBIT_SESSION_ID = "session-tool-order";
+	process.env.BOBBIT_TOKEN = "token";
+	process.env.BOBBIT_HOST_HOOKS_ENABLED = "1";
+}
+
+describe("Pi host tool interceptor ordering", () => {
+	it("runs permission, beforeToolCall mutation, handler, then afterToolResult mutation", async () => {
+		installHostEnv();
+		const order: string[] = [];
+		globalThis.fetch = (async (url: string | URL | Request, init?: RequestInit) => {
+			const pathname = new URL(String(url)).pathname;
+			const body = JSON.parse(String(init?.body));
+			if (pathname.endsWith("/before-tool-call")) {
+				order.push("beforeToolCall");
+				assert.equal(body.toolCallId, "call-1");
+				assert.equal(body.toolName, "sample");
+				return Response.json({ decision: "replaceArgs", args: { value: 2 } });
+			}
+			order.push("afterToolResult");
+			assert.deepEqual(body.result, { content: [{ type: "text", text: "handler:2" }] });
+			return Response.json({ decision: "replaceResult", replacement: { content: [{ type: "text", text: "approved" }] } });
+		}) as typeof fetch;
+
+		const activate = await loadBridge();
+		const { pi, listeners, handlers } = makePi();
+		activate(pi);
+		// Pi runs tool_call listeners (including Bobbit's permission guard) before
+		// invoking the registered handler. The interceptor wrapper is on the latter.
+		pi.on("tool_call", async () => { order.push("permission"); return undefined; });
+		pi.tool({ name: "sample" }, async (_id: string, args: any) => {
+			order.push("handler");
+			return { content: [{ type: "text", text: `handler:${args.value}` }] };
+		});
+
+		for (const listener of listeners.get("tool_call") ?? []) await listener({ toolCallId: "call-1", toolName: "sample" });
+		const result = await handlers.get("sample")!("call-1", { value: 1 });
+
+		assert.deepEqual(order, ["permission", "beforeToolCall", "handler", "afterToolResult"]);
+		assert.deepEqual(result, { content: [{ type: "text", text: "approved" }] });
+	});
+
+	it("blocks before the handler and uses a constant host-owned error", async () => {
+		installHostEnv();
+		let handlerCalled = false;
+		globalThis.fetch = (async (url: string | URL | Request) => {
+			const pathname = new URL(String(url)).pathname;
+			assert.ok(pathname.endsWith("/before-tool-call"));
+			return Response.json({ decision: "block", reasonCode: "PRIVATE_POLICY_REASON" });
+		}) as typeof fetch;
+
+		const activate = await loadBridge();
+		const { pi, handlers } = makePi();
+		activate(pi);
+		pi.tool({ name: "sample" }, async () => {
+			handlerCalled = true;
+			return { content: [] };
+		});
+
+		await assert.rejects(
+			() => handlers.get("sample")!("call-block", { secret: "PRIVATE_ARGS" }),
+			(error: any) => {
+				assert.equal(error.name, "BobbitToolPolicyError");
+				assert.match(error.message, /policy_denied/);
+				assert.doesNotMatch(error.message, /PRIVATE_POLICY_REASON|PRIVATE_ARGS/);
+				return true;
+			},
+		);
+		assert.equal(handlerCalled, false);
+	});
+
+	it("applies protected synthetic results before Pi persistence", async () => {
+		installHostEnv();
+		globalThis.fetch = (async (url: string | URL | Request) => {
+			const pathname = new URL(String(url)).pathname;
+			if (pathname.endsWith("/before-tool-call")) return Response.json({ decision: "allow" });
+			return Response.json({ decision: "syntheticError", code: "protected_result" });
+		}) as typeof fetch;
+
+		const activate = await loadBridge();
+		const { pi, handlers } = makePi();
+		activate(pi);
+		pi.tool({ name: "sample" }, async () => ({
+			content: [{ type: "text", text: "PRIVATE_RESULT_BODY" }],
+		}));
+
+		await assert.rejects(
+			() => handlers.get("sample")!("call-result", {}),
+			(error: any) => {
+				assert.equal(error.name, "BobbitToolResultError");
+				assert.match(error.message, /protected_result/);
+				assert.doesNotMatch(error.message, /PRIVATE_RESULT_BODY/);
+				return true;
+			},
+		);
+	});
+});

--- a/tests2/core/host-tool-interceptor-order.test.ts
+++ b/tests2/core/host-tool-interceptor-order.test.ts
@@ -3,7 +3,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
-import { afterEach, describe, it } from "vitest";
+import { afterEach, describe, it, vi } from "vitest";
 
 import { guardProcessEnv } from "./helpers/env-guard.js";
 import { generateToolResultErrorBridgeExtension } from "../../src/server/agent/tool-result-error-bridge-extension.ts";
@@ -17,6 +17,7 @@ const originalEnv = {
 	session: process.env.BOBBIT_SESSION_ID,
 	token: process.env.BOBBIT_TOKEN,
 	hooks: process.env.BOBBIT_HOST_HOOKS_ENABLED,
+	beforeFailClosed: process.env.BOBBIT_HOST_BEFORE_TOOL_CALL_FAIL_CLOSED,
 };
 
 afterEach(() => {
@@ -26,6 +27,7 @@ afterEach(() => {
 		BOBBIT_SESSION_ID: originalEnv.session,
 		BOBBIT_TOKEN: originalEnv.token,
 		BOBBIT_HOST_HOOKS_ENABLED: originalEnv.hooks,
+		BOBBIT_HOST_BEFORE_TOOL_CALL_FAIL_CLOSED: originalEnv.beforeFailClosed,
 	})) {
 		if (value === undefined) delete process.env[key];
 		else process.env[key] = value;
@@ -62,6 +64,7 @@ function installHostEnv(): void {
 	process.env.BOBBIT_SESSION_ID = "session-tool-order";
 	process.env.BOBBIT_TOKEN = "token";
 	process.env.BOBBIT_HOST_HOOKS_ENABLED = "1";
+	process.env.BOBBIT_HOST_BEFORE_TOOL_CALL_FAIL_CLOSED = "0";
 }
 
 describe("Pi host tool interceptor ordering", () => {
@@ -121,12 +124,89 @@ describe("Pi host tool interceptor ordering", () => {
 			() => handlers.get("sample")!("call-block", { secret: "PRIVATE_ARGS" }),
 			(error: any) => {
 				assert.equal(error.name, "BobbitToolPolicyError");
-				assert.match(error.message, /policy_denied/);
+				assert.match(error.message, /not_permitted/);
 				assert.doesNotMatch(error.message, /PRIVATE_POLICY_REASON|PRIVATE_ARGS/);
 				return true;
 			},
 		);
 		assert.equal(handlerCalled, false);
+	});
+
+	it("blocks with a constant decision when protected beforeToolCall transport fails", async () => {
+		const failures: Array<{ name: string; configure: () => void }> = [
+			{ name: "disabled", configure: () => { delete process.env.BOBBIT_HOST_HOOKS_ENABLED; } },
+			{ name: "missing gateway", configure: () => { delete process.env.BOBBIT_GATEWAY_URL; } },
+			{ name: "forbidden", configure: () => { globalThis.fetch = (async () => new Response(null, { status: 403 })) as typeof fetch; } },
+			{ name: "non-2xx", configure: () => { globalThis.fetch = (async () => new Response(null, { status: 503 })) as typeof fetch; } },
+			{ name: "malformed", configure: () => { globalThis.fetch = (async () => Response.json({ unexpected: true })) as typeof fetch; } },
+			{ name: "unavailable", configure: () => { globalThis.fetch = (async () => { throw new Error("PRIVATE_TRANSPORT_FAILURE"); }) as typeof fetch; } },
+		];
+
+		for (const failure of failures) {
+			installHostEnv();
+			process.env.BOBBIT_HOST_BEFORE_TOOL_CALL_FAIL_CLOSED = "1";
+			failure.configure();
+			let handlerCalled = false;
+			const activate = await loadBridge();
+			const { pi, handlers } = makePi();
+			activate(pi);
+			pi.tool({ name: "sample" }, async () => { handlerCalled = true; return { content: [] }; });
+
+			await assert.rejects(
+				() => handlers.get("sample")!(`call-${failure.name}`, { secret: "PRIVATE_ARGS" }),
+				(error: any) => {
+					assert.equal(error.name, "BobbitToolPolicyError");
+					assert.match(error.message, /not_permitted/);
+					assert.doesNotMatch(error.message, /PRIVATE_TRANSPORT_FAILURE|PRIVATE_ARGS/);
+					return true;
+				},
+				failure.name,
+			);
+			assert.equal(handlerCalled, false, failure.name);
+			globalThis.fetch = originalFetch;
+		}
+	});
+
+	it("blocks a protected beforeToolCall when the host callback times out", async () => {
+		vi.useFakeTimers();
+		try {
+			installHostEnv();
+			process.env.BOBBIT_HOST_BEFORE_TOOL_CALL_FAIL_CLOSED = "1";
+			globalThis.fetch = ((_url: string | URL | Request, init?: RequestInit) => new Promise((_resolve, reject) => {
+				init?.signal?.addEventListener("abort", () => reject(new DOMException("aborted", "AbortError")), { once: true });
+			})) as typeof fetch;
+			const activate = await loadBridge();
+			const { pi, handlers } = makePi();
+			activate(pi);
+			pi.tool({ name: "sample" }, async () => ({ content: [] }));
+
+			const invocation = handlers.get("sample")!("call-timeout", {});
+			const rejection = assert.rejects(invocation, /not_permitted/);
+			await vi.advanceTimersByTimeAsync(2_501);
+			await rejection;
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it("keeps an ordinary fail-open beforeToolCall transport failure non-blocking", async () => {
+		installHostEnv();
+		let handlerCalled = false;
+		globalThis.fetch = (async (url: string | URL | Request) => {
+			return new URL(String(url)).pathname.endsWith("/before-tool-call")
+				? new Response(null, { status: 503 })
+				: Response.json({ decision: "allow" });
+		}) as typeof fetch;
+		const activate = await loadBridge();
+		const { pi, handlers } = makePi();
+		activate(pi);
+		pi.tool({ name: "sample" }, async () => {
+			handlerCalled = true;
+			return { content: [{ type: "text", text: "ok" }] };
+		});
+
+		assert.deepEqual(await handlers.get("sample")!("call-open", {}), { content: [{ type: "text", text: "ok" }] });
+		assert.equal(handlerCalled, true);
 	});
 
 	it("applies protected synthetic results before Pi persistence", async () => {

--- a/tests2/core/inbox-manager.test.ts
+++ b/tests2/core/inbox-manager.test.ts
@@ -30,31 +30,45 @@ interface MockCtx {
 	inboxStore: InstanceType<typeof InboxStore>;
 }
 
+interface MockStaff {
+	id: string;
+	projectId?: string;
+	currentSessionId?: string;
+}
+
 /** Build a minimal PCM with one project and one or more registered staff ids. */
-function buildHarness(staffIds: string[]) {
+function buildHarness(staffInput: Array<string | MockStaff>) {
 	const memfs = createMemFs();
 	const stateDir = path.resolve("/memfs/inbox-mgr", `h-${dirSeq++}`);
 	memfs.mkdirSync(stateDir);
 	const inboxStore = new InboxStore(stateDir, memfs);
-	const staffSet = new Set(staffIds);
+	const staff = new Map(staffInput.map((value) => {
+		const record = typeof value === "string" ? { id: value } : value;
+		return [record.id, record];
+	}));
 	const ctx: MockCtx = {
 		project: { id: "p1" },
-		staffStore: { get: (id: string) => (staffSet.has(id) ? { id } : undefined) },
+		staffStore: { get: (id: string) => staff.get(id) },
 		inboxStore,
 	};
 	const pcm = {
 		all: () => [ctx][Symbol.iterator](),
 	};
 	const events: any[] = [];
-	const broadcastToAll = (event: any) => { events.push(event); };
+	const deliveries: Array<{ event: any; address: any }> = [];
+	const publishLive = (event: any, address: any) => {
+		events.push(event);
+		deliveries.push({ event, address });
+	};
 	const nudger = { poke: vi.fn((_id: string) => {}) };
+	const staffManager = { getStaff: (id: string) => staff.get(id) };
 
 	// InboxManager's typed signature wants real classes; we cast at the call
 	// site because the methods we exercise touch only the subset we vi.
-	const mgr = new InboxManager(pcm as any, {} as any, broadcastToAll);
+	const mgr = new InboxManager(pcm as any, staffManager as any, publishLive);
 	mgr.setNudger(nudger as any);
 
-	return { mgr, events, nudger, inboxStore };
+	return { mgr, events, deliveries, nudger, inboxStore };
 }
 
 describe("InboxManager.enqueue", () => {
@@ -99,6 +113,78 @@ describe("InboxManager.enqueue", () => {
 		mgr.enqueue("s", { title: "a", prompt: "p", source: { type: "trigger", triggerId: "t" } });
 		assert.equal(inboxStore.listPending("s").length, 2);
 		assert.equal(nudger.poke.mock.calls.length, 2);
+	});
+});
+
+describe("InboxManager.enqueueWithId", () => {
+	it("keeps canonical notification controls durable while publishing a redacted DTO to the exact staff session", () => {
+		const { mgr, deliveries, nudger, inboxStore } = buildHarness([{
+			id: "staff-a",
+			projectId: "p1",
+			currentSessionId: "staff-session-a",
+		}]);
+		const notification = {
+			id: "notification-1",
+			scope: "project",
+			name: "goalUpdated",
+			payloadVersion: 1,
+			occurredAt: 1_700_000_000_000,
+			projectId: "p1",
+			aggregate: { kind: "goal", id: "goal-1", revision: 7 },
+			correlationId: "public-correlation",
+			causationId: "public-causation",
+			payload: { goalId: "goal-1", state: "in-progress", changedFields: ["title"] },
+		} as const;
+
+		const accepted = mgr.enqueueWithId("delivery-1", "staff-a", {
+			title: "Host notification: goalUpdated",
+			triggerId: "trigger-1",
+			notification: notification as any,
+			rootCorrelationId: "host-only-root",
+			causationDepth: 3,
+		});
+
+		assert.deepEqual(accepted.notificationInput, {
+			notification,
+			rootCorrelationId: "host-only-root",
+			causationDepth: 3,
+		});
+		assert.deepEqual(inboxStore.get("staff-a", "delivery-1")?.notificationInput, accepted.notificationInput);
+		assert.equal(deliveries.length, 1);
+		assert.deepEqual(deliveries[0].address, {
+			staffId: "staff-a",
+			staffSessionId: "staff-session-a",
+			projectId: "p1",
+		});
+		assert.deepEqual(deliveries[0].event, {
+			type: "inbox.entry.added",
+			staffId: "staff-a",
+			entry: {
+				id: "delivery-1",
+				staffId: "staff-a",
+				source: { type: "notification", triggerId: "trigger-1" },
+				title: "Host notification: goalUpdated",
+				prompt: "A host notification is available in this inbox entry's notification metadata.",
+				state: "pending",
+				createdAt: accepted.createdAt,
+			},
+		});
+		assert.equal("notificationInput" in deliveries[0].event.entry, false);
+		assert.equal(JSON.stringify(deliveries[0]).includes("host-only-root"), false);
+		assert.equal(JSON.stringify(deliveries[0]).includes("public-causation"), false);
+		assert.equal(nudger.poke.mock.calls.length, 1);
+
+		// Durable acceptance is idempotent and cannot re-publish or re-wake.
+		const duplicate = mgr.enqueueWithId("delivery-1", "staff-a", {
+			title: "Host notification: goalUpdated",
+			triggerId: "trigger-1",
+			notification: notification as any,
+			rootCorrelationId: "host-only-root",
+			causationDepth: 3,
+		});
+		assert.deepEqual(duplicate.notificationInput, accepted.notificationInput);
+		assert.equal(deliveries.length, 1);
+		assert.equal(nudger.poke.mock.calls.length, 1);
 	});
 });
 

--- a/tests2/core/inbox-tool-credentials.test.ts
+++ b/tests2/core/inbox-tool-credentials.test.ts
@@ -1,0 +1,83 @@
+import { guardProcessEnv } from "./helpers/env-guard.js";
+guardProcessEnv();
+
+import assert from "node:assert/strict";
+import { afterEach, beforeEach, describe, it } from "vitest";
+import inboxExtension from "../../defaults/tools/inbox/extension.ts";
+
+interface RegisteredTool {
+	name: string;
+	execute(toolCallId: string, params: any): Promise<any>;
+}
+
+const envKeys = [
+	"BOBBIT_SESSION_ID",
+	"BOBBIT_SESSION_SECRET",
+	"BOBBIT_STAFF_ID",
+	"BOBBIT_TOKEN",
+	"BOBBIT_GATEWAY_URL",
+] as const;
+
+describe("first-party inbox tool credentials", () => {
+	let previousEnv: Record<string, string | undefined>;
+	let realFetch: typeof fetch;
+
+	beforeEach(() => {
+		previousEnv = Object.fromEntries(envKeys.map(key => [key, process.env[key]]));
+		Object.assign(process.env, {
+			BOBBIT_SESSION_ID: "staff-session",
+			BOBBIT_SESSION_SECRET: "host-issued-session-secret",
+			BOBBIT_STAFF_ID: "staff-id",
+			BOBBIT_TOKEN: "gateway-token",
+			BOBBIT_GATEWAY_URL: "https://gateway.test",
+		});
+		realFetch = globalThis.fetch;
+	});
+
+	afterEach(() => {
+		globalThis.fetch = realFetch;
+		for (const key of envKeys) {
+			const value = previousEnv[key];
+			if (value === undefined) delete process.env[key];
+			else process.env[key] = value;
+		}
+	});
+
+	it("forwards only the host-issued session capability on every inbox request", async () => {
+		const requests: Array<{ url: string; init: RequestInit }> = [];
+		globalThis.fetch = (async (input, init = {}) => {
+			requests.push({ url: String(input), init });
+			return new Response(JSON.stringify({ entries: [], ok: true }), {
+				status: 200,
+				headers: { "Content-Type": "application/json" },
+			});
+		}) as typeof fetch;
+
+		const tools = new Map<string, RegisteredTool>();
+		inboxExtension({ registerTool(tool: RegisteredTool) { tools.set(tool.name, tool); } } as any);
+		assert.deepEqual([...tools.keys()].sort(), ["inbox_complete", "inbox_dismiss", "inbox_list"]);
+
+		await tools.get("inbox_list")!.execute("list-call", { state: "pending", limit: 5 });
+		await tools.get("inbox_complete")!.execute("complete-call", { entry_id: "entry-1", summary: "done" });
+		await tools.get("inbox_dismiss")!.execute("dismiss-call", { entry_id: "entry-2", outcome: "cancelled", reason: "duplicate" });
+
+		assert.equal(requests.length, 3);
+		for (const request of requests) {
+			const headers = new Headers(request.init.headers);
+			assert.equal(headers.get("X-Bobbit-Session-Secret"), "host-issued-session-secret");
+			assert.equal(headers.get("Authorization"), "Bearer gateway-token");
+			const body = request.init.body ? JSON.parse(String(request.init.body)) : {};
+			assert.equal("rootCorrelationId" in body, false);
+			assert.equal("causationDepth" in body, false);
+			assert.equal("correlationId" in body, false);
+			assert.equal("causationId" in body, false);
+		}
+	});
+
+	it("does not register staff inbox tools without a host-issued session secret", () => {
+		delete process.env.BOBBIT_SESSION_SECRET;
+		const tools: RegisteredTool[] = [];
+		inboxExtension({ registerTool(tool: RegisteredTool) { tools.push(tool); } } as any);
+		assert.deepEqual(tools, []);
+	});
+});

--- a/tests2/core/orchestration-cascade.test.ts
+++ b/tests2/core/orchestration-cascade.test.ts
@@ -85,9 +85,15 @@ describe("SessionManager archive cascade-reap (OrchestrationCore §6)", () => {
 		return manager;
 	}
 
-	it("TERMINATE cascades to live children of EVERY child kind (not just pr-walkthrough)", async () => {
+	it("TERMINATE cascades to live children and invokes each archive listener once after persistence", async () => {
 		const store = new SessionStore(stateRoot);
 		const manager = makeManager(store);
+		const archived: string[] = [];
+		manager.addTerminationListener((id: string, info: any) => {
+			assert.equal(info.reason, "archived");
+			assert.equal(store.get(id)?.archived, true, `${id} listener must follow durable archive publication`);
+			archived.push(id);
+		});
 
 		manager.sessions.set("parent", makeInfo(store, "parent", {}));
 		// delegate child is linked by delegateOf; the rest by parentSessionId+childKind.
@@ -101,12 +107,19 @@ describe("SessionManager archive cascade-reap (OrchestrationCore §6)", () => {
 		for (const id of ["parent", "c-delegate", "c-team", "c-host", "c-prw"]) {
 			assert.equal(manager.sessions.has(id), false, `${id} must be terminated`);
 			assert.equal(store.get(id)?.archived, true, `${id} must be archived`);
+			assert.equal(archived.filter(archivedId => archivedId === id).length, 1, `${id} must notify exactly once`);
 		}
 	});
 
-	it("ARCHIVE (storeArchive) of a DORMANT parent cascade-reaps live + dormant children of every kind", async () => {
+	it("ARCHIVE of a dormant parent notifies live/dormant cascade rows once and suppresses repeat archive", async () => {
 		const store = new SessionStore(stateRoot);
 		const manager = makeManager(store);
+		const archived: string[] = [];
+		manager.addTerminationListener((id: string, info: any) => {
+			assert.equal(info.reason, "archived");
+			assert.equal(store.get(id)?.archived, true, `${id} listener must follow durable archive publication`);
+			archived.push(id);
+		});
 
 		// Parent exists only in the store (dormant — NOT in the in-memory map).
 		store.put({ id: "parent", title: "parent", cwd: stateRoot, agentSessionFile: "", createdAt: Date.now(), lastActivity: Date.now() } as any);
@@ -124,6 +137,45 @@ describe("SessionManager archive cascade-reap (OrchestrationCore §6)", () => {
 		assert.equal(store.get("c-live-host")?.archived, true, "live host-agents child must be archived");
 		assert.equal(store.get("c-dormant-delegate")?.archived, true, "dormant delegate child must be archived");
 		assert.equal(store.get("c-dormant-team")?.archived, true, "dormant team child must be archived");
+		for (const id of ["parent", "c-live-host", "c-dormant-delegate", "c-dormant-team"]) {
+			assert.equal(archived.filter(archivedId => archivedId === id).length, 1, `${id} must notify exactly once`);
+		}
+
+		const firstArchivedAt = store.get("parent")?.archivedAt;
+		assert.equal(await manager.storeArchive("parent"), false, "repeat archive is not a transition");
+		assert.equal(store.get("parent")?.archivedAt, firstArchivedAt, "repeat archive keeps the stable revision");
+		assert.equal(archived.length, 4, "repeat archive must not notify parent or cascade rows again");
+	});
+
+	it("emits no archive listener when dormant persistence fails and permits a later retry", async () => {
+		const row: any = {
+			id: "failing-dormant",
+			title: "failing-dormant",
+			cwd: stateRoot,
+			agentSessionFile: "",
+			createdAt: Date.now(),
+			lastActivity: Date.now(),
+		};
+		let fail = true;
+		const store: any = {
+			get: (id: string) => id === row.id ? row : undefined,
+			getLive: () => row.archived ? [] : [row],
+			archiveAsync: async () => {
+				if (fail) throw new Error("injected archive publication failure");
+				row.archived = true;
+				row.archivedAt = Date.now();
+				return true;
+			},
+		};
+		const manager = makeManager(store);
+		const archived: string[] = [];
+		manager.addTerminationListener((id: string) => archived.push(id));
+
+		assert.equal(await manager.storeArchive(row.id), false);
+		assert.deepEqual(archived, []);
+		fail = false;
+		assert.equal(await manager.storeArchive(row.id), true);
+		assert.deepEqual(archived, [row.id]);
 	});
 
 	it("ARCHIVE does NOT touch sessions belonging to a different parent", async () => {

--- a/tests2/core/pack-contributions.test.ts
+++ b/tests2/core/pack-contributions.test.ts
@@ -62,7 +62,7 @@ afterAll(() => {
 describe("Extension Host channel contract", () => {
 	it("keeps HOST_API_VERSION stable and bumps HOST_CONTRACT_VERSION for channel contracts", () => {
 		assert.equal(HOST_API_VERSION, 1);
-		assert.equal(HOST_CONTRACT_VERSION, 4);
+		assert.equal(HOST_CONTRACT_VERSION, 5);
 		const textFrame: HostChannelFrame = { kind: "text", data: "hello" };
 		const jsonFrame: HostChannelFrame = { kind: "json", data: { ok: true } };
 		assert.deepEqual([textFrame.kind, jsonFrame.kind], ["text", "json"]);

--- a/tests2/core/pi-tool-lifecycle-contract.test.ts
+++ b/tests2/core/pi-tool-lifecycle-contract.test.ts
@@ -267,6 +267,70 @@ describe("Pi 0.81 tool lifecycle contract", () => {
 		expect(persistedResult.message.addedToolNames).toEqual(["dynamic_search"]);
 	});
 
+	it("creates callback authority only from the current writer's accepted execution-start cursor", async () => {
+		const manager = makeManager();
+		let listener: ((event: any) => void) | undefined;
+		const session = makeSession(manager, {
+			onEvent: (fn: (event: any) => void) => {
+				listener = fn;
+				return () => { listener = undefined; };
+			},
+		});
+		const ctx: any = {
+			store: manager._testStore,
+			handleAgentLifecycle: (current: any, event: any) => manager.handleAgentLifecycle(current, event),
+			trackCostFromEvent: (current: any, event: any) => manager.trackCostFromEvent(current, event),
+		};
+		const unsub = subscribeToEvents(session, ctx);
+
+		const start = {
+			type: "tool_execution_start",
+			toolCallId: "call-provenance",
+			toolName: "read",
+			args: { path: "PRIVATE_ARGS" },
+		} satisfies ToolExecutionStartEvent;
+		listener?.(start);
+
+		const bufferedStart = session.eventBuffer.getAll()[0];
+		expect(bufferedStart.event).toBe(start);
+		const tracked = session.hostToolCallLifecycle.get(start.toolCallId);
+		expect(tracked).toMatchObject({
+			toolCallId: start.toolCallId,
+			toolName: start.toolName,
+			generation: 0,
+			startCursor: bufferedStart.seq,
+			phase: "observed",
+		});
+
+		const beforeClaim = await manager.claimToolCallBefore(session.id, start.toolCallId, start.toolName);
+		assert.ok(beforeClaim);
+		expect(await manager.claimToolCallBefore(session.id, start.toolCallId, start.toolName)).toBeUndefined();
+		expect(manager.settleToolCallBefore(beforeClaim, true)).toBe(true);
+		const afterClaim = manager.claimToolCallAfter(session.id, start.toolCallId, start.toolName);
+		assert.ok(afterClaim);
+		expect(manager.settleToolCallAfter(afterClaim)).toBe(true);
+
+		listener?.({
+			type: "tool_execution_end",
+			toolCallId: start.toolCallId,
+			toolName: start.toolName,
+			result: { content: [{ type: "text", text: "PRIVATE_RESULT" }] },
+			isError: false,
+		} satisfies ToolExecutionEndEvent);
+		expect(session.hostToolCallLifecycle.get(start.toolCallId)?.phase).toBe("ended");
+		listener?.({
+			type: "message_end",
+			message: {
+				role: "toolResult",
+				toolCallId: start.toolCallId,
+				toolName: start.toolName,
+				content: [{ type: "text", text: "PRIVATE_RESULT" }],
+			},
+		});
+		expect(session.hostToolCallLifecycle.has(start.toolCallId)).toBe(false);
+		unsub();
+	});
+
 	it("forwards partial/final payloads unchanged while policy and steer side effects stay on their boundaries", async () => {
 		const manager = makeManager();
 		let listener: ((event: any) => void) | undefined;

--- a/tests2/core/provider-bridge-extension.test.ts
+++ b/tests2/core/provider-bridge-extension.test.ts
@@ -11,7 +11,7 @@ guardProcessEnv();
  *
  * Covers:
  *   1. Codegen string shape — delimiters, gateway URL/token reads with
- *      state-file fallback, AbortController + 2500/5000 timeout paths,
+ *      state-file fallback, AbortController + bounded callback timeout paths,
  *      `before_agent_start` + `context` + `session_before_compact`
  *      subscriptions, hidden custom-message dynamic context path (never
  *      event.prompt), and future-context filtering of stale hidden dynamic context.
@@ -34,6 +34,7 @@ import {
 	stripDelimitedTail,
 	providersDeclareTurnHooks,
 	generateProviderBridgeExtension,
+	BEFORE_COMPACT_TIMEOUT_MS,
 } from "../../src/server/agent/provider-bridge-extension.ts";
 import type { ProviderContribution } from "../../src/server/agent/pack-contributions.ts";
 
@@ -97,10 +98,13 @@ describe("generateProviderBridgeExtension", () => {
 		assert.ok(source.includes('"token"'), "expected token state file fallback");
 	});
 
-	it("uses AbortController with 2500ms and 5000ms timeouts", () => {
+	it("uses AbortController with bounded before-prompt and compact client-margin timeouts", () => {
 		assert.ok(source.includes("AbortController"), "expected AbortController");
 		assert.ok(source.includes("2500"), "expected before-prompt 2500ms timeout");
-		assert.ok(source.includes("5000"), "expected before-compact 5000ms timeout");
+		assert.ok(
+			source.includes(String(BEFORE_COMPACT_TIMEOUT_MS)),
+			`expected before-compact ${BEFORE_COMPACT_TIMEOUT_MS}ms client-margin timeout`,
+		);
 	});
 
 	it("does NOT downgrade TLS verification process-wide", () => {

--- a/tests2/core/runSubgoalStep-merge-then-archive.test.ts
+++ b/tests2/core/runSubgoalStep-merge-then-archive.test.ts
@@ -56,17 +56,17 @@ describe("runSubgoalStep — merge + archive flow", () => {
 	it("R-028: archiveGoalAfterMerge sets state=complete BEFORE archiving (stale-pointer invalidation rescue path)", async () => {
 		// Order is load-bearing: the archived snapshot must have
 		// state=complete on disk so the rescue-path tier-2 short-circuit fires.
-		// Wrap goalStore.update to log the state stamp; wrap the strict durable
+		// Wrap goalStore.updateStrict to log the state stamp; wrap the strict durable
 		// archive boundary to log publication. Assert state-complete < archive.
 		const fx = await buildFixture();
 		afterAll(() => fx.cleanup());
 
 		const storeCalls: string[] = [];
-		const origUpdate = fx.goalStore.update.bind(fx.goalStore);
+		const origUpdateStrict = fx.goalStore.updateStrict.bind(fx.goalStore);
 		const origArchiveStrict = fx.goalStore.archiveStrict.bind(fx.goalStore);
-		(fx.goalStore as any).update = (id: string, updates: any) => {
+		(fx.goalStore as any).updateStrict = async (id: string, updates: any) => {
 			if (updates && updates.state === "complete") storeCalls.push(`state-complete:${id}`);
-			return origUpdate(id, updates);
+			return await origUpdateStrict(id, updates);
 		};
 		(fx.goalStore as any).archiveStrict = async (id: string) => {
 			storeCalls.push(`archive-strict:${id}`);

--- a/tests2/core/sandbox-guard.test.ts
+++ b/tests2/core/sandbox-guard.test.ts
@@ -23,6 +23,8 @@ describe("sandbox route guard", () => {
 			["GET", "/api/sessions/session-1"],
 			["PATCH", "/api/sessions/session-1"],
 			["POST", "/api/sessions/session-1/activate-skill"],
+			["POST", "/api/sessions/session-1/host-hooks/before-tool-call"],
+			["POST", "/api/sessions/session-1/host-hooks/after-tool-result"],
 			["GET", "/api/sessions/session-1/transcript"],
 			["POST", "/api/sessions/session-1/prompt"],
 			["GET", "/api/sessions/session-1/proposals"],
@@ -42,6 +44,8 @@ describe("sandbox route guard", () => {
 				`${method} ${pathname} must not cross sessions`,
 			);
 		}
+		assert.equal(isSandboxAllowed("/api/sessions/session-1/host-hooks/before-tool-call", "GET", scope()), false);
+		assert.equal(isSandboxAllowed("/api/sessions/session-1/host-hooks/other", "POST", scope()), false);
 	});
 
 	it("allows only secret-authenticated review upload from sandboxes", () => {

--- a/tests2/core/session-manager-respawn-provider-bridge.test.ts
+++ b/tests2/core/session-manager-respawn-provider-bridge.test.ts
@@ -58,7 +58,7 @@ function extensionPaths(args: string[]): string[] {
 }
 
 describe("initial tool hook transport snapshot", () => {
-	it("injects the host-owned protected beforeToolCall decision during setup", () => {
+	it("injects the host-owned protected tool-hook decisions during setup", () => {
 		const seen: Array<{ name: string; projectId?: string; goalId?: string }> = [];
 		const plan: any = {
 			id: "sess-initial-protected",
@@ -86,7 +86,11 @@ describe("initial tool hook transport snapshot", () => {
 
 		assert.equal(plan.bridgeOptions.env.BOBBIT_HOST_HOOKS_ENABLED, "1");
 		assert.equal(plan.bridgeOptions.env.BOBBIT_HOST_BEFORE_TOOL_CALL_FAIL_CLOSED, "1");
-		assert.deepEqual(seen, [{ name: "beforeToolCall", projectId: "proj-initial", goalId: "goal-initial" }]);
+		assert.equal(plan.bridgeOptions.env.BOBBIT_HOST_AFTER_TOOL_RESULT_FAIL_CLOSED, "1");
+		assert.deepEqual(seen, [
+			{ name: "beforeToolCall", projectId: "proj-initial", goalId: "goal-initial" },
+			{ name: "afterToolResult", projectId: "proj-initial", goalId: "goal-initial" },
+		]);
 	});
 });
 
@@ -140,7 +144,7 @@ describe("buildToolActivationArgs provider-bridge re-attachment (respawn/restore
 		);
 	});
 
-	it("refreshes the authoritative protected beforeToolCall transport snapshot on respawn", () => {
+	it("refreshes the authoritative protected tool-hook transport snapshots on respawn", () => {
 		const manager = makeManager();
 		let failClosed = true;
 		const seen: Array<{ name: string; projectId?: string; goalId?: string }> = [];
@@ -155,12 +159,16 @@ describe("buildToolActivationArgs provider-bridge re-attachment (respawn/restore
 
 		const protectedActivation = manager.buildToolActivationArgs("sess-protected", undefined, undefined, tmpRoot, "proj-protected", "goal-protected");
 		assert.equal(protectedActivation.env.BOBBIT_HOST_BEFORE_TOOL_CALL_FAIL_CLOSED, "1");
+		assert.equal(protectedActivation.env.BOBBIT_HOST_AFTER_TOOL_RESULT_FAIL_CLOSED, "1");
 		failClosed = false;
 		const refreshedActivation = manager.buildToolActivationArgs("sess-protected", undefined, undefined, tmpRoot, "proj-protected", "goal-protected");
 		assert.equal(refreshedActivation.env.BOBBIT_HOST_BEFORE_TOOL_CALL_FAIL_CLOSED, "0");
+		assert.equal(refreshedActivation.env.BOBBIT_HOST_AFTER_TOOL_RESULT_FAIL_CLOSED, "0");
 		assert.deepEqual(seen, [
 			{ name: "beforeToolCall", projectId: "proj-protected", goalId: "goal-protected" },
+			{ name: "afterToolResult", projectId: "proj-protected", goalId: "goal-protected" },
 			{ name: "beforeToolCall", projectId: "proj-protected", goalId: "goal-protected" },
+			{ name: "afterToolResult", projectId: "proj-protected", goalId: "goal-protected" },
 		]);
 	});
 

--- a/tests2/core/session-manager-respawn-provider-bridge.test.ts
+++ b/tests2/core/session-manager-respawn-provider-bridge.test.ts
@@ -58,6 +58,28 @@ function extensionPaths(args: string[]): string[] {
 }
 
 describe("initial tool hook transport snapshot", () => {
+	it("enables metadata-only tool lifecycle callbacks without interceptors", () => {
+		const plan: any = {
+			id: "sess-initial-observational",
+			projectId: "proj-initial",
+			cwd: tmpRoot,
+			effectiveAllowedTools: [],
+			bridgeOptions: { args: [], env: {} },
+		};
+		resolveToolActivation(plan, {
+			toolManager: null,
+			mcpManager: null,
+			groupPolicyStore: null,
+			lifecycleHub: undefined,
+			resolveGoalMetadata: () => ({}),
+			hostInterceptors: undefined,
+		} as any);
+
+		assert.equal(plan.bridgeOptions.env.BOBBIT_HOST_HOOKS_ENABLED, "1");
+		assert.equal(plan.bridgeOptions.env.BOBBIT_HOST_BEFORE_TOOL_CALL_FAIL_CLOSED, "0");
+		assert.equal(plan.bridgeOptions.env.BOBBIT_HOST_AFTER_TOOL_RESULT_FAIL_CLOSED, "0");
+	});
+
 	it("injects the host-owned protected tool-hook decisions during setup", () => {
 		const seen: Array<{ name: string; projectId?: string; goalId?: string }> = [];
 		const plan: any = {
@@ -95,6 +117,18 @@ describe("initial tool hook transport snapshot", () => {
 });
 
 describe("buildToolActivationArgs provider-bridge re-attachment (respawn/restore)", () => {
+	it("keeps metadata-only tool lifecycle callbacks enabled after respawn without interceptors", () => {
+		const manager = makeManager();
+		manager.hostInterceptors = undefined;
+
+		const { env } = manager.buildToolActivationArgs(
+			"sess-respawn-observational", undefined, undefined, tmpRoot, "proj-observational",
+		);
+		assert.equal(env.BOBBIT_HOST_HOOKS_ENABLED, "1");
+		assert.equal(env.BOBBIT_HOST_BEFORE_TOOL_CALL_FAIL_CLOSED, "0");
+		assert.equal(env.BOBBIT_HOST_AFTER_TOOL_RESULT_FAIL_CLOSED, "0");
+	});
+
 	it("appends the provider-bridge extension when the project declares a per-turn hook", () => {
 		const manager = makeManager();
 		const seen: Array<{ projectId?: string; hooks: readonly string[] }> = [];

--- a/tests2/core/session-manager-respawn-provider-bridge.test.ts
+++ b/tests2/core/session-manager-respawn-provider-bridge.test.ts
@@ -32,6 +32,7 @@ const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "respawn-bridge-test-"));
 process.env.BOBBIT_DIR = tmpRoot;
 
 const { SessionManager } = await import("../../src/server/agent/session-manager.ts");
+const { resolveToolActivation } = await import("../../src/server/agent/session-setup.ts");
 
 const managers: any[] = [];
 
@@ -55,6 +56,39 @@ function extensionPaths(args: string[]): string[] {
 	}
 	return out;
 }
+
+describe("initial tool hook transport snapshot", () => {
+	it("injects the host-owned protected beforeToolCall decision during setup", () => {
+		const seen: Array<{ name: string; projectId?: string; goalId?: string }> = [];
+		const plan: any = {
+			id: "sess-initial-protected",
+			projectId: "proj-initial",
+			goalId: "goal-initial",
+			cwd: tmpRoot,
+			effectiveAllowedTools: [],
+			bridgeOptions: { args: [], env: {} },
+		};
+		resolveToolActivation(plan, {
+			toolManager: null,
+			mcpManager: null,
+			groupPolicyStore: null,
+			lifecycleHub: undefined,
+			resolveGoalMetadata: () => ({}),
+			hostInterceptors: {
+				dispatch: async () => undefined,
+				hasAny: () => true,
+				requiresFailClosed(name: string, projectId?: string, goalId?: string) {
+					seen.push({ name, projectId, goalId });
+					return true;
+				},
+			},
+		} as any);
+
+		assert.equal(plan.bridgeOptions.env.BOBBIT_HOST_HOOKS_ENABLED, "1");
+		assert.equal(plan.bridgeOptions.env.BOBBIT_HOST_BEFORE_TOOL_CALL_FAIL_CLOSED, "1");
+		assert.deepEqual(seen, [{ name: "beforeToolCall", projectId: "proj-initial", goalId: "goal-initial" }]);
+	});
+});
 
 describe("buildToolActivationArgs provider-bridge re-attachment (respawn/restore)", () => {
 	it("appends the provider-bridge extension when the project declares a per-turn hook", () => {
@@ -104,6 +138,30 @@ describe("buildToolActivationArgs provider-bridge re-attachment (respawn/restore
 			!exts.some((p) => p.includes("provider-bridge")),
 			`expected NO provider-bridge --extension without a hub, got: ${JSON.stringify(exts)}`,
 		);
+	});
+
+	it("refreshes the authoritative protected beforeToolCall transport snapshot on respawn", () => {
+		const manager = makeManager();
+		let failClosed = true;
+		const seen: Array<{ name: string; projectId?: string; goalId?: string }> = [];
+		manager.setHostInterceptorPort({
+			dispatch: async () => undefined,
+			hasAny: () => true,
+			requiresFailClosed(name: string, projectId?: string, goalId?: string) {
+				seen.push({ name, projectId, goalId });
+				return failClosed;
+			},
+		});
+
+		const protectedActivation = manager.buildToolActivationArgs("sess-protected", undefined, undefined, tmpRoot, "proj-protected", "goal-protected");
+		assert.equal(protectedActivation.env.BOBBIT_HOST_BEFORE_TOOL_CALL_FAIL_CLOSED, "1");
+		failClosed = false;
+		const refreshedActivation = manager.buildToolActivationArgs("sess-protected", undefined, undefined, tmpRoot, "proj-protected", "goal-protected");
+		assert.equal(refreshedActivation.env.BOBBIT_HOST_BEFORE_TOOL_CALL_FAIL_CLOSED, "0");
+		assert.deepEqual(seen, [
+			{ name: "beforeToolCall", projectId: "proj-protected", goalId: "goal-protected" },
+			{ name: "beforeToolCall", projectId: "proj-protected", goalId: "goal-protected" },
+		]);
 	});
 
 	it("forwards the session's effective goal id to the hub so disabled providers filter after respawn", () => {

--- a/tests2/core/session-store-atomic-write.test.ts
+++ b/tests2/core/session-store-atomic-write.test.ts
@@ -217,6 +217,26 @@ describe("SessionStore atomic write", () => {
 		assert.equal(memfs.existsSync(TMP), false, "serialized writers must leave no shared tmp artifact");
 	});
 
+	it("rolls back a failed archive publication and suppresses repeat transitions", async () => {
+		const store = new SessionStore(stateDir, memfs);
+		store.put(makeSession("archive-once"));
+		await store.flushAsync();
+		const originalRename = memfs.promises.rename.bind(memfs.promises);
+		(memfs.promises as any).rename = async () => { throw new Error("injected archive rename failure"); };
+		try {
+			await assert.rejects(store.archiveAsync("archive-once"), /injected archive rename failure/);
+			assert.equal(store.get("archive-once")?.archived, undefined, "failed publication is not an in-memory transition");
+			assert.equal(store.get("archive-once")?.archivedAt, undefined);
+		} finally {
+			(memfs.promises as any).rename = originalRename;
+		}
+
+		assert.equal(await store.archiveAsync("archive-once"), true, "a failed archive remains retryable");
+		const revision = store.get("archive-once")?.archivedAt;
+		assert.equal(await store.archiveAsync("archive-once"), false, "a repeated archive is not a transition");
+		assert.equal(store.get("archive-once")?.archivedAt, revision);
+	});
+
 	it("does not leave a .tmp file behind after a successful save", async () => {
 		const store = new SessionStore(stateDir, memfs);
 		store.put(makeSession("s1"));

--- a/tests2/core/session-store-atomic-write.test.ts
+++ b/tests2/core/session-store-atomic-write.test.ts
@@ -217,7 +217,7 @@ describe("SessionStore atomic write", () => {
 		assert.equal(memfs.existsSync(TMP), false, "serialized writers must leave no shared tmp artifact");
 	});
 
-	it("rolls back a failed archive publication and suppresses repeat transitions", async () => {
+	it("keeps a failed archive hidden and retryable until one durable acknowledgement", async () => {
 		const store = new SessionStore(stateDir, memfs);
 		store.put(makeSession("archive-once"));
 		await store.flushAsync();
@@ -225,16 +225,52 @@ describe("SessionStore atomic write", () => {
 		(memfs.promises as any).rename = async () => { throw new Error("injected archive rename failure"); };
 		try {
 			await assert.rejects(store.archiveAsync("archive-once"), /injected archive rename failure/);
-			assert.equal(store.get("archive-once")?.archived, undefined, "failed publication is not an in-memory transition");
-			assert.equal(store.get("archive-once")?.archivedAt, undefined);
+			assert.equal(store.get("archive-once")?.archived, true, "failed publication still suppresses restore/getLive");
+			assert.equal(store.getLive().some(session => session.id === "archive-once"), false);
 		} finally {
 			(memfs.promises as any).rename = originalRename;
 		}
 
-		assert.equal(await store.archiveAsync("archive-once"), true, "a failed archive remains retryable");
 		const revision = store.get("archive-once")?.archivedAt;
+		store.put(makeSession("unrelated-write"));
+		await store.flushAsync();
+		const epochAfterUnrelatedWrite = store.getWrittenEpoch();
+		assert.equal(await store.archiveAsync("archive-once"), true, "the pending archive remains explicitly acknowledgeable");
+		assert.equal(store.getWrittenEpoch(), epochAfterUnrelatedWrite, "an unrelated write may already carry the pending archive across its fence");
+		assert.equal(store.get("archive-once")?.archivedAt, revision, "retry keeps the original stable archive revision");
 		assert.equal(await store.archiveAsync("archive-once"), false, "a repeated archive is not a transition");
-		assert.equal(store.get("archive-once")?.archivedAt, revision);
+
+		const restored = new SessionStore(stateDir, memfs);
+		assert.equal(await restored.archiveAsync("archive-once"), false, "a durably archived row is not pending after restart");
+	});
+
+	it("gives only one concurrent archive caller the durable transition", async () => {
+		const store = new SessionStore(stateDir, memfs);
+		store.put(makeSession("archive-concurrent"));
+		await store.flushAsync();
+		const originalRename = memfs.promises.rename.bind(memfs.promises);
+		let releaseRename!: () => void;
+		let enterRename!: () => void;
+		const renameEntered = new Promise<void>((resolve) => { enterRename = resolve; });
+		const renameReleased = new Promise<void>((resolve) => { releaseRename = resolve; });
+		(memfs.promises as any).rename = async (from: PathLike, to: PathLike) => {
+			if (path.resolve(String(to)) === path.resolve(STORE_FILE)) {
+				enterRename();
+				await renameReleased;
+			}
+			return originalRename(from, to);
+		};
+		try {
+			const first = store.archiveAsync("archive-concurrent");
+			await renameEntered;
+			const second = store.archiveAsync("archive-concurrent");
+			releaseRename();
+			assert.deepEqual(await Promise.all([first, second]), [true, false]);
+			assert.equal(await store.archiveAsync("archive-concurrent"), false);
+		} finally {
+			releaseRename?.();
+			(memfs.promises as any).rename = originalRename;
+		}
 	});
 
 	it("does not leave a .tmp file behind after a successful save", async () => {

--- a/tests2/core/test-map-execution.test.ts
+++ b/tests2/core/test-map-execution.test.ts
@@ -22,6 +22,7 @@ const MATERIALIZED_PATHS = [
 	"tests2/dom/example.test.ts",
 	"tests2/integration/example.test.ts",
 	"tests2/core/bobbit-dir-agent-dir.test.ts",
+	"tests2/core/extension-host-module-isolation.test.ts",
 	"tests2/core/file-mentions-authenticated-boundary.test.ts",
 	"tests2/core/git-lifecycle-no-publication-real-git.test.ts",
 	"tests2/core/marketplace-install.test.ts",
@@ -83,7 +84,10 @@ describe("tests-map execution metadata", () => {
 		expect(execution.core).toEqual(["tests2/core/example.test.ts"]);
 		expect(execution.dom).toEqual(["tests2/dom/example.test.ts"]);
 		expect(execution.integration).toEqual(["tests2/integration/example.test.ts"]);
-		expect(execution.isolated).toEqual(["tests2/core/bobbit-dir-agent-dir.test.ts"]);
+		expect(execution.isolated).toEqual([
+			"tests2/core/bobbit-dir-agent-dir.test.ts",
+			"tests2/core/extension-host-module-isolation.test.ts",
+		]);
 		expect(execution.e2e).toEqual([
 			"tests2/core/file-mentions-authenticated-boundary.test.ts",
 			"tests2/core/git-lifecycle-no-publication-real-git.test.ts",

--- a/tests2/core/tool-description-budget.test.ts
+++ b/tests2/core/tool-description-budget.test.ts
@@ -97,6 +97,9 @@ beforeAll(() => {
 	if (!process.env.BOBBIT_SESSION_ID) {
 		process.env.BOBBIT_SESSION_ID = "00000000-0000-0000-0000-000000000000";
 	}
+	if (!process.env.BOBBIT_SESSION_SECRET) {
+		process.env.BOBBIT_SESSION_SECRET = "test-host-issued-session-secret";
+	}
 	if (!process.env.BOBBIT_GOAL_ID) {
 		process.env.BOBBIT_GOAL_ID = "00000000-0000-0000-0000-000000000000";
 	}

--- a/tests2/core/tool-result-error-bridge-extension.test.ts
+++ b/tests2/core/tool-result-error-bridge-extension.test.ts
@@ -102,6 +102,98 @@ describe("tool result error bridge extension", () => {
 		assert.deepEqual(await handlers.get("x")!({}), { content: [{ type: "text", text: "ok" }] });
 	});
 
+	it("preserves the original thrown error when the host does not return a synthetic terminal", async () => {
+		const previousFetch = globalThis.fetch;
+		const previousEnv = {
+			gateway: process.env.BOBBIT_GATEWAY_URL,
+			session: process.env.BOBBIT_SESSION_ID,
+			hooks: process.env.BOBBIT_HOST_HOOKS_ENABLED,
+			afterFailClosed: process.env.BOBBIT_HOST_AFTER_TOOL_RESULT_FAIL_CLOSED,
+		};
+		try {
+			process.env.BOBBIT_GATEWAY_URL = "http://host-hooks.test";
+			process.env.BOBBIT_SESSION_ID = "session-error-bridge";
+			process.env.BOBBIT_HOST_HOOKS_ENABLED = "1";
+			process.env.BOBBIT_HOST_AFTER_TOOL_RESULT_FAIL_CLOSED = "0";
+			let afterBody: unknown;
+			globalThis.fetch = (async (url: string | URL | Request, init?: RequestInit) => {
+				if (new URL(String(url)).pathname.endsWith("/before-tool-call")) {
+					return Response.json({ action: "replaceArgs", args: {} });
+				}
+				afterBody = JSON.parse(String(init?.body));
+				return Response.json({ action: "replaceResult", result: { isError: true } });
+			}) as typeof fetch;
+
+			const original = new TypeError("PRIVATE_VALIDATION_DETAIL");
+			const activate = await loadGeneratedExtension();
+			const { pi, handlers } = makePi();
+			activate(pi);
+			pi.tool({ name: "x" }, async () => { throw original; });
+
+			await assert.rejects(() => handlers.get("x")!("call-thrown", {}), (error: unknown) => error === original);
+			assert.deepEqual(afterBody, {
+				toolCallId: "call-thrown",
+				toolName: "x",
+				result: { isError: true },
+			});
+			assert.doesNotMatch(JSON.stringify(afterBody), /PRIVATE_VALIDATION_DETAIL/);
+		} finally {
+			globalThis.fetch = previousFetch;
+			for (const [key, value] of Object.entries({
+				BOBBIT_GATEWAY_URL: previousEnv.gateway,
+				BOBBIT_SESSION_ID: previousEnv.session,
+				BOBBIT_HOST_HOOKS_ENABLED: previousEnv.hooks,
+				BOBBIT_HOST_AFTER_TOOL_RESULT_FAIL_CLOSED: previousEnv.afterFailClosed,
+			})) {
+				if (value === undefined) delete process.env[key];
+				else process.env[key] = value;
+			}
+		}
+	});
+
+	it("replaces a thrown error when protected after-result transport fails closed", async () => {
+		const previousFetch = globalThis.fetch;
+		const previousEnv = {
+			gateway: process.env.BOBBIT_GATEWAY_URL,
+			session: process.env.BOBBIT_SESSION_ID,
+			hooks: process.env.BOBBIT_HOST_HOOKS_ENABLED,
+			afterFailClosed: process.env.BOBBIT_HOST_AFTER_TOOL_RESULT_FAIL_CLOSED,
+		};
+		try {
+			process.env.BOBBIT_GATEWAY_URL = "http://host-hooks.test";
+			process.env.BOBBIT_SESSION_ID = "session-error-bridge";
+			process.env.BOBBIT_HOST_HOOKS_ENABLED = "1";
+			process.env.BOBBIT_HOST_AFTER_TOOL_RESULT_FAIL_CLOSED = "1";
+			globalThis.fetch = (async () => { throw new Error("PRIVATE_TRANSPORT_DETAIL"); }) as typeof fetch;
+
+			const activate = await loadGeneratedExtension();
+			const { pi, handlers } = makePi();
+			activate(pi);
+			pi.tool({ name: "x" }, async () => { throw new TypeError("PRIVATE_VALIDATION_DETAIL"); });
+
+			await assert.rejects(
+				() => handlers.get("x")!("call-protected", {}),
+				(error: any) => {
+					assert.equal(error.name, "BobbitToolResultError");
+					assert.match(error.message, /handler_error/);
+					assert.doesNotMatch(error.message, /PRIVATE_VALIDATION_DETAIL|PRIVATE_TRANSPORT_DETAIL/);
+					return true;
+				},
+			);
+		} finally {
+			globalThis.fetch = previousFetch;
+			for (const [key, value] of Object.entries({
+				BOBBIT_GATEWAY_URL: previousEnv.gateway,
+				BOBBIT_SESSION_ID: previousEnv.session,
+				BOBBIT_HOST_HOOKS_ENABLED: previousEnv.hooks,
+				BOBBIT_HOST_AFTER_TOOL_RESULT_FAIL_CLOSED: previousEnv.afterFailClosed,
+			})) {
+				if (value === undefined) delete process.env[key];
+				else process.env[key] = value;
+			}
+		}
+	});
+
 	it("names every unknown field without changing provider schema payloads", async () => {
 		const parameters = Type.Object({ operation: Type.Literal("health") }, { additionalProperties: false });
 		const providerSchema = JSON.stringify(parameters);

--- a/tests2/dom/client-host-api.test.ts
+++ b/tests2/dom/client-host-api.test.ts
@@ -39,6 +39,8 @@ function caps() {
 		session: h.capabilities.session,
 		ui: h.capabilities.ui,
 		store: h.capabilities.store,
+		sessionNotifications: h.capabilities.sessionNotifications,
+		projectNotifications: h.capabilities.projectNotifications,
 		hasInvokeAction: h.capabilities.has("invokeAction"),
 		hasCallRoute: h.capabilities.has("callRoute"),
 		hasUnknown: h.capabilities.has("nope"),
@@ -313,7 +315,7 @@ describe("getHostApi — durable v1 capabilities (extension-host §3)", () => {
 	it("capabilities reports Phase-1 caps true, Phase-2 caps false; no gateway member", () => {
 		const c = caps();
 		expect(c.version).toBe(1);
-		expect(c.contractVersion).toBe(4);
+		expect(c.contractVersion).toBe(5);
 		expect(c.invokeAction).toBe(true);
 		expect(c.requestRender).toBe(true);
 		expect(c.hasInvokeAction).toBe(true);
@@ -321,6 +323,8 @@ describe("getHostApi — durable v1 capabilities (extension-host §3)", () => {
 		expect(c.session).toBe(true);
 		expect(c.ui).toBe(true);
 		expect(c.store).toBe(true);
+		expect(c.sessionNotifications).toBe(true);
+		expect(c.projectNotifications).toBe(true);
 		expect(c.hasCallRoute).toBe(true);
 		expect(c.hasUnknown).toBe(false);
 		expect(c.hasGatewayMember).toBe(false);

--- a/tests2/dom/extension-host-notification-bus.test.ts
+++ b/tests2/dom/extension-host-notification-bus.test.ts
@@ -1,0 +1,184 @@
+import { beforeAll as __syncBeforeAll } from "vitest";
+import { syncCustomElements as __syncCE } from "./_setup/custom-elements.js";
+__syncBeforeAll(() => __syncCE());
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+// Preserve the host-api module-cycle initialization order used by existing DOM tests.
+import "../../src/app/session-manager.js";
+import { getHostApi } from "../../src/app/host-api.js";
+import {
+	__resetHostNotificationBusForTests,
+	publishHostNotificationFrame,
+	publishHostNotificationRefreshRequired,
+	resetHostNotificationStreams,
+	subscribeHostNotification,
+	subscribeHostNotificationRefresh,
+} from "../../src/app/host-notification-bus.js";
+import { publishClientStatus } from "../../src/app/session-event-bus.js";
+import type { HostNotification } from "../../src/shared/extension-host/host-hooks.js";
+
+const tick = async (): Promise<void> => {
+	await Promise.resolve();
+	await Promise.resolve();
+};
+
+function sessionEvent(id: string, statusVersion = 1): HostNotification<"statusChanged"> {
+	return {
+		id,
+		scope: "session",
+		name: "statusChanged",
+		payloadVersion: 1,
+		occurredAt: 100,
+		projectId: "project-1",
+		sessionId: "session-1",
+		aggregate: { kind: "session", id: "session-1", revision: statusVersion },
+		payload: { previousStatus: "starting", status: "idle", statusVersion },
+	};
+}
+
+function projectEvent(id: string): HostNotification<"goalUpdated"> {
+	return {
+		id,
+		scope: "project",
+		name: "goalUpdated",
+		payloadVersion: 1,
+		occurredAt: 100,
+		projectId: "project-1",
+		aggregate: { kind: "goal", id: "goal-1", revision: 1 },
+		payload: { goalId: "goal-1", state: "in-progress", changedFields: ["state"] },
+	};
+}
+
+afterEach(() => {
+	__resetHostNotificationBusForTests();
+	vi.restoreAllMocks();
+});
+
+describe("canonical Extension Host notification bus", () => {
+	it("routes typed session/project names only within the RemoteAgent-owned binding", async () => {
+		const ownSession: string[] = [];
+		const foreignSession: string[] = [];
+		const project: string[] = [];
+		subscribeHostNotification("session-1", "session", "statusChanged", (event) => ownSession.push(event.id));
+		subscribeHostNotification("session-2", "session", "statusChanged", (event) => foreignSession.push(event.id));
+		subscribeHostNotification("session-1", "project", "goalUpdated", (event) => project.push(event.id));
+
+		publishHostNotificationFrame("session-1", { notification: sessionEvent("session-event"), stream: { epoch: "epoch-1", sequence: 1 } });
+		publishHostNotificationFrame("session-1", { notification: projectEvent("project-event"), stream: { epoch: "epoch-1", sequence: 1 } });
+		await tick();
+
+		expect(ownSession).toEqual(["session-event"]);
+		expect(project).toEqual(["project-event"]);
+		expect(foreignSession).toEqual([]);
+	});
+
+	it("returns inert subscriptions when the host has no bound session", async () => {
+		const handler = vi.fn();
+		const refresh = vi.fn();
+		const unsubscribe = subscribeHostNotification(undefined, "session", "statusChanged", handler);
+		const unsubscribeRefresh = subscribeHostNotificationRefresh(undefined, "session", refresh);
+		unsubscribe();
+		unsubscribe();
+		unsubscribeRefresh();
+		publishHostNotificationFrame("session-1", { notification: sessionEvent("event-1"), stream: { epoch: "epoch-1", sequence: 1 } });
+		await tick();
+		expect(handler).not.toHaveBeenCalled();
+		expect(refresh).not.toHaveBeenCalled();
+	});
+
+	it("makes unsubscribe idempotent and fences callbacks already queued for delivery or refresh", async () => {
+		const handler = vi.fn();
+		const refresh = vi.fn();
+		const unsubscribe = subscribeHostNotification("session-1", "session", "statusChanged", handler);
+		const unsubscribeRefresh = subscribeHostNotificationRefresh("session-1", "session", refresh);
+		publishHostNotificationFrame("session-1", { notification: sessionEvent("event-1"), stream: { epoch: "epoch-1", sequence: 1 } });
+		unsubscribe();
+		unsubscribe();
+		unsubscribeRefresh();
+		unsubscribeRefresh();
+		await tick();
+		expect(handler).not.toHaveBeenCalled();
+		expect(refresh).not.toHaveBeenCalled();
+	});
+
+	it("preserves ordered delivery and deduplicates recent semantic IDs", async () => {
+		const ids: string[] = [];
+		subscribeHostNotification("session-1", "session", "statusChanged", (event) => ids.push(event.id));
+		publishHostNotificationFrame("session-1", { notification: sessionEvent("event-1", 1), stream: { epoch: "epoch-1", sequence: 1 } });
+		publishHostNotificationFrame("session-1", { notification: sessionEvent("event-1", 2), stream: { epoch: "epoch-1", sequence: 2 } });
+		publishHostNotificationFrame("session-1", { notification: sessionEvent("event-2", 3), stream: { epoch: "epoch-1", sequence: 3 } });
+		await tick();
+		expect(ids).toEqual(["event-1", "event-2"]);
+	});
+
+	it("drops gap/epoch deltas and coalesces initial, gap, explicit, and reconnect refreshes", async () => {
+		const ids: string[] = [];
+		const refresh = vi.fn();
+		subscribeHostNotification("session-1", "session", "statusChanged", (event) => ids.push(event.id));
+		subscribeHostNotificationRefresh("session-1", "session", refresh);
+		await tick();
+		expect(refresh).toHaveBeenCalledTimes(1); // snapshot-first mount
+
+		publishHostNotificationFrame("session-1", { notification: sessionEvent("event-1", 1), stream: { epoch: "epoch-1", sequence: 1 } });
+		publishHostNotificationFrame("session-1", { notification: sessionEvent("gap-event", 3), stream: { epoch: "epoch-1", sequence: 3 } });
+		publishHostNotificationRefreshRequired("session-1", { scope: "session", epoch: "epoch-1", sequence: 4 });
+		await tick();
+		expect(ids).toEqual(["event-1"]);
+		expect(refresh).toHaveBeenCalledTimes(2);
+
+		publishHostNotificationFrame("session-1", { notification: sessionEvent("new-epoch", 1), stream: { epoch: "epoch-2", sequence: 1 } });
+		resetHostNotificationStreams("session-1");
+		await tick();
+		expect(ids).toEqual(["event-1"]);
+		expect(refresh).toHaveBeenCalledTimes(3);
+	});
+
+	it("keeps recent-ID dedupe across reconnect while resetting sequence state", async () => {
+		const ids: string[] = [];
+		subscribeHostNotification("session-1", "session", "statusChanged", (event) => ids.push(event.id));
+		publishHostNotificationFrame("session-1", { notification: sessionEvent("stable-id"), stream: { epoch: "epoch-1", sequence: 1 } });
+		await tick();
+		resetHostNotificationStreams("session-1");
+		publishHostNotificationFrame("session-1", { notification: sessionEvent("stable-id"), stream: { epoch: "epoch-2", sequence: 1 } });
+		await tick();
+		expect(ids).toEqual(["stable-id"]);
+	});
+});
+
+describe("additive scoped Host API", () => {
+	it("exposes contract v5 flags and server-bound session/project namespaces", async () => {
+		const host = getHostApi("session-1", undefined, {
+			kind: "pack",
+			packId: "fixture",
+			contributionKind: "panel",
+			contributionId: "fixture-panel",
+		});
+		expect(host.version).toBe(1);
+		expect(host.contractVersion).toBe(5);
+		expect(host.capabilities.sessionNotifications).toBe(true);
+		expect(host.capabilities.projectNotifications).toBe(true);
+		expect(host.capabilities.has("sessionNotifications")).toBe(true);
+		expect(host.capabilities.has("projectNotifications")).toBe(true);
+
+		const session = vi.fn();
+		const project = vi.fn();
+		const stopSession = host.session.notifications.subscribe("statusChanged", session);
+		const stopProject = host.project.notifications.subscribe("goalUpdated", project);
+		publishHostNotificationFrame("session-1", { notification: sessionEvent("session-event"), stream: { epoch: "epoch-1", sequence: 1 } });
+		publishHostNotificationFrame("session-1", { notification: projectEvent("project-event"), stream: { epoch: "epoch-1", sequence: 1 } });
+		await tick();
+		expect(session).toHaveBeenCalledWith(expect.objectContaining({ id: "session-event", scope: "session" }));
+		expect(project).toHaveBeenCalledWith(expect.objectContaining({ id: "project-event", scope: "project" }));
+		stopSession();
+		stopProject();
+	});
+
+	it("keeps legacy host.session.subscribe payloads unchanged", () => {
+		const host = getHostApi("session-1", undefined);
+		const payloads: unknown[] = [];
+		const unsubscribe = host.session.subscribe("status", (payload) => payloads.push(payload));
+		publishClientStatus("session-1", "streaming", "legacy detail");
+		expect(payloads).toEqual([{ status: "running", detail: "legacy detail" }]);
+		unsubscribe();
+	});
+});

--- a/tests2/harness/gateway.ts
+++ b/tests2/harness/gateway.ts
@@ -113,6 +113,7 @@ export interface GatewayFixture {
 	readonly orchestrationCore: any;
 	readonly bgProcessManager: any;
 	readonly projectContextManager: any;
+	readonly hostInterceptorRouter: any;
 	/** Authed fetch against the gateway; `path` starts with `/`. */
 	api(path: string, init?: RequestInit): Promise<Response>;
 	/** Authed fetch returning parsed JSON, throwing on non-2xx. */
@@ -390,6 +391,7 @@ async function boot(): Promise<BootedGateway> {
 		orchestrationCore: (gw as any).orchestrationCore,
 		bgProcessManager: gw.bgProcessManager,
 		projectContextManager: gw.projectContextManager,
+		hostInterceptorRouter: (gw as any).hostInterceptorRouter,
 		restoreAgentDirRuntime,
 		async api(path, init) {
 			restoreAgentDirRuntime();

--- a/tests2/integration/delegate-prompt-sections.test.ts
+++ b/tests2/integration/delegate-prompt-sections.test.ts
@@ -33,9 +33,10 @@ async function promptSectionsText(sessionId: string): Promise<string> {
 		.join("\n\n---\n\n");
 }
 
-async function refreshPromptSections(sessionId: string): Promise<void> {
+async function refreshPromptSections(sessionId: string, sessionSecret: string): Promise<void> {
 	const resp = await apiFetch(`/api/sessions/${sessionId}/provider-hooks/before-prompt`, {
 		method: "POST",
+		headers: { "X-Bobbit-Session-Secret": sessionSecret },
 		body: JSON.stringify({ prompt: "refresh prompt-section snapshot" }),
 	});
 	expect(resp.status).toBe(200);
@@ -45,7 +46,7 @@ for (const { name, readOnly } of [
 	{ name: "normal delegate", readOnly: false },
 	{ name: "read-only delegate", readOnly: true },
 ]) {
-	test(`${name} keeps durable instructions in prompt sections after before-prompt refresh`, async () => {
+	test(`${name} keeps durable instructions in prompt sections after before-prompt refresh`, async ({ gateway }) => {
 		const parentId = await createSession();
 		const marker = `delegate-prompt-viewer-${readOnly ? "readonly" : "normal"}-${Date.now()}`;
 		const instructions = `Preserve this durable delegate task marker in prompt sections: ${marker}`;
@@ -60,7 +61,8 @@ for (const { name, readOnly } of [
 				"Delegate prompt sections should initially expose the durable instructions before the provider hook refresh",
 			).toContain(marker);
 
-			await refreshPromptSections(delegateId);
+			const sessionSecret = gateway.sessionManager.sessionSecretStore.getOrCreateSecret(delegateId);
+			await refreshPromptSections(delegateId, sessionSecret);
 
 			const afterRefresh = await promptSectionsText(delegateId);
 			expect(afterRefresh, PROMPT_REFRESH_ASSERTION).toContain(marker);

--- a/tests2/integration/hindsight-external.test.ts
+++ b/tests2/integration/hindsight-external.test.ts
@@ -118,9 +118,10 @@ async function notifyPackFilesystemMutation(order: string[]): Promise<void> {
 	expect(response.status).toBe(200);
 }
 
-async function callBeforePrompt(sessionId: string, prompt: string): Promise<{ status: number; content: string }> {
+async function callBeforePrompt(sessionId: string, prompt: string, sessionSecret: string): Promise<{ status: number; content: string }> {
 	const response = await apiFetch(`/api/sessions/${sessionId}/provider-hooks/before-prompt`, {
 		method: "POST",
+		headers: { "X-Bobbit-Session-Secret": sessionSecret },
 		body: JSON.stringify({ prompt }),
 	});
 	const body = response.status === 200 ? await response.json() : {};
@@ -168,7 +169,7 @@ describe("hindsight installed-provider worker boundary", () => {
 		if (originalPackOrder) await notifyPackFilesystemMutation(originalPackOrder).catch(() => {});
 	});
 
-	test("configured pack recalls and retains through ModuleHost and the host-store proxy", async () => {
+	test("configured pack recalls and retains through ModuleHost and the host-store proxy", async ({ gateway }) => {
 		seedConfig(bobbitDir, {
 			mode: "external",
 			externalUrl: stub.url,
@@ -188,7 +189,8 @@ describe("hindsight installed-provider worker boundary", () => {
 		const sessionId = await createSession({ cwd });
 		sessionIds.push(sessionId);
 
-		const recalled = await callBeforePrompt(sessionId, "how should this roll out?");
+		const sessionSecret = gateway.sessionManager.sessionSecretStore.getOrCreateSecret(sessionId);
+		const recalled = await callBeforePrompt(sessionId, "how should this roll out?", sessionSecret);
 		expect(recalled.status).toBe(200);
 		expect(recalled.content).toContain("source=\"Relevant memory\"");
 		expect(recalled.content).toContain("feature flag");

--- a/tests2/integration/host-hooks-server-boundaries.test.ts
+++ b/tests2/integration/host-hooks-server-boundaries.test.ts
@@ -12,6 +12,7 @@ import {
 } from "../../src/server/extension-host/host-notification-dispatcher.js";
 import type { HostNotification } from "../../src/shared/extension-host/host-hooks.js";
 import { wireProjectHostNotificationBoundaries } from "../../src/server/server.js";
+import { enableTsWorkerResolver } from "../core/helpers/enable-ts-worker.js";
 import { createMemFs } from "../harness/mem-fs.js";
 import { getGateway, type EntityCounts, type GatewayFixture } from "../harness/gateway.js";
 import { assertNoLeaks, snapshotEntities } from "../harness/leak-detector.js";
@@ -345,6 +346,9 @@ describe("real gateway notification authority", () => {
 	let tempRoots: string[];
 
 	beforeAll(async () => {
+		// The integration gateway runs from the TypeScript source bundle. ModuleHost
+		// workers need the supported .js-to-.ts resolver before their first spawn.
+		enableTsWorkerResolver();
 		gw = await getGateway();
 		baseline = snapshotEntities(gw);
 	});
@@ -533,6 +537,9 @@ describe("real gateway notification authority", () => {
 		try {
 			await refreshServerPackIndex(gw);
 			const sourceSession = gw.sessionManager.getSession(source.id);
+			const persistedBeforeMove = gw.sessionManager.getPersistedSession(source.id);
+			expect(persistedBeforeMove?.agentSessionFile).toEqual(expect.any(String));
+			const agentSessionFile = persistedBeforeMove!.agentSessionFile!;
 			const beforeChildren = gw.orchestrationCore.list(source.id).map((row: any) => row.sessionId);
 			broadcastStatus(sourceSession, "streaming");
 			await poll(() => existsSync(fixture.startedPath) ? true : undefined, "paused notification handler");
@@ -542,10 +549,9 @@ describe("real gateway notification authority", () => {
 				body: JSON.stringify({ projectId: destination.id }),
 			});
 			expect(moved.status, await moved.clone().text()).toBe(200);
-			const persisted = gw.sessionManager.getPersistedSession(source.id);
-			expect(persisted?.projectId).toBe(destination.id);
-			expect(persisted?.agentSessionFile).toEqual(expect.any(String));
-			appendFileSync(persisted.agentSessionFile, `${JSON.stringify({
+			expect(gw.sessionManager.getSession(source.id)?.projectId).toBe(destination.id);
+			expect(gw.sessionManager.getSessionStore(gw.defaultProjectId).get(source.id)?.projectId).toBe(destination.id);
+			appendFileSync(agentSessionFile, `${JSON.stringify({
 				type: "message",
 				message: { role: "assistant", content: "destination-project-transcript-sentinel" },
 			})}\n`);
@@ -560,6 +566,9 @@ describe("real gateway notification authority", () => {
 			expect(JSON.stringify(result)).not.toContain("destination-project-transcript-sentinel");
 			expect(gw.orchestrationCore.list(source.id).map((row: any) => row.sessionId)).toEqual(beforeChildren);
 		} finally {
+			// Unblock a worker even when an assertion fails so its ordered module lane
+			// cannot bleed into a retry or a later boundary case in this shared gateway.
+			writeFileSync(fixture.releasePath, "release");
 			const live = gw.sessionManager.getSession(source.id);
 			if (live) {
 				broadcastStatus(live, "idle");

--- a/tests2/integration/host-hooks-server-boundaries.test.ts
+++ b/tests2/integration/host-hooks-server-boundaries.test.ts
@@ -14,19 +14,22 @@ import { wireProjectHostNotificationBoundaries } from "../../src/server/server.j
 import { createMemFs } from "../harness/mem-fs.js";
 import { getGateway, type EntityCounts, type GatewayFixture } from "../harness/gateway.js";
 import { assertNoLeaks, snapshotEntities } from "../harness/leak-detector.js";
+import { createRunChild, removeOwnedRunChild } from "../harness/run-isolation.js";
 import { createScope, type TestScope } from "../harness/scope.js";
 
 const contexts: ProjectContext[] = [];
+const contextRoots: string[] = [];
 
 afterEach(async () => {
 	await Promise.allSettled(contexts.splice(0).map(context => context.close()));
+	for (const root of contextRoots.splice(0)) removeOwnedRunChild(root);
 });
 
-function project(id: string): RegisteredProject {
+function project(id: string, rootPath: string): RegisteredProject {
 	return {
 		id,
 		name: id,
-		rootPath: path.resolve(`/memfs/${id}`),
+		rootPath,
 		createdAt: 1,
 		kind: "normal",
 		colorLight: "oklch(0.6 0.1 250)",
@@ -35,16 +38,23 @@ function project(id: string): RegisteredProject {
 }
 
 function context(id: string, fs = createMemFs()): ProjectContext {
-	const registered = project(id);
+	const rootPath = createRunChild("host-hooks-project");
+	const registered = project(id, rootPath);
 	fs.mkdirSync(registered.rootPath, { recursive: true });
-	const ctx = new ProjectContext(registered, {
-		fsImpl: fs,
-		goalPersistence: "json",
-		taskPersistence: "json",
-		gatePersistence: "json",
-	});
-	contexts.push(ctx);
-	return ctx;
+	try {
+		const ctx = new ProjectContext(registered, {
+			fsImpl: fs,
+			goalPersistence: "json",
+			taskPersistence: "json",
+			gatePersistence: "json",
+		});
+		contexts.push(ctx);
+		contextRoots.push(rootPath);
+		return ctx;
+	} catch (error) {
+		removeOwnedRunChild(rootPath);
+		throw error;
+	}
 }
 
 async function settleFanout(): Promise<void> {

--- a/tests2/integration/host-hooks-server-boundaries.test.ts
+++ b/tests2/integration/host-hooks-server-boundaries.test.ts
@@ -1,0 +1,113 @@
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { ProjectContext } from "../../src/server/agent/project-context.js";
+import type { RegisteredProject } from "../../src/server/agent/project-registry.js";
+import { TaskManager } from "../../src/server/agent/task-manager.js";
+import {
+	HostNotificationDispatcher,
+	type HostNotificationDeliveryAdapter,
+} from "../../src/server/extension-host/host-notification-dispatcher.js";
+import type { HostNotification } from "../../src/shared/extension-host/host-hooks.js";
+import { wireProjectHostNotificationBoundaries } from "../../src/server/server.js";
+import { createMemFs } from "../harness/mem-fs.js";
+
+const contexts: ProjectContext[] = [];
+
+afterEach(async () => {
+	await Promise.allSettled(contexts.splice(0).map(context => context.close()));
+});
+
+function project(id: string): RegisteredProject {
+	return {
+		id,
+		name: id,
+		rootPath: path.resolve(`/memfs/${id}`),
+		createdAt: 1,
+		kind: "normal",
+		colorLight: "oklch(0.6 0.1 250)",
+		colorDark: "oklch(0.7 0.1 250)",
+	};
+}
+
+function context(id: string): ProjectContext {
+	const fs = createMemFs();
+	const registered = project(id);
+	fs.mkdirSync(registered.rootPath, { recursive: true });
+	const ctx = new ProjectContext(registered, {
+		fsImpl: fs,
+		goalPersistence: "json",
+		taskPersistence: "json",
+		gatePersistence: "json",
+	});
+	contexts.push(ctx);
+	return ctx;
+}
+
+async function settleFanout(): Promise<void> {
+	await new Promise<void>(resolve => setTimeout(resolve, 0));
+}
+
+describe("gateway-owned host hook boundaries", () => {
+	it("routes project store commits through one canonical dispatcher without replacing legacy callbacks", async () => {
+		const delivered: HostNotification[] = [];
+		const adapter: HostNotificationDeliveryAdapter = {
+			consumer: "browser",
+			deliver: notification => { delivered.push(notification); },
+		};
+		const dispatcher = new HostNotificationDispatcher({
+			adapters: [adapter],
+			idGenerator: (() => { let id = 0; return () => `notification-${++id}`; })(),
+			now: (() => { let now = 100; return () => ++now; })(),
+		});
+		const ctx = context("project-a");
+		let legacyCreates = 0;
+		ctx.goalStore.onGoalCreated = () => { legacyCreates++; };
+		ctx.setHostNotificationDispatcher(dispatcher);
+		wireProjectHostNotificationBoundaries(ctx);
+
+		await ctx.goalStore.putStrict({
+			id: "goal-1",
+			title: "Goal",
+			cwd: ctx.project.rootPath,
+			state: "todo",
+			spec: "",
+			createdAt: 10,
+			updatedAt: 10,
+			setupStatus: "ready",
+			projectId: ctx.project.id,
+		});
+		expect(await ctx.goalManager.updateGoal("goal-1", { state: "complete" })).toBe(true);
+
+		const tasks = new TaskManager(ctx.taskStore);
+		const task = tasks.createTask("goal-1", "Implement", "implementation");
+		tasks.updateTask(task.id, { state: "in-progress", title: "Implement safely" });
+		await ctx.taskStore.flush();
+
+		ctx.gateStore.initGatesForGoal("goal-1", ["implementation"]);
+		ctx.gateStore.updateGateStatus("goal-1", "implementation", "passed");
+		await ctx.gateStore.flush();
+		ctx.projectConfigStore.set("build_command", "npm run build");
+		await settleFanout();
+
+		expect(legacyCreates).toBe(1);
+		expect(delivered.map(notification => notification.name)).toEqual([
+			"goalCreated",
+			"goalUpdated",
+			"goalCompleted",
+			"taskCreated",
+			"taskUpdated",
+			"taskStateChanged",
+			"gateStatusChanged",
+			"settingsChanged",
+		]);
+		expect(delivered.every(notification => notification.projectId === "project-a")).toBe(true);
+		expect(delivered.find(notification => notification.name === "gateStatusChanged")).toMatchObject({
+			aggregate: { id: "goal-1:implementation", revision: 1 },
+			payload: { goalId: "goal-1", gateId: "implementation", previousStatus: "pending", status: "passed" },
+		});
+		expect(delivered.find(notification => notification.name === "settingsChanged")?.payload).toEqual({
+			target: "project",
+			changedKeys: ["commands"],
+		});
+	});
+});

--- a/tests2/integration/host-hooks-server-boundaries.test.ts
+++ b/tests2/integration/host-hooks-server-boundaries.test.ts
@@ -1,8 +1,9 @@
-import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { appendFileSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import WebSocket from "ws";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { ProjectContext } from "../../src/server/agent/project-context.js";
+import { broadcastStatus } from "../../src/server/agent/session-status.js";
 import type { RegisteredProject } from "../../src/server/agent/project-registry.js";
 import { TaskManager } from "../../src/server/agent/task-manager.js";
 import {
@@ -156,6 +157,45 @@ async function refreshServerPackIndex(gw: GatewayFixture): Promise<void> {
 		body: JSON.stringify({ scope: "server", order: current.order }),
 	});
 	expect(response.status, await response.clone().text()).toBe(200);
+}
+
+function writeSessionAuthorityPack(gw: GatewayFixture, packName: string) {
+	const packDir = path.join(gw.bobbitDir, "config", "market-packs", packName);
+	const startedPath = path.join(packDir, "handler-started");
+	const releasePath = path.join(packDir, "handler-release");
+	const resultPath = path.join(packDir, "handler-result.json");
+	mkdirSync(path.join(packDir, "hooks"), { recursive: true });
+	mkdirSync(path.join(packDir, "lib"), { recursive: true });
+	writeFileSync(path.join(packDir, "pack.yaml"), [
+		"schema: 2", `name: ${packName}`, "description: Session authority fixture", "version: 1.0.0",
+		"contents:", "  roles: []", "  tools: []", "  skills: []", "  entrypoints: []", "  hooks: [session-authority]",
+	].join("\n") + "\n");
+	writeFileSync(path.join(packDir, ".pack-meta.yaml"), [
+		"sourceUrl: integration", "sourceRef: local", "commit: test", `packName: ${packName}`, "version: 1.0.0",
+		"installedAt: '2026-01-01T00:00:00.000Z'", "updatedAt: '2026-01-01T00:00:00.000Z'", "scope: server",
+	].join("\n") + "\n");
+	writeFileSync(path.join(packDir, "hooks", "session-authority.yaml"), [
+		"id: session.authority", "module: ../lib/hooks.mjs", "kind: notification",
+		"notifications:", "  - { scope: session, name: statusChanged }",
+		"capabilities: [session, agents]", "budget: { timeoutMs: 5000 }",
+	].join("\n") + "\n");
+	writeFileSync(path.join(packDir, "lib", "hooks.mjs"), [
+		'import { existsSync, writeFileSync } from "node:fs";',
+		`const started = ${JSON.stringify(startedPath)};`,
+		`const release = ${JSON.stringify(releasePath)};`,
+		`const result = ${JSON.stringify(resultPath)};`,
+		"const sleep = (ms) => new Promise(resolve => setTimeout(resolve, ms));",
+		"export default { statusChanged: async (ctx, notification) => {",
+		"  if (notification.payload.status !== 'streaming') return;",
+		"  writeFileSync(started, 'started');",
+		"  while (!existsSync(release)) await sleep(5);",
+		"  const out = {};",
+		"  try { out.transcript = await ctx.host.session.readTranscript(); } catch (error) { out.transcriptError = String(error?.message ?? error); }",
+		"  try { out.spawn = await ctx.host.agents.spawn({ instructions: 'must-not-cross-project-move' }); } catch (error) { out.spawnError = String(error?.message ?? error); }",
+		"  writeFileSync(result, JSON.stringify(out));",
+		"} };",
+	].join("\n") + "\n");
+	return { packDir, startedPath, releasePath, resultPath };
 }
 
 function writeInterceptorAuditPack(gw: GatewayFixture, packName: string): string {
@@ -474,6 +514,62 @@ describe("real gateway notification authority", () => {
 				body: JSON.stringify({ projectId: gw.defaultProjectId }),
 			});
 			captured.ws.close();
+		}
+	});
+
+	it("revokes paused session and agents capabilities when the source session moves projects", async () => {
+		const defaultProject = gw.projectContextManager.getRegistry().get(gw.defaultProjectId);
+		const foreignRoot = path.join(path.dirname(gw.bobbitDir), `host-hooks-capability-move-${Date.now()}`);
+		tempRoots.push(foreignRoot);
+		mkdirSync(foreignRoot, { recursive: true });
+		const destination = await gw.apiJson("/api/projects", {
+			method: "POST",
+			body: JSON.stringify({ name: `host-hooks-capability-move-${Date.now()}`, rootPath: foreignRoot }),
+		});
+		scope.trackProject(destination.id);
+		const source = await scope.createSession({ cwd: defaultProject.rootPath });
+		await waitForIdle(gw, source.id);
+		const fixture = writeSessionAuthorityPack(gw, `host-authority-${process.pid}-${Date.now()}`);
+		try {
+			await refreshServerPackIndex(gw);
+			const sourceSession = gw.sessionManager.getSession(source.id);
+			const beforeChildren = gw.orchestrationCore.list(source.id).map((row: any) => row.sessionId);
+			broadcastStatus(sourceSession, "streaming");
+			await poll(() => existsSync(fixture.startedPath) ? true : undefined, "paused notification handler");
+
+			const moved = await gw.api(`/api/sessions/${encodeURIComponent(source.id)}`, {
+				method: "PATCH",
+				body: JSON.stringify({ projectId: destination.id }),
+			});
+			expect(moved.status, await moved.clone().text()).toBe(200);
+			const persisted = gw.sessionManager.getPersistedSession(source.id);
+			expect(persisted?.projectId).toBe(destination.id);
+			expect(persisted?.agentSessionFile).toEqual(expect.any(String));
+			appendFileSync(persisted.agentSessionFile, `${JSON.stringify({
+				type: "message",
+				message: { role: "assistant", content: "destination-project-transcript-sentinel" },
+			})}\n`);
+			writeFileSync(fixture.releasePath, "release");
+			await poll(() => existsSync(fixture.resultPath) ? true : undefined, "fenced notification result", 5_000);
+			const result = JSON.parse(readFileSync(fixture.resultPath, "utf8"));
+
+			expect(result).not.toHaveProperty("transcript");
+			expect(result).not.toHaveProperty("spawn");
+			expect(result.transcriptError).toMatch(/session authority is no longer valid/);
+			expect(result.spawnError).toMatch(/session authority is no longer valid/);
+			expect(JSON.stringify(result)).not.toContain("destination-project-transcript-sentinel");
+			expect(gw.orchestrationCore.list(source.id).map((row: any) => row.sessionId)).toEqual(beforeChildren);
+		} finally {
+			const live = gw.sessionManager.getSession(source.id);
+			if (live) {
+				broadcastStatus(live, "idle");
+				await gw.api(`/api/sessions/${encodeURIComponent(source.id)}`, {
+					method: "PATCH",
+					body: JSON.stringify({ projectId: gw.defaultProjectId }),
+				});
+			}
+			rmSync(fixture.packDir, { recursive: true, force: true });
+			await refreshServerPackIndex(gw);
 		}
 	});
 

--- a/tests2/integration/host-hooks-server-boundaries.test.ts
+++ b/tests2/integration/host-hooks-server-boundaries.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, rmSync } from "node:fs";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import WebSocket from "ws";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
@@ -34,8 +34,7 @@ function project(id: string): RegisteredProject {
 	};
 }
 
-function context(id: string): ProjectContext {
-	const fs = createMemFs();
+function context(id: string, fs = createMemFs()): ProjectContext {
 	const registered = project(id);
 	fs.mkdirSync(registered.rootPath, { recursive: true });
 	const ctx = new ProjectContext(registered, {
@@ -140,6 +139,34 @@ async function waitForInboxCount(gw: GatewayFixture, staffId: string, count: num
 	}, `${count} inbox entries for ${staffId}`, 5_000);
 }
 
+async function refreshServerPackIndex(gw: GatewayFixture): Promise<void> {
+	const current = await gw.apiJson<{ order: string[] }>("/api/marketplace/pack-order?scope=server");
+	const response = await gw.api("/api/marketplace/pack-order", {
+		method: "PUT",
+		body: JSON.stringify({ scope: "server", order: current.order }),
+	});
+	expect(response.status, await response.clone().text()).toBe(200);
+}
+
+function writeInterceptorAuditPack(gw: GatewayFixture, packName: string): string {
+	const packDir = path.join(gw.bobbitDir, "config", "market-packs", packName);
+	mkdirSync(path.join(packDir, "hooks"), { recursive: true });
+	mkdirSync(path.join(packDir, "lib"), { recursive: true });
+	writeFileSync(path.join(packDir, "pack.yaml"), [
+		"schema: 2", `name: ${packName}`, "description: Host interceptor audit fixture", "version: 1.0.0",
+		"contents:", "  roles: []", "  tools: []", "  skills: []", "  entrypoints: []", "  hooks: [audit-project]",
+	].join("\n") + "\n");
+	writeFileSync(path.join(packDir, ".pack-meta.yaml"), [
+		"sourceUrl: integration", "sourceRef: local", "commit: test", `packName: ${packName}`, "version: 1.0.0",
+		"installedAt: '2026-01-01T00:00:00.000Z'", "updatedAt: '2026-01-01T00:00:00.000Z'", "scope: server",
+	].join("\n") + "\n");
+	writeFileSync(path.join(packDir, "hooks", "audit-project.yaml"), [
+		"id: audit.project", "module: ../lib/hooks.mjs", "kind: interceptor", "interceptors: [projectImported]", "capabilities: []",
+	].join("\n") + "\n");
+	writeFileSync(path.join(packDir, "lib", "hooks.mjs"), "export default { projectImported: async () => { throw new Error('private worker failure sentinel'); } };\n");
+	return packDir;
+}
+
 describe("gateway-owned host hook boundaries", () => {
 	it("routes project store commits through one canonical dispatcher without replacing legacy callbacks", async () => {
 		const delivered: HostNotification[] = [];
@@ -206,6 +233,59 @@ describe("gateway-owned host hook boundaries", () => {
 			changedKeys: ["commands"],
 		});
 	});
+
+	it("publishes every public worktree setting family only after rename and omits values, unknown keys, and failed writes", async () => {
+		const delivered: HostNotification[] = [];
+		const fs = createMemFs();
+		let renameCount = 0;
+		const rename = fs.renameSync.bind(fs);
+		fs.renameSync = ((from: Parameters<typeof fs.renameSync>[0], to: Parameters<typeof fs.renameSync>[1]) => {
+			rename(from, to);
+			renameCount++;
+		}) as typeof fs.renameSync;
+		const dispatcher = new HostNotificationDispatcher({
+			adapters: [{
+				consumer: "browser",
+				deliver: notification => {
+					expect(renameCount).toBeGreaterThan(0);
+					delivered.push(notification);
+				},
+			}],
+			idGenerator: (() => { let id = 0; return () => `settings-${++id}`; })(),
+		});
+		const ctx = context("project-settings", fs);
+		ctx.setHostNotificationDispatcher(dispatcher);
+		wireProjectHostNotificationBoundaries(ctx);
+
+		ctx.projectConfigStore.set("base_ref", "origin/sensitive-value");
+		ctx.projectConfigStore.set("worktree_pool_size", "19");
+		ctx.projectConfigStore.set("worktree_setup_timeout_ms", "987654");
+		ctx.projectConfigStore.set("arbitrary_secret_key", "forbidden-secret-value");
+		await settleFanout();
+
+		expect(delivered).toHaveLength(3);
+		expect(delivered.map(notification => notification.payload)).toEqual([
+			{ target: "project", changedKeys: ["baseRef"] },
+			{ target: "project", changedKeys: ["worktrees"] },
+			{ target: "project", changedKeys: ["worktrees"] },
+		]);
+		expect(new Set(delivered.map(notification => notification.aggregate.revision)).size).toBe(3);
+		for (const notification of delivered) {
+			expect(notification.aggregate.revision).toMatch(/^[a-f0-9]{64}$/);
+		}
+		const publicFacts = JSON.stringify(delivered);
+		expect(publicFacts).not.toContain("sensitive-value");
+		expect(publicFacts).not.toContain("987654");
+		expect(publicFacts).not.toContain("forbidden-secret-value");
+
+		const committedRename = fs.renameSync;
+		fs.renameSync = (() => { throw new Error("rename sentinel path and value"); }) as typeof fs.renameSync;
+		expect(() => ctx.projectConfigStore.set("sandbox", "docker")).toThrow();
+		fs.renameSync = committedRename;
+		await settleFanout();
+		expect(delivered).toHaveLength(3);
+		expect(ctx.projectConfigStore.get("sandbox")).toBeUndefined();
+	});
 });
 
 describe("real gateway notification authority", () => {
@@ -227,6 +307,39 @@ describe("real gateway notification authority", () => {
 		for (const root of tempRoots) rmSync(root, { recursive: true, force: true });
 	});
 	afterAll(() => { assertNoLeaks(baseline, snapshotEntities(gw)); });
+
+	it("uses the production router audit sink for project-only interceptor decisions", async () => {
+		const packName = `host-audit-${process.pid}-${Date.now()}`;
+		const packDir = writeInterceptorAuditPack(gw, packName);
+		const log = vi.spyOn(console, "log").mockImplementation(() => {});
+		try {
+			await refreshServerPackIndex(gw);
+			const result = await gw.hostInterceptorRouter.dispatch("projectImported", {
+				projectId: gw.defaultProjectId,
+				components: [],
+			}, {
+				projectId: gw.defaultProjectId,
+				cwd: gw.projectContextManager.getOrCreate(gw.defaultProjectId).project.rootPath,
+				signal: new AbortController().signal,
+			});
+			expect(result.decisions).toHaveLength(1);
+			expect(result.decisions[0]).toMatchObject({
+				hook: "projectImported", projectId: gw.defaultProjectId, contributionId: "audit.project",
+				outcome: "failed-open", proposalReceived: false, valid: false, applied: false,
+			});
+			expect(result.decisions[0]).not.toHaveProperty("sessionId");
+			const auditCalls = log.mock.calls.filter(call => call[0] === "[host-interceptor-audit] %s");
+			expect(auditCalls).toHaveLength(1);
+			const diagnostic = JSON.parse(String(auditCalls[0]?.[1]));
+			expect(diagnostic).toEqual(result.decisions[0]);
+			expect(diagnostic).not.toHaveProperty("sessionId");
+			expect(JSON.stringify(diagnostic)).not.toContain("private worker failure sentinel");
+		} finally {
+			log.mockRestore();
+			rmSync(packDir, { recursive: true, force: true });
+			await refreshServerPackIndex(gw);
+		}
+	});
 
 	async function createTaskAndObserver(suffix: string) {
 		const project = gw.projectContextManager.getRegistry().get(gw.defaultProjectId);

--- a/tests2/integration/host-hooks-server-boundaries.test.ts
+++ b/tests2/integration/host-hooks-server-boundaries.test.ts
@@ -175,6 +175,7 @@ describe("gateway-owned host hook boundaries", () => {
 		await ctx.taskStore.flush();
 
 		ctx.gateStore.initGatesForGoal("goal-1", ["implementation"]);
+		await ctx.gateStore.flush();
 		ctx.gateStore.updateGateStatus("goal-1", "implementation", "passed");
 		await ctx.gateStore.flush();
 		ctx.projectConfigStore.set("build_command", "npm run build");
@@ -186,12 +187,14 @@ describe("gateway-owned host hook boundaries", () => {
 			"goalUpdated",
 			"goalCompleted",
 			"taskCreated",
-			"taskUpdated",
-			"taskStateChanged",
 			"gateStatusChanged",
 			"settingsChanged",
 		]);
 		expect(delivered.every(notification => notification.projectId === "project-a")).toBe(true);
+		expect(delivered.find(notification => notification.name === "taskCreated")).toMatchObject({
+			aggregate: { id: task.id, revision: task.updatedAt },
+			payload: { taskId: task.id, goalId: "goal-1", type: "implementation", state: "in-progress" },
+		});
 		expect(delivered.find(notification => notification.name === "gateStatusChanged")).toMatchObject({
 			aggregate: { id: "goal-1:implementation", revision: 1 },
 			payload: { goalId: "goal-1", gateId: "implementation", previousStatus: "pending", status: "passed" },

--- a/tests2/integration/host-hooks-server-boundaries.test.ts
+++ b/tests2/integration/host-hooks-server-boundaries.test.ts
@@ -397,6 +397,86 @@ describe("real gateway notification authority", () => {
 		});
 	}
 
+	it("rebinds an authenticated app socket after the session PATCH route moves projects", async () => {
+		const defaultProject = gw.projectContextManager.getRegistry().get(gw.defaultProjectId);
+		const foreignRoot = path.join(path.dirname(gw.bobbitDir), `host-hooks-moved-${Date.now()}`);
+		tempRoots.push(foreignRoot);
+		mkdirSync(foreignRoot, { recursive: true });
+		const destination = await gw.apiJson("/api/projects", {
+			method: "POST",
+			body: JSON.stringify({ name: `host-hooks-moved-${Date.now()}`, rootPath: foreignRoot }),
+		});
+		scope.trackProject(destination.id);
+		const session = await scope.createSession({ cwd: defaultProject.rootPath });
+		const oldGoal = await scope.createGoal({
+			title: "Moved socket old project",
+			spec: "Old-project notification fixture with enough detail for validation.",
+			cwd: defaultProject.rootPath,
+			worktree: false,
+		});
+		const newGoal = await scope.createGoal({
+			title: "Moved socket new project",
+			spec: "New-project notification fixture with enough detail for validation.",
+			cwd: foreignRoot,
+			projectId: destination.id,
+			worktree: false,
+		});
+		await waitForIdle(gw, session.id);
+		const captured = await connectCaptured(gw.wsBase, session.id, gw.token, "app");
+		const cursor = captured.cursor();
+		try {
+			const moved = await gw.api(`/api/sessions/${encodeURIComponent(session.id)}`, {
+				method: "PATCH",
+				body: JSON.stringify({ projectId: destination.id }),
+			});
+			expect(moved.status, await moved.clone().text()).toBe(200);
+
+			const oldUpdate = await gw.api(`/api/goals/${encodeURIComponent(oldGoal.id)}`, {
+				method: "PUT",
+				body: JSON.stringify({ title: "Old project must stay silent" }),
+			});
+			expect(oldUpdate.status, await oldUpdate.clone().text()).toBe(200);
+			const refresh = await captured.waitFor(
+				frame => frame.type === "host_notifications_refresh_required" && frame.scope === "project",
+				cursor,
+			);
+			expect(refresh).toMatchObject({ type: "host_notifications_refresh_required", scope: "project" });
+			await captured.barrier(cursor);
+			expect(captured.frames.slice(cursor).filter(frame =>
+				frame.type === "host_notification" && frame.notification?.aggregate?.id === oldGoal.id,
+			)).toHaveLength(0);
+
+			const newUpdate = await gw.api(`/api/goals/${encodeURIComponent(newGoal.id)}`, {
+				method: "PUT",
+				body: JSON.stringify({ title: "New project is authoritative" }),
+			});
+			expect(newUpdate.status, await newUpdate.clone().text()).toBe(200);
+			const newFact = await captured.waitFor(
+				frame => frame.type === "host_notification" && frame.notification?.aggregate?.id === newGoal.id,
+				cursor,
+			);
+			expect(newFact.notification).toMatchObject({
+				name: "goalUpdated",
+				projectId: destination.id,
+				aggregate: { id: newGoal.id },
+			});
+			const scopedFrames = captured.frames.slice(cursor).filter(frame =>
+				frame.type === "host_notifications_refresh_required"
+				|| (frame.type === "host_notification" && frame.notification?.aggregate?.id === newGoal.id),
+			);
+			expect(scopedFrames.map(frame => frame.type)).toEqual([
+				"host_notifications_refresh_required",
+				"host_notification",
+			]);
+		} finally {
+			await gw.api(`/api/sessions/${encodeURIComponent(session.id)}`, {
+				method: "PATCH",
+				body: JSON.stringify({ projectId: gw.defaultProjectId }),
+			});
+			captured.ws.close();
+		}
+	});
+
 	it("sends enqueueWithId invalidations only to the current staff UI principal and keeps canonical input off the wire", async () => {
 		const { task, staff } = await createTaskAndObserver("socket-routing");
 		const foreignRoot = path.join(path.dirname(gw.bobbitDir), `host-hooks-foreign-${Date.now()}`);

--- a/tests2/integration/host-hooks-server-boundaries.test.ts
+++ b/tests2/integration/host-hooks-server-boundaries.test.ts
@@ -125,15 +125,17 @@ async function waitForIdle(gw: GatewayFixture, sessionId: string): Promise<void>
 	await poll(() => gw.sessionManager.getSession(sessionId)?.status === "idle" ? true : undefined, `idle session ${sessionId}`);
 }
 
-async function inboxEntries(gw: GatewayFixture, staffId: string): Promise<any[]> {
-	const response = await gw.api(`/api/staff/${encodeURIComponent(staffId)}/inbox`);
+async function inboxEntries(gw: GatewayFixture, staffId: string, sessionSecret?: string): Promise<any[]> {
+	const response = await gw.api(`/api/staff/${encodeURIComponent(staffId)}/inbox`, {
+		headers: sessionSecret ? { "X-Bobbit-Session-Secret": sessionSecret } : undefined,
+	});
 	expect(response.status, await response.clone().text()).toBe(200);
 	return (await response.json()).entries;
 }
 
-async function waitForInboxCount(gw: GatewayFixture, staffId: string, count: number): Promise<any[]> {
+async function waitForInboxCount(gw: GatewayFixture, staffId: string, count: number, sessionSecret?: string): Promise<any[]> {
 	return poll(async () => {
-		const entries = await inboxEntries(gw, staffId);
+		const entries = await inboxEntries(gw, staffId, sessionSecret);
 		return entries.length === count ? entries : undefined;
 	}, `${count} inbox entries for ${staffId}`, 5_000);
 }
@@ -297,6 +299,7 @@ describe("real gateway notification authority", () => {
 			connectCaptured(gw.wsBase, "__viewer__", gw.token, "app"),
 		]);
 		const [exact, sandbox, stale, foreign, viewer] = sockets;
+		const staffSessionSecret = gw.sessionManager.sessionSecretStore.getOrCreateSecret(staff.currentSessionId);
 		const cursors = sockets.map(socket => socket.cursor());
 		const unboundFrames: any[] = [];
 		const unbound = {
@@ -324,7 +327,7 @@ describe("real gateway notification authority", () => {
 			expect(JSON.stringify(live)).not.toContain("rootCorrelationId");
 			expect(JSON.stringify(live)).not.toContain("causationDepth");
 
-			const persisted = await waitForInboxCount(gw, staff.id, 1);
+			const persisted = await waitForInboxCount(gw, staff.id, 1, staffSessionSecret);
 			expect(persisted[0].id).toBe(live.entry.id);
 			expect(persisted[0].notificationInput).toMatchObject({
 				rootCorrelationId: expect.any(String),
@@ -363,7 +366,7 @@ describe("real gateway notification authority", () => {
 		const foreignSecret = gw.sessionManager.sessionSecretStore.getOrCreateSecret(foreignSession.id);
 		try {
 			expect((await updateTask(task.id, "seed notification root")).status).toBe(200);
-			const initialEntries = await waitForInboxCount(gw, staff.id, 1);
+			const initialEntries = await waitForInboxCount(gw, staff.id, 1, secret);
 			const initialInput = initialEntries[0].notificationInput;
 			const turn = await poll(
 				() => gw.sessionManager.getStaffNotificationTurnContext(sessionId),
@@ -405,7 +408,7 @@ describe("real gateway notification authority", () => {
 				const response = await updateTask(task.id, `${label} secret gets a fresh root`, headers);
 				expect(response.status, await response.clone().text()).toBe(200);
 			}
-			const independentEntries = await waitForInboxCount(gw, staff.id, 4);
+			const independentEntries = await waitForInboxCount(gw, staff.id, 4, secret);
 			const roots = independentEntries.map(entry => entry.notificationInput.rootCorrelationId);
 			expect(new Set(roots).size).toBe(4);
 			expect(roots.slice(1)).not.toContain(initialInput.rootCorrelationId);

--- a/tests2/integration/host-hooks-server-boundaries.test.ts
+++ b/tests2/integration/host-hooks-server-boundaries.test.ts
@@ -1,5 +1,7 @@
+import { mkdirSync, rmSync } from "node:fs";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import WebSocket from "ws";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { ProjectContext } from "../../src/server/agent/project-context.js";
 import type { RegisteredProject } from "../../src/server/agent/project-registry.js";
 import { TaskManager } from "../../src/server/agent/task-manager.js";
@@ -10,6 +12,9 @@ import {
 import type { HostNotification } from "../../src/shared/extension-host/host-hooks.js";
 import { wireProjectHostNotificationBoundaries } from "../../src/server/server.js";
 import { createMemFs } from "../harness/mem-fs.js";
+import { getGateway, type EntityCounts, type GatewayFixture } from "../harness/gateway.js";
+import { assertNoLeaks, snapshotEntities } from "../harness/leak-detector.js";
+import { createScope, type TestScope } from "../harness/scope.js";
 
 const contexts: ProjectContext[] = [];
 
@@ -45,6 +50,92 @@ function context(id: string): ProjectContext {
 
 async function settleFanout(): Promise<void> {
 	await new Promise<void>(resolve => setTimeout(resolve, 0));
+}
+
+interface CapturedSocket {
+	ws: WebSocket;
+	frames: any[];
+	cursor(): number;
+	waitFor(predicate: (frame: any) => boolean, from?: number, timeoutMs?: number): Promise<any>;
+	barrier(from?: number): Promise<void>;
+}
+
+async function connectCaptured(
+	wsBase: string,
+	sessionId: string,
+	token: string,
+	clientKind?: "app",
+): Promise<CapturedSocket> {
+	const ws = new WebSocket(`${wsBase}/ws/${sessionId}`);
+	const frames: any[] = [];
+	ws.on("message", raw => {
+		try { frames.push(JSON.parse(String(raw))); } catch { /* ignore non-JSON frames */ }
+	});
+	await new Promise<void>((resolve, reject) => {
+		ws.once("open", resolve);
+		ws.once("error", reject);
+	});
+	ws.send(JSON.stringify({ type: "auth", token, ...(clientKind ? { clientKind } : {}) }));
+	const waitFor = (predicate: (frame: any) => boolean, from = 0, timeoutMs = 3_000): Promise<any> => {
+		const existing = frames.slice(from).find(predicate);
+		if (existing) return Promise.resolve(existing);
+		return new Promise((resolve, reject) => {
+			const timer = setTimeout(() => {
+				cleanup();
+				reject(new Error(`WebSocket frame timed out for ${sessionId}`));
+			}, timeoutMs);
+			const onMessage = (raw: unknown) => {
+				let frame: any;
+				try { frame = JSON.parse(String(raw)); } catch { return; }
+				if (!predicate(frame) || frames.length - 1 < from) return;
+				cleanup();
+				resolve(frame);
+			};
+			const cleanup = () => {
+				clearTimeout(timer);
+				ws.off("message", onMessage);
+			};
+			ws.on("message", onMessage);
+		});
+	};
+	await waitFor(frame => frame.type === "auth_ok");
+	return {
+		ws,
+		frames,
+		cursor: () => frames.length,
+		waitFor,
+		async barrier(from = frames.length) {
+			ws.send(JSON.stringify({ type: "ping" }));
+			await waitFor(frame => frame.type === "pong", from);
+		},
+	};
+}
+
+async function poll<T>(read: () => T | undefined | Promise<T | undefined>, label: string, timeoutMs = 3_000): Promise<T> {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		const value = await read();
+		if (value !== undefined) return value;
+		await new Promise<void>(resolve => setTimeout(resolve, 10));
+	}
+	throw new Error(`Timed out waiting for ${label}`);
+}
+
+async function waitForIdle(gw: GatewayFixture, sessionId: string): Promise<void> {
+	await poll(() => gw.sessionManager.getSession(sessionId)?.status === "idle" ? true : undefined, `idle session ${sessionId}`);
+}
+
+async function inboxEntries(gw: GatewayFixture, staffId: string): Promise<any[]> {
+	const response = await gw.api(`/api/staff/${encodeURIComponent(staffId)}/inbox`);
+	expect(response.status, await response.clone().text()).toBe(200);
+	return (await response.json()).entries;
+}
+
+async function waitForInboxCount(gw: GatewayFixture, staffId: string, count: number): Promise<any[]> {
+	return poll(async () => {
+		const entries = await inboxEntries(gw, staffId);
+		return entries.length === count ? entries : undefined;
+	}, `${count} inbox entries for ${staffId}`, 5_000);
 }
 
 describe("gateway-owned host hook boundaries", () => {
@@ -109,5 +200,262 @@ describe("gateway-owned host hook boundaries", () => {
 			target: "project",
 			changedKeys: ["commands"],
 		});
+	});
+});
+
+describe("real gateway notification authority", () => {
+	let gw: GatewayFixture;
+	let scope: TestScope;
+	let baseline: EntityCounts;
+	let tempRoots: string[];
+
+	beforeAll(async () => {
+		gw = await getGateway();
+		baseline = snapshotEntities(gw);
+	});
+	beforeEach(() => {
+		scope = createScope(gw);
+		tempRoots = [];
+	});
+	afterEach(async () => {
+		await scope.cleanup();
+		for (const root of tempRoots) rmSync(root, { recursive: true, force: true });
+	});
+	afterAll(() => { assertNoLeaks(baseline, snapshotEntities(gw)); });
+
+	async function createTaskAndObserver(suffix: string) {
+		const project = gw.projectContextManager.getRegistry().get(gw.defaultProjectId);
+		const cwd = project.rootPath as string;
+		const goal = await scope.createGoal({
+			title: `Host hook authority ${suffix}`,
+			spec: "Deterministic host hook authority fixture with enough detail to satisfy goal validation.",
+			cwd,
+			worktree: false,
+		});
+		const task = await gw.apiJson(`/api/goals/${encodeURIComponent(goal.id)}/tasks`, {
+			method: "POST",
+			body: JSON.stringify({ title: `Observed task ${suffix}`, type: "testing", spec: "fixture" }),
+		});
+		const staff = await gw.apiJson("/api/staff", {
+			method: "POST",
+			body: JSON.stringify({
+				name: `Task observer ${suffix}`,
+				systemPrompt: "Observe bounded task notifications.",
+				cwd,
+				projectId: gw.defaultProjectId,
+				worktree: false,
+				sandboxed: false,
+				contextPolicy: "preserve",
+				triggers: [{
+					id: "task-updated",
+					type: "notification",
+					notification: { scope: "project", name: "taskUpdated" },
+					filter: { state: "todo" },
+					enabled: true,
+				}],
+			}),
+		});
+		expect(staff.currentSessionId).toEqual(expect.any(String));
+		scope.trackSession(staff.currentSessionId);
+		await waitForIdle(gw, staff.currentSessionId);
+		return { goal, task, staff, cwd };
+	}
+
+	async function updateTask(taskId: string, title: string, headers?: HeadersInit, extra: Record<string, unknown> = {}) {
+		return gw.api(`/api/tasks/${encodeURIComponent(taskId)}`, {
+			method: "PUT",
+			headers,
+			body: JSON.stringify({ title, ...extra }),
+		});
+	}
+
+	it("sends enqueueWithId invalidations only to the current staff UI principal and keeps canonical input off the wire", async () => {
+		const { task, staff } = await createTaskAndObserver("socket-routing");
+		const foreignRoot = path.join(path.dirname(gw.bobbitDir), `host-hooks-foreign-${Date.now()}`);
+		tempRoots.push(foreignRoot);
+		mkdirSync(foreignRoot, { recursive: true });
+		const foreignProject = await gw.apiJson("/api/projects", {
+			method: "POST",
+			body: JSON.stringify({ name: `host-hooks-foreign-${Date.now()}`, rootPath: foreignRoot }),
+		});
+		scope.trackProject(foreignProject.id);
+		const foreignSession = await scope.createSession({ projectId: foreignProject.id, cwd: foreignRoot });
+		const staleSession = await scope.createSession({ cwd: gw.projectContextManager.getRegistry().get(gw.defaultProjectId).rootPath });
+		await Promise.all([waitForIdle(gw, foreignSession.id), waitForIdle(gw, staleSession.id)]);
+
+		const sandboxStore = gw.sessionManager.sandboxTokenStore;
+		const sandboxToken = sandboxStore.register(gw.defaultProjectId);
+		sandboxStore.addSession(gw.defaultProjectId, staff.currentSessionId);
+		const sockets = await Promise.all([
+			connectCaptured(gw.wsBase, staff.currentSessionId, gw.token, "app"),
+			connectCaptured(gw.wsBase, staff.currentSessionId, sandboxToken, "app"),
+			connectCaptured(gw.wsBase, staleSession.id, gw.token, "app"),
+			connectCaptured(gw.wsBase, foreignSession.id, gw.token, "app"),
+			connectCaptured(gw.wsBase, "__viewer__", gw.token, "app"),
+		]);
+		const [exact, sandbox, stale, foreign, viewer] = sockets;
+		const cursors = sockets.map(socket => socket.cursor());
+		const unboundFrames: any[] = [];
+		const unbound = {
+			authenticated: true,
+			isViewer: false,
+			authPrincipal: { kind: "admin" },
+			readyState: WebSocket.OPEN,
+			send: (data: string) => { unboundFrames.push(JSON.parse(data)); },
+		};
+		gw.sessionManager.getSession(staff.currentSessionId).clients.add(unbound as any);
+		try {
+			const response = await updateTask(task.id, "route this notification");
+			expect(response.status, await response.clone().text()).toBe(200);
+			const live = await exact.waitFor(frame => frame.type === "inbox.entry.added", cursors[0]);
+			expect(live).toMatchObject({
+				type: "inbox.entry.added",
+				staffId: staff.id,
+				entry: {
+					staffId: staff.id,
+					source: { type: "notification", triggerId: "task-updated" },
+					prompt: "A host notification is available in this inbox entry's notification metadata.",
+				},
+			});
+			expect(live.entry).not.toHaveProperty("notificationInput");
+			expect(JSON.stringify(live)).not.toContain("rootCorrelationId");
+			expect(JSON.stringify(live)).not.toContain("causationDepth");
+
+			const persisted = await waitForInboxCount(gw, staff.id, 1);
+			expect(persisted[0].id).toBe(live.entry.id);
+			expect(persisted[0].notificationInput).toMatchObject({
+				rootCorrelationId: expect.any(String),
+				causationDepth: 1,
+				notification: {
+					name: "taskUpdated",
+					projectId: gw.defaultProjectId,
+					aggregate: { id: task.id },
+				},
+			});
+
+			await Promise.all(sockets.slice(1).map((socket, index) => socket.barrier(cursors[index + 1])));
+			expect(unboundFrames.filter(frame => frame.type === "inbox.entry.added"), "unbound principal").toHaveLength(0);
+			for (const [name, socket, cursor] of [
+				["sandbox", sandbox, cursors[1]],
+				["stale", stale, cursors[2]],
+				["foreign", foreign, cursors[3]],
+				["viewer", viewer, cursors[4]],
+			] as const) {
+				expect(socket.frames.slice(cursor).filter(frame => frame.type === "inbox.entry.added"), `${name} principal`).toHaveLength(0);
+			}
+		} finally {
+			gw.sessionManager.getSession(staff.currentSessionId)?.clients.delete(unbound as any);
+			for (const socket of sockets) socket.ws.close();
+			sandboxStore.removeSession(gw.defaultProjectId, staff.currentSessionId);
+			await gw.api(`/api/staff/${encodeURIComponent(staff.id)}`, { method: "DELETE" });
+		}
+	});
+
+	it("propagates only an authentic notification turn through a first-party mutation and fences stale authority", async () => {
+		const { task, staff } = await createTaskAndObserver("causal-loop");
+		const enqueuePrompt = vi.spyOn(gw.sessionManager, "enqueuePrompt").mockResolvedValue({ status: "dispatched" });
+		const sessionId = staff.currentSessionId as string;
+		const secret = gw.sessionManager.sessionSecretStore.getOrCreateSecret(sessionId);
+		const foreignSession = await scope.createSession({ cwd: gw.projectContextManager.getRegistry().get(gw.defaultProjectId).rootPath });
+		const foreignSecret = gw.sessionManager.sessionSecretStore.getOrCreateSecret(foreignSession.id);
+		try {
+			expect((await updateTask(task.id, "seed notification root")).status).toBe(200);
+			const initialEntries = await waitForInboxCount(gw, staff.id, 1);
+			const initialInput = initialEntries[0].notificationInput;
+			const turn = await poll(
+				() => gw.sessionManager.getStaffNotificationTurnContext(sessionId),
+				"notification-triggered staff turn context",
+				5_000,
+			);
+			expect(turn).toMatchObject({
+				sessionId,
+				projectId: gw.defaultProjectId,
+				staffId: staff.id,
+				triggerId: "task-updated",
+				notificationId: initialInput.notification.id,
+				rootCorrelationId: initialInput.rootCorrelationId,
+				causationDepth: 1,
+			});
+			expect(enqueuePrompt).toHaveBeenCalledWith(sessionId, expect.stringContaining(initialEntries[0].id), expect.objectContaining({ source: "system" }));
+
+			// The real request/session-secret/ALS/task-publisher/dispatcher path keeps
+			// this child fact in the original root, so the same subscriber is suppressed.
+			const sameRoot = await updateTask(task.id, "same root child fact", { "X-Bobbit-Session-Secret": secret });
+			expect(sameRoot.status, await sameRoot.clone().text()).toBe(200);
+			await settleFanout();
+			expect(await inboxEntries(gw, staff.id)).toHaveLength(1);
+
+			// Callers cannot smuggle loop controls through the strict first-party body.
+			const forgedFields = await updateTask(task.id, "forged fields", undefined, {
+				rootCorrelationId: initialInput.rootCorrelationId,
+				causationDepth: 1,
+			});
+			expect(forgedFields.status).toBe(400);
+			expect(await inboxEntries(gw, staff.id)).toHaveLength(1);
+
+			// Missing, random, and another real session's secret cannot borrow the turn.
+			for (const [label, headers] of [
+				["missing", undefined],
+				["forged", { "X-Bobbit-Session-Secret": "not-a-host-secret" }],
+				["foreign", { "X-Bobbit-Session-Secret": foreignSecret }],
+			] as const) {
+				const response = await updateTask(task.id, `${label} secret gets a fresh root`, headers);
+				expect(response.status, await response.clone().text()).toBe(200);
+			}
+			const independentEntries = await waitForInboxCount(gw, staff.id, 4);
+			const roots = independentEntries.map(entry => entry.notificationInput.rootCorrelationId);
+			expect(new Set(roots).size).toBe(4);
+			expect(roots.slice(1)).not.toContain(initialInput.rootCorrelationId);
+
+			// Retirement invalidates the live staff/session authority before another
+			// request can inherit it; reactivation does not resurrect the stale root.
+			expect((await gw.api(`/api/staff/${staff.id}`, { method: "PUT", body: JSON.stringify({ state: "retired" }) })).status).toBe(200);
+			expect(gw.sessionManager.getStaffNotificationTurnContext(sessionId)).toBeUndefined();
+			expect((await gw.api(`/api/staff/${staff.id}`, { method: "PUT", body: JSON.stringify({ state: "active" }) })).status).toBe(200);
+			expect((await updateTask(task.id, "after retirement fence", { "X-Bobbit-Session-Secret": secret })).status).toBe(200);
+			await waitForInboxCount(gw, staff.id, 5);
+
+			const reserve = async (notificationId: string, rootCorrelationId: string) => {
+				const result = await gw.sessionManager.enqueueStaffNotificationPrompt(sessionId, `[INBOX] ${notificationId}`, {
+					projectId: gw.defaultProjectId,
+					staffId: staff.id,
+					triggerId: "task-updated",
+					notificationId,
+					rootCorrelationId,
+					causationDepth: 1,
+				});
+				expect(result.status).toBe("dispatched");
+			};
+
+			// Terminal completion clears only the exact notification turn.
+			await reserve("completion-notification", "completion-root");
+			gw.sessionManager.clearStaffNotificationTurnContext(sessionId, "different-notification");
+			expect(gw.sessionManager.getStaffNotificationTurnContext(sessionId)?.notificationId).toBe("completion-notification");
+			gw.sessionManager.clearStaffNotificationTurnContext(sessionId, "completion-notification");
+			expect(gw.sessionManager.getStaffNotificationTurnContext(sessionId)).toBeUndefined();
+			expect((await updateTask(task.id, "after completion fence", { "X-Bobbit-Session-Secret": secret })).status).toBe(200);
+			await waitForInboxCount(gw, staff.id, 6);
+
+			// Abort clears authority before the bridge abort can settle.
+			await reserve("abort-notification", "abort-root");
+			const liveSession = gw.sessionManager.getSession(sessionId);
+			liveSession.status = "streaming";
+			await gw.sessionManager.abortSessionTurn(sessionId);
+			expect(gw.sessionManager.getStaffNotificationTurnContext(sessionId)).toBeUndefined();
+			liveSession.status = "idle";
+			expect((await updateTask(task.id, "after abort fence", { "X-Bobbit-Session-Secret": secret })).status).toBe(200);
+			await waitForInboxCount(gw, staff.id, 7);
+
+			// Lifecycle fencing (the in-process half of restart) erases a stale turn.
+			await reserve("restart-notification", "restart-root");
+			liveSession.lifecycleFenced = true;
+			expect(gw.sessionManager.getStaffNotificationTurnContext(sessionId)).toBeUndefined();
+			liveSession.lifecycleFenced = false;
+			expect((await updateTask(task.id, "after lifecycle fence", { "X-Bobbit-Session-Secret": secret })).status).toBe(200);
+			await waitForInboxCount(gw, staff.id, 8);
+		} finally {
+			enqueuePrompt.mockRestore();
+			await gw.api(`/api/staff/${encodeURIComponent(staff.id)}`, { method: "DELETE" });
+		}
 	});
 });

--- a/tests2/integration/host-notification-routing.test.ts
+++ b/tests2/integration/host-notification-routing.test.ts
@@ -1,0 +1,148 @@
+import { afterEach, describe, expect, it } from "vitest";
+import type { WebSocket } from "ws";
+import { HostNotificationDispatcher } from "../../src/server/extension-host/host-notification-dispatcher.js";
+import {
+	HostNotificationSocketRouter,
+	bindHostNotificationSocket,
+	unbindHostNotificationSocket,
+} from "../../src/server/extension-host/host-notification-socket-router.js";
+import type { ServerMessage } from "../../src/server/ws/protocol.js";
+
+interface FakeSocket {
+	readyState: number;
+	bufferedAmount: number;
+	authenticated?: boolean;
+	isViewer?: boolean;
+	frames: ServerMessage[];
+	send(data: string): void;
+}
+
+const socketsToUnbind: WebSocket[] = [];
+
+function socket(overrides: Partial<FakeSocket> = {}): FakeSocket {
+	const ws: FakeSocket = {
+		readyState: 1,
+		bufferedAmount: 0,
+		authenticated: true,
+		frames: [],
+		send(data) { this.frames.push(JSON.parse(data) as ServerMessage); },
+		...overrides,
+	};
+	return ws;
+}
+
+function bind(ws: FakeSocket, sessionId: string, projectId: string): void {
+	const real = ws as unknown as WebSocket;
+	bindHostNotificationSocket(real, { sessionId, projectId });
+	socketsToUnbind.push(real);
+}
+
+async function settleRouting(): Promise<void> {
+	await new Promise<void>(resolve => setImmediate(resolve));
+	await new Promise<void>(resolve => setImmediate(resolve));
+}
+
+afterEach(() => {
+	for (const ws of socketsToUnbind.splice(0)) unbindHostNotificationSocket(ws);
+});
+
+function sessionPublication() {
+	return {
+		projectId: "project-a",
+		sessionId: "session-a",
+		aggregateId: "session-a",
+		aggregateRevision: 1,
+		payload: { previousStatus: "starting" as const, status: "idle" as const, statusVersion: 1 },
+	};
+}
+
+function projectPublication() {
+	return {
+		projectId: "project-a",
+		aggregateId: "goal-1",
+		aggregateRevision: 2,
+		payload: { goalId: "goal-1", state: "in-progress" as const, changedFields: ["title" as const] },
+	};
+}
+
+function names(ws: FakeSocket): string[] {
+	return ws.frames.flatMap(frame => frame.type === "host_notification" ? [frame.notification.name] : []);
+}
+
+describe("canonical host notification socket routing", () => {
+	it("routes session facts to the exact server binding and project facts only to same-project app sockets", async () => {
+		const exact = socket();
+		const siblingSession = socket();
+		const foreignProject = socket();
+		const unbound = socket();
+		const viewer = socket({ isViewer: true });
+		const unauthenticated = socket({ authenticated: false });
+		bind(exact, "session-a", "project-a");
+		bind(siblingSession, "session-b", "project-a");
+		bind(foreignProject, "session-a", "project-b");
+		bind(viewer, "session-a", "project-a");
+		bind(unauthenticated, "session-a", "project-a");
+		const all = [exact, siblingSession, foreignProject, unbound, viewer, unauthenticated];
+		const router = new HostNotificationSocketRouter(all as unknown as WebSocket[], { epochGenerator: () => "epoch" });
+		const dispatcher = new HostNotificationDispatcher({
+			adapters: [router],
+			resolveSessionProject: sessionId => sessionId === "session-a" || sessionId === "session-b" ? "project-a" : undefined,
+			idGenerator: (() => { let id = 0; return () => `notification-${++id}`; })(),
+			now: () => 10,
+		});
+
+		expect(dispatcher.publish("statusChanged", sessionPublication())).toBeDefined();
+		expect(dispatcher.publish("goalUpdated", projectPublication())).toBeDefined();
+		await settleRouting();
+
+		expect(names(exact)).toEqual(["statusChanged", "goalUpdated"]);
+		expect(names(siblingSession)).toEqual(["goalUpdated"]);
+		expect(names(foreignProject)).toEqual([]);
+		expect(names(unbound)).toEqual([]);
+		expect(names(viewer)).toEqual([]);
+		expect(names(unauthenticated)).toEqual([]);
+		const exactNotifications = exact.frames.filter(frame => frame.type === "host_notification");
+		expect(exactNotifications.map(frame => frame.notification.projectId)).toEqual(["project-a", "project-a"]);
+	});
+
+	it("uses independent scope epochs, monotonic sequences, and one coalesced refresh frame after dispatcher gaps", async () => {
+		const exact = socket();
+		bind(exact, "session-a", "project-a");
+		let epoch = 0;
+		let notificationId = 0;
+		const router = new HostNotificationSocketRouter([exact] as unknown as WebSocket[], {
+			epochGenerator: () => `epoch-${++epoch}`,
+		});
+		const dispatcher = new HostNotificationDispatcher({
+			adapters: [router],
+			queueCapacity: 1,
+			resolveSessionProject: sessionId => sessionId === "session-a" ? "project-a" : undefined,
+			idGenerator: () => `notification-${++notificationId}`,
+			now: () => 20,
+		});
+
+		dispatcher.publish("statusChanged", sessionPublication());
+		dispatcher.publish("statusChanged", { ...sessionPublication(), aggregateRevision: 2, payload: { ...sessionPublication().payload, statusVersion: 2 } });
+		dispatcher.publish("statusChanged", { ...sessionPublication(), aggregateRevision: 3, payload: { ...sessionPublication().payload, statusVersion: 3 } });
+		await settleRouting();
+
+		expect(exact.frames).toEqual([
+			expect.objectContaining({ type: "host_notification", stream: { epoch: "epoch-1", sequence: 1 } }),
+			expect.objectContaining({ type: "host_notifications_refresh_required", scope: "session", epoch: "epoch-1", sequence: 2 }),
+		]);
+		expect(dispatcher.getDiagnostics().filter(row => row.code === "queue_overflow")).toHaveLength(2);
+
+		dispatcher.publish("statusChanged", { ...sessionPublication(), aggregateRevision: 4, payload: { ...sessionPublication().payload, statusVersion: 4 } });
+		await settleRouting();
+		dispatcher.publish("goalUpdated", projectPublication());
+		await settleRouting();
+		dispatcher.publish("goalUpdated", { ...projectPublication(), aggregateRevision: 3 });
+		await settleRouting();
+
+		expect(exact.frames.slice(2)).toEqual([
+			expect.objectContaining({ type: "host_notification", stream: { epoch: "epoch-1", sequence: 3 } }),
+			expect.objectContaining({ type: "host_notification", stream: { epoch: "epoch-2", sequence: 1 } }),
+			expect.objectContaining({ type: "host_notification", stream: { epoch: "epoch-2", sequence: 2 } }),
+		]);
+	});
+});

--- a/tests2/integration/host-notification-routing.test.ts
+++ b/tests2/integration/host-notification-routing.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { WebSocket } from "ws";
 import { HostNotificationDispatcher } from "../../src/server/extension-host/host-notification-dispatcher.js";
 import {
@@ -14,7 +14,15 @@ interface FakeSocket {
 	authenticated?: boolean;
 	isViewer?: boolean;
 	frames: ServerMessage[];
-	send(data: string): void;
+	sendErrors: Array<Error | undefined>;
+	closes: Array<{ code?: number; reason?: string }>;
+	terminated: boolean;
+	closeListeners: Array<() => void>;
+	send(data: string, callback?: (error?: Error) => void): void;
+	close(code?: number, reason?: string): void;
+	terminate(): void;
+	once(event: string, listener: () => void): void;
+	emitClose(): void;
 }
 
 const socketsToUnbind: WebSocket[] = [];
@@ -25,7 +33,26 @@ function socket(overrides: Partial<FakeSocket> = {}): FakeSocket {
 		bufferedAmount: 0,
 		authenticated: true,
 		frames: [],
-		send(data) { this.frames.push(JSON.parse(data) as ServerMessage); },
+		sendErrors: [],
+		closes: [],
+		terminated: false,
+		closeListeners: [],
+		send(data, callback) {
+			this.frames.push(JSON.parse(data) as ServerMessage);
+			callback?.(this.sendErrors.shift());
+		},
+		close(code, reason) {
+			this.closes.push({ code, reason });
+			this.readyState = 3;
+		},
+		terminate() { this.terminated = true; },
+		once(event, listener) {
+			if (event === "close") this.closeListeners.push(listener);
+		},
+		emitClose() {
+			this.readyState = 3;
+			for (const listener of this.closeListeners.splice(0)) listener();
+		},
 		...overrides,
 	};
 	return ws;
@@ -44,6 +71,8 @@ async function settleRouting(): Promise<void> {
 
 afterEach(() => {
 	for (const ws of socketsToUnbind.splice(0)) unbindHostNotificationSocket(ws);
+	vi.useRealTimers();
+	vi.restoreAllMocks();
 });
 
 function sessionPublication() {
@@ -144,5 +173,137 @@ describe("canonical host notification socket routing", () => {
 			expect.objectContaining({ type: "host_notification", stream: { epoch: "epoch-2", sequence: 1 } }),
 			expect.objectContaining({ type: "host_notification", stream: { epoch: "epoch-2", sequence: 2 } }),
 		]);
+	});
+
+	it("retries a final pressure gap without another event while preserving healthy peer order", async () => {
+		vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+		const pressured = socket({ bufferedAmount: 100 });
+		const healthy = socket();
+		bind(pressured, "session-a", "project-a");
+		bind(healthy, "session-a", "project-a");
+		const router = new HostNotificationSocketRouter([pressured, healthy] as unknown as WebSocket[], {
+			epochGenerator: (() => { let epoch = 0; return () => `epoch-${++epoch}`; })(),
+			maxBufferedBytes: 10,
+			refreshRetryDelayMs: 5,
+			maxRefreshRetries: 4,
+		});
+		const dispatcher = new HostNotificationDispatcher({
+			adapters: [router],
+			resolveSessionProject: () => "project-a",
+			idGenerator: (() => { let id = 0; return () => `notification-${++id}`; })(),
+			now: () => 30,
+		});
+
+		dispatcher.publish("statusChanged", sessionPublication());
+		dispatcher.publish("statusChanged", {
+			...sessionPublication(),
+			aggregateRevision: 2,
+			payload: { ...sessionPublication().payload, statusVersion: 2 },
+		});
+		await settleRouting();
+
+		expect(pressured.frames).toEqual([]);
+		expect(healthy.frames).toEqual([
+			expect.objectContaining({ type: "host_notification", stream: expect.objectContaining({ sequence: 1 }) }),
+			expect.objectContaining({ type: "host_notification", stream: expect.objectContaining({ sequence: 2 }) }),
+		]);
+		expect(healthy.frames.flatMap(frame => frame.type === "host_notification"
+			? [frame.notification.aggregate.revision]
+			: [])).toEqual([1, 2]);
+
+		pressured.bufferedAmount = 0;
+		await vi.advanceTimersByTimeAsync(5);
+
+		expect(pressured.frames).toEqual([
+			expect.objectContaining({ type: "host_notifications_refresh_required", scope: "session", sequence: 1 }),
+		]);
+		expect(names(healthy)).toEqual(["statusChanged", "statusChanged"]);
+	});
+
+	it("retries failed delta and refresh sends without another event", async () => {
+		vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+		const exact = socket({ sendErrors: [new Error("delta failed"), new Error("refresh failed"), undefined] });
+		bind(exact, "session-a", "project-a");
+		const router = new HostNotificationSocketRouter([exact] as unknown as WebSocket[], {
+			epochGenerator: () => "epoch",
+			refreshRetryDelayMs: 7,
+			maxRefreshRetries: 4,
+		});
+		const dispatcher = new HostNotificationDispatcher({
+			adapters: [router],
+			resolveSessionProject: () => "project-a",
+			idGenerator: () => "notification-1",
+			now: () => 40,
+		});
+
+		dispatcher.publish("statusChanged", sessionPublication());
+		await settleRouting();
+		expect(exact.frames.map(frame => frame.type)).toEqual([
+			"host_notification",
+			"host_notifications_refresh_required",
+		]);
+
+		await vi.advanceTimersByTimeAsync(7);
+
+		expect(exact.frames).toEqual([
+			expect.objectContaining({ type: "host_notification", stream: { epoch: "epoch", sequence: 1 } }),
+			expect.objectContaining({ type: "host_notifications_refresh_required", epoch: "epoch", sequence: 2 }),
+			expect.objectContaining({ type: "host_notifications_refresh_required", epoch: "epoch", sequence: 3 }),
+		]);
+		expect(exact.closes).toEqual([]);
+	});
+
+	it("closes with 1013 after persistent refresh pressure", async () => {
+		vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+		const exact = socket({ bufferedAmount: 100 });
+		bind(exact, "session-a", "project-a");
+		const router = new HostNotificationSocketRouter([exact] as unknown as WebSocket[], {
+			maxBufferedBytes: 10,
+			refreshRetryDelayMs: 5,
+			maxRefreshRetries: 3,
+		});
+		const dispatcher = new HostNotificationDispatcher({
+			adapters: [router],
+			resolveSessionProject: () => "project-a",
+			now: () => 50,
+		});
+
+		dispatcher.publish("statusChanged", sessionPublication());
+		await settleRouting();
+		await vi.advanceTimersByTimeAsync(5);
+		expect(exact.closes).toEqual([]);
+		await vi.advanceTimersByTimeAsync(10);
+
+		expect(exact.closes).toEqual([{ code: 1013, reason: "host notification refresh required" }]);
+		expect(exact.terminated).toBe(false);
+		expect(exact.frames).toEqual([]);
+	});
+
+	it("cancels pending refresh retries when the socket closes", async () => {
+		vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+		const exact = socket({ bufferedAmount: 100 });
+		bind(exact, "session-a", "project-a");
+		const router = new HostNotificationSocketRouter([exact] as unknown as WebSocket[], {
+			maxBufferedBytes: 10,
+			refreshRetryDelayMs: 5,
+			maxRefreshRetries: 3,
+		});
+		const dispatcher = new HostNotificationDispatcher({
+			adapters: [router],
+			resolveSessionProject: () => "project-a",
+			now: () => 60,
+		});
+
+		dispatcher.publish("statusChanged", sessionPublication());
+		await settleRouting();
+		expect(vi.getTimerCount()).toBe(1);
+
+		exact.emitClose();
+		expect(vi.getTimerCount()).toBe(0);
+		await vi.advanceTimersByTimeAsync(1_000);
+
+		expect(exact.frames).toEqual([]);
+		expect(exact.closes).toEqual([]);
+		expect(exact.terminated).toBe(false);
 	});
 });

--- a/tests2/integration/host-notification-routing.test.ts
+++ b/tests2/integration/host-notification-routing.test.ts
@@ -100,6 +100,12 @@ function names(ws: FakeSocket): string[] {
 	return ws.frames.flatMap(frame => frame.type === "host_notification" ? [frame.notification.name] : []);
 }
 
+function resolveTestSessionProject(sessionId: string): string | undefined {
+	if (sessionId === "session-a" || sessionId === "session-b") return "project-a";
+	if (sessionId === "session-c") return "project-b";
+	return undefined;
+}
+
 describe("canonical host notification socket routing", () => {
 	it("routes session facts to the exact server binding and project facts only to same-project app sockets", async () => {
 		const exact = socket();
@@ -110,11 +116,14 @@ describe("canonical host notification socket routing", () => {
 		const unauthenticated = socket({ authenticated: false });
 		bind(exact, "session-a", "project-a");
 		bind(siblingSession, "session-b", "project-a");
-		bind(foreignProject, "session-a", "project-b");
+		bind(foreignProject, "session-c", "project-b");
 		bind(viewer, "session-a", "project-a");
 		bind(unauthenticated, "session-a", "project-a");
 		const all = [exact, siblingSession, foreignProject, unbound, viewer, unauthenticated];
-		const router = new HostNotificationSocketRouter(all as unknown as WebSocket[], { epochGenerator: () => "epoch" });
+		const router = new HostNotificationSocketRouter(all as unknown as WebSocket[], {
+			resolveSessionProject: resolveTestSessionProject,
+			epochGenerator: () => "epoch",
+		});
 		const dispatcher = new HostNotificationDispatcher({
 			adapters: [router],
 			resolveSessionProject: sessionId => sessionId === "session-a" || sessionId === "session-b" ? "project-a" : undefined,
@@ -136,6 +145,93 @@ describe("canonical host notification socket routing", () => {
 		expect(exactNotifications.map(frame => frame.notification.projectId)).toEqual(["project-a", "project-a"]);
 	});
 
+	it("rebinds a moved session from host authority and refreshes before new-project deltas", async () => {
+		const exact = socket();
+		bind(exact, "session-a", "project-a");
+		let authoritativeProject: string | undefined = "project-a";
+		const router = new HostNotificationSocketRouter([exact] as unknown as WebSocket[], {
+			resolveSessionProject: sessionId => sessionId === "session-a" ? authoritativeProject : undefined,
+			epochGenerator: () => "project-epoch",
+		});
+		const dispatcher = new HostNotificationDispatcher({
+			adapters: [router],
+			idGenerator: (() => { let id = 0; return () => `moved-${++id}`; })(),
+			now: () => 12,
+		});
+
+		authoritativeProject = "project-b";
+		dispatcher.publish("goalUpdated", projectPublication());
+		// A new-project delta racing the coalesced refresh must also be suppressed.
+		dispatcher.publish("goalUpdated", { ...projectPublication(), projectId: "project-b", aggregateRevision: 3 });
+		await settleRouting();
+
+		expect(exact.frames).toEqual([
+			expect.objectContaining({
+				type: "host_notifications_refresh_required",
+				scope: "project",
+				epoch: "project-epoch",
+				sequence: 1,
+			}),
+		]);
+
+		dispatcher.publish("goalUpdated", { ...projectPublication(), projectId: "project-b", aggregateRevision: 4 });
+		dispatcher.publish("goalUpdated", { ...projectPublication(), projectId: "project-c", aggregateRevision: 5 });
+		await settleRouting();
+
+		expect(exact.frames.slice(1)).toEqual([
+			expect.objectContaining({
+				type: "host_notification",
+				notification: expect.objectContaining({ projectId: "project-b" }),
+				stream: { epoch: "project-epoch", sequence: 2 },
+			}),
+		]);
+	});
+
+	it("unbinds and fails closed when live session authority disappears", async () => {
+		const exact = socket();
+		bind(exact, "session-a", "project-a");
+		let authoritativeProject: string | undefined;
+		const router = new HostNotificationSocketRouter([exact] as unknown as WebSocket[], {
+			resolveSessionProject: () => authoritativeProject,
+		});
+		const dispatcher = new HostNotificationDispatcher({ adapters: [router] });
+
+		dispatcher.publish("goalUpdated", projectPublication());
+		await settleRouting();
+		authoritativeProject = "project-a";
+		dispatcher.publish("goalUpdated", { ...projectPublication(), aggregateRevision: 3 });
+		await settleRouting();
+
+		expect(exact.frames).toEqual([]);
+	});
+
+	it("revalidates a pressured refresh and replaces a stale session refresh with a project refresh", async () => {
+		vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+		const exact = socket({ bufferedAmount: 100 });
+		bind(exact, "session-a", "project-a");
+		let authoritativeProject = "project-a";
+		const router = new HostNotificationSocketRouter([exact] as unknown as WebSocket[], {
+			resolveSessionProject: () => authoritativeProject,
+			maxBufferedBytes: 10,
+			refreshRetryDelayMs: 5,
+		});
+		const dispatcher = new HostNotificationDispatcher({
+			adapters: [router],
+			resolveSessionProject: () => authoritativeProject,
+		});
+
+		dispatcher.publish("statusChanged", sessionPublication());
+		await settleRouting();
+		authoritativeProject = "project-b";
+		exact.bufferedAmount = 0;
+		await vi.advanceTimersByTimeAsync(5);
+		await settleRouting();
+
+		expect(exact.frames).toEqual([
+			expect.objectContaining({ type: "host_notifications_refresh_required", scope: "project", sequence: 1 }),
+		]);
+	});
+
 	it("refuses sandbox-principal bindings and rechecks principal authority for deltas and refreshes", async () => {
 		const sandbox = socket({ authPrincipal: { kind: "sandbox" } });
 		const revoked = socket();
@@ -143,6 +239,7 @@ describe("canonical host notification socket routing", () => {
 		bind(revoked, "session-a", "project-a");
 		revoked.authPrincipal = { kind: "sandbox" };
 		const router = new HostNotificationSocketRouter([sandbox, revoked] as unknown as WebSocket[], {
+			resolveSessionProject: resolveTestSessionProject,
 			epochGenerator: () => "epoch",
 		});
 		const dispatcher = new HostNotificationDispatcher({
@@ -166,6 +263,7 @@ describe("canonical host notification socket routing", () => {
 		const exact = socket({ bufferedAmount: 100 });
 		bind(exact, "session-a", "project-a");
 		const router = new HostNotificationSocketRouter([exact] as unknown as WebSocket[], {
+			resolveSessionProject: resolveTestSessionProject,
 			maxBufferedBytes: 10,
 			refreshRetryDelayMs: 5,
 			maxRefreshRetries: 3,
@@ -195,6 +293,7 @@ describe("canonical host notification socket routing", () => {
 		let epoch = 0;
 		let notificationId = 0;
 		const router = new HostNotificationSocketRouter([exact] as unknown as WebSocket[], {
+			resolveSessionProject: resolveTestSessionProject,
 			epochGenerator: () => `epoch-${++epoch}`,
 		});
 		const dispatcher = new HostNotificationDispatcher({
@@ -237,6 +336,7 @@ describe("canonical host notification socket routing", () => {
 		bind(pressured, "session-a", "project-a");
 		bind(healthy, "session-a", "project-a");
 		const router = new HostNotificationSocketRouter([pressured, healthy] as unknown as WebSocket[], {
+			resolveSessionProject: resolveTestSessionProject,
 			epochGenerator: (() => { let epoch = 0; return () => `epoch-${++epoch}`; })(),
 			maxBufferedBytes: 10,
 			refreshRetryDelayMs: 5,
@@ -280,6 +380,7 @@ describe("canonical host notification socket routing", () => {
 		const exact = socket({ sendErrors: [new Error("delta failed"), new Error("refresh failed"), undefined] });
 		bind(exact, "session-a", "project-a");
 		const router = new HostNotificationSocketRouter([exact] as unknown as WebSocket[], {
+			resolveSessionProject: resolveTestSessionProject,
 			epochGenerator: () => "epoch",
 			refreshRetryDelayMs: 7,
 			maxRefreshRetries: 4,
@@ -313,6 +414,7 @@ describe("canonical host notification socket routing", () => {
 		const exact = socket({ bufferedAmount: 100 });
 		bind(exact, "session-a", "project-a");
 		const router = new HostNotificationSocketRouter([exact] as unknown as WebSocket[], {
+			resolveSessionProject: resolveTestSessionProject,
 			maxBufferedBytes: 10,
 			refreshRetryDelayMs: 5,
 			maxRefreshRetries: 3,
@@ -339,6 +441,7 @@ describe("canonical host notification socket routing", () => {
 		const exact = socket({ bufferedAmount: 100 });
 		bind(exact, "session-a", "project-a");
 		const router = new HostNotificationSocketRouter([exact] as unknown as WebSocket[], {
+			resolveSessionProject: resolveTestSessionProject,
 			maxBufferedBytes: 10,
 			refreshRetryDelayMs: 5,
 			maxRefreshRetries: 3,

--- a/tests2/integration/host-notification-routing.test.ts
+++ b/tests2/integration/host-notification-routing.test.ts
@@ -13,6 +13,7 @@ interface FakeSocket {
 	bufferedAmount: number;
 	authenticated?: boolean;
 	isViewer?: boolean;
+	authPrincipal?: { kind: "admin" | "sandbox" | "localhost" };
 	frames: ServerMessage[];
 	sendErrors: Array<Error | undefined>;
 	closes: Array<{ code?: number; reason?: string }>;
@@ -32,6 +33,7 @@ function socket(overrides: Partial<FakeSocket> = {}): FakeSocket {
 		readyState: 1,
 		bufferedAmount: 0,
 		authenticated: true,
+		authPrincipal: { kind: "admin" },
 		frames: [],
 		sendErrors: [],
 		closes: [],
@@ -132,6 +134,59 @@ describe("canonical host notification socket routing", () => {
 		expect(names(unauthenticated)).toEqual([]);
 		const exactNotifications = exact.frames.filter(frame => frame.type === "host_notification");
 		expect(exactNotifications.map(frame => frame.notification.projectId)).toEqual(["project-a", "project-a"]);
+	});
+
+	it("refuses sandbox-principal bindings and rechecks principal authority for deltas and refreshes", async () => {
+		const sandbox = socket({ authPrincipal: { kind: "sandbox" } });
+		const revoked = socket();
+		bind(sandbox, "session-a", "project-a");
+		bind(revoked, "session-a", "project-a");
+		revoked.authPrincipal = { kind: "sandbox" };
+		const router = new HostNotificationSocketRouter([sandbox, revoked] as unknown as WebSocket[], {
+			epochGenerator: () => "epoch",
+		});
+		const dispatcher = new HostNotificationDispatcher({
+			adapters: [router],
+			resolveSessionProject: () => "project-a",
+			idGenerator: () => "notification-1",
+			now: () => 15,
+		});
+
+		const notification = dispatcher.publish("statusChanged", sessionPublication());
+		expect(notification).toBeDefined();
+		router.refreshRequired(notification!);
+		await settleRouting();
+
+		expect(sandbox.frames).toEqual([]);
+		expect(revoked.frames).toEqual([]);
+	});
+
+	it("cancels an already-scheduled refresh when UI principal authority is revoked", async () => {
+		vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+		const exact = socket({ bufferedAmount: 100 });
+		bind(exact, "session-a", "project-a");
+		const router = new HostNotificationSocketRouter([exact] as unknown as WebSocket[], {
+			maxBufferedBytes: 10,
+			refreshRetryDelayMs: 5,
+			maxRefreshRetries: 3,
+		});
+		const dispatcher = new HostNotificationDispatcher({
+			adapters: [router],
+			resolveSessionProject: () => "project-a",
+			now: () => 16,
+		});
+
+		dispatcher.publish("statusChanged", sessionPublication());
+		await settleRouting();
+		expect(vi.getTimerCount()).toBe(1);
+
+		exact.authPrincipal = { kind: "sandbox" };
+		exact.bufferedAmount = 0;
+		await vi.advanceTimersByTimeAsync(5);
+
+		expect(exact.frames).toEqual([]);
+		expect(exact.closes).toEqual([]);
+		expect(vi.getTimerCount()).toBe(0);
 	});
 
 	it("uses independent scope epochs, monotonic sequences, and one coalesced refresh frame after dispatcher gaps", async () => {

--- a/tests2/integration/host-notification-sandbox-ws.test.ts
+++ b/tests2/integration/host-notification-sandbox-ws.test.ts
@@ -1,0 +1,104 @@
+import { randomUUID } from "node:crypto";
+import WebSocket from "ws";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { getGateway, type EntityCounts, type GatewayFixture } from "../harness/gateway.js";
+import { assertNoLeaks, snapshotEntities } from "../harness/leak-detector.js";
+import { createScope, type TestScope } from "../harness/scope.js";
+
+interface CapturedSocket {
+	readonly ws: WebSocket;
+	readonly frames: any[];
+	waitFor(predicate: (frame: any) => boolean, timeoutMs?: number): Promise<any>;
+}
+
+let gw: GatewayFixture;
+let scope: TestScope;
+let baseline: EntityCounts;
+const sockets: WebSocket[] = [];
+
+beforeAll(async () => {
+	gw = await getGateway();
+	baseline = snapshotEntities(gw);
+});
+beforeEach(() => { scope = createScope(gw); });
+afterEach(async () => {
+	for (const ws of sockets.splice(0)) ws.close();
+	await scope.cleanup();
+});
+afterAll(() => { assertNoLeaks(baseline, snapshotEntities(gw)); });
+
+async function connect(sessionId: string, token: string): Promise<CapturedSocket> {
+	const ws = new WebSocket(`${gw.wsBase}/ws/${sessionId}`);
+	sockets.push(ws);
+	const frames: any[] = [];
+	ws.on("message", raw => {
+		try { frames.push(JSON.parse(String(raw))); } catch { /* ignore non-JSON frames */ }
+	});
+	await new Promise<void>((resolve, reject) => {
+		ws.once("open", resolve);
+		ws.once("error", reject);
+	});
+	const waitFor = (predicate: (frame: any) => boolean, timeoutMs = 3_000): Promise<any> => {
+		const existing = frames.find(predicate);
+		if (existing) return Promise.resolve(existing);
+		return new Promise((resolve, reject) => {
+			const timer = setTimeout(() => {
+				cleanup();
+				reject(new Error(`WebSocket frame timed out for ${sessionId}`));
+			}, timeoutMs);
+			const onMessage = (raw: unknown) => {
+				let frame: any;
+				try { frame = JSON.parse(String(raw)); } catch { return; }
+				if (!predicate(frame)) return;
+				cleanup();
+				resolve(frame);
+			};
+			const cleanup = () => {
+				clearTimeout(timer);
+				ws.off("message", onMessage);
+			};
+			ws.on("message", onMessage);
+		});
+	};
+	ws.send(JSON.stringify({ type: "auth", token, clientKind: "app" }));
+	await waitFor(frame => frame.type === "auth_ok");
+	return { ws, frames, waitFor };
+}
+
+describe("host notification WebSocket principal isolation", () => {
+	it("does not bind a sandbox token that claims the app client kind", async () => {
+		const session = await scope.createSession({});
+		const sandboxStore = gw.sessionManager.sandboxTokenStore;
+		const sandboxToken = sandboxStore.register(gw.defaultProjectId);
+		sandboxStore.addSession(gw.defaultProjectId, session.id);
+		try {
+			const admin = await connect(session.id, gw.token);
+			const sandbox = await connect(session.id, sandboxToken);
+			const adminCursor = admin.frames.length;
+			const sandboxCursor = sandbox.frames.length;
+			const aggregateId = `goal-${randomUUID()}`;
+			const context = gw.projectContextManager.getOrCreate(gw.defaultProjectId);
+			expect(context).not.toBeNull();
+
+			const notification = context!.publishHostNotification("goalUpdated", {
+				aggregateId,
+				aggregateRevision: 1,
+				payload: { goalId: aggregateId, state: "in-progress", changedFields: ["title"] },
+			});
+			expect(notification).toBeDefined();
+			await admin.waitFor(frame => frame.type === "host_notification" && frame.notification?.id === notification!.id);
+
+			sandbox.ws.send(JSON.stringify({ type: "ping" }));
+			await sandbox.waitFor(frame => frame.type === "pong");
+			expect(admin.frames.slice(adminCursor)).toContainEqual(expect.objectContaining({
+				type: "host_notification",
+				notification: expect.objectContaining({ id: notification!.id, projectId: gw.defaultProjectId }),
+			}));
+			expect(sandbox.frames.slice(sandboxCursor).filter(frame =>
+				frame.type === "host_notification" || frame.type === "host_notifications_refresh_required",
+			)).toEqual([]);
+		} finally {
+			sandboxStore.removeSession(gw.defaultProjectId, session.id);
+		}
+	});
+});

--- a/tests2/integration/notification-staff-dispatcher.test.ts
+++ b/tests2/integration/notification-staff-dispatcher.test.ts
@@ -1,0 +1,261 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, describe, expect, it, vi } from "vitest";
+import { HOST_NOTIFICATION_CATALOGUE, type HostNotification } from "../../src/shared/extension-host/host-hooks.js";
+import { InboxManager } from "../../src/server/agent/inbox-manager.js";
+import { InboxStore } from "../../src/server/agent/inbox-store.js";
+import { NotificationDeliveryStore } from "../../src/server/agent/notification-delivery-store.js";
+import {
+	NotificationStaffDispatcher,
+	notificationDeliveryId,
+} from "../../src/server/agent/notification-staff-dispatcher.js";
+import { StaffManager } from "../../src/server/agent/staff-manager.js";
+import { StaffStore, type PersistedStaff } from "../../src/server/agent/staff-store.js";
+import { createMemFs } from "../harness/mem-fs.js";
+
+const cleanupDirs: string[] = [];
+afterAll(() => {
+	for (const dir of cleanupDirs) fs.rmSync(dir, { recursive: true, force: true });
+});
+
+function clockHarness(start = 10_000) {
+	let now = start;
+	return {
+		clock: {
+			now: () => now,
+			setTimeout: globalThis.setTimeout,
+			setInterval: globalThis.setInterval,
+			clearTimeout: globalThis.clearTimeout,
+			clearInterval: globalThis.clearInterval,
+		},
+		advance(ms: number) { now += ms; },
+	};
+}
+
+function notification(name: "toolCallCompleted" = "toolCallCompleted", projectId = "project-a"): HostNotification<"toolCallCompleted"> {
+	const definition = HOST_NOTIFICATION_CATALOGUE[name];
+	return {
+		id: "notification-1",
+		scope: "session",
+		name,
+		payloadVersion: definition.payloadVersion,
+		occurredAt: 9_000,
+		projectId,
+		sessionId: "session-1",
+		aggregate: { kind: definition.aggregateKind, id: "tool-call-1", revision: 7 },
+		correlationId: "correlation-1",
+		causationId: "causation-1",
+		payload: {
+			toolCallId: "tool-call-1",
+			toolName: "example_tool",
+			status: "succeeded",
+			durationMs: 12,
+		},
+	} as HostNotification<"toolCallCompleted">;
+}
+
+function projectNotification(projectId = "project-a"): HostNotification<"goalUpdated"> {
+	const definition = HOST_NOTIFICATION_CATALOGUE.goalUpdated;
+	return {
+		id: "notification-goal-1",
+		scope: "project",
+		name: "goalUpdated",
+		payloadVersion: definition.payloadVersion,
+		occurredAt: 9_100,
+		projectId,
+		aggregate: { kind: definition.aggregateKind, id: "goal-1", revision: 8 },
+		correlationId: "correlation-goal-1",
+		payload: { goalId: "goal-1", state: "in-progress", changedFields: ["state"] },
+	} as HostNotification<"goalUpdated">;
+}
+
+function staffRecord(projectId = "project-a"): PersistedStaff {
+	return {
+		id: "staff-1",
+		name: "Observer",
+		description: "",
+		systemPrompt: "Observe committed facts",
+		cwd: "/repo",
+		state: "active",
+		triggers: [
+			{ id: "legacy-goal", type: "goal_created", config: {}, enabled: true, prompt: "legacy" },
+			{
+				id: "notify-tool",
+				type: "notification",
+				notification: { scope: "session", name: "toolCallCompleted" },
+				filter: { toolName: "example_tool", status: "succeeded" },
+				enabled: true,
+			},
+		],
+		memory: "",
+		accessory: "none",
+		createdAt: 1,
+		updatedAt: 1,
+		projectId,
+		sandboxed: false,
+	};
+}
+
+function harness() {
+	const memfs = createMemFs();
+	const stateDir = path.resolve("/memfs/notification-staff/project-a");
+	memfs.mkdirSync(stateDir, { recursive: true });
+	const staff = staffRecord();
+	const inboxStore = new InboxStore(stateDir, memfs);
+	const ctx = {
+		project: { id: "project-a" },
+		stateDir,
+		staffStore: { get: (id: string) => id === staff.id ? staff : undefined },
+		inboxStore,
+	};
+	const pcm = {
+		getOrCreate: (id: string) => id === "project-a" ? ctx : null,
+		all: () => [ctx][Symbol.iterator](),
+	};
+	const updates: unknown[] = [];
+	let reconciler: ((projectId: string, staffId: string) => void) | null = null;
+	const staffManager = {
+		listStaff: (projectId?: string) => !projectId || projectId === staff.projectId ? [staff] : [],
+		getStaff: (id: string) => id === staff.id ? staff : undefined,
+		updateTriggerState: (staffId: string, triggerId: string, update: unknown) => { updates.push({ staffId, triggerId, update }); return true; },
+		setNotificationDeliveryReconciler: (next: typeof reconciler) => { reconciler = next; },
+	};
+	const inbox = new InboxManager(pcm as never, staffManager as never, () => undefined);
+	const timer = clockHarness();
+	let deliveryStore = new NotificationDeliveryStore(stateDir, "project-a", memfs, timer.clock);
+	const dispatcher = new NotificationStaffDispatcher(pcm as never, staffManager as never, inbox, {
+		clock: timer.clock,
+		storeFactory: () => deliveryStore,
+	});
+	return { memfs, stateDir, staff, pcm, inbox, inboxStore, timer, dispatcher, staffManager, updates, get reconciler() { return reconciler; }, get store() { return deliveryStore; }, replaceStore(store: NotificationDeliveryStore) { deliveryStore = store; } };
+}
+
+async function flushMicrotasks(): Promise<void> {
+	await new Promise<void>((resolve) => queueMicrotask(resolve));
+	await new Promise<void>((resolve) => queueMicrotask(resolve));
+}
+
+describe("notification staff delivery", () => {
+	it("persists and delivers the exact canonical envelope under a deterministic inbox id", async () => {
+		const h = harness();
+		const event = notification();
+		expect(h.dispatcher.enqueueNow(event)).toBe(1);
+		await flushMicrotasks();
+
+		const deliveryId = notificationDeliveryId("staff-1", "notify-tool", event.id);
+		const row = h.store.get(deliveryId)!;
+		expect(row.state).toBe("accepted");
+		expect(row.notification).toEqual(event);
+		const entries = h.inboxStore.list("staff-1");
+		expect(entries).toHaveLength(1);
+		expect(entries[0].id).toBe(deliveryId);
+		expect(entries[0].source).toEqual({ type: "notification", triggerId: "notify-tool" });
+		expect(entries[0].notificationInput?.notification).toEqual(event);
+		expect(entries[0].prompt).not.toContain(event.payload.toolName);
+
+		// Duplicate fanout, a new event in the same host-owned root, and the
+		// unrelated legacy trigger cannot double wake this subscriber.
+		expect(h.dispatcher.enqueueNow(event)).toBe(0);
+		expect(h.dispatcher.enqueueNow({ ...event, id: "notification-2" })).toBe(0);
+		await flushMicrotasks();
+		expect(h.inboxStore.list("staff-1")).toHaveLength(1);
+	});
+
+	it("delivers project facts through the same byte-equivalent canonical contract", async () => {
+		const h = harness();
+		h.staff.triggers.push({
+			id: "notify-goal",
+			type: "notification",
+			notification: { scope: "project", name: "goalUpdated" },
+			filter: { state: "in-progress" },
+			enabled: true,
+		});
+		const event = projectNotification();
+		expect(h.dispatcher.enqueueNow(event)).toBe(1);
+		await flushMicrotasks();
+		const entry = h.inboxStore.list("staff-1")[0];
+		expect(entry.notificationInput?.notification).toEqual(event);
+		expect(entry.notificationInput?.notification.aggregate.revision).toBe(8);
+	});
+
+	it("fails closed for wrong projects, unsupported selectors, and forbidden payload fields", async () => {
+		const h = harness();
+		expect(h.dispatcher.enqueueNow(notification("toolCallCompleted", "project-b"))).toBe(0);
+		const tainted = {
+			...notification(),
+			payload: { ...notification().payload, rawPrompt: "FORBIDDEN_SENTINEL" },
+		} as HostNotification;
+		expect(h.dispatcher.enqueueNow(tainted)).toBe(0);
+		await flushMicrotasks();
+		expect(h.inboxStore.list("staff-1")).toHaveLength(0);
+		expect(Array.from(h.memfs.files.values()).join("\n")).not.toContain("FORBIDDEN_SENTINEL");
+	});
+
+	it("reconciles a crash after inbox commit without inserting a duplicate", async () => {
+		const h = harness();
+		const finishSpy = vi.spyOn(h.store, "finishLease").mockImplementation(() => { throw Object.assign(new Error("crash"), { code: "UNAVAILABLE" }); });
+		h.dispatcher.enqueueNow(notification());
+		await flushMicrotasks();
+		expect(h.inboxStore.list("staff-1")).toHaveLength(1);
+		finishSpy.mockRestore();
+
+		h.timer.advance(31_000);
+		const restartedStore = new NotificationDeliveryStore(h.stateDir, "project-a", h.memfs, h.timer.clock);
+		h.replaceStore(restartedStore);
+		const restarted = new NotificationStaffDispatcher(h.pcm as never, h.staffManager as never, h.inbox, {
+			clock: h.timer.clock,
+			storeFactory: () => restartedStore,
+		});
+		restarted.reconcileProject("project-a");
+		expect(restartedStore.list()[0].state).toBe("accepted");
+		expect(h.inboxStore.list("staff-1")).toHaveLength(1);
+	});
+
+	it("cancels pending delivery when its notification trigger is disabled", async () => {
+		const h = harness();
+		vi.spyOn(h.inbox, "enqueueWithId").mockImplementation(() => { throw Object.assign(new Error("busy"), { code: "EAGAIN" }); });
+		h.dispatcher.enqueueNow(notification());
+		await flushMicrotasks();
+		expect(h.store.list()[0].state).toBe("pending");
+		(h.staff.triggers.find((trigger) => trigger.id === "notify-tool")!).enabled = false;
+		h.reconciler?.("project-a", "staff-1");
+		expect(h.store.list()[0].state).toBe("cancelled");
+	});
+});
+
+describe("notification trigger validation and staff facts", () => {
+	it("validates catalogue-owned selectors and exact scalar filters", () => {
+		const pcm = { all: () => [][Symbol.iterator]() };
+		const manager = new StaffManager(pcm as never);
+		expect(() => manager.validateTriggers(staffRecord().triggers)).not.toThrow();
+		expect(() => manager.validateTriggers([{
+			id: "bad", type: "notification", notification: { scope: "project", name: "toolCallCompleted" }, filter: {}, enabled: true,
+		} as never])).toThrow(/Invalid notification trigger/);
+		expect(() => manager.validateTriggers([{
+			id: "bad-filter", type: "notification", notification: { scope: "session", name: "toolCallCompleted" }, filter: { rawPrompt: "x" }, enabled: true,
+		} as never])).toThrow(/Invalid notification trigger/);
+	});
+
+	it("publishes bounded config, retirement, and session facts only after strict store updates", () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "notification-staff-facts-"));
+		cleanupDirs.push(root);
+		const store = new StaffStore(root);
+		const staff = staffRecord();
+		store.putStrict(staff);
+		const ctx = { project: { id: "project-a" }, staffStore: store, searchIndex: { indexStaff: vi.fn() } };
+		const pcm = {
+			all: () => [ctx][Symbol.iterator](),
+			getOrCreate: (id: string) => id === "project-a" ? ctx : null,
+		};
+		const manager = new StaffManager(pcm as never);
+		const publish = vi.fn();
+		manager.setStaffNotificationPublisher({ publish });
+		expect(manager.updateStaff("staff-1", { description: "changed", state: "retired" })).toBe(true);
+		expect(manager.commitCurrentSession("staff-1", "session-new")).toBe(true);
+		expect(publish.mock.calls.map((call) => call[0])).toEqual([
+			"staffConfigChanged", "staffRetired", "staffSessionChanged",
+		]);
+		expect(publish.mock.calls[0][1].payload).toEqual({ staffId: "staff-1", changedFields: ["description", "state"] });
+	});
+});

--- a/tests2/integration/notification-staff-inbox-auth.test.ts
+++ b/tests2/integration/notification-staff-inbox-auth.test.ts
@@ -1,0 +1,151 @@
+import { randomUUID } from "node:crypto";
+import { mkdirSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { test, expect } from "./_e2e/in-process-harness.js";
+
+function notification(projectId: string, sessionId: string, id: string) {
+	return {
+		id: `notification-${id}`,
+		scope: "project",
+		name: "taskUpdated",
+		payloadVersion: 1,
+		occurredAt: 1_700_000_000_000,
+		projectId,
+		sessionId,
+		aggregate: { kind: "task", id: `task-${id}`, revision: 7 },
+		correlationId: "canonical-correlation",
+		causationId: "canonical-causation",
+		payload: { taskId: `task-${id}`, title: "bounded title", state: "in-progress" },
+	};
+}
+
+test.describe("notification staff inbox authority", () => {
+	test("binds canonical metadata and mutations to the exact owning staff-session secret", async ({ gateway, scope }) => {
+		const projectBRoot = join(dirname(gateway.bobbitDir), `notification-inbox-project-${randomUUID()}`);
+		mkdirSync(projectBRoot, { recursive: true });
+		const projectB = await gateway.apiJson<any>("/api/projects", {
+			method: "POST",
+			body: JSON.stringify({ name: `notification-inbox-${randomUUID()}`, rootPath: projectBRoot, __e2e_seed_skip__: true }),
+		});
+		scope.trackProject(projectB.id);
+
+		const createStaff = async (projectId: string, cwd: string, name: string) => {
+			const response = await gateway.api("/api/staff", {
+				method: "POST",
+				body: JSON.stringify({ name, systemPrompt: "Inbox authority fixture.", cwd, projectId, worktree: false }),
+			});
+			expect(response.status, await response.clone().text()).toBe(201);
+			return response.json();
+		};
+
+		const defaultRoot = gateway.projectContextManager.getRegistry().get(gateway.defaultProjectId).rootPath;
+		const staffA = await createStaff(gateway.defaultProjectId, defaultRoot, `foreign-staff-${randomUUID()}`);
+		const staffB = await createStaff(projectB.id, projectBRoot, `owning-staff-${randomUUID()}`);
+		try {
+			expect(staffA.currentSessionId).toBeTruthy();
+			expect(staffB.currentSessionId).toBeTruthy();
+			const projectBContext = gateway.projectContextManager.all().find((ctx: any) => ctx.staffStore.get(staffB.id));
+			expect(projectBContext).toBeTruthy();
+
+			const canonical = notification(projectB.id, staffB.currentSessionId, "complete");
+			for (const [entryId, event] of [
+				["notification-entry-complete", canonical],
+				["notification-entry-dismiss", notification(projectB.id, staffB.currentSessionId, "dismiss")],
+				["notification-entry-delete", notification(projectB.id, staffB.currentSessionId, "delete")],
+			] as const) {
+				projectBContext.inboxStore.put({
+					id: entryId,
+					staffId: staffB.id,
+					source: { type: "notification", triggerId: "fixture-trigger" },
+					title: "Canonical notification",
+					prompt: "A host notification is available in this inbox entry's notification metadata.",
+					notificationInput: {
+						notification: event,
+						rootCorrelationId: "host-owned-root",
+						causationDepth: 2,
+					},
+					state: "pending",
+					createdAt: Date.now(),
+				});
+			}
+
+			const foreignSecret = gateway.sessionManager.sessionSecretStore.getOrCreateSecret(staffA.currentSessionId);
+			const ownerSecret = gateway.sessionManager.sessionSecretStore.getOrCreateSecret(staffB.currentSessionId);
+			const unboundSecret = gateway.sessionManager.sessionSecretStore.getOrCreateSecret(`unbound-${randomUUID()}`);
+			const ownerHeaders = { "X-Bobbit-Session-Secret": ownerSecret };
+
+			// Browser/operator and cross-project callers keep the legacy list surface,
+			// but receive only the bounded DTO used by live UI publication.
+			for (const headers of [undefined, { "X-Bobbit-Session-Secret": foreignSecret }, { "X-Bobbit-Session-Secret": unboundSecret }]) {
+				const listed = await gateway.api(`/api/staff/${staffB.id}/inbox?state=pending`, { headers });
+				expect(listed.status).toBe(200);
+				const body = await listed.json();
+				expect(body.entries).toHaveLength(3);
+				expect(JSON.stringify(body)).not.toContain("notificationInput");
+				expect(JSON.stringify(body)).not.toContain("rootCorrelationId");
+				expect(JSON.stringify(body)).not.toContain("causationDepth");
+			}
+
+			const ownerList = await gateway.api(`/api/staff/${staffB.id}/inbox?state=pending`, { headers: ownerHeaders });
+			expect(ownerList.status).toBe(200);
+			const ownerBody = await ownerList.json();
+			const completeEntry = ownerBody.entries.find((entry: any) => entry.id === "notification-entry-complete");
+			expect(completeEntry.notificationInput).toEqual({
+				notification: canonical,
+				rootCorrelationId: "host-owned-root",
+				causationDepth: 2,
+			});
+
+			// A project-A capability cannot borrow project B's public staff/session ids.
+			const foreignComplete = await gateway.api(`/api/staff/${staffB.id}/inbox/notification-entry-complete/complete`, {
+				method: "POST",
+				headers: { "X-Bobbit-Session-Secret": foreignSecret },
+				body: JSON.stringify({ sessionId: staffB.currentSessionId, summary: "forged" }),
+			});
+			expect(foreignComplete.status).toBe(403);
+
+			// Unbound and browser/viewer bearer callers cannot suppress delivery either.
+			const unboundDismiss = await gateway.api(`/api/staff/${staffB.id}/inbox/notification-entry-dismiss/dismiss`, {
+				method: "POST",
+				headers: { "X-Bobbit-Session-Secret": unboundSecret },
+				body: JSON.stringify({ sessionId: staffB.currentSessionId, outcome: "cancelled", reason: "forged" }),
+			});
+			expect(unboundDismiss.status).toBe(403);
+			const viewerDelete = await gateway.api(`/api/staff/${staffB.id}/inbox/notification-entry-delete`, { method: "DELETE" });
+			expect(viewerDelete.status).toBe(403);
+			for (const id of ["notification-entry-complete", "notification-entry-dismiss", "notification-entry-delete"]) {
+				expect(projectBContext.inboxStore.get(staffB.id, id)?.state).toBe("pending");
+			}
+
+			// The capability is the authority: caller-supplied session ids are ignored,
+			// while the exact owner retains the original canonical input.
+			const completed = await gateway.api(`/api/staff/${staffB.id}/inbox/notification-entry-complete/complete`, {
+				method: "POST",
+				headers: ownerHeaders,
+				body: JSON.stringify({ sessionId: staffA.currentSessionId, summary: "accepted by owner" }),
+			});
+			expect(completed.status, await completed.clone().text()).toBe(200);
+			const completedBody = await completed.json();
+			expect(completedBody.entry.notificationInput.notification).toEqual(canonical);
+			expect(completedBody.entry.state).toBe("completed");
+
+			const dismissed = await gateway.api(`/api/staff/${staffB.id}/inbox/notification-entry-dismiss/dismiss`, {
+				method: "POST",
+				headers: ownerHeaders,
+				body: JSON.stringify({ outcome: "cancelled", reason: "owner decision" }),
+			});
+			expect(dismissed.status, await dismissed.clone().text()).toBe(200);
+			expect((await dismissed.json()).entry.state).toBe("cancelled");
+
+			const deleted = await gateway.api(`/api/staff/${staffB.id}/inbox/notification-entry-delete`, {
+				method: "DELETE",
+				headers: ownerHeaders,
+			});
+			expect(deleted.status, await deleted.clone().text()).toBe(200);
+			expect(projectBContext.inboxStore.get(staffB.id, "notification-entry-delete")).toBeUndefined();
+		} finally {
+			await gateway.api(`/api/staff/${staffA.id}`, { method: "DELETE" }).catch(() => undefined);
+			await gateway.api(`/api/staff/${staffB.id}`, { method: "DELETE" }).catch(() => undefined);
+		}
+	});
+});

--- a/tests2/integration/orchestrate-restart.test.ts
+++ b/tests2/integration/orchestrate-restart.test.ts
@@ -65,9 +65,11 @@ async function promptSectionsText(sessionId: string): Promise<string> {
 		.join("\n\n---\n\n");
 }
 
-async function refreshPromptSections(sessionId: string): Promise<void> {
+async function refreshPromptSections(gateway: { sessionManager: any }, sessionId: string): Promise<void> {
+	const sessionSecret = gateway.sessionManager.sessionSecretStore.getOrCreateSecret(sessionId);
 	const resp = await apiFetch(`/api/sessions/${sessionId}/provider-hooks/before-prompt`, {
 		method: "POST",
+		headers: { "X-Bobbit-Session-Secret": sessionSecret },
 		body: JSON.stringify({ prompt: "refresh restored delegate prompt sections" }),
 	});
 	expect(resp.status).toBe(200);
@@ -238,7 +240,7 @@ test.describe("orchestration restart survival", () => {
 				"Restored delegate prompt sections should expose the durable task instructions",
 			).toContain(marker);
 
-			await refreshPromptSections(child);
+			await refreshPromptSections(gateway, child);
 			const refreshedSections = await promptSectionsText(child);
 			expect(
 				refreshedSections,

--- a/tests2/integration/provider-before-compact-api.test.ts
+++ b/tests2/integration/provider-before-compact-api.test.ts
@@ -2,33 +2,42 @@ import { expect, test } from "./_e2e/in-process-harness.js";
 
 test.describe("POST /api/sessions/:id/provider-hooks/before-compact", () => {
 	test("forwards a string span to the lifecycle hook and rejects non-string spans", async ({ gateway, scope }) => {
-		const sessionId = `before-compact-api-${process.pid}-${Date.now()}`;
-		const context = gateway.projectContextManager.getOrCreate(gateway.defaultProjectId);
-		expect(context).toBeTruthy();
-		context.sessionStore.put({
-			id: sessionId,
+		const session = await scope.createSession({
 			title: "Before compact API fixture",
-			cwd: gateway.bobbitDir,
-			agentSessionFile: `${gateway.bobbitDir}/${sessionId}.jsonl`,
-			createdAt: Date.now(),
-			lastActivity: Date.now(),
-			archived: false,
+			cwd: gateway.projectContextManager.getRegistry().get(gateway.defaultProjectId).rootPath,
 			projectId: gateway.defaultProjectId,
 		});
-		scope.trackSession(sessionId);
+		const sessionId = session.id;
 
-		const originalHub = gateway.sessionManager.lifecycleHub;
+		const originalHostInterceptors = gateway.sessionManager.hostInterceptors;
 		const dispatches: Array<{ hook: string; hookContext: Record<string, unknown> }> = [];
-		gateway.sessionManager.lifecycleHub = {
-			async dispatch(hook: string, hookContext: Record<string, unknown>) {
-				dispatches.push({ hook, hookContext });
-				return { blocks: [], diagnostics: [] };
+		gateway.sessionManager.setHostInterceptorPort({
+			async dispatch(hook: string, input: Record<string, unknown>, requestContext: Record<string, unknown>) {
+				dispatches.push({ hook, hookContext: { ...input, projectId: requestContext.projectId } });
+				return input;
 			},
-		};
+		});
 
 		try {
+			const sessionSecret = gateway.sessionManager.sessionSecretStore.getOrCreateSecret(sessionId);
+			const foreignSecret = gateway.sessionManager.sessionSecretStore.getOrCreateSecret(`${sessionId}-foreign`);
+
+			for (const headers of [
+				undefined,
+				{ "X-Bobbit-Session-Secret": foreignSecret },
+			]) {
+				const unauthorized = await gateway.api(`/api/sessions/${sessionId}/provider-hooks/before-compact`, {
+					method: "POST",
+					headers,
+					body: JSON.stringify({ span: "conversation span to retain" }),
+				});
+				expect(unauthorized.status).toBe(403);
+			}
+			expect(dispatches).toHaveLength(0);
+
 			const valid = await gateway.api(`/api/sessions/${sessionId}/provider-hooks/before-compact`, {
 				method: "POST",
+				headers: { "X-Bobbit-Session-Secret": sessionSecret },
 				body: JSON.stringify({ span: "conversation span to retain" }),
 			});
 			expect(valid.status).toBe(200);
@@ -45,13 +54,14 @@ test.describe("POST /api/sessions/:id/provider-hooks/before-compact", () => {
 
 			const invalid = await gateway.api(`/api/sessions/${sessionId}/provider-hooks/before-compact`, {
 				method: "POST",
+				headers: { "X-Bobbit-Session-Secret": sessionSecret },
 				body: JSON.stringify({ span: 42 }),
 			});
 			expect(invalid.status).toBe(400);
-			expect(await invalid.json()).toEqual({ error: "span must be a string" });
+			expect(await invalid.json()).toEqual({ error: "Invalid bounded beforeCompact body" });
 			expect(dispatches).toHaveLength(1);
 		} finally {
-			gateway.sessionManager.lifecycleHub = originalHub;
+			gateway.sessionManager.setHostInterceptorPort(originalHostInterceptors);
 		}
 	});
 });

--- a/tests2/integration/sandbox-security.test.ts
+++ b/tests2/integration/sandbox-security.test.ts
@@ -120,6 +120,9 @@ function installSyntheticContext(
 		taskStore: {
 			get: (id: string) => taskRecords.get(id),
 			put: (task: PersistedTask) => taskRecords.set(task.id, task),
+			putCommitted: async (task: PersistedTask, _facts: unknown) => {
+				taskRecords.set(task.id, task);
+			},
 			getAll: () => [...taskRecords.values()],
 			getByGoalId: (goalId: string) => [...taskRecords.values()].filter(task => task.goalId === goalId),
 			getBySessionId: (ownerId: string) => [...taskRecords.values()].filter(task => task.assignedSessionId === ownerId),

--- a/tests2/integration/sandbox-security.test.ts
+++ b/tests2/integration/sandbox-security.test.ts
@@ -208,6 +208,50 @@ test.describe("Sandbox Security Boundaries", () => {
 
 	// ── ALLOWED endpoints ──────────────────────────────────────────────
 
+	test("host hook callbacks require both own-session sandbox scope and the current session secret", async ({ gateway }) => {
+		const secret = gateway.sessionManager.sessionSecretStore.getOrCreateSecret(sessionId);
+		const cases = [
+			{
+				route: "before-tool-call",
+				body: { toolCallId: "sandbox-call", toolName: "fixture", args: { safe: true } },
+			},
+			{
+				route: "after-tool-result",
+				body: { toolCallId: "sandbox-call", toolName: "fixture", result: { isError: false } },
+			},
+		];
+
+		for (const fixture of cases) {
+			const route = `/api/sessions/${sessionId}/host-hooks/${fixture.route}`;
+			const missingSecret = await sandboxFetch(gateway.baseURL, route, scopedToken, {
+				method: "POST",
+				body: JSON.stringify(fixture.body),
+			});
+			expect(missingSecret.status).toBe(403);
+
+			const wrongSecret = await sandboxFetch(gateway.baseURL, route, scopedToken, {
+				method: "POST",
+				headers: { "X-Bobbit-Session-Secret": "not-the-current-secret" },
+				body: JSON.stringify(fixture.body),
+			});
+			expect(wrongSecret.status).toBe(403);
+
+			const accepted = await sandboxFetch(gateway.baseURL, route, scopedToken, {
+				method: "POST",
+				headers: { "X-Bobbit-Session-Secret": secret },
+				body: JSON.stringify(fixture.body),
+			});
+			expect(accepted.status).toBe(200);
+		}
+
+		const crossSession = await sandboxFetch(gateway.baseURL, "/api/sessions/not-owned/host-hooks/before-tool-call", scopedToken, {
+			method: "POST",
+			headers: { "X-Bobbit-Session-Secret": secret },
+			body: JSON.stringify(cases[0].body),
+		});
+		expect(crossSession.status).toBe(403);
+	});
+
 	test("can access own session", async ({ gateway }) => {
 		const res = await sandboxFetch(gateway.baseURL, `/api/sessions/${sessionId}`, scopedToken);
 		expect(res.status).toBe(200);

--- a/tests2/integration/sandbox-security.test.ts
+++ b/tests2/integration/sandbox-security.test.ts
@@ -12,7 +12,12 @@
 import fs from "node:fs";
 import { request as httpRequest } from "node:http";
 import path from "node:path";
+import { vi } from "vitest";
+import { EventBuffer } from "../../src/server/agent/event-buffer.js";
 import type { PersistedGoal } from "../../src/server/agent/goal-store.js";
+import { PromptQueue } from "../../src/server/agent/prompt-queue.js";
+import { emitSessionEvent } from "../../src/server/agent/session-manager.js";
+import { broadcastStatus } from "../../src/server/agent/session-status.js";
 import type { PersistedTask } from "../../src/server/agent/task-store.js";
 import { test, expect } from "./_e2e/in-process-harness.js";
 import { readE2EToken, nonGitCwd } from "./_e2e/e2e-setup.js";
@@ -69,13 +74,20 @@ function installSyntheticSession(gateway: any, id: string): () => void {
 		createdAt: now,
 		lastActivity: now,
 		clients: new Set(),
+		eventBuffer: new EventBuffer(),
+		promptQueue: new PromptQueue(),
 		isCompacting: false,
+		setupComplete: true,
+		lifecycleGeneration: sessionManager._currentRespawnGeneration(id),
 		projectId: gateway.defaultProjectId,
 		sandboxed: false,
 	};
 	const persisted = { ...live, agentSessionFile: "" };
 	delete (persisted as any).clients;
+	delete (persisted as any).eventBuffer;
+	delete (persisted as any).promptQueue;
 	delete (persisted as any).isCompacting;
+	delete (persisted as any).setupComplete;
 
 	const ctx = sessionManager.getProjectContextManager().getOrCreate(gateway.defaultProjectId);
 	const originalStoreGet = ctx.sessionStore.get;
@@ -103,6 +115,21 @@ function installSyntheticSession(gateway: any, id: string): () => void {
 		sessionManager.createDelegateSession = originalCreateDelegate;
 		bgProcessManager.create = originalBgCreate;
 	};
+}
+
+async function waitForToolCallbackWaiter(gateway: any, sessionId: string, toolCallId: string): Promise<void> {
+	for (let attempt = 0; attempt < 100; attempt += 1) {
+		if (gateway.sessionManager.getSession(sessionId)?.hostToolCallBeforeWaiters?.has(toolCallId)) return;
+		await new Promise<void>((resolve) => setImmediate(resolve));
+	}
+	throw new Error(`tool callback waiter was not installed for ${toolCallId}`);
+}
+
+function acceptToolStart(gateway: any, sessionId: string, toolCallId: string, toolName: string): void {
+	const session = gateway.sessionManager.getSession(sessionId);
+	const event = { type: "tool_execution_start", toolCallId, toolName };
+	gateway.sessionManager.handleAgentLifecycle(session, event);
+	emitSessionEvent(session, event);
 }
 
 function installSyntheticContext(
@@ -211,48 +238,170 @@ test.describe("Sandbox Security Boundaries", () => {
 
 	// ── ALLOWED endpoints ──────────────────────────────────────────────
 
-	test("host hook callbacks require both own-session sandbox scope and the current session secret", async ({ gateway }) => {
-		const secret = gateway.sessionManager.sessionSecretStore.getOrCreateSecret(sessionId);
-		const cases = [
-			{
-				route: "before-tool-call",
-				body: { toolCallId: "sandbox-call", toolName: "fixture", args: { safe: true } },
+	test("valid-secret tool callbacks still require exact current Pi lifecycle provenance", async ({ gateway }) => {
+		const manager = gateway.sessionManager as any;
+		const secret = manager.sessionSecretStore.getOrCreateSecret(sessionId);
+		const originalHostInterceptors = manager.hostInterceptors;
+		const dispatcher = manager.hostNotificationPublisher;
+		const publishSpy = vi.spyOn(dispatcher, "publish");
+		const dispatches: Array<{ name: string; input: any }> = [];
+		manager.setHostInterceptorPort({
+			async dispatch(name: string, input: any) {
+				dispatches.push({ name, input });
+				return { value: input };
 			},
-			{
-				route: "after-tool-result",
-				body: { toolCallId: "sandbox-call", toolName: "fixture", result: { isError: false } },
-			},
-		];
-
-		for (const fixture of cases) {
-			const route = `/api/sessions/${sessionId}/host-hooks/${fixture.route}`;
-			const missingSecret = await sandboxFetch(gateway.baseURL, route, scopedToken, {
-				method: "POST",
-				body: JSON.stringify(fixture.body),
-			});
-			expect(missingSecret.status).toBe(403);
-
-			const wrongSecret = await sandboxFetch(gateway.baseURL, route, scopedToken, {
-				method: "POST",
-				headers: { "X-Bobbit-Session-Secret": "not-the-current-secret" },
-				body: JSON.stringify(fixture.body),
-			});
-			expect(wrongSecret.status).toBe(403);
-
-			const accepted = await sandboxFetch(gateway.baseURL, route, scopedToken, {
-				method: "POST",
-				headers: { "X-Bobbit-Session-Secret": secret },
-				body: JSON.stringify(fixture.body),
-			});
-			expect(accepted.status).toBe(200);
-		}
-
-		const crossSession = await sandboxFetch(gateway.baseURL, "/api/sessions/not-owned/host-hooks/before-tool-call", scopedToken, {
-			method: "POST",
-			headers: { "X-Bobbit-Session-Secret": secret },
-			body: JSON.stringify(cases[0].body),
 		});
-		expect(crossSession.status).toBe(403);
+		const headers = { "X-Bobbit-Session-Secret": secret };
+		const beforeBody = { toolCallId: "forged-call", toolName: "fixture", args: { secret: "PRIVATE_ARGS" } };
+		const afterBody = { toolCallId: "forged-call", toolName: "fixture", result: { content: [{ type: "text", text: "PRIVATE_RESULT" }] } };
+		const toolFacts = () => publishSpy.mock.calls.filter(([name]) => name === "toolCallStarted" || name === "toolCallCompleted");
+
+		try {
+			for (const candidateHeaders of [undefined, { "X-Bobbit-Session-Secret": "not-the-current-secret" }]) {
+				const unauthorized = await sandboxFetch(gateway.baseURL, `/api/sessions/${sessionId}/host-hooks/before-tool-call`, scopedToken, {
+					method: "POST",
+					headers: candidateHeaders,
+					body: JSON.stringify(beforeBody),
+				});
+				expect(unauthorized.status).toBe(403);
+			}
+
+			const forgedBeforeRequest = sandboxFetch(gateway.baseURL, `/api/sessions/${sessionId}/host-hooks/before-tool-call`, scopedToken, {
+				method: "POST",
+				headers,
+				body: JSON.stringify(beforeBody),
+			});
+			await waitForToolCallbackWaiter(gateway, sessionId, beforeBody.toolCallId);
+			gateway.clock.advance(101);
+			const forgedBefore = await forgedBeforeRequest;
+			expect(forgedBefore.status).toBe(409);
+			expect(await forgedBefore.json()).toEqual({ error: "Tool callback provenance unavailable" });
+
+			const forgedAfter = await sandboxFetch(gateway.baseURL, `/api/sessions/${sessionId}/host-hooks/after-tool-result`, scopedToken, {
+				method: "POST",
+				headers,
+				body: JSON.stringify(afterBody),
+			});
+			expect(forgedAfter.status).toBe(409);
+			expect(dispatches).toHaveLength(0);
+			expect(toolFacts()).toHaveLength(0);
+			expect(manager.getSession(sessionId).hostToolCallLifecycle?.has(beforeBody.toolCallId) ?? false).toBe(false);
+			// Staff delivery is downstream of canonical publication, so zero tool facts
+			// also proves the forged callbacks cannot enqueue or wake a staff subscriber.
+
+			acceptToolStart(gateway, sessionId, "mismatch-call", "fixture");
+			const mismatch = await sandboxFetch(gateway.baseURL, `/api/sessions/${sessionId}/host-hooks/before-tool-call`, scopedToken, {
+				method: "POST",
+				headers,
+				body: JSON.stringify({ toolCallId: "mismatch-call", toolName: "other-tool", args: {} }),
+			});
+			expect(mismatch.status).toBe(409);
+			expect(dispatches).toHaveLength(0);
+			expect(toolFacts()).toHaveLength(0);
+
+			acceptToolStart(gateway, sessionId, "real-call", "fixture");
+			const realBeforeOptions = {
+				method: "POST",
+				headers,
+				body: JSON.stringify({ toolCallId: "real-call", toolName: "fixture", args: { secret: "PRIVATE_ARGS" } }),
+			};
+			const realBefore = await sandboxFetch(gateway.baseURL, `/api/sessions/${sessionId}/host-hooks/before-tool-call`, scopedToken, realBeforeOptions);
+			expect(realBefore.status).toBe(200);
+			expect((await realBefore.json()).action).toBe("replaceArgs");
+			expect(dispatches.map(({ name }) => name)).toEqual(["beforeToolCall"]);
+			expect(toolFacts().map(([name]) => name)).toEqual(["toolCallStarted"]);
+
+			const duplicateBefore = await sandboxFetch(gateway.baseURL, `/api/sessions/${sessionId}/host-hooks/before-tool-call`, scopedToken, realBeforeOptions);
+			expect(duplicateBefore.status).toBe(409);
+			expect(dispatches.map(({ name }) => name)).toEqual(["beforeToolCall"]);
+
+			const realAfterOptions = {
+				method: "POST",
+				headers,
+				body: JSON.stringify({ toolCallId: "real-call", toolName: "fixture", result: { content: [{ type: "text", text: "PRIVATE_RESULT" }] } }),
+			};
+			const realAfter = await sandboxFetch(gateway.baseURL, `/api/sessions/${sessionId}/host-hooks/after-tool-result`, scopedToken, realAfterOptions);
+			expect(realAfter.status).toBe(200);
+			expect(dispatches.map(({ name }) => name)).toEqual(["beforeToolCall", "afterToolResult"]);
+			const duplicateAfter = await sandboxFetch(gateway.baseURL, `/api/sessions/${sessionId}/host-hooks/after-tool-result`, scopedToken, realAfterOptions);
+			expect(duplicateAfter.status).toBe(409);
+			expect(dispatches.map(({ name }) => name)).toEqual(["beforeToolCall", "afterToolResult"]);
+
+			const session = manager.getSession(sessionId);
+			const end = {
+				type: "tool_execution_end",
+				toolCallId: "real-call",
+				toolName: "fixture",
+				isError: false,
+				result: { content: [{ type: "text", text: "PRIVATE_RESULT" }] },
+			};
+			manager.handleAgentLifecycle(session, end);
+			emitSessionEvent(session, end);
+			const persisted = {
+				type: "message_end",
+				message: {
+					role: "toolResult",
+					toolCallId: "real-call",
+					toolName: "fixture",
+					content: [{ type: "text", text: "PRIVATE_RESULT" }],
+				},
+			};
+			emitSessionEvent(session, persisted);
+			emitSessionEvent(session, persisted);
+			expect(toolFacts().map(([name]) => name)).toEqual(["toolCallStarted", "toolCallCompleted"]);
+			expect(JSON.stringify(toolFacts())).not.toContain("PRIVATE_ARGS");
+			expect(JSON.stringify(toolFacts())).not.toContain("PRIVATE_RESULT");
+			expect(session.hostToolCallLifecycle.has("real-call")).toBe(false);
+
+			const preArrivalRequest = sandboxFetch(gateway.baseURL, `/api/sessions/${sessionId}/host-hooks/before-tool-call`, scopedToken, {
+				method: "POST",
+				headers,
+				body: JSON.stringify({ toolCallId: "pre-arrival-call", toolName: "fixture", args: {} }),
+			});
+			await waitForToolCallbackWaiter(gateway, sessionId, "pre-arrival-call");
+			acceptToolStart(gateway, sessionId, "pre-arrival-call", "fixture");
+			expect((await preArrivalRequest).status).toBe(200);
+			expect(dispatches.map(({ name }) => name)).toEqual(["beforeToolCall", "afterToolResult", "beforeToolCall"]);
+
+			acceptToolStart(gateway, sessionId, "generation-call", "fixture");
+			const generationBefore = await sandboxFetch(gateway.baseURL, `/api/sessions/${sessionId}/host-hooks/before-tool-call`, scopedToken, {
+				method: "POST",
+				headers,
+				body: JSON.stringify({ toolCallId: "generation-call", toolName: "fixture", args: {} }),
+			});
+			expect(generationBefore.status).toBe(200);
+			const currentGeneration = manager._currentRespawnGeneration(sessionId);
+			manager._sessionRespawnGenerations.set(sessionId, currentGeneration + 1);
+			const staleAfter = await sandboxFetch(gateway.baseURL, `/api/sessions/${sessionId}/host-hooks/after-tool-result`, scopedToken, {
+				method: "POST",
+				headers,
+				body: JSON.stringify({ toolCallId: "generation-call", toolName: "fixture", result: {} }),
+			});
+			expect(staleAfter.status).toBe(409);
+			expect(dispatches.map(({ name }) => name)).toEqual(["beforeToolCall", "afterToolResult", "beforeToolCall", "beforeToolCall"]);
+
+			manager._sessionRespawnGenerations.set(sessionId, currentGeneration);
+			session.lifecycleGeneration = currentGeneration;
+			broadcastStatus(session, "terminated");
+			expect(session.hostToolCallLifecycle.size).toBe(0);
+			const afterCleanup = await sandboxFetch(gateway.baseURL, `/api/sessions/${sessionId}/host-hooks/after-tool-result`, scopedToken, {
+				method: "POST",
+				headers,
+				body: JSON.stringify({ toolCallId: "pre-arrival-call", toolName: "fixture", result: {} }),
+			});
+			expect(afterCleanup.status).toBe(409);
+
+			const crossSession = await sandboxFetch(gateway.baseURL, "/api/sessions/not-owned/host-hooks/before-tool-call", scopedToken, {
+				method: "POST",
+				headers,
+				body: JSON.stringify(beforeBody),
+			});
+			expect(crossSession.status).toBe(403);
+		} finally {
+			manager._sessionRespawnGenerations.delete(sessionId);
+			manager.setHostInterceptorPort(originalHostInterceptors);
+			publishSpy.mockRestore();
+		}
 	});
 
 	test("can access own session", async ({ gateway }) => {

--- a/tests2/integration/stateless-cookie-regression.test.ts
+++ b/tests2/integration/stateless-cookie-regression.test.ts
@@ -81,14 +81,14 @@ describe("stateless browser-cookie issuance regression", () => {
 				method: "POST",
 				path: "/api/sessions/stateless-cookie-missing/provider-hooks/before-prompt",
 				body: JSON.stringify({ prompt: "regression probe" }),
-				expectedStatus: 404,
+				expectedStatus: 403,
 			},
 			{
 				label: "provider before-compact callback",
 				method: "POST",
 				path: "/api/sessions/stateless-cookie-missing/provider-hooks/before-compact",
 				body: JSON.stringify({ span: "regression probe" }),
-				expectedStatus: 404,
+				expectedStatus: 403,
 			},
 			{
 				label: "Google Code Assist token callback",
@@ -116,7 +116,7 @@ describe("stateless browser-cookie issuance regression", () => {
 			const response = await requestWithBearerOnly(gateway.baseURL, gateway.token, testCase);
 			expect.soft(
 				response.status,
-				`${REGRESSION}: ${testCase.label} must reach its real gateway handler; body=${response.body}`,
+				`${REGRESSION}: ${testCase.label} must preserve its expected route or authentication boundary; body=${response.body}`,
 			).toBe(testCase.expectedStatus);
 			expect.soft(
 				response.setCookies,

--- a/tests2/tests-map.json
+++ b/tests2/tests-map.json
@@ -10217,7 +10217,8 @@
       "execution": {
         "runner": "vitest",
         "tier": "unit",
-        "project": "core"
+        "project": "isolated",
+        "reason": "Spawns real ModuleHost workers and must not share a reusable core fork whose sibling environment guards can restore its worker resolver."
       }
     },
     {

--- a/tests2/tests-map.json
+++ b/tests2/tests-map.json
@@ -21,6 +21,132 @@
   },
   "v2Native": [
     {
+      "path": "tests2/core/host-goal-notifications.test.ts",
+      "reason": "Core coverage for authoritative goal notification transitions, revisions, ordering, and non-fatal publication.",
+      "execution": {
+        "runner": "vitest",
+        "tier": "unit",
+        "project": "core"
+      }
+    },
+    {
+      "path": "tests2/core/host-hook-contributions.test.ts",
+      "reason": "Core coverage for declarative interceptor and notification contributions, activation, grants, ordering, and compatibility.",
+      "execution": {
+        "runner": "vitest",
+        "tier": "unit",
+        "project": "core"
+      }
+    },
+    {
+      "path": "tests2/core/host-hooks-catalogue.test.ts",
+      "reason": "Core contract coverage for the canonical host-hook catalogue, schemas, scopes, filters, versions, and privacy bounds.",
+      "execution": {
+        "runner": "vitest",
+        "tier": "unit",
+        "project": "core"
+      }
+    },
+    {
+      "path": "tests2/core/host-interceptor-router.test.ts",
+      "reason": "Core coverage for typed interceptor routing, deterministic folding, deadlines, authority rechecks, validation, and failure policy.",
+      "execution": {
+        "runner": "vitest",
+        "tier": "unit",
+        "project": "core"
+      }
+    },
+    {
+      "path": "tests2/core/host-notification-dispatcher.test.ts",
+      "reason": "Core coverage for canonical notification validation, immutable fanout, ordered queues, isolation, and diagnostics.",
+      "execution": {
+        "runner": "vitest",
+        "tier": "unit",
+        "project": "core"
+      }
+    },
+    {
+      "path": "tests2/core/host-pr-settings-notifications.test.ts",
+      "reason": "Core coverage for authoritative pull-request and settings notification publication with bounded value-free payloads.",
+      "execution": {
+        "runner": "vitest",
+        "tier": "unit",
+        "project": "core"
+      }
+    },
+    {
+      "path": "tests2/core/host-session-notifications.test.ts",
+      "reason": "Core coverage for canonical session and turn notification boundaries, retry suppression, revisions, and privacy.",
+      "execution": {
+        "runner": "vitest",
+        "tier": "unit",
+        "project": "core"
+      }
+    },
+    {
+      "path": "tests2/core/host-task-gate-notifications.test.ts",
+      "reason": "Core coverage for authoritative task and gate notification transitions, revisions, and publication ordering.",
+      "execution": {
+        "runner": "vitest",
+        "tier": "unit",
+        "project": "core"
+      }
+    },
+    {
+      "path": "tests2/core/host-tool-interceptor-order.test.ts",
+      "reason": "Core coverage for protected afterToolResult interception before persistence and safe toolCallCompleted publication.",
+      "execution": {
+        "runner": "vitest",
+        "tier": "unit",
+        "project": "core"
+      }
+    },
+    {
+      "path": "tests2/dom/extension-host-notification-bus.test.ts",
+      "reason": "DOM coverage for scoped Host notification subscriptions, generation fencing, gaps, coalesced refresh, unsubscribe, and legacy isolation.",
+      "execution": {
+        "runner": "vitest",
+        "tier": "unit",
+        "project": "dom"
+      }
+    },
+    {
+      "path": "tests2/integration/host-hooks-server-boundaries.test.ts",
+      "reason": "Integration coverage for real server hook publication boundaries and canonical payload projection.",
+      "execution": {
+        "runner": "vitest",
+        "tier": "unit",
+        "project": "integration"
+      }
+    },
+    {
+      "path": "tests2/integration/host-notification-routing.test.ts",
+      "reason": "Integration coverage for exact session/project WebSocket notification routing, binding, ordering, and project isolation.",
+      "execution": {
+        "runner": "vitest",
+        "tier": "unit",
+        "project": "integration"
+      }
+    },
+    {
+      "path": "tests2/integration/notification-staff-dispatcher.test.ts",
+      "reason": "Integration coverage for notification staff filtering, canonical durable envelopes, deduplication, retry, cancellation, loop protection, and reconciliation.",
+      "execution": {
+        "runner": "vitest",
+        "tier": "unit",
+        "project": "integration"
+      }
+    },
+    {
+      "path": "tests2/browser/journeys/host-notifications.journey.spec.ts",
+      "reason": "Browser journey for scoped session/project Host notifications, authoritative refresh after load/reload/gaps, clean unsubscribe, and project isolation.",
+      "execution": {
+        "runner": "playwright",
+        "tier": "browser",
+        "project": "browser"
+      }
+    },
+    {
       "path": "tests2/core/github-trusted-host-resolver.test.ts",
       "reason": "Core security and caching coverage for token-free gh-config GitHub host discovery, environment stripping, normalization, failure fallback, and single-flight refreshes.",
       "execution": {
@@ -18418,6 +18544,13 @@
       "method": "relocate",
       "replacement": [],
       "rationale": "Opt-in real Pi/real-model context-pressure smoke for exact-once steer and follow-up delivery through automatic compaction; manual/daily only, with explicit credentials, no provider fallback, and bounded request/token/cost/time guards."
+    },
+    {
+      "file": "tests/e2e/host-notifications.spec.ts",
+      "bucket": "daily",
+      "method": "relocate",
+      "replacement": [],
+      "rationale": "Real WebSocket project routing and durable notification-to-staff delivery reconciliation across a real gateway crash/restart."
     }
   ]
 }

--- a/tests2/tests-map.json
+++ b/tests2/tests-map.json
@@ -21,6 +21,24 @@
   },
   "v2Native": [
     {
+      "path": "tests2/core/inbox-tool-credentials.test.ts",
+      "reason": "Core coverage that the first-party inbox tool forwards only the host-issued staff-session capability and no caller-controlled causation fields.",
+      "execution": {
+        "runner": "vitest",
+        "tier": "unit",
+        "project": "core"
+      }
+    },
+    {
+      "path": "tests2/integration/notification-staff-inbox-auth.test.ts",
+      "reason": "Integration coverage for exact owning staff-session authority, redacted operator reads, cross-project isolation, and protected notification entry mutations.",
+      "execution": {
+        "runner": "vitest",
+        "tier": "unit",
+        "project": "integration"
+      }
+    },
+    {
       "path": "tests2/core/host-goal-notifications.test.ts",
       "reason": "Core coverage for authoritative goal notification transitions, revisions, ordering, and non-fatal publication.",
       "execution": {

--- a/tests2/tests-map.json
+++ b/tests2/tests-map.json
@@ -147,6 +147,15 @@
       }
     },
     {
+      "path": "tests2/integration/host-notification-sandbox-ws.test.ts",
+      "reason": "Integration regression proving sandbox tokens cannot claim app client metadata to receive canonical notification deltas or refresh signals.",
+      "execution": {
+        "runner": "vitest",
+        "tier": "unit",
+        "project": "integration"
+      }
+    },
+    {
       "path": "tests2/integration/notification-staff-dispatcher.test.ts",
       "reason": "Integration coverage for notification staff filtering, canonical durable envelopes, deduplication, retry, cancellation, loop protection, and reconciliation.",
       "execution": {

--- a/tests2/tests-map.json
+++ b/tests2/tests-map.json
@@ -1886,7 +1886,7 @@
     },
     {
       "path": "tests2/core/bobbit-tool-credentials.test.ts",
-      "reason": "bobbit gateway tool suite: credential/URL resolution — env creds, state-file fallback, absent-creds (logs + no registration, no throw), baseUrl trailing-slash trimming.",
+      "reason": "bobbit gateway tool suite: credential/URL resolution, host-issued session-secret propagation without caller causation controls, state-file fallback, absent credentials, and baseUrl trimming.",
       "execution": {
         "runner": "vitest",
         "tier": "unit",


### PR DESCRIPTION
## Summary
- add typed interceptor and canonical notification catalogues with deterministic host dispatch, validation, deadlines, grants, audit, and legacy provider compatibility
- publish bounded post-authority session/project facts to scoped browser APIs, observational extension handlers, and durable notification-based staff triggers
- enforce exact project/session authority, sandbox WebSocket exclusion, redacted inbox access, host-owned causation, durable mutation fences, and snapshot refresh on gaps
- document hook authoring, lifecycle and delivery guarantees, staff triggers, inbox security, Marketplace activation, and WebSocket behavior

## Testing
- `npm run build`
- `npm run check`
- `npm run test:unit`
- `npm run test:browser`
- `npm run test:e2e`
- focused retry-free authority, routing, backpressure, inbox, interceptor, settings, and sandbox WebSocket suites

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)
