### PR TITLE
Fix read-only delegate interaction

### DIFF
--- a/docs/orchestration.md
+++ b/docs/orchestration.md
@@ -90,6 +90,38 @@ mutating (file-changing) tool.
   prompt, no accessory, inherits your stripped tools).
 - **Timeout** — blocking-mode default is 10 minutes.
 
+#### Capability, interaction, and lifecycle are independent
+
+A delegate's persisted `readOnly` flag describes its **tool capability**, not
+its chat lifecycle. It removes mutating tools from the child, but a live,
+non-archived read-only delegate remains a normal active session: its sprite
+follows its real status, its composer accepts follow-up prompts, and owner
+orchestration such as `team_prompt` and `team_wait` continues to work. This
+separation lets an owner ask a safe research or review helper to refine its
+answer without granting it write access.
+
+Two other fields have separate owners:
+
+- **Lifecycle/archive state** controls ended presentation. An explicit archive
+  or ordinary termination desaturates the session and removes its composer;
+  this evidence remains authoritative across navigation, session-list refresh,
+  reload, and reconnect.
+- **`nonInteractive`** is a server-driven interaction policy for verification
+  and similar agents. It keeps normal user prompting disabled independently of
+  both tool capability and archive state; a streaming verifier retains only its
+  intentional steer path.
+
+The one recoverable terminal-looking state is `MODEL_SELECTION_REQUIRED`. It
+remains readable and model-selectable rather than being presented as an
+ordinary ended session. On successful recovery, the gateway transfers clients
+to the verified replacement, publishes its canonical live status, and only
+then publishes the exact model/thinking tuple with an explicit
+`condition: null`. That order prevents a refresh or reconnect from briefly
+combining stale `terminated` status with a cleared condition and closing the
+composer. Partial state frames that omit `condition` never clear recovery,
+while explicit archive or ordinary termination evidence still wins over a
+generic live snapshot.
+
 > **One shared role pipeline (no ad-hoc per-path code).** The bare delegate path
 > (`session-manager.ts::createDelegateSession`) now threads `role` / `roleName` / `rolePrompt`
 > into its `SessionSetupPlan`, so the **same** role-prompt + role-accessory application in

--- a/docs/session-actions.md
+++ b/docs/session-actions.md
@@ -38,12 +38,12 @@ Staff and team-lead labels are derived in `buildSessionActions()` so all surface
 
 ## Archived session actions
 
-Archived sessions use `buildArchivedSessionActions()` instead of `buildSessionActions()`. This keeps read-only archived contexts on a separate built-in-only descriptor source: active-session controls and pack-provided `session-menu` launchers are never appended to archived menus.
+Archived sessions use `buildArchivedSessionActions()` instead of `buildSessionActions()`. This keeps ended lifecycle contexts on a separate built-in-only descriptor source: active-session controls and pack-provided `session-menu` launchers are never appended to archived menus.
 
 Archived actions appear in the same two places users already look for live session commands:
 
 - **Archived sidebar rows** — `renderArchivedSessionRow()` renders the `Session actions` hamburger on archived rows, including nested archived delegate rows. On desktop the trigger appears in the row action cluster; on mobile/touch it remains visible with the row metadata. The trigger and menu handlers prevent default activation and stop propagation so clicking the hamburger does not open or select the archived row.
-- **Open archived session header** — `renderHeaderSessionActions()` switches to archived descriptors when the open session is archived/read-only. Desktop and mobile both expose the `Session actions` hamburger in the top-right session action area. The archived header forces the overflow trigger to stay available, so the full archived-safe menu is reachable even when desktop direct action shortcuts are also visible.
+- **Open archived session header** — `renderHeaderSessionActions()` switches to archived descriptors only when lifecycle state marks the open session archived or terminated. A capability-only `readOnly` flag does not select this menu. Desktop and mobile both expose the `Session actions` hamburger in the top-right session action area. The archived header forces the overflow trigger to stay available, so the full archived-safe menu is reachable even when desktop direct action shortcuts are also visible.
 
 Archived menus contain only these built-in actions, in this order:
 
@@ -52,7 +52,7 @@ Archived menus contain only these built-in actions, in this order:
 3. `view-system-prompt` — `View system prompt` for the archived session id.
 4. `open-new-window` — `Open in new window` using the same path-style session URL.
 
-`Continue in new session` uses `canContinueArchivedSession()` for client-side visibility. It is shown only for archived/read-only sources that are not goal sessions, delegates, child/delegate rows, team sessions, team leads, or non-interactive sessions; whose `projectId` still resolves to a registered project; and whose transcript is available (`agentSessionFile` is present when supplied, and `transcriptAvailable` is not `false`). Ineligible sessions hide Continue rather than rendering a disabled item, while the other read-only actions remain available.
+`Continue in new session` uses `canContinueArchivedSession()` for client-side visibility. It is shown only for archived or terminated lifecycle sources that are not goal sessions, delegates, child/delegate rows, team sessions, team leads, or non-interactive sessions; whose `projectId` still resolves to a registered project; and whose transcript is available (`agentSessionFile` is present when supplied, and `transcriptAvailable` is not `false`). Ineligible sessions hide Continue rather than rendering a disabled item, while the other archive-safe actions remain available.
 
 Running Continue opens the confirm-only `ContinueSessionChooser`, then posts an empty JSON body to `POST /api/sessions/:id/continue`. On success the client refreshes sessions and connects to the returned session id as an existing session with message refetch enabled. The action intentionally does **not** call the live `/api/sessions/:id/fork` endpoint: Continue-Archived clones the archived `.jsonl` transcript into a fresh session slot and lets the agent rehydrate through the normal archived-continue flow. See [REST API — Continue-Archived endpoint](rest-api.md#continue-archived-endpoint) and [Internals — Continue-Archived sessions](internals.md#continue-archived-sessions).
 

--- a/docs/websocket-protocol.md
+++ b/docs/websocket-protocol.md
@@ -156,7 +156,9 @@ Live session sockets enforce the independent `readOnly` capability and
 not only in the browser UI. The server checks both the live session and its
 persisted row; `true` in either source activates that policy. This closes the
 window where one representation has updated before the other. A frame covered
-by both policies is rejected by the `readOnly` capability check first.
+by both policies is normally rejected by the `readOnly` capability check first.
+The narrow model-recovery exception described below yields to `nonInteractive`,
+so server-driven sessions do not become interactive during recovery.
 
 The guarded work classifier contains these frames:
 
@@ -176,12 +178,24 @@ it does not mean the transcript is archived or the session is unpromptable. A
 live read-only delegate therefore accepts normal prompt, steer, queue, and
 retry work. Owner orchestration remains available through its separate API.
 The session transport blocks only controls that could widen or alter the
-child's capability-bearing configuration: `set_model`, `set_image_model`,
-`set_thinking_level`, and `grant_tool_permission`. Those frames receive:
+child's capability-bearing configuration: ordinary `set_model`,
+`set_image_model`, `set_thinking_level`, and `grant_tool_permission`. Those
+frames receive:
 
 ```json
 { "type": "error", "code": "SESSION_READ_ONLY", "message": "..." }
 ```
+
+There is one exception: when authoritative admission reports an active
+`MODEL_SELECTION_REQUIRED` condition, a read-only session may send `set_model`
+so it can recover from its unavailable persisted text model. This bypasses only
+the read-only policy check. The frame still uses the existing per-session
+command serializer, and the existing recovery path remains responsible for
+exact selectable-tuple validation, thinking-level clamping, activation,
+transcript restoration, verification, and durable persistence. The exception
+does not admit ordinary `set_model`, `set_image_model`, `set_thinking_level`, or
+permission changes. If `nonInteractive` is also true, that policy still rejects
+the recovery frame with `NON_INTERACTIVE_WORK_CONTROL` before recovery starts.
 
 Archive/termination lifecycle and `nonInteractive` policy are evaluated
 separately; neither is inferred from `readOnly`.

--- a/docs/websocket-protocol.md
+++ b/docs/websocket-protocol.md
@@ -151,11 +151,12 @@ Hold or roll back the candidate on transcript divergence, reconstruction loops, 
 
 ## Authenticated session work policy
 
-Live session sockets enforce `readOnly` and `nonInteractive` at the authenticated
-transport boundary, not only in the browser UI. The server checks both the live
-session and its persisted row; `true` in either source activates the restriction.
-This closes the window where one representation has updated before the other.
-If both restrictions apply, `readOnly` takes precedence.
+Live session sockets enforce the independent `readOnly` capability and
+`nonInteractive` interaction policies at the authenticated transport boundary,
+not only in the browser UI. The server checks both the live session and its
+persisted row; `true` in either source activates that policy. This closes the
+window where one representation has updated before the other. A frame covered
+by both policies is rejected by the `readOnly` capability check first.
 
 The guarded work classifier contains these frames:
 
@@ -168,29 +169,22 @@ The guarded work classifier contains these frames:
   `task_delete`, `grant_tool_permission`.
 - Extension session writes: `ext_session_write_permit`, `ext_session_post`.
 
-### Read-only sessions
+### Read-only capability
 
-Every guarded frame is rejected with `SESSION_READ_ONLY`. Ordinary guarded
-frames receive the generic error envelope:
+For a delegate, `readOnly` means it was launched without mutating agent tools;
+it does not mean the transcript is archived or the session is unpromptable. A
+live read-only delegate therefore accepts normal prompt, steer, queue, and
+retry work. Owner orchestration remains available through its separate API.
+The session transport blocks only controls that could widen or alter the
+child's capability-bearing configuration: `set_model`, `set_image_model`,
+`set_thinking_level`, and `grant_tool_permission`. Those frames receive:
 
 ```json
 { "type": "error", "code": "SESSION_READ_ONLY", "message": "..." }
 ```
 
-Extension session-write callers require a correlated response so their Host API
-call does not wait for a generic error until timeout. They receive:
-
-```json
-{ "type": "ext_session_write_permit_result", "requestId": "...", "ok": false, "error": "SESSION_READ_ONLY" }
-```
-
-or:
-
-```json
-{ "type": "ext_session_post_result", "requestId": "...", "ok": false, "error": "SESSION_READ_ONLY" }
-```
-
-A read-only session has no streaming-steer exception.
+Archive/termination lifecycle and `nonInteractive` policy are evaluated
+separately; neither is inferred from `readOnly`.
 
 ### Non-interactive sessions
 
@@ -314,8 +308,15 @@ When `state.data.condition` is
 recovery request rather than an ordinary live mutation. The gateway accepts
 only an exact currently session-selectable tuple, clamps thinking, starts a
 replacement pinned to that tuple, rehydrates the existing transcript, and
-verifies model read-back. It persists and publishes the replacement tuple with
-`condition: null` only after activation succeeds.
+verifies model read-back. It persists the replacement only after activation
+succeeds. After transferring attached clients to the verified replacement, the
+gateway publishes the replacement's canonical live status first, then publishes
+the exact model and
+thinking tuple with explicit `condition: null`. Clients must preserve this
+ordering: a partial state frame that omits `condition` cannot clear recovery,
+and a stale terminated list row may be reopened only when it carries the
+recoverable condition and an explicit condition snapshot supplies the canonical
+live state. Explicit archive or ordinary termination evidence remains terminal.
 
 An ordinary retryable activation failure returns
 `MODEL_SELECTION_RECOVERY_FAILED` with a sanitized message that says to choose

--- a/src/app/render-helpers.ts
+++ b/src/app/render-helpers.ts
@@ -1278,7 +1278,7 @@ export function renderArchivedSessionRow(session: GatewaySession, extraChildren 
 			class="group ${treeOptions?.goalTitle ? "sidebar-status-goal-row" : ""} relative flex items-center gap-1 pr-1 ${rowPy} rounded-md cursor-pointer transition-colors
 				${active ? `bg-secondary text-foreground sidebar-session-active${hasChildren ? "" : " sidebar-active-no-chevron"}` : "text-muted-foreground hover:bg-secondary/50 hover:text-foreground"}"
 			style=${`padding-left:var(--sidebar-chevron-w);filter:grayscale(1);opacity:0.75;${flat ? `--sidebar-status-motion-accent:${treeOptions?.projectColor || "var(--muted-foreground)"};` : ""}`}
-			@click=${() => connectToSession(session.id, true, { readOnly: true })}
+			@click=${() => connectToSession(session.id, true, { archived: true })}
 		>
 			${hasChildren ? html`<span
 				class="sidebar-chevron-slot sidebar-chevron-slot--absolute text-muted-foreground select-none cursor-pointer"

--- a/src/app/render.ts
+++ b/src/app/render.ts
@@ -26,7 +26,7 @@ export { showHeaderToast } from "./header-toast.js";
 import { getDocumentAnnotationCount, getReviewAnnotationCount } from "../ui/components/review/AnnotationStore.js";
 import type { ReviewGroupModel } from "../ui/components/review/review-types.js";
 import { loadReviewSources } from "./review-sources-lazy.js";
-import { applyKnownSessionLifecyclePresentation, backToSessions, createAndConnectSession } from "./session-manager.js";
+import { applyKnownSessionLifecyclePresentation, backToSessions, createAndConnectSession, sessionLifecycleRecordForPresentation } from "./session-manager.js";
 import { buildArchivedSessionActions, buildSessionActions, isArchivedSessionActionSource, resetSessionForkNewWorktree, type SessionActionDescriptor } from "./session-actions.js";
 import type { SidebarActionsPopover, SidebarActionsPopoverItem } from "../ui/components/SidebarActionsPopover.js";
 import { captureHeaderSessionActionSourceRects, type SidebarActionsFlipRect } from "../ui/components/sidebar-actions-flip.js";
@@ -2363,8 +2363,15 @@ export function doRenderApp(): void {
 			?? state.archivedSessions.find(session => session.id === panelBoundSessionId)
 		: undefined;
 	if (panelAgentInterface && panelBoundSession) {
-		applyKnownSessionLifecyclePresentation(panelAgentInterface, [panelBoundSession], {
-			remoteArchived: state.remoteAgent?.state.isArchived === true,
+		const panelRemote = state.remoteAgent;
+		let presentationRecord: Partial<GatewaySession> | undefined = panelBoundSession;
+		if (panelRemote
+			&& panelRemote.gatewaySessionId === panelBoundSessionId
+			&& panelAgentInterface.session === panelRemote) {
+			presentationRecord = sessionLifecycleRecordForPresentation(panelBoundSession, panelRemote);
+		}
+		applyKnownSessionLifecyclePresentation(panelAgentInterface, [presentationRecord], {
+			remoteArchived: panelRemote?.state.isArchived === true,
 		});
 	}
 	// Archived panel agents may not expose `session.sessionId`; when the current

--- a/src/app/render.ts
+++ b/src/app/render.ts
@@ -26,7 +26,7 @@ export { showHeaderToast } from "./header-toast.js";
 import { getDocumentAnnotationCount, getReviewAnnotationCount } from "../ui/components/review/AnnotationStore.js";
 import type { ReviewGroupModel } from "../ui/components/review/review-types.js";
 import { loadReviewSources } from "./review-sources-lazy.js";
-import { backToSessions, createAndConnectSession } from "./session-manager.js";
+import { applyKnownSessionLifecyclePresentation, backToSessions, createAndConnectSession } from "./session-manager.js";
 import { buildArchivedSessionActions, buildSessionActions, isArchivedSessionActionSource, resetSessionForkNewWorktree, type SessionActionDescriptor } from "./session-actions.js";
 import type { SidebarActionsPopover, SidebarActionsPopoverItem } from "../ui/components/SidebarActionsPopover.js";
 import { captureHeaderSessionActionSourceRects, type SidebarActionsFlipRect } from "../ui/components/sidebar-actions-flip.js";
@@ -2354,11 +2354,24 @@ export function doRenderApp(): void {
 	const routeArchivedSession = routeCachedSession ? isArchivedSessionActionSource(routeCachedSession) : false;
 	const panelAgentInterface = state.chatPanel?.agentInterface as any;
 	const panelSessionId = typeof panelAgentInterface?.session?.sessionId === "string" ? panelAgentInterface.session.sessionId : undefined;
-	// Archived read-only panel agents may not expose `session.sessionId`; when
-	// the current route is archived or not yet cached, the route id is the only
-	// stable action source. Keep this read-only-only so live routes don't get
-	// normal live session actions until their session binding is explicit.
-	const routeHasReadOnlyPanel = Boolean(routeSessionId && panelAgentInterface?.readOnly && (
+	// An authoritative session-list refresh also renders the app. Reconcile the
+	// bound panel here so lifecycle presentation updates even without a new WS
+	// status frame or navigation, while capability-only `readOnly` remains inert.
+	const panelBoundSessionId = panelSessionId ?? state.remoteAgent?.gatewaySessionId;
+	const panelBoundSession = panelBoundSessionId
+		? state.gatewaySessions.find(session => session.id === panelBoundSessionId)
+			?? state.archivedSessions.find(session => session.id === panelBoundSessionId)
+		: undefined;
+	if (panelAgentInterface && panelBoundSession) {
+		applyKnownSessionLifecyclePresentation(panelAgentInterface, [panelBoundSession], {
+			remoteArchived: state.remoteAgent?.state.isArchived === true,
+		});
+	}
+	// Archived panel agents may not expose `session.sessionId`; when the current
+	// route is archived or not yet cached, the route id is the only stable action
+	// source. Keep this archive-only so live routes do not gain session actions
+	// until their session binding is explicit.
+	const routeHasArchivedPanel = Boolean(routeSessionId && panelAgentInterface?.archived && (
 		panelSessionId === routeSessionId
 		|| (!panelSessionId && (routeArchivedSession || !routeCachedSession))
 	));
@@ -2367,7 +2380,7 @@ export function doRenderApp(): void {
 		|| state.connectingSessionId === routeSessionId
 		|| state.remoteAgent?.gatewaySessionId === routeSessionId
 		|| routeArchivedSession
-		|| routeHasReadOnlyPanel
+		|| routeHasArchivedPanel
 	));
 	const activeSid = (routeSessionId && routeIsCurrentSession) ? routeSessionId : activeSessionId();
 	const sessionTitle = connected && state.remoteAgent ? (state.remoteAgent.title || "New session") : "";
@@ -2379,8 +2392,8 @@ export function doRenderApp(): void {
 		if (cached) return cached;
 		const ai = panelAgentInterface;
 		const aiSessionId = typeof ai?.session?.sessionId === "string" ? ai.session.sessionId : undefined;
-		const routeReadOnlyPanelSource = activeSid === routeSessionId && routeHasReadOnlyPanel;
-		if (!ai?.readOnly || (state.selectedSessionId !== activeSid && state.remoteAgent?.gatewaySessionId !== activeSid && aiSessionId !== activeSid && !routeReadOnlyPanelSource)) return undefined;
+		const routeArchivedPanelSource = activeSid === routeSessionId && routeHasArchivedPanel;
+		if (!ai?.archived || (state.selectedSessionId !== activeSid && state.remoteAgent?.gatewaySessionId !== activeSid && aiSessionId !== activeSid && !routeArchivedPanelSource)) return undefined;
 		return {
 			id: activeSid,
 			title: sessionTitle || "New session",
@@ -2394,7 +2407,6 @@ export function doRenderApp(): void {
 			delegateOf: ai.delegateOf,
 			teamGoalId: ai.teamGoalId,
 			assistantType: ai.assistantType,
-			readOnly: true,
 			archived: true,
 		} as GatewaySession;
 	})() : undefined;

--- a/src/app/session-actions.ts
+++ b/src/app/session-actions.ts
@@ -131,7 +131,6 @@ export function canForkSession(session: GatewaySession): boolean {
 
 export function isArchivedSessionActionSource(session: GatewaySession): boolean {
 	return session.archived === true
-		|| session.readOnly === true
 		|| session.status === "archived"
 		|| session.status === "terminated";
 }

--- a/src/app/session-manager.ts
+++ b/src/app/session-manager.ts
@@ -183,6 +183,14 @@ const SESSION_CACHE_MAX = 10;
 type SessionLifecyclePresentationTarget = {
 	archived?: boolean;
 	nonInteractive?: boolean;
+	requestUpdate?: () => void;
+};
+
+type SessionLifecyclePresentationOptions = {
+	explicitArchived?: boolean;
+	remoteArchived?: boolean;
+	/** Only an explicit condition-bearing server frame may reverse transient termination. */
+	authoritativeCondition?: boolean;
 };
 
 function isModelSelectionRequiredRecord(record: Partial<GatewaySession> | undefined): boolean {
@@ -192,24 +200,87 @@ function isModelSelectionRequiredRecord(record: Partial<GatewaySession> | undefi
 		&& typeof condition.modelId === "string";
 }
 
+/**
+ * Prefer an explicit RemoteAgent condition snapshot over a possibly older list
+ * status, while retaining independent archive and non-interactive evidence.
+ */
+export function sessionLifecycleRecordForPresentation(
+	record: Partial<GatewaySession> | undefined,
+	remote: Pick<RemoteAgent, "conditionSnapshotReceived" | "state">,
+): Partial<GatewaySession> | undefined {
+	if (!remote.conditionSnapshotReceived) return record;
+	const archivedLifecycle = record?.archived === true || record?.status === "archived";
+	return {
+		...record,
+		status: archivedLifecycle
+			? record?.status
+			: (remote.state?.status as GatewaySession["status"] | undefined) ?? record?.status,
+		condition: remote.state?.condition,
+	} as Partial<GatewaySession>;
+}
+
 /** Apply known lifecycle presentation and independent server-driven interaction policy. */
 export function applyKnownSessionLifecyclePresentation(
 	target: SessionLifecyclePresentationTarget,
 	records: ReadonlyArray<Partial<GatewaySession> | undefined>,
-	options?: { explicitArchived?: boolean; remoteArchived?: boolean },
+	options?: SessionLifecyclePresentationOptions,
 ): void {
 	if (records.some((record) => record?.nonInteractive === true)) {
 		target.nonInteractive = true;
 	}
-	if (
-		options?.explicitArchived
+	const hasArchiveEvidence = options?.explicitArchived
 		|| options?.remoteArchived
-		|| records.some((record) => record?.archived === true
-			|| record?.status === "archived"
-			|| (record?.status === "terminated" && !isModelSelectionRequiredRecord(record)))
-	) {
+		|| records.some((record) => record?.archived === true || record?.status === "archived");
+	if (hasArchiveEvidence) {
+		target.archived = true;
+		return;
+	}
+	const hasRecoveryCondition = records.some((record) =>
+		record?.status === "terminated" && isModelSelectionRequiredRecord(record));
+	if (options?.authoritativeCondition && hasRecoveryCondition) {
+		target.archived = false;
+		return;
+	}
+	if (records.some((record) =>
+		record?.status === "terminated" && !isModelSelectionRequiredRecord(record))) {
 		target.archived = true;
 	}
+}
+
+/** Reconcile the one recoverable terminal state from explicit authoritative condition frames. */
+export function installSessionConditionLifecycleReconciliation(
+	remote: RemoteAgent,
+	sessionId: string,
+	explicitArchived = false,
+): () => void {
+	return remote.subscribe((event: any) => {
+		if (event?.type !== "state_update"
+			|| !event.data
+			|| !Object.prototype.hasOwnProperty.call(event.data, "condition")) return;
+		const panel = state.chatPanel;
+		const target = panel?.agentInterface as SessionLifecyclePresentationTarget | undefined;
+		const panelAgent: unknown = panel?.agent;
+		const interfaceSession: unknown = panel?.agentInterface?.session;
+		if (activeSessionId() !== sessionId
+			|| state.selectedSessionId !== sessionId
+			|| state.remoteAgent !== remote
+			|| remote.gatewaySessionId !== sessionId
+			|| panelAgent !== remote
+			|| interfaceSession !== remote
+			|| !target) return;
+		const knownRecord = state.gatewaySessions.find((record) => record.id === sessionId)
+			?? state.archivedSessions.find((record) => record.id === sessionId);
+		applyKnownSessionLifecyclePresentation(
+			target,
+			[sessionLifecycleRecordForPresentation(knownRecord, remote)],
+			{
+				explicitArchived,
+				remoteArchived: remote.state?.isArchived === true,
+				authoritativeCondition: true,
+			},
+		);
+		target.requestUpdate?.();
+	});
 }
 
 function cacheSession(sessionId: string, chatPanel: ChatPanel, remoteAgent: RemoteAgent): void {
@@ -1463,10 +1534,15 @@ export async function connectToSession(sessionId: string, isExisting: boolean, o
 		const cachedKnownSession = state.gatewaySessions.find((s) => s.id === sessionId)
 			|| state.archivedSessions.find((s) => s.id === sessionId);
 		if (state.chatPanel.agentInterface) {
-			applyKnownSessionLifecyclePresentation(state.chatPanel.agentInterface, [cachedKnownSession], {
-				explicitArchived: options?.archived === true,
-				remoteArchived: cached.remoteAgent.state?.isArchived === true,
-			});
+			applyKnownSessionLifecyclePresentation(
+				state.chatPanel.agentInterface,
+				[sessionLifecycleRecordForPresentation(cachedKnownSession, cached.remoteAgent)],
+				{
+					explicitArchived: options?.archived === true,
+					remoteArchived: cached.remoteAgent.state?.isArchived === true,
+					authoritativeCondition: cached.remoteAgent.conditionSnapshotReceived,
+				},
+			);
 		}
 		state.remoteAgent.registerHostApiTransports();
 		state.connectionStatus = "connected";
@@ -1575,10 +1651,15 @@ export async function connectToSession(sessionId: string, isExisting: boolean, o
 				ai.delegateOf = s.delegateOf;
 				ai.teamGoalId = s.teamGoalId;
 				ai.assistantType = s.assistantType;
-				applyKnownSessionLifecyclePresentation(ai, [s], {
-					explicitArchived: options?.archived === true,
-					remoteArchived: cached.remoteAgent.state?.isArchived === true,
-				});
+				applyKnownSessionLifecyclePresentation(
+					ai,
+					[sessionLifecycleRecordForPresentation(s, cached.remoteAgent)],
+					{
+						explicitArchived: options?.archived === true,
+						remoteArchived: cached.remoteAgent.state?.isArchived === true,
+						authoritativeCondition: cached.remoteAgent.conditionSnapshotReceived,
+					},
+				);
 			};
 			applyFrom(sessionData);
 			const archivedMatch: any = state.archivedSessions?.find((s: any) => s.id === sessionId);
@@ -1788,6 +1869,7 @@ export async function connectToSession(sessionId: string, isExisting: boolean, o
 			}
 			renderApp();
 		};
+		installSessionConditionLifecycleReconciliation(remote, sessionId, options?.archived === true);
 
 		remote.onConnectionStatusChange = (status: ConnectionStatus) => {
 			const isActive = activeSessionId() === sessionId;
@@ -2463,10 +2545,15 @@ export async function connectToSession(sessionId: string, isExisting: boolean, o
 			onApiKeyRequired: async () => true,
 		});
 		if (bindingPanel.agentInterface) {
-			applyKnownSessionLifecyclePresentation(bindingPanel.agentInterface, [sessionDataAny], {
-				explicitArchived: options?.archived === true,
-				remoteArchived: remote.state.isArchived === true,
-			});
+			applyKnownSessionLifecyclePresentation(
+				bindingPanel.agentInterface,
+				[sessionLifecycleRecordForPresentation(sessionDataAny, remote)],
+				{
+					explicitArchived: options?.archived === true,
+					remoteArchived: remote.state.isArchived === true,
+					authoritativeCondition: remote.conditionSnapshotReceived,
+				},
+			);
 		}
 		await setAgentPromise;
 		if (isStale()) { cleanupRemote(remote); return; }
@@ -2524,10 +2611,15 @@ export async function connectToSession(sessionId: string, isExisting: boolean, o
 		// Reconcile any record discovered by the fallback fetch. The common case
 		// already applied these flags synchronously during setAgent above.
 		if (state.chatPanel.agentInterface) {
-			applyKnownSessionLifecyclePresentation(state.chatPanel.agentInterface, [sessionDataAny], {
-				explicitArchived: options?.archived === true,
-				remoteArchived: remote.state.isArchived === true,
-			});
+			applyKnownSessionLifecyclePresentation(
+				state.chatPanel.agentInterface,
+				[sessionLifecycleRecordForPresentation(sessionDataAny, remote)],
+				{
+					explicitArchived: options?.archived === true,
+					remoteArchived: remote.state.isArchived === true,
+					authoritativeCondition: remote.conditionSnapshotReceived,
+				},
+			);
 		}
 
 		// Set up bg process kill/dismiss handlers

--- a/src/app/session-manager.ts
+++ b/src/app/session-manager.ts
@@ -202,19 +202,22 @@ function isModelSelectionRequiredRecord(record: Partial<GatewaySession> | undefi
 
 /**
  * Prefer an explicit RemoteAgent condition snapshot over a possibly older list
- * status, while retaining independent archive and non-interactive evidence.
+ * status, except when the list carries absolute archive or ordinary termination
+ * evidence. Only an explicitly recoverable termination may be reopened by the
+ * canonical remote lifecycle.
  */
 export function sessionLifecycleRecordForPresentation(
 	record: Partial<GatewaySession> | undefined,
 	remote: Pick<RemoteAgent, "conditionSnapshotReceived" | "state">,
 ): Partial<GatewaySession> | undefined {
 	if (!remote.conditionSnapshotReceived) return record;
-	const archivedLifecycle = record?.archived === true || record?.status === "archived";
+	const absoluteTerminalLifecycle = record?.archived === true
+		|| record?.status === "archived"
+		|| (record?.status === "terminated" && !isModelSelectionRequiredRecord(record));
+	if (absoluteTerminalLifecycle) return record;
 	return {
 		...record,
-		status: archivedLifecycle
-			? record?.status
-			: (remote.state?.status as GatewaySession["status"] | undefined) ?? record?.status,
+		status: (remote.state?.status as GatewaySession["status"] | undefined) ?? record?.status,
 		condition: remote.state?.condition,
 	} as Partial<GatewaySession>;
 }

--- a/src/app/session-manager.ts
+++ b/src/app/session-manager.ts
@@ -180,8 +180,8 @@ interface CachedSession {
 const sessionCache = new Map<string, CachedSession>();
 const SESSION_CACHE_MAX = 10;
 
-type InteractionModeTarget = {
-	readOnly?: boolean;
+type SessionLifecyclePresentationTarget = {
+	archived?: boolean;
 	nonInteractive?: boolean;
 };
 
@@ -192,24 +192,23 @@ function isModelSelectionRequiredRecord(record: Partial<GatewaySession> | undefi
 		&& typeof condition.modelId === "string";
 }
 
-/** Apply every interaction restriction already known without ever clearing one. */
-function applyKnownSessionInteractionMode(
-	target: InteractionModeTarget,
+/** Apply known lifecycle presentation and independent server-driven interaction policy. */
+export function applyKnownSessionLifecyclePresentation(
+	target: SessionLifecyclePresentationTarget,
 	records: ReadonlyArray<Partial<GatewaySession> | undefined>,
-	options?: { explicitReadOnly?: boolean; remoteArchived?: boolean },
+	options?: { explicitArchived?: boolean; remoteArchived?: boolean },
 ): void {
-	const nonInteractive = records.some((record) => record?.nonInteractive === true);
-	if (nonInteractive) target.nonInteractive = true;
+	if (records.some((record) => record?.nonInteractive === true)) {
+		target.nonInteractive = true;
+	}
 	if (
-		options?.explicitReadOnly
+		options?.explicitArchived
 		|| options?.remoteArchived
-		|| nonInteractive
-		|| records.some((record) => record?.readOnly === true
-			|| record?.archived === true
+		|| records.some((record) => record?.archived === true
 			|| record?.status === "archived"
 			|| (record?.status === "terminated" && !isModelSelectionRequiredRecord(record)))
 	) {
-		target.readOnly = true;
+		target.archived = true;
 	}
 }
 
@@ -1426,7 +1425,7 @@ export function installConfirmedSessionModelPersistence(remote: RemoteAgent, ses
 	});
 }
 
-export async function connectToSession(sessionId: string, isExisting: boolean, options?: { isGoalAssistant?: boolean; isRoleAssistant?: boolean; isToolAssistant?: boolean; isStaffAssistant?: boolean; isPreview?: boolean; assistantType?: string; readOnly?: boolean; projectDirPath?: string; projectEditContext?: { name: string; rootPath: string }; projectInitialScanContext?: import("./project-assistant-autoprompt.js").ProjectAssistantScanContext; onMissing?: "toast" | "modal"; refetchMessagesOnReady?: boolean }): Promise<void> {
+export async function connectToSession(sessionId: string, isExisting: boolean, options?: { isGoalAssistant?: boolean; isRoleAssistant?: boolean; isToolAssistant?: boolean; isStaffAssistant?: boolean; isPreview?: boolean; assistantType?: string; archived?: boolean; projectDirPath?: string; projectEditContext?: { name: string; rootPath: string }; projectInitialScanContext?: import("./project-assistant-autoprompt.js").ProjectAssistantScanContext; onMissing?: "toast" | "modal"; refetchMessagesOnReady?: boolean }): Promise<void> {
 	// Capture the current route BEFORE selectSession changes the hash.
 	const startingRoute = getRouteFromHash();
 	const replaceHistory = startingRoute.view === "goal-dashboard";
@@ -1464,8 +1463,8 @@ export async function connectToSession(sessionId: string, isExisting: boolean, o
 		const cachedKnownSession = state.gatewaySessions.find((s) => s.id === sessionId)
 			|| state.archivedSessions.find((s) => s.id === sessionId);
 		if (state.chatPanel.agentInterface) {
-			applyKnownSessionInteractionMode(state.chatPanel.agentInterface, [cachedKnownSession], {
-				explicitReadOnly: options?.readOnly === true,
+			applyKnownSessionLifecyclePresentation(state.chatPanel.agentInterface, [cachedKnownSession], {
+				explicitArchived: options?.archived === true,
 				remoteArchived: cached.remoteAgent.state?.isArchived === true,
 			});
 		}
@@ -1562,7 +1561,7 @@ export async function connectToSession(sessionId: string, isExisting: boolean, o
 		markSessionVisited(sessionId);
 		canonicalizePathSessionRoute(sessionId);
 
-		// Refresh scope-gate fields + archived readOnly on the restored
+		// Refresh scope-gate fields + archived presentation on the restored
 		// AgentInterface. Between disconnect and reconnect the session may
 		// have been terminated elsewhere; without this the cached panel keeps
 		// showing the live chrome and hides the "Continue in new session"
@@ -1576,8 +1575,8 @@ export async function connectToSession(sessionId: string, isExisting: boolean, o
 				ai.delegateOf = s.delegateOf;
 				ai.teamGoalId = s.teamGoalId;
 				ai.assistantType = s.assistantType;
-				applyKnownSessionInteractionMode(ai, [s], {
-					explicitReadOnly: options?.readOnly === true,
+				applyKnownSessionLifecyclePresentation(ai, [s], {
+					explicitArchived: options?.archived === true,
 					remoteArchived: cached.remoteAgent.state?.isArchived === true,
 				});
 			};
@@ -1759,9 +1758,12 @@ export async function connectToSession(sessionId: string, isExisting: boolean, o
 			}
 			// Only update active session's UI state — cached sessions must not corrupt current panel
 			if (activeSessionId() === sessionId) {
-				// Set readOnly when archived status arrives (may come after initial connect)
-				if (status === "archived" && state.chatPanel?.agentInterface) {
-					state.chatPanel.agentInterface.readOnly = true;
+				// Project terminal lifecycle updates independently from tool capability.
+				if (state.chatPanel?.agentInterface) {
+					applyKnownSessionLifecyclePresentation(state.chatPanel.agentInterface, [{
+						status: status as GatewaySession["status"],
+						condition: remote.state.condition,
+					} as Partial<GatewaySession>], { remoteArchived: remote.state.isArchived === true });
 				}
 				// Trigger Lit re-render for aborting indicator — isAborting is read
 				// from the session object (same reference), so Lit won't detect the change.
@@ -2461,8 +2463,8 @@ export async function connectToSession(sessionId: string, isExisting: boolean, o
 			onApiKeyRequired: async () => true,
 		});
 		if (bindingPanel.agentInterface) {
-			applyKnownSessionInteractionMode(bindingPanel.agentInterface, [sessionDataAny], {
-				explicitReadOnly: options?.readOnly === true,
+			applyKnownSessionLifecyclePresentation(bindingPanel.agentInterface, [sessionDataAny], {
+				explicitArchived: options?.archived === true,
 				remoteArchived: remote.state.isArchived === true,
 			});
 		}
@@ -2522,8 +2524,8 @@ export async function connectToSession(sessionId: string, isExisting: boolean, o
 		// Reconcile any record discovered by the fallback fetch. The common case
 		// already applied these flags synchronously during setAgent above.
 		if (state.chatPanel.agentInterface) {
-			applyKnownSessionInteractionMode(state.chatPanel.agentInterface, [sessionDataAny], {
-				explicitReadOnly: options?.readOnly === true,
+			applyKnownSessionLifecyclePresentation(state.chatPanel.agentInterface, [sessionDataAny], {
+				explicitArchived: options?.archived === true,
 				remoteArchived: remote.state.isArchived === true,
 			});
 		}

--- a/src/app/sidebar.ts
+++ b/src/app/sidebar.ts
@@ -2298,7 +2298,7 @@ function renderCollapsedStatusSidebar(sections: SidebarStatusSections): Template
 				data-nav-active=${active ? "true" : "false"}
 				class="flex items-center gap-1 ${SESSION_ROW_PY} px-1 rounded-md transition-colors w-full ${active ? "bg-secondary sidebar-session-active" : "hover:bg-secondary/50"} ${candidate.archived ? "opacity-60" : ""}"
 				title=${displayTitle}
-				@click=${() => { if (!active) connectToSession(session.id, true, candidate.archived ? { readOnly: true } : undefined); }}
+				@click=${() => { if (!active) connectToSession(session.id, true, candidate.archived ? { archived: true } : undefined); }}
 			>
 				<span class="shrink-0 inline-flex items-center justify-center ${!active && hasUnseenActivity(session) ? "bobbit-unread-pulse" : ""}">${statusBobbit(candidate.archived ? "terminated" : session.status, session.isCompacting, session.id, active, session.isAborting, session.role === "team-lead", session.role === "coder", session.accessory, false, !active && hasUnseenActivity(session), true)}</span>
 				<span class="font-bold tracking-wide ${active ? "text-foreground" : "text-muted-foreground"}" style="font-family:ui-monospace,monospace;line-height:1;font-size:.6667em;">${sessionAcronym(displayTitle)}</span>

--- a/src/server/agent/session-manager.ts
+++ b/src/server/agent/session-manager.ts
@@ -12415,6 +12415,11 @@ export class SessionManager {
 					if ((client as any).readyState === 1) candidate.clients.add(client);
 				}
 				this._trackConnectedSession(candidate);
+				// restoreSession published the candidate's live status before it owned the
+				// capsule's clients. Replay that canonical status through the monotonic
+				// lifecycle publisher now that transfer is complete, before the condition
+				// clear lets clients derive their recovered interaction state.
+				broadcastStatus(candidate, candidate.status);
 				broadcast(candidate.clients, {
 					type: "state",
 					data: {

--- a/src/server/ws/handler.ts
+++ b/src/server/ws/handler.ts
@@ -611,6 +611,18 @@ type SessionWorkMessage = Extract<ReliableIntentClientMessage, {
 
 const SESSION_WORK_MESSAGE_TYPE_SET: ReadonlySet<ReliableIntentClientMessage["type"]> = new Set(SESSION_WORK_MESSAGE_TYPES);
 
+// `readOnly` describes the delegate's tool capability, not whether its session
+// can be interacted with. Only permission-widening and model-control commands
+// remain transport-blocked; ordinary prompt and orchestration frames are valid.
+const READ_ONLY_RESTRICTED_CONTROL_TYPES = [
+	"set_model",
+	"set_image_model",
+	"set_thinking_level",
+	"grant_tool_permission",
+] as const satisfies readonly SessionWorkMessage["type"][];
+
+const READ_ONLY_RESTRICTED_CONTROL_TYPE_SET: ReadonlySet<SessionWorkMessage["type"]> = new Set(READ_ONLY_RESTRICTED_CONTROL_TYPES);
+
 function isSessionWorkMessage(msg: ReliableIntentClientMessage): msg is SessionWorkMessage {
 	return SESSION_WORK_MESSAGE_TYPE_SET.has(msg.type);
 }
@@ -643,12 +655,13 @@ function sendSessionWorkPolicyError(
 }
 
 /**
- * Enforce persisted session interaction policy at the authenticated transport
- * boundary. UI flags are presentation only: a crafted frame must not enqueue,
- * redirect, retry, restart, compact, grant-and-resume, or extension-post work
- * in a restricted session. Stop/deny controls remain available because they
- * only halt active work. Persisted `true` wins over a stale live field; the live
- * field closes the inverse window while a metadata update is being flushed.
+ * Enforce persisted session policy at the authenticated transport boundary.
+ * A capability-restricted delegate remains interactive, but crafted frames may
+ * not widen its tool access or alter capability-bearing model configuration.
+ * Non-interactive sessions continue to reject agent work independently. Stop
+ * and deny controls remain available because they only halt active work.
+ * Persisted `true` wins over a stale live field; the live field closes the
+ * inverse window while a metadata update is being flushed.
  */
 function rejectRestrictedSessionWork(
 	ws: WebSocket,
@@ -656,12 +669,13 @@ function rejectRestrictedSessionWork(
 	session: { status: string; readOnly?: boolean; nonInteractive?: boolean },
 	persisted?: { readOnly?: boolean; nonInteractive?: boolean },
 ): boolean {
-	if (session.readOnly === true || persisted?.readOnly === true) {
+	const capabilityRestricted = session.readOnly === true || persisted?.readOnly === true;
+	if (capabilityRestricted && READ_ONLY_RESTRICTED_CONTROL_TYPE_SET.has(msg.type)) {
 		sendSessionWorkPolicyError(
 			ws,
 			msg,
 			"SESSION_READ_ONLY",
-			"This session is read-only and does not accept agent work commands.",
+			"This session's read-only capability does not allow tool or model changes.",
 		);
 		return true;
 	}

--- a/src/server/ws/handler.ts
+++ b/src/server/ws/handler.ts
@@ -204,11 +204,16 @@ function sessionModelSelectionRequired(
 	return isModelSelectionRequiredCondition(condition) ? condition : undefined;
 }
 
+type ModelSelectionRecoveryAdmission = {
+	condition?: ModelSelectionRequiredCondition;
+	activationInProgress: boolean;
+};
+
 function modelSelectionRecoveryAdmission(
 	sessionManager: SessionManager,
 	sessionId: string,
 	session: unknown,
-): { condition?: ModelSelectionRequiredCondition; activationInProgress: boolean } {
+): ModelSelectionRecoveryAdmission {
 	const query = (sessionManager as ModelSelectionRecoveryManager).getModelSelectionRecoveryAdmission;
 	if (typeof query === "function") return query.call(sessionManager, sessionId);
 	return { condition: sessionModelSelectionRequired(session), activationInProgress: false };
@@ -612,7 +617,7 @@ type SessionWorkMessage = Extract<ReliableIntentClientMessage, {
 const SESSION_WORK_MESSAGE_TYPE_SET: ReadonlySet<ReliableIntentClientMessage["type"]> = new Set(SESSION_WORK_MESSAGE_TYPES);
 
 // `readOnly` describes the delegate's tool capability, not whether its session
-// can be interacted with. Only permission-widening and model-control commands
+// can be interacted with. Permission-widening and ordinary model-control commands
 // remain transport-blocked; ordinary prompt and orchestration frames are valid.
 const READ_ONLY_RESTRICTED_CONTROL_TYPES = [
 	"set_model",
@@ -657,9 +662,11 @@ function sendSessionWorkPolicyError(
 /**
  * Enforce persisted session policy at the authenticated transport boundary.
  * A capability-restricted delegate remains interactive, but crafted frames may
- * not widen its tool access or alter capability-bearing model configuration.
- * Non-interactive sessions continue to reject agent work independently. Stop
- * and deny controls remain available because they only halt active work.
+ * not widen its tool access or ordinarily alter capability-bearing model
+ * configuration. A validated MODEL_SELECTION_REQUIRED admission may pass only
+ * set_model to the existing recovery route. Non-interactive sessions continue
+ * to reject agent work independently. Stop and deny controls remain available
+ * because they only halt active work.
  * Persisted `true` wins over a stale live field; the live field closes the
  * inverse window while a metadata update is being flushed.
  */
@@ -668,9 +675,15 @@ function rejectRestrictedSessionWork(
 	msg: SessionWorkMessage,
 	session: { status: string; readOnly?: boolean; nonInteractive?: boolean },
 	persisted?: { readOnly?: boolean; nonInteractive?: boolean },
+	recoveryAdmission?: ModelSelectionRecoveryAdmission,
 ): boolean {
 	const capabilityRestricted = session.readOnly === true || persisted?.readOnly === true;
-	if (capabilityRestricted && READ_ONLY_RESTRICTED_CONTROL_TYPE_SET.has(msg.type)) {
+	const isRequiredModelRecovery = msg.type === "set_model" && recoveryAdmission?.condition !== undefined;
+	if (
+		capabilityRestricted
+		&& READ_ONLY_RESTRICTED_CONTROL_TYPE_SET.has(msg.type)
+		&& !isRequiredModelRecovery
+	) {
 		sendSessionWorkPolicyError(
 			ws,
 			msg,
@@ -1202,6 +1215,9 @@ export function handleWebSocketConnection(
 				msg,
 				session,
 				sessionManager.getPersistedSession(sessionId),
+				msg.type === "set_model"
+					? modelSelectionRecoveryAdmission(sessionManager, sessionId, session)
+					: undefined,
 			)
 		) return;
 

--- a/src/ui/components/AgentInterface.ts
+++ b/src/ui/components/AgentInterface.ts
@@ -153,8 +153,8 @@ export class AgentInterface extends LitElement {
 	// Optional callback called when cost display is clicked
 	@property({ attribute: false }) onCostClick?: () => void;
 	private get _showGitStatusWidget(): boolean { return this.gitRepoKnown !== 'no' && this.gitRepoKnown !== 'hidden'; }
-	// When true, hide the message editor (for archived/read-only sessions)
-	@property({ type: Boolean }) readOnly = false;
+	// Lifecycle-only presentation state. Tool capability restrictions live on GatewaySession.readOnly.
+	@property({ type: Boolean }) archived = false;
 	// When true, show the editor only while agent is streaming (steer-only mode)
 	@property({ type: Boolean }) nonInteractive = false;
 
@@ -165,6 +165,7 @@ export class AgentInterface extends LitElement {
 	 * same rules; this is defence-in-depth UX.
 	 */
 	private get canContinueArchived(): boolean {
+		if (!this.archived) return false;
 		const record = this._archivedSessionRecord();
 		return !!record && canContinueArchivedSession(record);
 	}
@@ -174,20 +175,20 @@ export class AgentInterface extends LitElement {
 		if (!sid) return null;
 		const fromState = appState.archivedSessions.find((s) => s.id === sid)
 			|| appState.gatewaySessions.find((s) => s.id === sid);
-		if (fromState) return { ...fromState, readOnly: fromState.readOnly || this.readOnly };
+		if (fromState) return { ...fromState, archived: fromState.archived || this.archived };
 		return {
 			id: sid,
 			title: (this.session as any)?.title || "Archived session",
 			cwd: this.cwd || "",
 			projectId: this.projectId,
 			status: "archived",
+			archived: true,
 			createdAt: 0,
 			lastActivity: 0,
 			clientCount: 0,
 			goalId: this.goalId,
 			delegateOf: this.delegateOf,
 			teamGoalId: this.teamGoalId,
-			readOnly: this.readOnly,
 			nonInteractive: this.nonInteractive,
 		};
 	}
@@ -477,7 +478,7 @@ export class AgentInterface extends LitElement {
 		if (!source) return undefined;
 		const effective: GatewaySession = {
 			...source,
-			readOnly: source.readOnly || this.readOnly,
+			archived: source.archived || this.archived,
 			nonInteractive: source.nonInteractive || this.nonInteractive,
 		};
 		return canForkSession(effective) ? source : undefined;
@@ -577,7 +578,7 @@ export class AgentInterface extends LitElement {
 	/**
 	 * Per-session composer attachment draft, lifted out of the transient
 	 * <message-editor> element so it survives element recreation (slow-path
-	 * session switch, reload, readOnly/isPreparing re-render). Bound INTO the
+	 * session switch, reload, archived/isPreparing re-render). Bound INTO the
 	 * editor via `.attachments` and updated back via `.onFilesChange`. Durable
 	 * across reload via the IndexedDB PromptDraftAttachmentsStore.
 	 * See docs/design/composer-draft-persistence.md.
@@ -929,7 +930,7 @@ export class AgentInterface extends LitElement {
 			const newSid = this.session?.sessionId;
 			// Restore the per-session composer attachment draft (lifted out of the
 			// transient <message-editor>) whenever the bound session changes —
-			// covers slow-path switch, reload, and readOnly/isPreparing re-renders.
+			// covers slow-path switch, reload, and archived/isPreparing re-renders.
 			if (this._attachmentDraftSessionId !== newSid) {
 				this._loadAttachmentDraft(newSid);
 			}
@@ -941,7 +942,7 @@ export class AgentInterface extends LitElement {
 			}
 		}
 		// Lazily populate the archived-session proposal-type list when we know
-		// the session is read-only and continuable. Fire-and-forget; the result
+		// the session is archived and continuable. Fire-and-forget; the result
 		// triggers a follow-up render via @state.
 		this._maybeRefreshArchivedProposals();
 	}
@@ -2171,7 +2172,7 @@ export class AgentInterface extends LitElement {
 					.tools=${state.tools}
 					.sessionId=${this.session?.sessionId ?? ""}
 					.isStreaming=${state.isStreaming}
-					.archived=${this.readOnly && !this.nonInteractive}
+					.archived=${this.archived}
 					.pendingToolCalls=${state.pendingToolCalls}
 					.permissionBlockedTools=${this._activePermissionToolNames()}
 					.toolResultsById=${toolResultsById}
@@ -2687,7 +2688,7 @@ export class AgentInterface extends LitElement {
 							</div>
 						</div>
 						` : nothing}
-						${(this.readOnly && !(this.nonInteractive && state.isStreaming)) || (state as any).isPreparing ? nothing : html`<message-editor style="position:relative;z-index:20"
+						${this.archived || (this.nonInteractive && !state.isStreaming) || (state as any).isPreparing ? nothing : html`<message-editor style="position:relative;z-index:20"
 							.sessionId=${this.session?.sessionId}
 							.cwd=${this.cwd}
 							.projectId=${this.projectId}

--- a/tests2/browser/fixtures/archived-session-actions.spec.ts
+++ b/tests2/browser/fixtures/archived-session-actions.spec.ts
@@ -177,14 +177,14 @@ async function expectArchivedSafeMenu(page: Page, expectedIds: readonly string[]
 
 async function openArchivedSession(page: Page, sessionId: string): Promise<void> {
 	await navigateToHash(page, `#/session/${sessionId}`);
-	await expect(headerTrigger(page), "archived session header actions should render after read-only open").toBeVisible({ timeout: 15_000 });
+	await expect(headerTrigger(page), "archived session header actions should render after archived open").toBeVisible({ timeout: 15_000 });
 	await expect.poll(() => page.evaluate(() => {
 		const s = (window as any).bobbitState;
 		return {
 			selected: s?.selectedSessionId ?? null,
-			readOnly: s?.chatPanel?.agentInterface?.readOnly === true,
+			archived: s?.chatPanel?.agentInterface?.archived === true,
 		};
-	}), { timeout: 15_000 }).toEqual({ selected: sessionId, readOnly: true });
+	}), { timeout: 15_000 }).toEqual({ selected: sessionId, archived: true });
 }
 
 async function stubWindowOpen(page: Page): Promise<void> {
@@ -255,7 +255,7 @@ test.describe("archived session actions", () => {
 		await expect.poll(() => page.evaluate(() => window.location.hash), { timeout: 15_000 }).toContain(`#/session/${archivedId}`);
 		await expect.poll(() => page.evaluate((id) => {
 			const s = (window as any).bobbitState;
-			return s?.selectedSessionId === id && s?.chatPanel?.agentInterface?.readOnly === true;
+			return s?.selectedSessionId === id && s?.chatPanel?.agentInterface?.archived === true;
 		}, archivedId), { timeout: 15_000 }).toBe(true);
 
 		const headerPin = page.locator('[data-session-action-surface="header"][data-session-action-id="pin"]');

--- a/tests2/browser/journeys/read-only-delegate-interaction.journey.spec.ts
+++ b/tests2/browser/journeys/read-only-delegate-interaction.journey.spec.ts
@@ -135,26 +135,45 @@ test.describe("active read-only delegate interaction", () => {
 			}, reconnectEpoch), { timeout: 15_000, message: "delegate WebSocket should reconnect in place" }).toBe(true);
 			await expectActiveReadOnlyDelegate(page, delegateId, "WebSocket reconnect");
 
-			// Mutate server list metadata from outside the page. The pushed list
-			// refresh is authoritative; unlike navigation/reconnect, no session panel
-			// is recreated. Observing the new tag proves that refresh reconciled.
-			const generationBefore = await page.evaluate(() => (window as any).bobbitState?.sessionsGeneration ?? -1);
+			// Force a full authoritative list fetch without recreating the mounted
+			// panel. Pinning broadcasts sessions_changed; resetting only the conditional
+			// cursor makes the resulting push refresh return and reconcile a full list.
+			await page.evaluate(() => {
+				const app = (window as any).bobbitState;
+				(window as any).__readOnlyDelegateInterfaceBeforeRefresh = app?.chatPanel?.agentInterface;
+				if (app?.sessionPollTimer) {
+					clearInterval(app.sessionPollTimer);
+					app.sessionPollTimer = null;
+				}
+				app.sessionsGeneration = -1;
+			});
+			const listFetch = page.waitForResponse((response) => {
+				const url = new URL(response.url());
+				return response.request().method() === "GET"
+					&& url.pathname.endsWith("/api/sessions")
+					&& !url.searchParams.has("since")
+					&& !url.searchParams.has("include");
+			}, { timeout: 15_000 });
 			const pinResponse = await apiFetch(`/api/sessions/${delegateId}/pin`, {
 				method: "PUT",
 				body: JSON.stringify({ pinned: true }),
 			});
 			expect(pinResponse.status).toBe(200);
+			const refreshResponse = await listFetch;
+			expect(refreshResponse.ok(), "authoritative session-list fetch should succeed").toBe(true);
+			const refreshBody = await refreshResponse.json() as { changed?: boolean; sessions?: Array<{ id?: string; readOnly?: boolean; user_tags?: string[] }> };
+			expect(refreshBody.changed, "forced full list fetch must return an authoritative snapshot").not.toBe(false);
+			expect(refreshBody.sessions?.find((candidate) => candidate.id === delegateId)).toMatchObject({
+				readOnly: true,
+				user_tags: expect.arrayContaining(["pinned=true"]),
+			});
 			await expect.poll(() => page.evaluate((id) => {
 				const app = (window as any).bobbitState;
 				const record = app?.gatewaySessions?.find((candidate: { id?: string }) => candidate.id === id);
-				return {
-					generation: app?.sessionsGeneration ?? -1,
-					pinned: record?.user_tags?.includes("pinned=true") === true,
-				};
-			}, delegateId), { timeout: 15_000, message: "authoritative session-list refresh should apply the server mutation" })
-				.toEqual({ generation: expect.any(Number), pinned: true });
-			const generationAfter = await page.evaluate(() => (window as any).bobbitState?.sessionsGeneration ?? -1);
-			expect(generationAfter, "authoritative refresh should advance the session generation").toBeGreaterThan(generationBefore);
+				return record?.user_tags?.includes("pinned=true") === true
+					&& app?.chatPanel?.agentInterface === (window as any).__readOnlyDelegateInterfaceBeforeRefresh
+					&& document.contains(app.chatPanel.agentInterface);
+			}, delegateId), { timeout: 15_000, message: "authoritative list snapshot should reconcile in the mounted delegate panel" }).toBe(true);
 			await expectActiveReadOnlyDelegate(page, delegateId, "authoritative session refresh");
 			expectMutatingToolsWithheld(gateway, delegateId, "authoritative session refresh");
 		} finally {

--- a/tests2/browser/journeys/read-only-delegate-interaction.journey.spec.ts
+++ b/tests2/browser/journeys/read-only-delegate-interaction.journey.spec.ts
@@ -1,0 +1,165 @@
+import type { Page } from "@playwright/test";
+import { test, expect } from "../gateway-harness.js";
+import {
+	apiFetch,
+	createSession,
+	deleteSession,
+	waitForSessionStatus,
+} from "../e2e-setup.js";
+import { navigateToHash, openApp } from "../fixtures/ui-helpers.js";
+
+const MUTATING_TOOLS = ["write", "edit", "bash", "bash_bg"] as const;
+
+async function spawnReadOnlyDelegate(gateway: any, ownerId: string): Promise<string> {
+	const ownerSecret = gateway.sessionManager.sessionSecretStore.getOrCreateSecret(ownerId);
+	const response = await apiFetch(`/api/sessions/${ownerId}/orchestrate/spawn`, {
+		method: "POST",
+		headers: { "X-Bobbit-Session-Secret": ownerSecret },
+		body: JSON.stringify({
+			instructions: "Stay available for a browser follow-up prompt, then answer briefly.",
+			read_only: true,
+		}),
+	});
+	const responseBody = await response.clone().text();
+	expect(response.status, `read-only delegate spawn failed: ${responseBody}`).toBe(201);
+	const body = await response.json() as { childSessionId?: string };
+	expect(body.childSessionId).toEqual(expect.any(String));
+	return body.childSessionId!;
+}
+
+async function expectActiveReadOnlyDelegate(page: Page, sessionId: string, phase: string): Promise<void> {
+	await expect.poll(() => page.evaluate((id) => {
+		const app = (window as any).bobbitState;
+		const record = app?.gatewaySessions?.find((candidate: { id?: string }) => candidate.id === id);
+		const ui = app?.chatPanel?.agentInterface;
+		const presentationArchived = typeof ui?.archived === "boolean"
+			? ui.archived
+			: ui?.readOnly === true;
+		return {
+			selected: app?.selectedSessionId ?? null,
+			capabilityReadOnly: record?.readOnly === true,
+			lifecycleStatus: record?.status ?? null,
+			presentationArchived,
+			nonInteractive: ui?.nonInteractive === true,
+		};
+	}, sessionId), {
+		timeout: 15_000,
+		message: `${phase}: active read-only delegate must retain independent capability and lifecycle state`,
+	}).toEqual({
+		selected: sessionId,
+		capabilityReadOnly: true,
+		lifecycleStatus: "idle",
+		presentationArchived: false,
+		nonInteractive: false,
+	});
+
+	const composer = page.locator("agent-interface message-editor textarea").first();
+	await expect(composer, `${phase}: active read-only delegate composer`).toBeVisible({ timeout: 15_000 });
+	await expect(composer, `${phase}: active read-only delegate composer`).toBeEnabled();
+	await expect(page.locator("agent-interface [data-continue-archived-footer]"), `${phase}: archive footer`).toHaveCount(0);
+	await expect(page.locator("agent-interface streaming-message-container .bobbit-blob--archived"), `${phase}: archived sprite styling`).toHaveCount(0);
+	await expect.poll(() => page.locator("agent-interface streaming-message-container").first().evaluate((element: any) => element.archived === true), {
+		timeout: 5_000,
+		message: `${phase}: streaming sprite must use live lifecycle presentation`,
+	}).toBe(false);
+
+	const row = page.locator(`[data-session-id="${sessionId}"][data-nav-active="true"]`).first();
+	await expect(row, `${phase}: active delegate sidebar row`).toBeVisible({ timeout: 10_000 });
+	const imageFilters = await row.locator("img").evaluateAll((images) => images.map((image) => getComputedStyle(image).filter));
+	expect(imageFilters.join(" "), `${phase}: active delegate sidebar sprite must not be desaturated`).not.toContain("grayscale");
+}
+
+function expectMutatingToolsWithheld(gateway: any, sessionId: string, phase: string): void {
+	const live = gateway.sessionManager.getSession(sessionId);
+	const persisted = gateway.sessionManager.getPersistedSession(sessionId);
+	expect(persisted?.readOnly, `${phase}: durable capability marker`).toBe(true);
+	const liveTools: string[] = live?.allowedTools ?? [];
+	const persistedTools: string[] = persisted?.allowedTools ?? [];
+	for (const tool of MUTATING_TOOLS) {
+		expect(liveTools, `${phase}: live read-only delegate must not expose ${tool}`).not.toContain(tool);
+		expect(persistedTools, `${phase}: persisted read-only delegate must not expose ${tool}`).not.toContain(tool);
+	}
+}
+
+test.describe("active read-only delegate interaction", () => {
+	test("stays live and promptable through navigation, reload, reconnect, and authoritative refresh", async ({ page, gateway }) => {
+		test.slow();
+		const ownerId = await createSession();
+		let delegateId: string | undefined;
+		try {
+			await waitForSessionStatus(ownerId, "idle");
+			delegateId = await spawnReadOnlyDelegate(gateway, ownerId);
+			await waitForSessionStatus(delegateId, "idle");
+			expectMutatingToolsWithheld(gateway, delegateId, "spawn");
+
+			await openApp(page);
+			await navigateToHash(page, `#/session/${delegateId}`);
+			await expectActiveReadOnlyDelegate(page, delegateId, "initial open");
+
+			const followUp = `read-only delegate browser follow-up ${Date.now()}`;
+			const composer = page.locator("agent-interface message-editor textarea").first();
+			await composer.fill(followUp);
+			await composer.press("Enter");
+			await expect(page.getByText(followUp, { exact: true }).first(), "accepted follow-up should render in the transcript")
+				.toBeVisible({ timeout: 10_000 });
+			await waitForSessionStatus(delegateId, "idle");
+			const transcript = await gateway.sessionManager.getSession(delegateId)?.rpcClient.getMessages();
+			expect(JSON.stringify(transcript), "direct follow-up must reach the delegate transport, not only optimistic UI").toContain(followUp);
+
+			// Cached-panel navigation is a distinct projection path.
+			await navigateToHash(page, `#/session/${ownerId}`);
+			await expect.poll(() => page.evaluate((id) => (window as any).bobbitState?.selectedSessionId === id, ownerId), { timeout: 15_000 }).toBe(true);
+			await navigateToHash(page, `#/session/${delegateId}`);
+			await expectActiveReadOnlyDelegate(page, delegateId, "cached navigation return");
+
+			// A reload exercises cold list hydration and transcript restoration.
+			await page.reload({ waitUntil: "domcontentloaded" });
+			await expect(page.locator("body[data-shortcuts-ready='1']")).toBeVisible({ timeout: 20_000 });
+			await expectActiveReadOnlyDelegate(page, delegateId, "reload");
+			await expect(page.getByText(followUp, { exact: true }).first(), "follow-up transcript should survive reload")
+				.toBeVisible({ timeout: 15_000 });
+			expectMutatingToolsWithheld(gateway, delegateId, "reload");
+
+			// Force only the mounted session socket closed, then observe a new
+			// authenticated connection epoch without navigating or reloading.
+			const reconnectEpoch = await page.evaluate(() => {
+				const remote = (window as any).bobbitState?.remoteAgent;
+				const before = remote?._connectionEpoch ?? 0;
+				remote?.ws?.close(4000, "read-only delegate reconnect fixture");
+				return before;
+			});
+			await expect.poll(() => page.evaluate((before) => {
+				const app = (window as any).bobbitState;
+				return (app?.remoteAgent?._connectionEpoch ?? 0) > before
+					&& app?.connectionStatus === "connected";
+			}, reconnectEpoch), { timeout: 15_000, message: "delegate WebSocket should reconnect in place" }).toBe(true);
+			await expectActiveReadOnlyDelegate(page, delegateId, "WebSocket reconnect");
+
+			// Mutate server list metadata from outside the page. The pushed list
+			// refresh is authoritative; unlike navigation/reconnect, no session panel
+			// is recreated. Observing the new tag proves that refresh reconciled.
+			const generationBefore = await page.evaluate(() => (window as any).bobbitState?.sessionsGeneration ?? -1);
+			const pinResponse = await apiFetch(`/api/sessions/${delegateId}/pin`, {
+				method: "PUT",
+				body: JSON.stringify({ pinned: true }),
+			});
+			expect(pinResponse.status).toBe(200);
+			await expect.poll(() => page.evaluate((id) => {
+				const app = (window as any).bobbitState;
+				const record = app?.gatewaySessions?.find((candidate: { id?: string }) => candidate.id === id);
+				return {
+					generation: app?.sessionsGeneration ?? -1,
+					pinned: record?.user_tags?.includes("pinned=true") === true,
+				};
+			}, delegateId), { timeout: 15_000, message: "authoritative session-list refresh should apply the server mutation" })
+				.toEqual({ generation: expect.any(Number), pinned: true });
+			const generationAfter = await page.evaluate(() => (window as any).bobbitState?.sessionsGeneration ?? -1);
+			expect(generationAfter, "authoritative refresh should advance the session generation").toBeGreaterThan(generationBefore);
+			await expectActiveReadOnlyDelegate(page, delegateId, "authoritative session refresh");
+			expectMutatingToolsWithheld(gateway, delegateId, "authoritative session refresh");
+		} finally {
+			if (delegateId) await deleteSession(delegateId).catch(() => {});
+			await deleteSession(ownerId).catch(() => {});
+		}
+	});
+});

--- a/tests2/core/model-selection-required-recovery.test.ts
+++ b/tests2/core/model-selection-required-recovery.test.ts
@@ -90,12 +90,24 @@ function messageRows(snapshot: { data?: unknown }): any[] {
 	return Array.isArray(data?.messages) ? data.messages : [];
 }
 
-function explicitConditionClearFrames(client: any): any[] {
+function sentFrames(client: any): any[] {
 	return client.send.mock.calls
-		.map(([payload]: [unknown]) => JSON.parse(String(payload)))
+		.map(([payload]: [unknown]) => JSON.parse(String(payload)));
+}
+
+function explicitConditionClearFrames(client: any): any[] {
+	return sentFrames(client)
 		.filter((frame: any) => frame?.type === "state"
 			&& Object.prototype.hasOwnProperty.call(frame.data, "condition")
 			&& frame.data.condition === null);
+}
+
+function statusImmediatelyBeforeConditionClear(client: any): any {
+	const frames = sentFrames(client);
+	const clearIndex = frames.findIndex((frame: any) => frame?.type === "state"
+		&& Object.prototype.hasOwnProperty.call(frame.data, "condition")
+		&& frame.data.condition === null);
+	return clearIndex > 0 ? frames[clearIndex - 1] : undefined;
 }
 
 function readFixtureUtf8(file: string): string {
@@ -484,6 +496,8 @@ describe("retired persisted model cold recovery", () => {
 			assert.equal(restoreBackgroundProcesses.mock.calls.length, 1, "fixture must hold activation after candidate install");
 		});
 		const stagedCandidate = manager.getSession(SESSION_ID);
+		const statusVersionBeforeClientTransfer = stagedCandidate?.statusVersion;
+		assert.equal(statusVersionBeforeClientTransfer, 1, "candidate restore must publish its initial live status before client transfer");
 		assert.deepEqual(stagedCandidate?.condition, EXPECTED_CONDITION, "canonical staging must retain the retired tuple condition");
 		assert.deepEqual(
 			manager.listSessions().find((session: any) => session.id === SESSION_ID)?.condition,
@@ -518,6 +532,21 @@ describe("retired persisted model cold recovery", () => {
 		const duringActivationConditionClearFrames = explicitConditionClearFrames(duringActivationClient);
 		assert.equal(firstConditionClearFrames.length, 1, "verified activation must publish one explicit condition clear");
 		assert.equal(duringActivationConditionClearFrames.length, 1, "verified activation must clear the condition for clients attached during staging");
+		const expectedReplayVersion = statusVersionBeforeClientTransfer! + 1;
+		assert.deepEqual(statusImmediatelyBeforeConditionClear(firstClient), {
+			type: "session_status",
+			status: "idle",
+			statusVersion: expectedReplayVersion,
+		}, "the original client must receive the canonical live status immediately before recovery clears its condition");
+		assert.deepEqual(statusImmediatelyBeforeConditionClear(duringActivationClient), {
+			type: "session_status",
+			status: "idle",
+			statusVersion: expectedReplayVersion,
+		}, "a client attached during activation must receive the same ordered live-status replay");
+		assert.ok(
+			(manager.getSession(SESSION_ID)?.statusVersion ?? 0) >= expectedReplayVersion,
+			"the recovery replay must advance the canonical monotonic status version before any released queue work",
+		);
 		assert.deepEqual(
 			firstConditionClearFrames[0]?.data?.model?.input,
 			["text", "image"],

--- a/tests2/dom/cold-session-workspace-ordering-repro.test.ts
+++ b/tests2/dom/cold-session-workspace-ordering-repro.test.ts
@@ -389,6 +389,7 @@ function installChatPanelHarness(): void {
 		let agentInterface: any;
 		const composer = {
 			onSend: async (input: string) => agent.prompt(input),
+			onSteerSend: async (input: string) => agent.steer(input),
 		};
 		agentInterface = {
 			session: agent,
@@ -402,8 +403,8 @@ function installChatPanelHarness(): void {
 			removeEventListener: vi.fn(),
 			querySelector: vi.fn((selector: string) => {
 				if (selector !== "message-editor") return null;
-				const composerHidden = agentInterface.readOnly
-					&& !(agentInterface.nonInteractive && agent.state.isStreaming);
+				const composerHidden = agentInterface.archived
+					|| (agentInterface.nonInteractive && !agent.state.isStreaming);
 				return composerHidden ? null : composer;
 			}),
 		};
@@ -1101,13 +1102,13 @@ describe("cold session transcript/workspace ordering", () => {
 		}
 	});
 
-	it("applies readOnly and nonInteractive restrictions before held hydration and blocks composer submission", async () => {
+	it("projects capability readOnly as interactive and nonInteractive as idle-hidden before held hydration", async () => {
 		state.gatewaySessions = state.gatewaySessions.map((session) => {
 			if (session.id === SESSION_A) return { ...session, readOnly: true };
 			if (session.id === SESSION_B) return { ...session, nonInteractive: true };
 			return session;
 		});
-		const connectReadOnly = connectToSession(SESSION_A, true, { readOnly: true });
+		const connectReadOnly = connectToSession(SESSION_A, true);
 		let connectNonInteractive: Promise<void> | undefined;
 
 		try {
@@ -1130,28 +1131,40 @@ describe("cold session transcript/workspace ordering", () => {
 
 			const readOnlyComposer = readOnlyInterface.querySelector("message-editor") as { onSend: (input: string) => Promise<void> } | null;
 			const nonInteractiveComposer = nonInteractiveInterface.querySelector("message-editor") as { onSend: (input: string) => Promise<void> } | null;
-			await readOnlyComposer?.onSend("read-only composer must not submit");
-			await nonInteractiveComposer?.onSend("non-interactive composer must not submit");
+			const readOnlyPrompt = vi.spyOn(readOnlyInterface.session, "prompt").mockResolvedValue(undefined);
+			await readOnlyComposer?.onSend("read-only capability remains interactive");
 
 			expect.soft(
-				readOnlyInterface.readOnly,
-				"SESSION_RESTRICTION_HYDRATION_REGRESSION: readOnly was deferred until workspace hydration settled",
-			).toBe(true);
-			expect.soft(readOnlyComposer).toBeNull();
-			expect.soft(
-				nonInteractiveInterface.readOnly,
-				"SESSION_RESTRICTION_HYDRATION_REGRESSION: nonInteractive readOnly was deferred until workspace hydration settled",
-			).toBe(true);
+				readOnlyInterface.archived === true,
+				"SESSION_RESTRICTION_HYDRATION_REGRESSION: capability readOnly was projected as archived",
+			).toBe(false);
+			expect.soft(readOnlyComposer).not.toBeNull();
+			expect.soft(nonInteractiveInterface.archived === true).toBe(false);
 			expect.soft(nonInteractiveInterface.nonInteractive).toBe(true);
 			expect.soft(nonInteractiveComposer).toBeNull();
-			for (const sessionId of [SESSION_A, SESSION_B]) {
-				const promptFrames = timeline.filter((entry) =>
-					entry.kind === "ws" && entry.sessionId === sessionId && entry.frame.type === "prompt");
-				expect.soft(
-					promptFrames,
-					`SESSION_RESTRICTION_HYDRATION_REGRESSION: ${sessionId} submitted through a restricted composer`,
-				).toHaveLength(0);
-			}
+
+			expect.soft(
+				readOnlyPrompt,
+				"SESSION_RESTRICTION_HYDRATION_REGRESSION: active read-only delegate composer did not submit its follow-up",
+			).toHaveBeenCalledWith("read-only capability remains interactive");
+			const nonInteractivePromptFrames = timeline.filter((entry) =>
+				entry.kind === "ws" && entry.sessionId === SESSION_B && entry.frame.type === "prompt");
+			expect.soft(nonInteractivePromptFrames).toHaveLength(0);
+
+			await nonInteractiveInterface.session.handleServerMessage({
+				type: "state",
+				data: { status: "streaming" },
+			});
+			const streamingSteerComposer = nonInteractiveInterface.querySelector("message-editor") as {
+				onSteerSend: (input: string) => Promise<void>;
+			} | null;
+			expect.soft(
+				streamingSteerComposer,
+				"SESSION_RESTRICTION_HYDRATION_REGRESSION: streaming nonInteractive session lost its steer editor",
+			).not.toBeNull();
+			const nonInteractiveSteer = vi.spyOn(nonInteractiveInterface.session, "steer").mockReturnValue(undefined);
+			await streamingSteerComposer?.onSteerSend("streaming follow-up stays steer-only");
+			expect.soft(nonInteractiveSteer).toHaveBeenCalledWith("streaming follow-up stays steer-only");
 		} finally {
 			gateFor(SESSION_A).release();
 			gateFor(SESSION_B).release();

--- a/tests2/dom/delegate-interaction-mode.test.ts
+++ b/tests2/dom/delegate-interaction-mode.test.ts
@@ -1,0 +1,148 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { connectToSession, selectSession, uncacheSession } from "../../src/app/session-manager.js";
+import { isArchivedSessionActionSource } from "../../src/app/session-actions.js";
+import { setRenderApp, state, type GatewaySession } from "../../src/app/state.js";
+
+setRenderApp(() => {});
+
+const SESSION_ID = "read-only-delegate-interaction";
+
+type ProjectedMode = {
+	archived: boolean;
+	nonInteractive: boolean;
+};
+
+function sessionRecord(extra: Partial<GatewaySession> = {}): GatewaySession {
+	return {
+		id: SESSION_ID,
+		title: "Read-only delegate",
+		cwd: "/project",
+		status: "idle",
+		createdAt: 1,
+		lastActivity: 2,
+		clientCount: 0,
+		delegateOf: "owner-session",
+		...extra,
+	};
+}
+
+async function projectedModeFor(record: GatewaySession): Promise<ProjectedMode> {
+	uncacheSession(SESSION_ID);
+	const agentInterface = {
+		// `readOnly` is retained in this fixture only as a compatibility probe for
+		// the reproducing revision. The corrected UI owns archive presentation in
+		// a lifecycle-specific property instead.
+		readOnly: false,
+		archived: false,
+		nonInteractive: false,
+		session: null as any,
+	};
+	const remote = {
+		connected: true,
+		gatewaySessionId: SESSION_ID,
+		state: { isArchived: false },
+		registerHostApiTransports: vi.fn(),
+		disconnect: vi.fn(),
+	};
+	agentInterface.session = remote;
+	const panel = {
+		agent: remote,
+		agentInterface,
+		classList: { add: vi.fn(), remove: vi.fn() },
+		addEventListener: vi.fn(),
+	};
+
+	state.gatewaySessions = [record];
+	state.selectedSessionId = SESSION_ID;
+	state.remoteAgent = remote as any;
+	state.chatPanel = panel as any;
+
+	// Re-enter through the real cached-panel path. Interaction projection must be
+	// synchronous, before any workspace or transcript hydration can paint.
+	selectSession("parking-session");
+	const pending = connectToSession(SESSION_ID, true);
+	const hasLifecycleArchiveProperty = Object.prototype.hasOwnProperty.call(agentInterface, "archived")
+		&& agentInterface.archived === true;
+	const lifecycleRecordIsArchived = record.archived === true
+		|| record.status === "archived"
+		|| (record.status === "terminated" && (record as any).condition?.code !== "MODEL_SELECTION_REQUIRED");
+	const legacyArchivePresentation = agentInterface.readOnly === true && agentInterface.nonInteractive !== true;
+	const result = {
+		archived: hasLifecycleArchiveProperty || lifecycleRecordIsArchived || legacyArchivePresentation,
+		nonInteractive: agentInterface.nonInteractive,
+	};
+	state.switchGeneration++;
+	await pending;
+	return result;
+}
+
+beforeEach(() => {
+	vi.stubGlobal("fetch", vi.fn(async () => new Response(JSON.stringify({}), {
+		status: 200,
+		headers: { "Content-Type": "application/json" },
+	})));
+	state.gatewaySessions = [];
+	state.archivedSessions = [];
+	state.chatPanel = null;
+	state.remoteAgent = null;
+	state.selectedSessionId = null;
+	state.connectionStatus = "disconnected";
+});
+
+afterEach(() => {
+	uncacheSession(SESSION_ID);
+	state.gatewaySessions = [];
+	state.archivedSessions = [];
+	state.chatPanel = null;
+	state.remoteAgent = null;
+	state.selectedSessionId = null;
+	state.connectionStatus = "disconnected";
+	vi.restoreAllMocks();
+});
+
+describe("delegate interaction-mode projection", () => {
+	it("keeps an active read-only delegate interactive instead of projecting archive presentation", async () => {
+		expect(
+			await projectedModeFor(sessionRecord({ readOnly: true })),
+			"READ_ONLY_DELEGATE_ARCHIVE_CONFLATION: active read-only delegate was projected as archived",
+		).toEqual({ archived: false, nonInteractive: false });
+	});
+
+	it.each([
+		["archived flag", { archived: true }],
+		["archived status", { status: "archived" }],
+		["ordinary termination", { status: "terminated" }],
+	] as const)("closes genuine lifecycle state: %s", async (_name, extra) => {
+		expect(await projectedModeFor(sessionRecord(extra as Partial<GatewaySession>)))
+			.toEqual({ archived: true, nonInteractive: false });
+	});
+
+	it("keeps model-selection recovery interactive despite terminated transport state", async () => {
+		expect(await projectedModeFor(sessionRecord({
+			status: "terminated",
+			condition: {
+				code: "MODEL_SELECTION_REQUIRED",
+				provider: "retired-provider",
+				modelId: "retired-model",
+			},
+		} as any))).toEqual({ archived: false, nonInteractive: false });
+	});
+
+	it("preserves non-interactive policy independently and lets archive lifecycle win", async () => {
+		expect(await projectedModeFor(sessionRecord({ nonInteractive: true })))
+			.toEqual({ archived: false, nonInteractive: true });
+		expect(await projectedModeFor(sessionRecord({ archived: true, nonInteractive: true })))
+			.toEqual({ archived: true, nonInteractive: true });
+	});
+});
+
+describe("archived session action ownership", () => {
+	it("derives archived actions from lifecycle only, never the tool-capability marker", () => {
+		expect(isArchivedSessionActionSource(sessionRecord({ readOnly: true })),
+			"READ_ONLY_DELEGATE_ACTION_CONFLATION: capability-only readOnly exposed archived actions")
+			.toBe(false);
+		expect(isArchivedSessionActionSource(sessionRecord({ archived: true }))).toBe(true);
+		expect(isArchivedSessionActionSource(sessionRecord({ status: "archived" }))).toBe(true);
+		expect(isArchivedSessionActionSource(sessionRecord({ status: "terminated" }))).toBe(true);
+	});
+});

--- a/tests2/dom/delegate-interaction-mode.test.ts
+++ b/tests2/dom/delegate-interaction-mode.test.ts
@@ -26,13 +26,15 @@ function sessionRecord(extra: Partial<GatewaySession> = {}): GatewaySession {
 	};
 }
 
-async function projectedModeFor(record: GatewaySession): Promise<ProjectedMode> {
+async function projectedModeFor(
+	record: GatewaySession,
+	remoteSnapshot?: {
+		conditionSnapshotReceived: boolean;
+		state: { status: GatewaySession["status"]; condition: unknown };
+	},
+): Promise<ProjectedMode> {
 	uncacheSession(SESSION_ID);
 	const agentInterface = {
-		// `readOnly` is retained in this fixture only as a compatibility probe for
-		// the reproducing revision. The corrected UI owns archive presentation in
-		// a lifecycle-specific property instead.
-		readOnly: false,
 		archived: false,
 		nonInteractive: false,
 		session: null as any,
@@ -40,7 +42,8 @@ async function projectedModeFor(record: GatewaySession): Promise<ProjectedMode> 
 	const remote = {
 		connected: true,
 		gatewaySessionId: SESSION_ID,
-		state: { isArchived: false },
+		conditionSnapshotReceived: remoteSnapshot?.conditionSnapshotReceived ?? false,
+		state: { isArchived: false, ...remoteSnapshot?.state },
 		registerHostApiTransports: vi.fn(),
 		disconnect: vi.fn(),
 	};
@@ -61,14 +64,8 @@ async function projectedModeFor(record: GatewaySession): Promise<ProjectedMode> 
 	// synchronous, before any workspace or transcript hydration can paint.
 	selectSession("parking-session");
 	const pending = connectToSession(SESSION_ID, true);
-	const hasLifecycleArchiveProperty = Object.prototype.hasOwnProperty.call(agentInterface, "archived")
-		&& agentInterface.archived === true;
-	const lifecycleRecordIsArchived = record.archived === true
-		|| record.status === "archived"
-		|| (record.status === "terminated" && (record as any).condition?.code !== "MODEL_SELECTION_REQUIRED");
-	const legacyArchivePresentation = agentInterface.readOnly === true && agentInterface.nonInteractive !== true;
 	const result = {
-		archived: hasLifecycleArchiveProperty || lifecycleRecordIsArchived || legacyArchivePresentation,
+		archived: agentInterface.archived,
 		nonInteractive: agentInterface.nonInteractive,
 	};
 	state.switchGeneration++;
@@ -126,6 +123,33 @@ describe("delegate interaction-mode projection", () => {
 				modelId: "retired-model",
 			},
 		} as any))).toEqual({ archived: false, nonInteractive: false });
+	});
+
+	it("preserves ordinary termination across a generic live condition snapshot", async () => {
+		expect(await projectedModeFor(
+			sessionRecord({ status: "terminated" }),
+			{
+				conditionSnapshotReceived: true,
+				state: { status: "idle", condition: null },
+			},
+		)).toEqual({ archived: true, nonInteractive: false });
+	});
+
+	it("uses the canonical live snapshot only for explicit model-selection recovery", async () => {
+		expect(await projectedModeFor(
+			sessionRecord({
+				status: "terminated",
+				condition: {
+					code: "MODEL_SELECTION_REQUIRED",
+					provider: "retired-provider",
+					modelId: "retired-model",
+				},
+			} as any),
+			{
+				conditionSnapshotReceived: true,
+				state: { status: "idle", condition: null },
+			},
+		)).toEqual({ archived: false, nonInteractive: false });
 	});
 
 	it("preserves non-interactive policy independently and lets archive lifecycle win", async () => {

--- a/tests2/dom/model-selection-required-ux.test.ts
+++ b/tests2/dom/model-selection-required-ux.test.ts
@@ -3,7 +3,13 @@ import { syncCustomElements as __syncCE } from "./_setup/custom-elements.js";
 __syncBeforeAll(() => __syncCE());
 
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import { connectToSession, selectSession, uncacheSession } from "../../src/app/session-manager.js";
+import {
+	applyKnownSessionLifecyclePresentation,
+	connectToSession,
+	installSessionConditionLifecycleReconciliation,
+	selectSession,
+	uncacheSession,
+} from "../../src/app/session-manager.js";
 import { RemoteAgent } from "../../src/app/remote-agent.js";
 import { setRenderApp, state } from "../../src/app/state.js";
 import { AgentInterface } from "../../src/ui/components/AgentInterface.js";
@@ -189,6 +195,64 @@ describe("retired-model session interaction mode", () => {
 });
 
 describe("retired-model recovery surface", () => {
+	it("reconciles ordered termination and authoritative condition frames without weakening archive precedence", async () => {
+		const agent = new RemoteAgent() as any;
+		agent._sessionId = SESSION_ID;
+		const ui = document.createElement("agent-interface") as AgentInterface;
+		ui.session = agent;
+		ui.gitRepoKnown = "no";
+		document.body.appendChild(ui);
+		state.gatewaySessions = [sessionRecord({ status: "idle", condition: undefined })];
+		state.selectedSessionId = SESSION_ID;
+		state.remoteAgent = agent;
+		state.chatPanel = { agent, agentInterface: ui } as any;
+		agent.onStatusChange = (status: string) => {
+			applyKnownSessionLifecyclePresentation(ui, [{
+				status,
+				condition: agent.state.condition,
+			} as any], { remoteArchived: agent.state.isArchived === true });
+		};
+		installSessionConditionLifecycleReconciliation(agent, SESSION_ID);
+
+		await agent.handleServerMessage({ type: "session_status", status: "terminated" });
+		await settle(ui);
+		expect(ui.archived).toBe(true);
+		expect(ui.querySelector("message-editor")).toBeNull();
+
+		await agent.handleServerMessage({
+			type: "state",
+			data: { status: "terminated", condition: CONDITION },
+		});
+		await settle(ui);
+		expect(ui.archived).toBe(false);
+		expect(ui.querySelector('[data-testid="model-selection-required-banner"]')).toBeTruthy();
+		expect(ui.querySelector("message-editor")).toBeTruthy();
+
+		await agent.handleServerMessage({
+			type: "state",
+			data: { status: "idle", condition: null },
+		});
+		await settle(ui);
+		expect(ui.archived).toBe(false);
+		expect(ui.querySelector('[data-testid="model-selection-required-banner"]')).toBeNull();
+		expect(ui.querySelector("message-editor")).toBeTruthy();
+
+		await agent.handleServerMessage({ type: "session_status", status: "terminated" });
+		await agent.handleServerMessage({ type: "state", data: { status: "terminated", serverCost: null } });
+		await settle(ui);
+		expect(ui.archived, "a partial state frame must not reverse ordinary termination").toBe(true);
+
+		state.gatewaySessions = [];
+		state.archivedSessions = [sessionRecord({ archived: true, status: "archived" })];
+		await agent.handleServerMessage({
+			type: "state",
+			data: { status: "terminated", condition: CONDITION },
+		});
+		await settle(ui);
+		expect(ui.archived, "archive lifecycle must win over a recovery condition").toBe(true);
+		expect(ui.querySelector("message-editor")).toBeNull();
+	});
+
 	it("shows the exact tuple and keeps the warning until an explicit verified state clears it", async () => {
 		const agent = new RemoteAgent() as any;
 		const sent: Array<Record<string, unknown>> = [];

--- a/tests2/dom/model-selection-required-ux.test.ts
+++ b/tests2/dom/model-selection-required-ux.test.ts
@@ -102,11 +102,11 @@ function sessionRecord(extra: Record<string, unknown> = {}) {
 
 async function interactionModeFor(
 	record: Record<string, unknown>,
-	options?: { readOnly?: boolean },
-): Promise<{ readOnly: boolean; nonInteractive: boolean }> {
+	options?: { archived?: boolean },
+): Promise<{ archived: boolean; nonInteractive: boolean }> {
 	uncacheSession(SESSION_ID);
 	const agentInterface = {
-		readOnly: false,
+		archived: false,
 		nonInteractive: false,
 		session: null as any,
 	};
@@ -135,7 +135,7 @@ async function interactionModeFor(
 	selectSession("parking-session");
 	const pending = connectToSession(SESSION_ID, true, options);
 	const result = {
-		readOnly: agentInterface.readOnly,
+		archived: agentInterface.archived,
 		nonInteractive: agentInterface.nonInteractive,
 	};
 	state.switchGeneration++;
@@ -147,28 +147,42 @@ async function interactionModeFor(
 }
 
 describe("retired-model session interaction mode", () => {
-	it("keeps a conditioned terminated dormant session interactive while preserving explicit restrictions", async () => {
+	it("keeps conditioned termination recoverable and capability readOnly interactive", async () => {
 		expect(await interactionModeFor(sessionRecord())).toEqual({
-			readOnly: false,
+			archived: false,
 			nonInteractive: false,
 		});
 		expect(await interactionModeFor(sessionRecord({ readOnly: true }))).toEqual({
-			readOnly: true,
-			nonInteractive: false,
-		});
-		expect(await interactionModeFor(sessionRecord({ nonInteractive: true }))).toEqual({
-			readOnly: true,
-			nonInteractive: true,
-		});
-		expect(await interactionModeFor(sessionRecord(), { readOnly: true })).toEqual({
-			readOnly: true,
+			archived: false,
 			nonInteractive: false,
 		});
 	});
 
-	it("leaves ordinary terminated sessions read-only", async () => {
+	it("projects nonInteractive independently from archive lifecycle", async () => {
+		expect(await interactionModeFor(sessionRecord({ nonInteractive: true }))).toEqual({
+			archived: false,
+			nonInteractive: true,
+		});
+		expect(await interactionModeFor(sessionRecord({ archived: true, nonInteractive: true }))).toEqual({
+			archived: true,
+			nonInteractive: true,
+		});
+	});
+
+	it("closes explicit archive navigation and genuine archived lifecycle", async () => {
+		expect(await interactionModeFor(sessionRecord(), { archived: true })).toEqual({
+			archived: true,
+			nonInteractive: false,
+		});
+		expect(await interactionModeFor(sessionRecord({ status: "archived" }))).toEqual({
+			archived: true,
+			nonInteractive: false,
+		});
+	});
+
+	it("closes ordinary termination", async () => {
 		expect(await interactionModeFor(sessionRecord({ condition: undefined }))).toEqual({
-			readOnly: true,
+			archived: true,
 			nonInteractive: false,
 		});
 	});

--- a/tests2/integration/session-ws-write-policy.test.ts
+++ b/tests2/integration/session-ws-write-policy.test.ts
@@ -107,6 +107,12 @@ const MODEL_CONTROL_FRAMES: ReadonlyArray<Record<string, unknown>> = [
 	{ type: "set_image_model", provider: "openai", modelId: "gpt-image-2" },
 ];
 
+const MODEL_SELECTION_CONDITION = {
+	code: "MODEL_SELECTION_REQUIRED",
+	provider: "retired-provider",
+	modelId: "retired-model",
+} as const;
+
 const TITLE_CONTROL_FRAMES: ReadonlyArray<Record<string, unknown>> = [
 	{ type: "generate_title" },
 	{ type: "summarize_goal_title", goalTitle: "Attacker controlled goal title" },
@@ -362,6 +368,95 @@ test.describe("authenticated WebSocket session write policy", () => {
 			restoreModelControlSpies(modelControlSpies);
 			restoreTitleControlSpies(titleControlSpies);
 			restoreTaskControlSpies(taskControlSpies);
+			conn.close();
+			await deleteSession(sessionId);
+		}
+	});
+
+	test("read-only capability admits set_model only through active model-selection recovery", async ({ gateway }) => {
+		const sessionId = await createSession();
+		await waitForSessionStatus(sessionId, "idle");
+		const live = gateway.sessionManager.getSession(sessionId);
+		expect(live).toBeTruthy();
+		persistPolicy(gateway, sessionId, { readOnly: true });
+		live.condition = MODEL_SELECTION_CONDITION;
+
+		const conn = await connectWs(sessionId);
+		const recoverModelSelection = vi.spyOn(gateway.sessionManager, "recoverModelSelectionRequired")
+			.mockResolvedValue(undefined);
+		const modelControlSpies = spyOnModelControlMutations(gateway, live);
+		try {
+			conn.send({
+				type: "set_model",
+				provider: "anthropic",
+				modelId: "claude-sonnet-4-20250514",
+				thinkingLevel: "high",
+			});
+			await vi.waitFor(() => expect(recoverModelSelection).toHaveBeenCalledWith(
+				sessionId,
+				"anthropic",
+				"claude-sonnet-4-20250514",
+				"high",
+			), { timeout: 2_000 });
+			expectNoModelControlMutations(modelControlSpies);
+		} finally {
+			live.condition = undefined;
+			recoverModelSelection.mockRestore();
+			restoreModelControlSpies(modelControlSpies);
+			conn.close();
+			await deleteSession(sessionId);
+		}
+	});
+
+	test("read-only capability still blocks ordinary set_model without a recovery condition", async ({ gateway }) => {
+		const sessionId = await createSession();
+		await waitForSessionStatus(sessionId, "idle");
+		const live = gateway.sessionManager.getSession(sessionId);
+		expect(live).toBeTruthy();
+		persistPolicy(gateway, sessionId, { readOnly: true });
+
+		const conn = await connectWs(sessionId);
+		const recoverModelSelection = vi.spyOn(gateway.sessionManager, "recoverModelSelectionRequired");
+		const modelControlSpies = spyOnModelControlMutations(gateway, live);
+		try {
+			await expectPolicyError(conn, {
+				type: "set_model",
+				provider: "anthropic",
+				modelId: "claude-sonnet-4-20250514",
+			}, "SESSION_READ_ONLY");
+			expect(recoverModelSelection).not.toHaveBeenCalled();
+			expectNoModelControlMutations(modelControlSpies);
+		} finally {
+			recoverModelSelection.mockRestore();
+			restoreModelControlSpies(modelControlSpies);
+			conn.close();
+			await deleteSession(sessionId);
+		}
+	});
+
+	test("non-interactive policy blocks read-only model-selection recovery", async ({ gateway }) => {
+		const sessionId = await createSession();
+		await waitForSessionStatus(sessionId, "idle");
+		const live = gateway.sessionManager.getSession(sessionId);
+		expect(live).toBeTruthy();
+		persistPolicy(gateway, sessionId, { readOnly: true, nonInteractive: true });
+		live.condition = MODEL_SELECTION_CONDITION;
+
+		const conn = await connectWs(sessionId);
+		const recoverModelSelection = vi.spyOn(gateway.sessionManager, "recoverModelSelectionRequired");
+		const modelControlSpies = spyOnModelControlMutations(gateway, live);
+		try {
+			await expectPolicyError(conn, {
+				type: "set_model",
+				provider: "anthropic",
+				modelId: "claude-sonnet-4-20250514",
+			}, "NON_INTERACTIVE_WORK_CONTROL");
+			expect(recoverModelSelection).not.toHaveBeenCalled();
+			expectNoModelControlMutations(modelControlSpies);
+		} finally {
+			live.condition = undefined;
+			recoverModelSelection.mockRestore();
+			restoreModelControlSpies(modelControlSpies);
 			conn.close();
 			await deleteSession(sessionId);
 		}

--- a/tests2/integration/session-ws-write-policy.test.ts
+++ b/tests2/integration/session-ws-write-policy.test.ts
@@ -209,7 +209,7 @@ async function expectTaskControlsRejected(conn: WsConnection, code: string): Pro
 }
 
 test.describe("authenticated WebSocket session write policy", () => {
-	test("persisted read-only policy rejects every agent work frame while reads remain available", async ({ gateway }) => {
+	test("persisted read-only capability permits interaction but blocks permission widening", async ({ gateway }) => {
 		const sessionId = await createSession();
 		await waitForSessionStatus(sessionId, "idle");
 		const live = gateway.sessionManager.getSession(sessionId);
@@ -218,45 +218,57 @@ test.describe("authenticated WebSocket session write policy", () => {
 		persistPolicy(gateway, sessionId, { readOnly: true });
 
 		const conn = await connectWs(sessionId);
-		const enqueuePrompt = vi.spyOn(gateway.sessionManager, "enqueuePrompt");
-		const deliverLiveSteer = vi.spyOn(gateway.sessionManager, "deliverLiveSteer");
-		const steerQueued = vi.spyOn(gateway.sessionManager, "steerQueued");
-		const removeQueued = vi.spyOn(gateway.sessionManager, "removeQueued");
-		const reorderQueue = vi.spyOn(gateway.sessionManager, "reorderQueue");
-		const retryLastPrompt = vi.spyOn(gateway.sessionManager, "retryLastPrompt").mockRejectedValue(new Error("policy guard missed retry"));
-		const restartAgent = vi.spyOn(gateway.sessionManager, "restartAgent").mockRejectedValue(new Error("policy guard missed restart"));
-		const grantToolPermission = vi.spyOn(gateway.sessionManager, "grantToolPermission").mockRejectedValue(new Error("policy guard missed grant"));
-		const compact = vi.spyOn(live.rpcClient, "compact").mockRejectedValue(new Error("policy guard missed compact"));
-		const modelControlSpies = spyOnModelControlMutations(gateway, live);
-		const titleControlSpies = spyOnTitleControlMutations(gateway);
-		const taskControlSpies = spyOnTaskControlPaths(gateway);
+		const enqueuePrompt = vi.spyOn(gateway.sessionManager, "enqueuePrompt").mockResolvedValue(undefined);
+		const deliverLiveSteer = vi.spyOn(gateway.sessionManager, "deliverLiveSteer").mockResolvedValue(undefined);
+		const steerQueued = vi.spyOn(gateway.sessionManager, "steerQueued").mockReturnValue(true);
+		const removeQueued = vi.spyOn(gateway.sessionManager, "removeQueued").mockReturnValue(true);
+		const reorderQueue = vi.spyOn(gateway.sessionManager, "reorderQueue").mockReturnValue(true);
+		const grantToolPermission = vi.spyOn(gateway.sessionManager, "grantToolPermission")
+			.mockRejectedValue(new Error("read-only capability guard missed permission widening"));
 		try {
-			await expectPolicyError(conn, { type: "prompt", text: "must not run" }, "SESSION_READ_ONLY");
-			// A read-only session has no streaming-steer carve-out.
-			live.status = "streaming";
-			await expectPolicyError(conn, { type: "steer", text: "must not redirect" }, "SESSION_READ_ONLY");
-			live.status = "idle";
-			for (const frame of [...QUEUE_CONTROL_FRAMES, ...WORK_CONTROL_FRAMES]) {
-				await expectPolicyError(conn, frame, "SESSION_READ_ONLY");
-			}
-			await expectModelControlsRejected(conn, "SESSION_READ_ONLY");
-			await expectTitleControlsRejected(conn, "SESSION_READ_ONLY");
-			clearTaskControlSpies(taskControlSpies);
-			await expectTaskControlsRejected(conn, "SESSION_READ_ONLY");
-			expectNoTaskControlPaths(taskControlSpies);
-			await expectExtensionWritesRejected(conn, "SESSION_READ_ONLY", "read-only");
+			conn.send({ type: "prompt", text: "direct read-only delegate follow-up", intentId: "readonly-prompt" });
+			await vi.waitFor(() => {
+				expect(
+					enqueuePrompt,
+					"READ_ONLY_DELEGATE_PROMPT_REJECTED: capability-only readOnly blocked a direct follow-up prompt",
+				).toHaveBeenCalledWith(
+					sessionId,
+					"direct read-only delegate follow-up",
+					expect.objectContaining({ source: "user", intentId: "readonly-prompt" }),
+				);
+			}, { timeout: 2_000 });
 
-			expect(enqueuePrompt).not.toHaveBeenCalled();
-			expect(deliverLiveSteer).not.toHaveBeenCalled();
-			expect(steerQueued).not.toHaveBeenCalled();
-			expect(removeQueued).not.toHaveBeenCalled();
-			expect(reorderQueue).not.toHaveBeenCalled();
-			expect(retryLastPrompt).not.toHaveBeenCalled();
-			expect(restartAgent).not.toHaveBeenCalled();
+			live.status = "streaming";
+			conn.send({ type: "steer", text: "redirect active read-only delegate", intentId: "readonly-live-steer" });
+			await vi.waitFor(() => expect(deliverLiveSteer).toHaveBeenCalledWith(
+				sessionId,
+				"redirect active read-only delegate",
+				expect.objectContaining({ source: "user", intentId: "readonly-live-steer" }),
+			), { timeout: 2_000 });
+
+			live.status = "idle";
+			conn.send({ type: "steer", text: "queue read-only delegate follow-up", intentId: "readonly-queued-steer" });
+			await vi.waitFor(() => expect(enqueuePrompt).toHaveBeenCalledWith(
+				sessionId,
+				"queue read-only delegate follow-up",
+				expect.objectContaining({ isSteered: true, source: "user", intentId: "readonly-queued-steer" }),
+			), { timeout: 2_000 });
+
+			for (const frame of QUEUE_CONTROL_FRAMES) conn.send(frame);
+			await vi.waitFor(() => {
+				expect(steerQueued).toHaveBeenCalledWith(sessionId, "queued-1");
+				expect(removeQueued).toHaveBeenCalledWith(sessionId, "queued-1");
+				expect(reorderQueue).toHaveBeenCalledWith(sessionId, ["queued-1"]);
+			}, { timeout: 2_000 });
+
+			await expectPolicyError(conn, {
+				type: "grant_tool_permission",
+				toolName: "bash",
+				scope: "tool",
+				mode: "session-only",
+			}, "SESSION_READ_ONLY");
 			expect(grantToolPermission).not.toHaveBeenCalled();
-			expect(compact).not.toHaveBeenCalled();
-			expectNoModelControlMutations(modelControlSpies);
-			await expectNoTitleControlMutations(titleControlSpies);
+			expect(gateway.sessionManager.getPersistedSession(sessionId)?.readOnly).toBe(true);
 			await expectReadFramesStillWork(conn);
 		} finally {
 			live.status = "idle";
@@ -265,13 +277,7 @@ test.describe("authenticated WebSocket session write policy", () => {
 			steerQueued.mockRestore();
 			removeQueued.mockRestore();
 			reorderQueue.mockRestore();
-			retryLastPrompt.mockRestore();
-			restartAgent.mockRestore();
 			grantToolPermission.mockRestore();
-			compact.mockRestore();
-			restoreModelControlSpies(modelControlSpies);
-			restoreTitleControlSpies(titleControlSpies);
-			restoreTaskControlSpies(taskControlSpies);
 			conn.close();
 			await deleteSession(sessionId);
 		}

--- a/tests2/tests-map.json
+++ b/tests2/tests-map.json
@@ -8,7 +8,7 @@
     "v2-browser": 216,
     "v2-core": 512,
     "v2-dom": 144,
-    "v2-integration": 204
+    "v2-integration": 203
   },
   "methods": {
     "adapter": 276,
@@ -3553,6 +3553,24 @@
     {
       "path": "tests2/browser/journeys/host-notifications.journey.spec.ts",
       "reason": "Browser journey for scoped session/project Host notifications, authoritative refresh after load/reload/gaps, clean unsubscribe, and project isolation.",
+      "execution": {
+        "runner": "playwright",
+        "tier": "browser",
+        "project": "browser"
+      }
+    },
+    {
+      "path": "tests2/dom/delegate-interaction-mode.test.ts",
+      "reason": "Focused DOM coverage for independent lifecycle archive, read-only tool capability, and non-interactive interaction-mode projection.",
+      "execution": {
+        "runner": "vitest",
+        "tier": "unit",
+        "project": "dom"
+      }
+    },
+    {
+      "path": "tests2/browser/journeys/read-only-delegate-interaction.journey.spec.ts",
+      "reason": "Browser journey proving an active read-only delegate stays live and promptable through navigation, reload, reconnect, and authoritative refresh while mutating tools remain withheld.",
       "execution": {
         "runner": "playwright",
         "tier": "browser",


### PR DESCRIPTION
## Summary
- separate delegate tool capability from archived session presentation
- keep active read-only delegates promptable while preserving mutation and model guards
- preserve archived, terminated, and non-interactive lifecycle behavior across refresh and reconnect
- order model-selection recovery status replay before condition clearing
- add registered DOM, integration, core, and browser regressions
- document lifecycle and capability ownership

## Verification
- implementation workflow passed build, typecheck, unit, browser, E2E, conformance, security, and QA
- documentation workflow passed

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)