### PR TITLE
Add Host Bobbit sprite API

### DIFF
--- a/docs/extension-host-authoring.md
+++ b/docs/extension-host-authoring.md
@@ -30,7 +30,7 @@ This guide is the practical how-to.
 - [docs/design/extension-host.md](design/extension-host.md) — the contribution-point model, two-host architecture, the frozen Host API, the security guard sequence, the adapter layer, and the isolation model. The *why* and the contract. (Its per-tool schema examples predate V1 — read them through [pack-schema-v1-rationalisation.md](design/pack-schema-v1-rationalisation.md).)
 - [docs/design/extension-channels-host-channels.md](design/extension-channels-host-channels.md) and [docs/design/extension-channels-terminal-ux.md](design/extension-channels-terminal-ux.md) — the design record for generic channels and the first-party terminal pack.
 
-**Status:** renderers, actions, panels, channels, routes, entrypoints, implicit stores, project-scoped local data, session access, unified lifecycle hooks, and worker isolation are all **implemented**. `HOST_API_VERSION` is `1`; `HOST_CONTRACT_VERSION` is `5`. Base capabilities report `true` on a current host; feature-detect additive capabilities through `host.capabilities`. `sessionNotifications` and `projectNotifications` are available on the current host, while `localData` is present only for a winning pack that declares it.
+**Status:** renderers, actions, panels, channels, routes, entrypoints, implicit stores, project-scoped local data, session access, unified lifecycle hooks, and worker isolation are all **implemented**. `HOST_API_VERSION` remains `1`; `HOST_CONTRACT_VERSION` is `6`. Base capabilities report `true` on a current host; feature-detect optional capabilities through `host.capabilities`. The v6 `host.ui.createBobbitSprite` method is required and has no capability flag. `sessionNotifications` and `projectNotifications` are available on the current host, while `localData` is present only for a winning pack that declares it.
 
 The renderer+action working example lives at `tests/fixtures/market-sources/retry-demo-src/retry-demo/`; the full pack-scoped surface set is exercised by `market-packs/artifacts/` (a tool + panel + deep-link pack), `market-packs/pr-walkthrough/` (a first-party tool + role + panel + route + entrypoint pack), `market-packs/terminal/` (the first-party xterm terminal over `host.channels`), and no-tools fixture packs such as `tests/fixtures/market-sources/no-tools-pack-src/no-tools-pack/`.
 
@@ -638,8 +638,10 @@ additionally receives `localData: true`; otherwise that flag and namespace are a
 **server-side** base capabilities are `{ session, store, agents }`, with `localData: true` added only
 for a bound declared directory. `host.version`
 (`HOST_API_VERSION`, `1`) and `host.contractVersion`
-(`HOST_CONTRACT_VERSION`) identify the contract revision. All capabilities are purely additive
+(`HOST_CONTRACT_VERSION`) identify the contract revision. Optional capabilities are additive
 (no signature churn), so code written against `capabilities` stays forward/backward-compatible.
+Required methods declared by the active contract are different: for contract v6,
+`host.ui.createBobbitSprite` is always present and must be called without feature detection.
 
 ## Step 5 — install, test, iterate
 
@@ -1201,6 +1203,83 @@ Run focused retry-free coverage after changing terminal lifecycle or worker chan
 npx vitest run tests2/core/extension-host-terminal.test.ts tests2/core/extension-host-channel-registry.test.ts --config vitest.config.ts --retry=0
 BOBBIT_V2_RETRY_FREE=1 npm run test:browser -- tests2/browser/e2e/terminal-pack.spec.ts --retries=0
 ```
+
+### Canonical Bobbit avatars (`host.ui.createBobbitSprite`)
+
+Browser extension surfaces can show the same Bobbit identity and presentation as the main
+application without copying sprite data, appearance rules, or animation. The host owns those
+details so an extension remains aligned when Bobbit's canonical renderer or persisted appearance
+changes. The extension supplies only a project-bound identity and presentation state.
+
+`createBobbitSprite` is a required member of `host.ui` in Host contract v6. Call it directly;
+do not feature-detect the method or add a compatibility fallback. `HOST_API_VERSION` remains `1`
+because the browser Host API change is additive.
+
+```ts
+type HostBobbitState = "active" | "idle" | "paused";
+
+type HostBobbitSubject =
+  | { kind: "session"; id: string }
+  | { kind: "staff"; id: string };
+
+interface HostBobbitSpriteOptions {
+  subject: HostBobbitSubject;
+  state: HostBobbitState;
+  label: string;
+  size?: number;
+  animated?: boolean;
+}
+
+host.ui.createBobbitSprite(options: HostBobbitSpriteOptions): HTMLElement;
+```
+
+For example, a panel can create and append an active session avatar:
+
+```js
+const avatar = host.ui.createBobbitSprite({
+  subject: { kind: "session", id: sessionId },
+  state: "active",
+  label: "Build session",
+});
+panelRoot.append(avatar);
+```
+
+Options have the following contract:
+
+- `subject` selects a session or staff identity. For a session, the host uses its persisted colour
+  and accessory. For staff, the host uses the staff accessory and the current session's persisted
+  colour when available; otherwise it uses the canonical default colour.
+- `state` selects the canonical main-app presentation: `active` uses the busy presentation,
+  `idle` uses the settled sleeping presentation, and `paused` uses the centred, open-eye awake
+  rest frame. Paused presentation is static even when animation is requested.
+- `label` is copied exactly to the returned avatar's accessible name. It must be a string with
+  non-whitespace content and at most 200 UTF-16 code units.
+- `size` is an optional integer CSS-pixel square size from `16` through `96`, inclusive. Omitting
+  it uses the canonical panel size of `40` CSS pixels.
+- `animated` defaults to `true`. Setting it to `false` renders the matching canonical static
+  state. The host always honours `prefers-reduced-motion`, including live preference changes, so
+  a caller cannot force motion. Active becomes the open centre frame, idle remains the sleeping
+  rest frame, and paused remains the awake rest frame when motion is disabled.
+
+Validation is synchronous and happens before rendering. The options and subject must be non-null
+objects; the subject kind, state, label, optional size, and optional animation flag must have the
+shapes and values above, and `subject.id` must be a string. A violation throws `TypeError`.
+Unknown extra properties are allowed. A structurally valid ID that is empty, missing from loaded
+state, backed by malformed appearance data, or foreign to the project is not a validation error:
+it renders the canonical default Bobbit.
+
+Identity lookup is private to the authenticated browser surface's bound session project. An
+out-of-project subject and an unknown subject produce the same canonical fallback, so extensions
+cannot probe whether an ID belongs to another project. Project snapshots do not expose colour,
+accessory, sprite, or rendering fields; pass an identity to this method instead of retaining
+appearance data.
+
+The result is a plain, non-interactive `HTMLElement` with `role="img"`; its `aria-label` is exactly
+the supplied `label`, and its visual descendants are hidden from assistive technology. The element
+is self-contained: it can be appended, moved, removed, and re-appended. Disconnecting immediately
+stops animation work and releases motion listeners, observers, timers, and rendered descendants;
+re-appending safely renders it again. Treat the element as opaque rather than reading or changing
+its visual descendants.
 
 ### Panels — persistent side panels (`host.ui.openPanel`)
 
@@ -2233,7 +2312,7 @@ sandbox/read-only enforcement. As an author, your obligations are:
 - [ ] **Use the bound Pack Local Data directory** — declare the fixed schema-2 `localData` block and call `host.localData.directory()` or select your exact pack id from `BOBBIT_PACK_LOCAL_DATA_JSON`; never reconstruct a project root from `cwd` or accept a caller-supplied directory.
 - [ ] **Server modules are trusted code with full ambient parity** — `child_process`/`fs`/network/`process.env` are available directly (no declaration). The worker is resource/crash isolation only; design handlers to be fast.
 - [ ] **Standalone pi extensions are host/runtime code** — source-level trust is required before executable discovery, and enabled extensions load into matching agent sessions by default via `--extension`.
-- [ ] **Feature-detect via `host.capabilities`**, never member presence.
+- [ ] **Feature-detect optional capabilities via `host.capabilities`**, never member presence; call required contract-v6 `host.ui.createBobbitSprite` directly.
 
 The deeper model — the allowlist-bypass fix, `toolUseId` ownership verification, the
 `authorizeScopedRequest` vs `authorizeActionRequest` split, the tool-or-pack surface binding,

--- a/src/app/api.ts
+++ b/src/app/api.ts
@@ -2970,6 +2970,7 @@ export async function refreshStaffStateFromApi(): Promise<void> {
 		currentSessionId: s.currentSessionId,
 		triggers: s.triggers,
 		projectId: s.projectId,
+		accessory: s.accessory,
 	}));
 	state.orphanedStaff = orphanedStaff.map((s) => ({
 		id: s.id,

--- a/src/app/host-api.ts
+++ b/src/app/host-api.ts
@@ -44,6 +44,7 @@ import {
 import { navigateToTarget } from "./pack-entrypoints.js";
 import { createHostChannelsApi, type HostChannelsApi } from "./channel-bridge.js";
 import { mintPackSurfaceTokenOverWs } from "./surface-token-bridge.js";
+import { createHostBobbitSprite, type BrowserHostBobbitSpriteOptions } from "./host-bobbit-sprite.js";
 
 /** Add the `x-bobbit-session-id` header to a fetch init, mirroring the
  *  propagation `defaults/tools/agent/extension.ts` uses (server reads it). The
@@ -402,6 +403,10 @@ export function getHostApi(
 			},
 		} as HostApi["project"],
 		ui: {
+			// Required browser-only sprite construction is bound to this closure's
+			// trusted session. Extensions cannot choose the authority project.
+			createBobbitSprite: (options: BrowserHostBobbitSpriteOptions) =>
+				createHostBobbitSprite(sessionId, options),
 			// Slice B4: open (or focus) a pack-contributed side panel via the client
 			// pack-panel registry (lazy Blob-URL import + mount). PACK-RELATIVE: BOTH a
 			// pack-bound surface (panel/entrypoint) AND a tool-renderer surface supply

--- a/src/app/host-bobbit-sprite.ts
+++ b/src/app/host-bobbit-sprite.ts
@@ -1,0 +1,235 @@
+import { html, nothing, render, type TemplateResult } from "lit";
+import type { AccessoryDef } from "../ui/bobbit-render.js";
+import * as bobbitRenderer from "../ui/bobbit-render.js";
+import { sessionColorMap } from "./session-colors.js";
+import { state, type GatewaySession } from "./state.js";
+
+/** Internal structural mirror used while constructing the browser-owned API. */
+type BrowserHostBobbitState = "active" | "idle" | "paused";
+type BrowserHostBobbitSubject =
+	| { kind: "session"; id: string }
+	| { kind: "staff"; id: string };
+export interface BrowserHostBobbitSpriteOptions {
+	subject: BrowserHostBobbitSubject;
+	state: BrowserHostBobbitState;
+	label: string;
+	size?: number;
+	animated?: boolean;
+}
+
+interface HostedRendererOptions {
+	state: BrowserHostBobbitState;
+	hueRotate: number;
+	accessory: AccessoryDef;
+	size?: number;
+	animated: boolean;
+}
+
+// The renderer is implemented in parallel. Keeping this assertion beside the
+// call site gives that integration one narrow, explicit contract while allowing
+// this branch to type-check independently before the renderer commit is merged.
+const hostedRenderer = bobbitRenderer as typeof bobbitRenderer & {
+	renderHostBobbitSprite(options: HostedRendererOptions): TemplateResult;
+	disposeHostBobbitSprite(root: ParentNode): void;
+};
+
+export interface HostBobbitAppearance {
+	readonly hueRotate: number;
+	readonly accessory: AccessoryDef;
+}
+
+const FALLBACK_APPEARANCE: HostBobbitAppearance = Object.freeze({
+	hueRotate: 0,
+	accessory: bobbitRenderer.NO_ACCESSORY,
+});
+
+function isNonEmptyString(value: unknown): value is string {
+	return typeof value === "string" && value.trim().length > 0;
+}
+
+function findLoadedSession(sessionId: string): GatewaySession | undefined {
+	const isMatch = (candidate: GatewaySession): boolean =>
+		isNonEmptyString(candidate?.id) && candidate.id === sessionId;
+	return state.gatewaySessions.find(isMatch) ?? state.archivedSessions.find(isMatch);
+}
+
+function validColorIndex(value: unknown): value is number {
+	return Number.isInteger(value)
+		&& (value as number) >= 0
+		&& (value as number) < bobbitRenderer.BOBBIT_HUE_ROTATIONS.length;
+}
+
+function hueForSession(session: GatewaySession | undefined): number {
+	if (!session) return 0;
+	const mappedIndex = sessionColorMap.get(session.id);
+	const colorIndex = validColorIndex(mappedIndex)
+		? mappedIndex
+		: validColorIndex(session.colorIndex)
+			? session.colorIndex
+			: undefined;
+	return colorIndex === undefined ? 0 : bobbitRenderer.BOBBIT_HUE_ROTATIONS[colorIndex];
+}
+
+/**
+ * Resolve appearance only from the already-loaded projection belonging to the
+ * closure-bound session's project. All misses share one canonical result so an
+ * extension cannot distinguish unknown IDs from IDs owned by another project.
+ */
+export function resolveHostBobbitAppearance(
+	boundSessionId: string | undefined,
+	subject: BrowserHostBobbitSubject,
+): HostBobbitAppearance {
+	if (!isNonEmptyString(boundSessionId)) return FALLBACK_APPEARANCE;
+	const boundSession = findLoadedSession(boundSessionId);
+	const boundProjectId = boundSession?.projectId;
+	if (!isNonEmptyString(boundProjectId)) return FALLBACK_APPEARANCE;
+
+	if (subject.kind === "session") {
+		const session = findLoadedSession(subject.id);
+		if (!session || session.projectId !== boundProjectId) return FALLBACK_APPEARANCE;
+		return {
+			hueRotate: hueForSession(session),
+			accessory: bobbitRenderer.getAccessoryDef(session.accessory),
+		};
+	}
+
+	const staff = state.staffList.find((candidate) =>
+		isNonEmptyString(candidate?.id)
+		&& candidate.id === subject.id
+		&& candidate.projectId === boundProjectId,
+	);
+	if (!staff) return FALLBACK_APPEARANCE;
+
+	const currentSession = isNonEmptyString(staff.currentSessionId)
+		? findLoadedSession(staff.currentSessionId)
+		: undefined;
+	const projectSession = currentSession?.projectId === boundProjectId
+		? currentSession
+		: undefined;
+	return {
+		hueRotate: hueForSession(projectSession),
+		accessory: bobbitRenderer.getAccessoryDef(staff.accessory),
+	};
+}
+
+function validateOptions(value: unknown): BrowserHostBobbitSpriteOptions {
+	if (!value || typeof value !== "object") {
+		throw new TypeError("Bobbit sprite options must be an object");
+	}
+	const options = value as Record<string, unknown>;
+	const subject = options.subject;
+	if (!subject || typeof subject !== "object") {
+		throw new TypeError("Bobbit sprite subject must be an object");
+	}
+	const subjectRecord = subject as Record<string, unknown>;
+	if (subjectRecord.kind !== "session" && subjectRecord.kind !== "staff") {
+		throw new TypeError("Bobbit sprite subject.kind must be session or staff");
+	}
+	if (typeof subjectRecord.id !== "string") {
+		throw new TypeError("Bobbit sprite subject.id must be a string");
+	}
+	if (options.state !== "active" && options.state !== "idle" && options.state !== "paused") {
+		throw new TypeError("Bobbit sprite state must be active, idle, or paused");
+	}
+	if (typeof options.label !== "string" || options.label.trim().length === 0 || options.label.length > 200) {
+		throw new TypeError("Bobbit sprite label must contain 1 to 200 characters");
+	}
+	if (options.size !== undefined
+		&& (!Number.isInteger(options.size) || (options.size as number) < 16 || (options.size as number) > 96)) {
+		throw new TypeError("Bobbit sprite size must be an integer from 16 to 96");
+	}
+	if (options.animated !== undefined && typeof options.animated !== "boolean") {
+		throw new TypeError("Bobbit sprite animated must be a boolean");
+	}
+	return {
+		subject: { kind: subjectRecord.kind, id: subjectRecord.id } as BrowserHostBobbitSubject,
+		state: options.state,
+		label: options.label,
+		...(options.size === undefined ? {} : { size: options.size as number }),
+		...(options.animated === undefined ? {} : { animated: options.animated }),
+	};
+}
+
+interface ElementRenderData {
+	readonly state: BrowserHostBobbitState;
+	readonly label: string;
+	readonly size?: number;
+	readonly animated: boolean;
+	readonly appearance: HostBobbitAppearance;
+}
+
+const elementData = new WeakMap<HostBobbitSpriteElement, ElementRenderData>();
+const REDUCED_MOTION_QUERY = "(prefers-reduced-motion: reduce)";
+
+class HostBobbitSpriteElement extends HTMLElement {
+	private motionQuery: MediaQueryList | undefined;
+
+	private readonly onMotionPreferenceChange = (): void => {
+		if (this.isConnected) this.paint();
+	};
+
+	connectedCallback(): void {
+		const data = elementData.get(this);
+		if (!data) return;
+		this.setAttribute("role", "img");
+		this.setAttribute("aria-label", data.label);
+		this.style.display = "inline-block";
+		this.style.width = `${data.size ?? 40}px`;
+		this.style.height = `${data.size ?? 40}px`;
+
+		if (data.animated && data.state !== "paused" && typeof window.matchMedia === "function") {
+			this.motionQuery = window.matchMedia(REDUCED_MOTION_QUERY);
+			this.motionQuery.addEventListener("change", this.onMotionPreferenceChange);
+		}
+		this.paint();
+	}
+
+	disconnectedCallback(): void {
+		this.motionQuery?.removeEventListener("change", this.onMotionPreferenceChange);
+		this.motionQuery = undefined;
+		hostedRenderer.disposeHostBobbitSprite(this);
+		render(nothing, this);
+	}
+
+	private paint(): void {
+		const data = elementData.get(this);
+		if (!data) return;
+		const animated = data.animated
+			&& data.state !== "paused"
+			&& this.motionQuery?.matches !== true;
+		const sprite = hostedRenderer.renderHostBobbitSprite({
+			state: data.state,
+			hueRotate: data.appearance.hueRotate,
+			accessory: data.appearance.accessory,
+			size: data.size,
+			animated,
+		});
+		render(html`<span aria-hidden="true">${sprite}</span>`, this);
+	}
+}
+
+const HOST_BOBBIT_ELEMENT = "bobbit-host-sprite";
+if (!customElements.get(HOST_BOBBIT_ELEMENT)) {
+	customElements.define(HOST_BOBBIT_ELEMENT, HostBobbitSpriteElement);
+}
+
+/** Create the required framework-neutral Host sprite element. */
+export function createHostBobbitSprite(
+	boundSessionId: string | undefined,
+	optionsValue: BrowserHostBobbitSpriteOptions,
+): HTMLElement {
+	// Validation deliberately precedes appearance lookup and element creation.
+	const options = validateOptions(optionsValue);
+	const appearance = resolveHostBobbitAppearance(boundSessionId, options.subject);
+	const element = document.createElement(HOST_BOBBIT_ELEMENT) as HostBobbitSpriteElement;
+	elementData.set(element, Object.freeze({
+		state: options.state,
+		label: options.label,
+		size: options.size,
+		animated: options.animated !== false,
+		appearance: Object.freeze({ ...appearance }),
+	}));
+	element.setAttribute("role", "img");
+	element.setAttribute("aria-label", options.label);
+	return element;
+}

--- a/src/app/state.ts
+++ b/src/app/state.ts
@@ -687,7 +687,7 @@ export const state = {
 	goalDashboardId: null as string | null,
 
 	/** Staff agents list */
-	staffList: [] as Array<{ id: string; name: string; description: string; state: string; lastWakeAt?: number; currentSessionId?: string; triggers: any[]; projectId?: string }>,
+	staffList: [] as Array<{ id: string; name: string; description: string; state: string; lastWakeAt?: number; currentSessionId?: string; triggers: any[]; projectId?: string; accessory?: string }>,
 
 	/** Orphaned staff records — projectId missing or set to the system project. Surfaced in the sidebar banner. */
 	orphanedStaff: [] as Array<{ id: string; name: string; description: string; state: string; projectId?: string }>,
@@ -1110,6 +1110,7 @@ function staffSidebarCacheKey(): string {
 		projectId: s.projectId,
 		currentSessionId: s.currentSessionId,
 		lastWakeAt: s.lastWakeAt,
+		accessory: s.accessory,
 		triggers: s.triggers ?? [],
 	})).join("|");
 }

--- a/src/shared/extension-host/host-api.ts
+++ b/src/shared/extension-host/host-api.ts
@@ -1,3 +1,5 @@
+/// <reference lib="dom" />
+
 // src/shared/extension-host/host-api.ts
 //
 // The FROZEN Bobbit Extension Host API — durable v1 contract
@@ -42,7 +44,8 @@ export const HOST_API_VERSION = 1 as const;
 // fall back to host-derived singleton/allowlisted param identity. See PanelTarget.
 // v4 (additive): added generic host.channels data contracts.
 // v5 (additive): added canonical scoped session/project notification contracts.
-export const HOST_CONTRACT_VERSION = 5 as const;
+// v6 (additive): added host.ui.createBobbitSprite and its presentation contracts.
+export const HOST_CONTRACT_VERSION = 6 as const;
 
 import type {
 	HostNotification,
@@ -223,14 +226,32 @@ export interface HostProjectApi {
 	readonly notifications: HostNotificationSubscriptionApi<ProjectNotificationName>;
 }
 
-/** PHASE 2 — frozen, not implemented. Drive non-chat UI surfaces. Targets are STRUCTURED
- *  typed objects, never hash strings — so the contract never bakes in today's router. */
+export type HostBobbitState = "active" | "idle" | "paused";
+
+export type HostBobbitSubject =
+	| { kind: "session"; id: string }
+	| { kind: "staff"; id: string };
+
+export interface HostBobbitSpriteOptions {
+	subject: HostBobbitSubject;
+	state: HostBobbitState;
+	label: string;
+	size?: number;
+	animated?: boolean;
+}
+
+/** PHASE 2 — drive non-chat UI surfaces. Targets are STRUCTURED typed objects, never
+ *  hash strings — so the contract never bakes in today's router. */
 export interface HostUiApi {
 	/** Open (or focus) a contributed panel, handing it typed params. */
 	openPanel(target: PanelTarget): void;
 	/** Navigate the SPA to a contributed route, by structured target. The host maps the
 	 *  target onto whatever URL scheme the router uses; packs never construct URLs. */
 	navigate(target: RouteTarget): void;
+	/** Create the canonical Bobbit avatar for a project-bound session or staff identity.
+	 *  This required browser capability is always present; callers do not feature-detect it.
+	 *  Invalid option shapes, labels, sizes, states, or animation flags throw TypeError. */
+	createBobbitSprite(options: HostBobbitSpriteOptions): HTMLElement;
 }
 
 /** PHASE 2 — frozen, not implemented. Ownership-scoped server persistence.

--- a/src/ui/app.css
+++ b/src/ui/app.css
@@ -5608,6 +5608,9 @@ canvas.bobbit-blob__sprite {
 	padding-top: 0;
 	margin-left: 0;
 }
+.bobbit-blob.bobbit-blob--hosted.bobbit-blob--hosted-tall {
+	padding-top: 6px;
+}
 
 /* Static/reduced-motion presentation has no CSS, transition, or pseudo-element
  * animation. Rest transforms are the matching canonical 0% poses. */

--- a/src/ui/app.css
+++ b/src/ui/app.css
@@ -5600,3 +5600,24 @@ canvas.bobbit-blob__sprite {
 .bobbit-blob.bobbit-blob--archived .bobbit-blob__zzz-letter {
 	opacity: 0 !important;
 }
+
+/* Hosted sprites reuse canonical layers while owning their local composition.
+ * Counter document-level accessory layout classes; only the renderer-emitted
+ * accessory layer can affect the hosted identity. */
+.bobbit-blob.bobbit-blob--hosted {
+	padding-top: 0;
+	margin-left: 0;
+}
+
+/* Static/reduced-motion presentation has no CSS, transition, or pseudo-element
+ * animation. Rest transforms are the matching canonical 0% poses. */
+.bobbit-blob.bobbit-blob--hosted-static,
+.bobbit-blob.bobbit-blob--hosted-static *,
+.bobbit-blob.bobbit-blob--hosted-static *::before,
+.bobbit-blob.bobbit-blob--hosted-static *::after {
+	animation: none !important;
+	transition: none !important;
+}
+.bobbit-blob.bobbit-blob--hosted-static.bobbit-blob--idle canvas.bobbit-blob__sprite {
+	transform: translateX(-28px);
+}

--- a/src/ui/bobbit-render.ts
+++ b/src/ui/bobbit-render.ts
@@ -740,6 +740,7 @@ export function renderHostBobbitSprite(opts: HostedBobbitOptions): TemplateResul
 		"bobbit-blob",
 		"bobbit-blob--inline",
 		"bobbit-blob--hosted",
+		accessory.addsHeight ? "bobbit-blob--hosted-tall" : "",
 		`bobbit-blob--hosted-${state}`,
 		isIdle ? "bobbit-blob--idle" : "",
 		animated ? "" : "bobbit-blob--hosted-static",

--- a/src/ui/bobbit-render.ts
+++ b/src/ui/bobbit-render.ts
@@ -61,6 +61,22 @@ export interface SidebarBobbitOptions {
 	centerInContainer?: boolean;
 }
 
+/** Presentation states supported by the framework-neutral hosted composition. */
+export type HostedBobbitState = "active" | "idle" | "paused";
+
+export interface HostedBobbitOptions {
+	state: HostedBobbitState;
+	hueRotate?: number;
+	accessory?: AccessoryDef;
+	/** CSS-pixel size. Validation of the public 16–96 range belongs to Host API. */
+	size?: number;
+	/** Whether canonical motion should run. Paused is always a rest frame. */
+	animated?: boolean;
+}
+
+const INLINE_BOBBIT_NATURAL_SIZE = 76;
+const INLINE_BOBBIT_DEFAULT_SIZE = 40;
+
 // ============================================================================
 // PALETTES
 // ============================================================================
@@ -508,6 +524,18 @@ function stopCanvasEyeAnimation(canvas: HTMLCanvasElement): void {
 	canvasEyeAnimations.delete(canvas);
 }
 
+/**
+ * Immediately release canonical canvas eye controllers below a lifecycle owner.
+ * Hosted elements call this before Lit removes their subtree so no deferred ref
+ * cleanup can retain animation work after disconnect.
+ */
+export function disposeHostBobbitSprite(root: ParentNode): void {
+	if (root instanceof HTMLCanvasElement) stopCanvasEyeAnimation(root);
+	for (const canvas of root.querySelectorAll("canvas.bobbit-blob__sprite")) {
+		if (canvas instanceof HTMLCanvasElement) stopCanvasEyeAnimation(canvas);
+	}
+}
+
 function scheduleCanvasEyeAnimationStop(canvas: HTMLCanvasElement): void {
 	const existing = canvasEyeAnimations.get(canvas);
 	if (!existing || existing.releaseTimer !== null) return;
@@ -532,16 +560,18 @@ function scheduleCanvasEyeAnimationStop(canvas: HTMLCanvasElement): void {
  * eyes at any DPR/zoom level. CSS animations use -canvas keyframe variants
  * (no scale(4), translates ×4).
  */
-export function renderBlobSpriteCanvas(isIdle: boolean, archived = false): TemplateResult {
-	if (archived) {
-		// Static frame: center gaze, no blink, no animation loop
+export function renderBlobSpriteCanvas(isIdle: boolean, archived = false, animated = true): TemplateResult {
+	if (archived || !animated) {
+		// Static rest frame: hosted idle sleeps; active/paused and archived stay
+		// center-facing and awake. No eye controller is created.
 		let attachedCanvas: HTMLCanvasElement | null = null;
 		const onRef = (el: Element | undefined) => {
 			if (el && el instanceof HTMLCanvasElement) {
 				attachedCanvas = el;
 				stopCanvasEyeAnimation(el);
-				const cache = buildEyePixelCache(CANONICAL_PALETTE, [{ pct: 0, gaze: "center", blink: false }]);
-				const pixels = cache.get("center-false");
+				const blink = !archived && isIdle;
+				const cache = buildEyePixelCache(CANONICAL_PALETTE, [{ pct: 0, gaze: "center", blink }]);
+				const pixels = cache.get(`center-${blink}`);
 				if (pixels) {
 					const dpr = window.devicePixelRatio || 1;
 					const devW = Math.round(BODY_WIDTH * CANVAS_HI * dpr);
@@ -640,9 +670,9 @@ export function renderChatBlobCanvas(opts: ChatBlobOptions): TemplateResult {
  * Only the sprite body is canvas-rendered; accessories use CSS box-shadow.
  */
 export function renderIdleBlobCanvas(opts: IdleBlobOptions): TemplateResult {
-	const { accId: _accId, accClass, size = 40, hueIndex = 0, phaseIndex = 0, clip = true } = opts;
+	const { accId: _accId, accClass, size = INLINE_BOBBIT_DEFAULT_SIZE, hueIndex = 0, phaseIndex = 0, clip = true } = opts;
 	const cls = `bobbit-blob bobbit-blob--idle bobbit-blob--inline ${accClass}`.trim();
-	const naturalSize = 76;
+	const naturalSize = INLINE_BOBBIT_NATURAL_SIZE;
 	const s = size / naturalSize;
 	const hue = BOBBIT_HUE_ROTATIONS[hueIndex % BOBBIT_HUE_ROTATIONS.length];
 	// Negative animation-delay: each blob starts at a different point in the
@@ -682,6 +712,50 @@ export function renderIdleBlobCanvas(opts: IdleBlobOptions): TemplateResult {
 					<div class="bobbit-blob__clipboard"></div>
 					<div class="bobbit-blob__headset"></div>
 					<div class="bobbit-blob__ponytail"></div>
+				</div>
+			</div>
+		</div>
+	`;
+}
+
+/** Map a canonical accessory id to the existing local CSS scope class. */
+function hostedAccessoryClass(accessory: AccessoryDef): string {
+	if (accessory.id === "none") return "";
+	return `bobbit-${accessory.id === "crown" ? "crowned" : accessory.id}`;
+}
+
+/**
+ * Render the canonical chat sprite in the established 76px composition used by
+ * inline panels. Only the requested accessory layer is emitted, preventing the
+ * application's document-level active-session class from changing its identity.
+ */
+export function renderHostBobbitSprite(opts: HostedBobbitOptions): TemplateResult {
+	const { state, hueRotate = 0, accessory = NO_ACCESSORY, size = INLINE_BOBBIT_DEFAULT_SIZE } = opts;
+	const isIdle = state === "idle";
+	const animated = opts.animated !== false && state !== "paused";
+	const naturalSize = INLINE_BOBBIT_NATURAL_SIZE;
+	const scale = size / naturalSize;
+	const accessoryClass = hostedAccessoryClass(accessory);
+	const blobClass = [
+		"bobbit-blob",
+		"bobbit-blob--inline",
+		"bobbit-blob--hosted",
+		`bobbit-blob--hosted-${state}`,
+		isIdle ? "bobbit-blob--idle" : "",
+		animated ? "" : "bobbit-blob--hosted-static",
+		accessoryClass,
+	].filter(Boolean).join(" ");
+	const accessoryLayer = accessory.id === "none"
+		? ""
+		: html`<div class="bobbit-blob__${accessory.id}"></div>`;
+
+	return html`
+		<div class="bobbit-hosted-composition" aria-hidden="true" style="width:${size}px;height:${size}px;flex-shrink:0;position:relative;overflow:visible;">
+			<div style="width:${naturalSize}px;height:${naturalSize}px;position:relative;overflow:visible;transform:scale(${scale.toFixed(3)});transform-origin:top left;">
+				<div class="${blobClass}" style="--bobbit-hue-rotate:${hueRotate}deg;">
+					${renderBlobSpriteCanvas(isIdle, false, animated)}
+					${accessoryLayer}
+					<div class="bobbit-blob__shadow"></div>
 				</div>
 			</div>
 		</div>

--- a/tests2/browser/fixtures/host-sprite/host-sprite-fixture/entrypoints/host-sprite-route.yaml
+++ b/tests2/browser/fixtures/host-sprite/host-sprite-fixture/entrypoints/host-sprite-route.yaml
@@ -1,0 +1,6 @@
+id: host-sprite.route
+kind: route
+routeId: host-sprite-fixture
+target:
+  panelId: host-sprite.panel
+paramKeys: [staffId]

--- a/tests2/browser/fixtures/host-sprite/host-sprite-fixture/lib/panel.js
+++ b/tests2/browser/fixtures/host-sprite/host-sprite-fixture/lib/panel.js
@@ -1,0 +1,74 @@
+// Fixture panel for the required framework-neutral Host Bobbit sprite API.
+// Every visual below is created by the Host and appended as a plain HTMLElement;
+// this pack intentionally owns no sprite data, colours, accessories, or animation.
+export default function createPanel({ html }) {
+	const instances = new Map();
+	let nextInstance = 0;
+
+	function createInstance(host, sessionId, staffId) {
+		const subjects = [
+			["session", { kind: "session", id: sessionId }],
+			["staff", { kind: "staff", id: staffId }],
+		];
+		const presentations = [
+			["active", "active", true],
+			["idle", "idle", true],
+			["paused", "paused", true],
+			["active-static", "active", false],
+		];
+		const sprites = new Map();
+		for (const [subjectName, subject] of subjects) {
+			for (const [presentation, state, animated] of presentations) {
+				const label = `${subjectName === "session" ? "Session" : "Staff"} ${presentation} avatar`;
+				const sprite = host.ui.createBobbitSprite({ subject, state, label, animated });
+				sprite.dataset.fixtureSprite = `${subjectName}-${presentation}`;
+				sprites.set(`${subjectName}-${presentation}`, sprite);
+			}
+		}
+		return { id: `host-sprite-fixture-${++nextInstance}`, sprites };
+	}
+
+	function appendSprites(instance) {
+		queueMicrotask(() => {
+			const panel = document.getElementById(instance.id);
+			if (!panel) return;
+			for (const [key, sprite] of instance.sprites) {
+				const holder = panel.querySelector(`[data-sprite-holder="${key}"]`);
+				if (holder && sprite.parentElement !== holder) holder.append(sprite);
+			}
+			panel.dataset.spritesAppended = "true";
+		});
+	}
+
+	return {
+		render(params, host) {
+			const sessionId = String(params?.__sessionId ?? "");
+			const staffId = String(params?.staffId ?? "");
+			if (!host || !sessionId || !staffId) {
+				return html`<section data-testid="host-sprite-fixture-error">Missing bound fixture identity</section>`;
+			}
+			const key = `${sessionId}:${staffId}`;
+			let instance = instances.get(key);
+			if (!instance) {
+				instance = createInstance(host, sessionId, staffId);
+				instances.set(key, instance);
+			}
+			appendSprites(instance);
+			return html`
+				<section id=${instance.id} data-testid="host-sprite-fixture-panel" style="padding:1rem;display:grid;gap:1rem;color:var(--foreground);background:var(--background)">
+					<header><strong>Host Sprite Fixture</strong></header>
+					${["session", "staff"].map(subject => html`
+						<section data-sprite-subject=${subject} style="display:grid;gap:.5rem">
+							<h3>${subject === "session" ? "Session" : "Staff"}</h3>
+							<div style="display:flex;align-items:center;gap:1rem;flex-wrap:wrap">
+								${["active", "idle", "paused", "active-static"].map(presentation => html`
+									<div data-sprite-holder=${`${subject}-${presentation}`} style="min-width:5rem;min-height:3rem;border:1px solid var(--border);display:flex;align-items:center;justify-content:center"></div>
+								`)}
+							</div>
+						</section>
+					`)}
+				</section>
+			`;
+		},
+	};
+}

--- a/tests2/browser/fixtures/host-sprite/host-sprite-fixture/pack.yaml
+++ b/tests2/browser/fixtures/host-sprite/host-sprite-fixture/pack.yaml
@@ -1,0 +1,9 @@
+name: host-sprite-fixture
+schema: 2
+description: Browser journey fixture for the canonical Host Bobbit sprite API.
+version: 1.0.0
+contents:
+  roles: []
+  tools: []
+  skills: []
+  entrypoints: [host-sprite-route]

--- a/tests2/browser/fixtures/host-sprite/host-sprite-fixture/panels/host-sprite-panel.yaml
+++ b/tests2/browser/fixtures/host-sprite/host-sprite-fixture/panels/host-sprite-panel.yaml
@@ -1,0 +1,4 @@
+id: host-sprite.panel
+title: Host Sprite Fixture
+entry: ../lib/panel.js
+instanceMode: singleton

--- a/tests2/browser/journeys/host-bobbit-sprite.journey.spec.ts
+++ b/tests2/browser/journeys/host-bobbit-sprite.journey.spec.ts
@@ -107,7 +107,7 @@ async function capturePanelSprite(sprite: Locator, accessoryClass: string): Prom
 }
 
 async function ensureSidebarRow(page: Page, sessionId: string, staff = false): Promise<Locator> {
-	const row = page.locator(`[data-testid="sidebar-expanded"] button[data-session-id="${sessionId}"]`).first();
+	const row = page.locator(`[data-nav-id="session:${sessionId}"]`).first();
 	if (staff && !(await row.isVisible().catch(() => false))) {
 		const header = page.getByTestId("sidebar-staff-header").first();
 		if (await header.isVisible().catch(() => false)) await header.click();

--- a/tests2/browser/journeys/host-bobbit-sprite.journey.spec.ts
+++ b/tests2/browser/journeys/host-bobbit-sprite.journey.spec.ts
@@ -15,9 +15,7 @@ import {
 const SOURCE_DIR = fileURLToPath(new URL("../fixtures/host-sprite", import.meta.url));
 const PACK_NAME = "host-sprite-fixture";
 const SESSION_COLOR_INDEX = 8;
-const SESSION_HUE = 40;
 const STAFF_COLOR_INDEX = 12;
-const STAFF_HUE = 100;
 
 type StaffRecord = { id: string; currentSessionId?: string };
 type MainSprite = { filter: string; imageCount: number; accessorySrc: string };
@@ -25,9 +23,11 @@ type PanelSprite = {
 	filter: string;
 	hueVariable: string;
 	blobClasses: string;
+	paddingTop: string;
 	canvasAnimationName: string;
 	runningAnimationNames: string[];
 	accessoryVisible: boolean;
+	conflictingAccessoryPresent: boolean;
 	canvasFrame: string;
 };
 
@@ -92,6 +92,7 @@ async function capturePanelSprite(sprite: Locator, accessoryClass: string): Prom
 			filter: getComputedStyle(blob).filter,
 			hueVariable,
 			blobClasses: blob.className,
+			paddingTop: getComputedStyle(blob).paddingTop,
 			canvasAnimationName: getComputedStyle(canvas).animationName,
 			runningAnimationNames: root.getAnimations({ subtree: true })
 				.filter(animation => animation.playState === "running" || animation.pending)
@@ -101,6 +102,7 @@ async function capturePanelSprite(sprite: Locator, accessoryClass: string): Prom
 				&& accessoryStyle.display !== "none"
 				&& accessoryStyle.visibility !== "hidden"
 				&& Number(accessoryStyle.opacity) > 0,
+			conflictingAccessoryPresent: !!root.querySelector(".bobbit-blob__wizard-hat"),
 			canvasFrame: canvas.toDataURL(),
 		};
 	}, accessoryClass);
@@ -134,6 +136,12 @@ async function captureMainSprite(row: Locator): Promise<MainSprite> {
 	});
 }
 
+function hueDegrees(filter: string): number {
+	const match = filter.match(/hue-rotate\((-?\d+(?:\.\d+)?)deg\)/);
+	if (!match) throw new Error(`missing canonical hue rotation in ${filter}`);
+	return Number(match[1]);
+}
+
 function expectHue(sprite: PanelSprite, degrees: number): void {
 	const evidence = `${sprite.hueVariable} ${sprite.filter}`;
 	expect(evidence).toContain(`${degrees}deg`);
@@ -159,14 +167,18 @@ async function expectSpriteParity(
 		captureMainSprite(await ensureSidebarRow(page, sessionId)),
 		captureMainSprite(await ensureSidebarRow(page, staffSessionId, true)),
 	]);
-	expect(sessionMain.filter).toContain(`hue-rotate(${SESSION_HUE}deg)`);
-	expect(staffMain.filter).toContain(`hue-rotate(${STAFF_HUE}deg)`);
+	const sessionHue = hueDegrees(sessionMain.filter);
+	const staffHue = hueDegrees(staffMain.filter);
+	expect(sessionHue, "session should use a persisted non-default colour").not.toBe(0);
+	expect(staffHue, "staff should use its current session's persisted non-default colour").not.toBe(0);
 	expect(sessionMain.imageCount).toBeGreaterThan(1);
 	expect(staffMain.imageCount).toBeGreaterThan(1);
 	expect(sessionMain.accessorySrc).toBeTruthy();
 	expect(staffMain.accessorySrc).toBeTruthy();
 	expect(sessionMain.accessorySrc, "crown and ponytail must remain distinct main-app identities").not.toBe(staffMain.accessorySrc);
 	if (priorMain) {
+		expect(sessionMain.filter, "session colour should survive reload").toBe(priorMain.session.filter);
+		expect(staffMain.filter, "staff colour should survive reload").toBe(priorMain.staff.filter);
 		expect(sessionMain.accessorySrc, "session accessory should survive reload").toBe(priorMain.session.accessorySrc);
 		expect(staffMain.accessorySrc, "staff accessory should survive reload").toBe(priorMain.staff.accessorySrc);
 	}
@@ -179,10 +191,19 @@ async function expectSpriteParity(
 			const sprite = panelSprite(page, key);
 			await expect(sprite).toBeVisible();
 			const capture = await capturePanelSprite(sprite, accessoryClass);
-			expectHue(capture, subject === "session" ? SESSION_HUE : STAFF_HUE);
+			expectHue(capture, subject === "session" ? sessionHue : staffHue);
 			expect(capture.accessoryVisible, `${key} should render its persisted accessory`).toBe(true);
 			captures.set(key, capture);
 		}
+	}
+
+	for (const presentation of ["active", "idle", "paused", "active-static"] as const) {
+		const session = captures.get(`session-${presentation}`)!;
+		const staff = captures.get(`staff-${presentation}`)!;
+		expect(session.paddingTop, "crown must retain canonical tall-accessory accommodation").toBe("6px");
+		expect(session.conflictingAccessoryPresent, "document accessory class must not inject a hosted layer").toBe(false);
+		expect(staff.paddingTop, "normal accessories must ignore document tall-accessory layout").toBe("0px");
+		expect(staff.conflictingAccessoryPresent).toBe(false);
 	}
 
 	for (const subject of ["session", "staff"] as const) {
@@ -252,12 +273,14 @@ test.describe("Journey: Host Bobbit sprite fixture panel", () => {
 			await navigateToHash(page, `#/session/${sessionId}`);
 			await expect(page.locator("message-editor textarea").first()).toBeVisible({ timeout: 20_000 });
 			await navigateToHash(page, `#/ext/host-sprite-fixture?staffId=${encodeURIComponent(staff.id)}`);
+			await page.evaluate(() => document.documentElement.classList.add("bobbit-wizard-hat"));
 			const firstMain = await expectSpriteParity(page, sessionId, staff.currentSessionId!);
 
 			await page.reload({ waitUntil: "domcontentloaded" });
 			await navigateToHash(page, `#/session/${sessionId}`);
 			await expect(page.locator("message-editor textarea").first()).toBeVisible({ timeout: 20_000 });
 			await navigateToHash(page, `#/ext/host-sprite-fixture?staffId=${encodeURIComponent(staff.id)}`);
+			await page.evaluate(() => document.documentElement.classList.add("bobbit-wizard-hat"));
 			await expectSpriteParity(page, sessionId, staff.currentSessionId!, firstMain);
 		} finally {
 			if (staff?.id) await apiFetch(`/api/staff/${encodeURIComponent(staff.id)}`, { method: "DELETE" }).catch(() => {});

--- a/tests2/browser/journeys/host-bobbit-sprite.journey.spec.ts
+++ b/tests2/browser/journeys/host-bobbit-sprite.journey.spec.ts
@@ -1,0 +1,270 @@
+import { fileURLToPath } from "node:url";
+import type { Locator, Page } from "@playwright/test";
+import {
+	apiFetch,
+	createSession,
+	defaultProject,
+	deleteSession,
+	expect,
+	navigateToHash,
+	openApp,
+	test,
+	waitForSessionStatus,
+} from "../_helpers/journey-fixture.js";
+
+const SOURCE_DIR = fileURLToPath(new URL("../fixtures/host-sprite", import.meta.url));
+const PACK_NAME = "host-sprite-fixture";
+const SESSION_COLOR_INDEX = 8;
+const SESSION_HUE = 40;
+const STAFF_COLOR_INDEX = 12;
+const STAFF_HUE = 100;
+
+type StaffRecord = { id: string; currentSessionId?: string };
+type MainSprite = { filter: string; imageCount: number; accessorySrc: string };
+type PanelSprite = {
+	filter: string;
+	hueVariable: string;
+	blobClasses: string;
+	canvasAnimationName: string;
+	runningAnimationNames: string[];
+	accessoryVisible: boolean;
+	canvasFrame: string;
+};
+
+async function responseText(response: Response): Promise<string> {
+	return response.clone().text().catch(() => "");
+}
+
+async function addFixtureSource(): Promise<string> {
+	const response = await apiFetch("/api/marketplace/sources", {
+		method: "POST",
+		body: JSON.stringify({ url: SOURCE_DIR }),
+	});
+	if (response.status === 409) {
+		const list = await apiFetch("/api/marketplace/sources");
+		const source = ((await list.json()).sources ?? []).find((item: { id: string; url: string }) => item.url === SOURCE_DIR);
+		expect(source, "the existing Host sprite fixture source should be discoverable").toBeTruthy();
+		return source.id;
+	}
+	expect(response.status, `fixture source registration failed: ${await responseText(response)}`).toBe(201);
+	return (await response.json()).source.id;
+}
+
+async function installFixturePack(sourceId: string, projectId: string): Promise<void> {
+	const response = await apiFetch("/api/marketplace/install", {
+		method: "POST",
+		body: JSON.stringify({ sourceId, dirName: PACK_NAME, scope: "project", projectId }),
+	});
+	expect(response.status, `fixture pack installation failed: ${await responseText(response)}`).toBe(201);
+}
+
+async function uninstallFixturePack(projectId: string): Promise<void> {
+	await apiFetch("/api/marketplace/installed", {
+		method: "DELETE",
+		body: JSON.stringify({ scope: "project", projectId, packName: PACK_NAME }),
+	}).catch(() => {});
+}
+
+async function patchSessionAppearance(sessionId: string, colorIndex: number, accessory: string): Promise<void> {
+	const response = await apiFetch(`/api/sessions/${encodeURIComponent(sessionId)}`, {
+		method: "PATCH",
+		body: JSON.stringify({ colorIndex, accessory }),
+	});
+	expect(response.status, `session appearance patch failed: ${await responseText(response)}`).toBe(200);
+}
+
+function panelSprite(page: Page, key: string): Locator {
+	return page.locator(`[data-fixture-sprite="${key}"]`);
+}
+
+async function capturePanelSprite(sprite: Locator, accessoryClass: string): Promise<PanelSprite> {
+	return sprite.evaluate((root, expectedAccessoryClass) => {
+		const blob = root.querySelector<HTMLElement>(".bobbit-blob");
+		const canvas = root.querySelector<HTMLCanvasElement>("canvas.bobbit-blob__sprite");
+		if (!blob || !canvas) throw new Error("Host sprite did not render the canonical Bobbit canvas");
+		const accessory = root.querySelector<HTMLElement>(expectedAccessoryClass);
+		const accessoryStyle = accessory ? getComputedStyle(accessory) : undefined;
+		const elements = [root, ...Array.from(root.querySelectorAll<HTMLElement>("*"))];
+		const hueVariable = elements
+			.map(element => getComputedStyle(element).getPropertyValue("--bobbit-hue-rotate").trim())
+			.find(Boolean) ?? "";
+		return {
+			filter: getComputedStyle(blob).filter,
+			hueVariable,
+			blobClasses: blob.className,
+			canvasAnimationName: getComputedStyle(canvas).animationName,
+			runningAnimationNames: root.getAnimations({ subtree: true })
+				.filter(animation => animation.playState === "running" || animation.pending)
+				.map(animation => (animation as Animation & { animationName?: string }).animationName ?? "")
+				.filter(Boolean),
+			accessoryVisible: !!accessoryStyle
+				&& accessoryStyle.display !== "none"
+				&& accessoryStyle.visibility !== "hidden"
+				&& Number(accessoryStyle.opacity) > 0,
+			canvasFrame: canvas.toDataURL(),
+		};
+	}, accessoryClass);
+}
+
+async function ensureSidebarRow(page: Page, sessionId: string, staff = false): Promise<Locator> {
+	const row = page.locator(`[data-testid="sidebar-expanded"] button[data-session-id="${sessionId}"]`).first();
+	if (staff && !(await row.isVisible().catch(() => false))) {
+		const header = page.getByTestId("sidebar-staff-header").first();
+		if (await header.isVisible().catch(() => false)) await header.click();
+	}
+	await expect(row, `main application should render ${staff ? "staff" : "session"} identity`).toBeVisible({ timeout: 20_000 });
+	return row;
+}
+
+async function captureMainSprite(row: Locator): Promise<MainSprite> {
+	return row.evaluate((root) => {
+		const sprite = Array.from(root.querySelectorAll<HTMLElement>("span")).find((element) => {
+			const style = getComputedStyle(element);
+			return style.position === "relative" && style.overflow === "hidden" && element.querySelector(":scope > img");
+		});
+		if (!sprite) throw new Error("main application row did not contain a canonical Bobbit sprite");
+		const images = Array.from(sprite.querySelectorAll<HTMLImageElement>(":scope > img"));
+		const accessory = images.find(image => image.className.includes("bobbit-sidebar-accessory--front"))
+			?? images.find(image => image.className.includes("bobbit-sidebar-accessory--right"));
+		return {
+			filter: getComputedStyle(sprite).filter,
+			imageCount: images.length,
+			accessorySrc: accessory?.src ?? "",
+		};
+	});
+}
+
+function expectHue(sprite: PanelSprite, degrees: number): void {
+	const evidence = `${sprite.hueVariable} ${sprite.filter}`;
+	expect(evidence).toContain(`${degrees}deg`);
+}
+
+async function expectSpriteParity(
+	page: Page,
+	sessionId: string,
+	staffSessionId: string,
+	priorMain?: { session: MainSprite; staff: MainSprite },
+): Promise<{ session: MainSprite; staff: MainSprite }> {
+	const panel = page.getByTestId("host-sprite-fixture-panel");
+	await expect(panel).toHaveAttribute("data-sprites-appended", "true", { timeout: 20_000 });
+
+	for (const label of [
+		"Session active avatar", "Session idle avatar", "Session paused avatar", "Session active-static avatar",
+		"Staff active avatar", "Staff idle avatar", "Staff paused avatar", "Staff active-static avatar",
+	]) {
+		await expect(page.getByRole("img", { name: label, exact: true }), `${label} should use the caller label as its accessible name`).toBeVisible();
+	}
+
+	const [sessionMain, staffMain] = await Promise.all([
+		captureMainSprite(await ensureSidebarRow(page, sessionId)),
+		captureMainSprite(await ensureSidebarRow(page, staffSessionId, true)),
+	]);
+	expect(sessionMain.filter).toContain(`hue-rotate(${SESSION_HUE}deg)`);
+	expect(staffMain.filter).toContain(`hue-rotate(${STAFF_HUE}deg)`);
+	expect(sessionMain.imageCount).toBeGreaterThan(1);
+	expect(staffMain.imageCount).toBeGreaterThan(1);
+	expect(sessionMain.accessorySrc).toBeTruthy();
+	expect(staffMain.accessorySrc).toBeTruthy();
+	expect(sessionMain.accessorySrc, "crown and ponytail must remain distinct main-app identities").not.toBe(staffMain.accessorySrc);
+	if (priorMain) {
+		expect(sessionMain.accessorySrc, "session accessory should survive reload").toBe(priorMain.session.accessorySrc);
+		expect(staffMain.accessorySrc, "staff accessory should survive reload").toBe(priorMain.staff.accessorySrc);
+	}
+
+	const captures = new Map<string, PanelSprite>();
+	for (const subject of ["session", "staff"] as const) {
+		const accessoryClass = subject === "session" ? ".bobbit-blob__crown" : ".bobbit-blob__ponytail";
+		for (const presentation of ["active", "idle", "paused", "active-static"] as const) {
+			const key = `${subject}-${presentation}`;
+			const sprite = panelSprite(page, key);
+			await expect(sprite).toBeVisible();
+			const capture = await capturePanelSprite(sprite, accessoryClass);
+			expectHue(capture, subject === "session" ? SESSION_HUE : STAFF_HUE);
+			expect(capture.accessoryVisible, `${key} should render its persisted accessory`).toBe(true);
+			captures.set(key, capture);
+		}
+	}
+
+	for (const subject of ["session", "staff"] as const) {
+		const active = captures.get(`${subject}-active`)!;
+		const idle = captures.get(`${subject}-idle`)!;
+		const paused = captures.get(`${subject}-paused`)!;
+		const staticActive = captures.get(`${subject}-active-static`)!;
+		expect(active.blobClasses).not.toContain("bobbit-blob--idle");
+		expect(active.canvasAnimationName).toContain("blob-busy-move-canvas");
+		expect(active.runningAnimationNames.length).toBeGreaterThan(0);
+		expect(idle.blobClasses).toContain("bobbit-blob--idle");
+		expect(idle.canvasAnimationName).toContain("blob-idle-eyes-canvas");
+		expect(idle.canvasAnimationName).toContain("blob-idle-sleep-breathe-canvas");
+		expect(idle.runningAnimationNames.length).toBeGreaterThan(0);
+		expect(paused.blobClasses).not.toContain("bobbit-blob--idle");
+		expect(paused.canvasAnimationName).toBe("none");
+		expect(paused.runningAnimationNames).toEqual([]);
+		expect(staticActive.canvasAnimationName).toBe("none");
+		expect(staticActive.runningAnimationNames).toEqual([]);
+		expect(staticActive.canvasFrame, "static active should use the canonical paused/open rest frame").toBe(paused.canvasFrame);
+	}
+
+	for (const presentation of ["active", "idle", "paused", "active-static"] as const) {
+		const session = captures.get(`session-${presentation}`)!;
+		const staff = captures.get(`staff-${presentation}`)!;
+		expect(staff.blobClasses.includes("bobbit-blob--idle")).toBe(session.blobClasses.includes("bobbit-blob--idle"));
+		expect(staff.canvasAnimationName).toBe(session.canvasAnimationName);
+	}
+	return { session: sessionMain, staff: staffMain };
+}
+
+test.describe("Journey: Host Bobbit sprite fixture panel", () => {
+	test("matches persisted session and staff identity plus canonical states before and after reload", async ({ page }) => {
+		test.setTimeout(120_000);
+		const project = await defaultProject();
+		let sourceId: string | undefined;
+		let sessionId: string | undefined;
+		let staff: StaffRecord | undefined;
+
+		try {
+			sourceId = await addFixtureSource();
+			await installFixturePack(sourceId, project.id);
+			sessionId = await createSession({ projectId: project.id, cwd: project.rootPath });
+			await waitForSessionStatus(sessionId, "idle", 30_000);
+			await patchSessionAppearance(sessionId, SESSION_COLOR_INDEX, "crown");
+
+			const staffResponse = await apiFetch("/api/staff", {
+				method: "POST",
+				body: JSON.stringify({
+					name: `HostSpriteStaff${Date.now().toString(36)}`,
+					description: "Host sprite browser fixture staff identity.",
+					systemPrompt: "Remain idle for deterministic Host sprite parity coverage.",
+					cwd: project.rootPath,
+					projectId: project.id,
+					worktree: false,
+					sandboxed: false,
+					accessory: "ponytail",
+				}),
+			});
+			expect(staffResponse.status, `staff create failed: ${await responseText(staffResponse)}`).toBe(201);
+			staff = await staffResponse.json() as StaffRecord;
+			expect(staff.currentSessionId, "fixture staff should have a current session for colour resolution").toBeTruthy();
+			await waitForSessionStatus(staff.currentSessionId!, "idle", 30_000);
+			await patchSessionAppearance(staff.currentSessionId!, STAFF_COLOR_INDEX, "ponytail");
+
+			await openApp(page);
+			await navigateToHash(page, `#/session/${sessionId}`);
+			await expect(page.locator("message-editor textarea").first()).toBeVisible({ timeout: 20_000 });
+			await navigateToHash(page, `#/ext/host-sprite-fixture?staffId=${encodeURIComponent(staff.id)}`);
+			const firstMain = await expectSpriteParity(page, sessionId, staff.currentSessionId!);
+
+			await page.reload({ waitUntil: "domcontentloaded" });
+			await navigateToHash(page, `#/session/${sessionId}`);
+			await expect(page.locator("message-editor textarea").first()).toBeVisible({ timeout: 20_000 });
+			await navigateToHash(page, `#/ext/host-sprite-fixture?staffId=${encodeURIComponent(staff.id)}`);
+			await expectSpriteParity(page, sessionId, staff.currentSessionId!, firstMain);
+		} finally {
+			if (staff?.id) await apiFetch(`/api/staff/${encodeURIComponent(staff.id)}`, { method: "DELETE" }).catch(() => {});
+			if (staff?.currentSessionId) await deleteSession(staff.currentSessionId).catch(() => {});
+			if (sessionId) await deleteSession(sessionId).catch(() => {});
+			await uninstallFixturePack(project.id);
+			if (sourceId) await apiFetch(`/api/marketplace/sources/${encodeURIComponent(sourceId)}`, { method: "DELETE" }).catch(() => {});
+		}
+	});
+});

--- a/tests2/core/extension-host-channel-contract.test.ts
+++ b/tests2/core/extension-host-channel-contract.test.ts
@@ -10,19 +10,52 @@
  * clear messages so the production slices know which contract points are still
  * missing.
  */
-import { describe, it } from "vitest";
+import { describe, expectTypeOf, it } from "vitest";
 import assert from "node:assert/strict";
 import fs from "node:fs";
 import path from "node:path";
-import { HOST_API_VERSION, HOST_CONTRACT_VERSION } from "../../src/shared/extension-host/host-api.ts";
+import {
+	HOST_API_VERSION,
+	HOST_CONTRACT_VERSION,
+	type HostBobbitSpriteOptions,
+	type HostBobbitState,
+	type HostBobbitSubject,
+	type HostProjectApi,
+	type HostUiApi,
+} from "../../src/shared/extension-host/host-api.ts";
 import { createServerHostApi } from "../../src/server/extension-host/server-host-api.ts";
 
 const hostApiSource = () => fs.readFileSync(path.join(process.cwd(), "src", "shared", "extension-host", "host-api.ts"), "utf-8");
 
+describe("host.ui.createBobbitSprite — public Host API contract", () => {
+	it("pins the exact required sprite types and method signature", () => {
+		expectTypeOf<HostBobbitState>().toEqualTypeOf<"active" | "idle" | "paused">();
+		expectTypeOf<HostBobbitSubject>().toEqualTypeOf<
+			| { kind: "session"; id: string }
+			| { kind: "staff"; id: string }
+		>();
+		expectTypeOf<HostBobbitSpriteOptions>().toEqualTypeOf<{
+			subject: HostBobbitSubject;
+			state: HostBobbitState;
+			label: string;
+			size?: number;
+			animated?: boolean;
+		}>();
+		expectTypeOf<keyof HostUiApi>().toEqualTypeOf<"openPanel" | "navigate" | "createBobbitSprite">();
+		expectTypeOf<HostUiApi["createBobbitSprite"]>().toEqualTypeOf<
+			(options: HostBobbitSpriteOptions) => HTMLElement
+		>();
+	});
+
+	it("does not add appearance data to the project contract", () => {
+		expectTypeOf<keyof HostProjectApi>().toEqualTypeOf<"notifications">();
+	});
+});
+
 describe("host.channels — public Host API contract", () => {
 	it("keeps the Host API version stable and bumps only the owned contract version", () => {
-		assert.equal(HOST_API_VERSION, 1, "host.channels is additive; HOST_API_VERSION must remain v1");
-		assert.equal(HOST_CONTRACT_VERSION, 5, "host notifications are additive; HOST_CONTRACT_VERSION must be 5");
+		assert.equal(HOST_API_VERSION, 1, "host.ui.createBobbitSprite is additive; HOST_API_VERSION must remain v1");
+		assert.equal(HOST_CONTRACT_VERSION, 6, "host.ui.createBobbitSprite is additive; HOST_CONTRACT_VERSION must be 6");
 	});
 
 	it("declares a generic text/json channel API with no terminal-specific core method", () => {

--- a/tests2/core/pack-contributions.test.ts
+++ b/tests2/core/pack-contributions.test.ts
@@ -60,9 +60,9 @@ afterAll(() => {
 });
 
 describe("Extension Host channel contract", () => {
-	it("keeps HOST_API_VERSION stable and bumps HOST_CONTRACT_VERSION for channel contracts", () => {
+	it("keeps HOST_API_VERSION stable and advances HOST_CONTRACT_VERSION for additive contracts", () => {
 		assert.equal(HOST_API_VERSION, 1);
-		assert.equal(HOST_CONTRACT_VERSION, 5);
+		assert.equal(HOST_CONTRACT_VERSION, 6);
 		const textFrame: HostChannelFrame = { kind: "text", data: "hello" };
 		const jsonFrame: HostChannelFrame = { kind: "json", data: { ok: true } };
 		assert.deepEqual([textFrame.kind, jsonFrame.kind], ["text", "json"]);

--- a/tests2/dom/client-host-api.test.ts
+++ b/tests2/dom/client-host-api.test.ts
@@ -358,7 +358,7 @@ describe("getHostApi — durable v1 capabilities (extension-host §3)", () => {
 	it("capabilities reports Phase-1 caps true, Phase-2 caps false; no gateway member", () => {
 		const c = caps();
 		expect(c.version).toBe(1);
-		expect(c.contractVersion).toBe(5);
+		expect(c.contractVersion).toBe(6);
 		expect(c.invokeAction).toBe(true);
 		expect(c.requestRender).toBe(true);
 		expect(c.hasInvokeAction).toBe(true);

--- a/tests2/dom/extension-host-notification-bus.test.ts
+++ b/tests2/dom/extension-host-notification-bus.test.ts
@@ -154,7 +154,7 @@ describe("additive scoped Host API", () => {
 			contributionId: "fixture-panel",
 		});
 		expect(host.version).toBe(1);
-		expect(host.contractVersion).toBe(5);
+		expect(host.contractVersion).toBe(6);
 		expect(host.capabilities.sessionNotifications).toBe(true);
 		expect(host.capabilities.projectNotifications).toBe(true);
 		expect(host.capabilities.has("sessionNotifications")).toBe(true);

--- a/tests2/dom/host-bobbit-sprite.test.ts
+++ b/tests2/dom/host-bobbit-sprite.test.ts
@@ -2,7 +2,7 @@ import { beforeAll as syncBeforeAll } from "vitest";
 import { syncCustomElements } from "./_setup/custom-elements.js";
 syncBeforeAll(() => syncCustomElements());
 
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 // Preserve the established host-api module-cycle initialization order.
 import "../../src/app/session-manager.js";
 import { getHostApi } from "../../src/app/host-api.js";
@@ -13,7 +13,7 @@ import {
 } from "../../src/app/host-bobbit-sprite.js";
 import { sessionColorMap } from "../../src/app/session-colors.js";
 import { state, type GatewaySession } from "../../src/app/state.js";
-import { BOBBIT_HUE_ROTATIONS } from "../../src/ui/bobbit-render.js";
+import { ACCESSORY_DEFS, BOBBIT_HUE_ROTATIONS } from "../../src/ui/bobbit-render.js";
 
 function session(id: string, projectId: string, overrides: Partial<GatewaySession> = {}): GatewaySession {
 	return {
@@ -29,16 +29,134 @@ function session(id: string, projectId: string, overrides: Partial<GatewaySessio
 	};
 }
 
+function staff(
+	id: string,
+	projectId: string,
+	overrides: Partial<(typeof state.staffList)[number]> = {},
+): (typeof state.staffList)[number] {
+	return {
+		id,
+		name: id,
+		description: "",
+		state: "idle",
+		triggers: [],
+		projectId,
+		...overrides,
+	};
+}
+
+function options(overrides: Partial<BrowserHostBobbitSpriteOptions> = {}): BrowserHostBobbitSpriteOptions {
+	return {
+		subject: { kind: "session", id: "live" },
+		state: "active",
+		label: "Agent avatar",
+		...overrides,
+	};
+}
+
+function appendSprite(
+	boundSessionId: string,
+	overrides: Partial<BrowserHostBobbitSpriteOptions> = {},
+): HTMLElement {
+	const sprite = getHostApi(boundSessionId, undefined).ui.createBobbitSprite(options(overrides));
+	document.body.append(sprite);
+	return sprite;
+}
+
+function blob(sprite: HTMLElement): HTMLElement {
+	const result = sprite.querySelector<HTMLElement>(".bobbit-blob");
+	expect(result).not.toBeNull();
+	return result!;
+}
+
+interface MotionController {
+	readonly query: MediaQueryList;
+	readonly add: ReturnType<typeof vi.fn>;
+	readonly remove: ReturnType<typeof vi.fn>;
+	setMatches(matches: boolean): void;
+}
+
+function installMatchMedia(initialMatches: boolean): MotionController {
+	let matches = initialMatches;
+	const listeners = new Set<(event: MediaQueryListEvent) => void>();
+	const add = vi.fn((_type: string, listener: EventListenerOrEventListenerObject) => {
+		if (typeof listener === "function") listeners.add(listener as (event: MediaQueryListEvent) => void);
+	});
+	const remove = vi.fn((_type: string, listener: EventListenerOrEventListenerObject) => {
+		if (typeof listener === "function") listeners.delete(listener as (event: MediaQueryListEvent) => void);
+	});
+	const query = {
+		get matches() { return matches; },
+		media: "(prefers-reduced-motion: reduce)",
+		onchange: null,
+		addEventListener: add,
+		removeEventListener: remove,
+		addListener: vi.fn(),
+		removeListener: vi.fn(),
+		dispatchEvent: vi.fn(() => true),
+	} as unknown as MediaQueryList;
+	Object.defineProperty(window, "matchMedia", {
+		configurable: true,
+		value: vi.fn(() => query),
+	});
+	return {
+		query,
+		add,
+		remove,
+		setMatches(next: boolean) {
+			matches = next;
+			const event = { matches: next, media: query.media } as MediaQueryListEvent;
+			for (const listener of [...listeners]) listener(event);
+		},
+	};
+}
+
+let originalMatchMedia: PropertyDescriptor | undefined;
+let originalHtmlClass = "";
+let canvasDraws = new WeakMap<HTMLCanvasElement, string[]>();
+
+function canvasFingerprint(sprite: HTMLElement): string {
+	const canvas = sprite.querySelector<HTMLCanvasElement>("canvas.bobbit-blob__sprite");
+	expect(canvas).not.toBeNull();
+	return (canvasDraws.get(canvas!) ?? []).join("|");
+}
+
 beforeEach(() => {
+	originalMatchMedia = Object.getOwnPropertyDescriptor(window, "matchMedia");
+	originalHtmlClass = document.documentElement.className;
 	state.gatewaySessions = [];
 	state.archivedSessions = [];
 	state.staffList = [];
 	sessionColorMap.clear();
+	canvasDraws = new WeakMap();
+	vi.spyOn(HTMLCanvasElement.prototype, "getContext").mockImplementation(function(this: HTMLCanvasElement) {
+		let fillStyle = "";
+		const draws: string[] = [];
+		canvasDraws.set(this, draws);
+		return {
+			get fillStyle() { return fillStyle; },
+			set fillStyle(value: string | CanvasGradient | CanvasPattern) { fillStyle = String(value); },
+			fillRect: (x: number, y: number, width: number, height: number) => {
+				draws.push(`${fillStyle}:${x},${y},${width},${height}`);
+			},
+			clearRect: () => {},
+			drawImage: () => {},
+		} as unknown as CanvasRenderingContext2D;
+	});
+	if (!(Element.prototype as Element & { getAnimations?: () => Animation[] }).getAnimations) {
+		Object.defineProperty(Element.prototype, "getAnimations", { configurable: true, value: () => [] });
+	}
 });
 
 afterEach(() => {
 	document.body.replaceChildren();
+	document.documentElement.className = originalHtmlClass;
 	sessionColorMap.clear();
+	vi.clearAllTimers();
+	vi.useRealTimers();
+	vi.restoreAllMocks();
+	if (originalMatchMedia) Object.defineProperty(window, "matchMedia", originalMatchMedia);
+	else delete (window as { matchMedia?: unknown }).matchMedia;
 });
 
 describe("browser Host Bobbit sprite client boundary", () => {
@@ -75,69 +193,200 @@ describe("browser Host Bobbit sprite client boundary", () => {
 		}
 	});
 
-	it("resolves only loaded same-project session and staff appearance without allocating colour", () => {
+	it("renders loaded live, archived, and staff appearance through the real Host API", () => {
+		installMatchMedia(false);
 		state.gatewaySessions = [
 			session("bound", "project-a"),
 			session("live", "project-a", { colorIndex: 2, accessory: "crown" }),
-			session("foreign", "project-b", { colorIndex: 4, accessory: "bandana" }),
 			session("staff-session", "project-a", { colorIndex: 3 }),
 		];
 		state.archivedSessions = [
 			session("archived", "project-a", { colorIndex: 5, accessory: "wand", archived: true }),
 		];
-		state.staffList = [{
-			id: "staff-a",
-			name: "Staff A",
-			description: "",
-			state: "active",
-			currentSessionId: "staff-session",
-			triggers: [],
-			projectId: "project-a",
-			accessory: "headset",
-		}];
+		state.staffList = [
+			staff("staff-a", "project-a", { currentSessionId: "staff-session", accessory: "headset" }),
+			staff("staff-no-session", "project-a", { accessory: "clipboard" }),
+		];
 		sessionColorMap.set("live", 7);
 		const mapSizeBefore = sessionColorMap.size;
 
-		expect(resolveHostBobbitAppearance("bound", { kind: "session", id: "live" }))
-			.toMatchObject({ hueRotate: BOBBIT_HUE_ROTATIONS[7], accessory: { id: "crown" } });
-		expect(resolveHostBobbitAppearance("bound", { kind: "session", id: "archived" }))
-			.toMatchObject({ hueRotate: BOBBIT_HUE_ROTATIONS[5], accessory: { id: "wand" } });
-		expect(resolveHostBobbitAppearance("bound", { kind: "staff", id: "staff-a" }))
-			.toMatchObject({ hueRotate: BOBBIT_HUE_ROTATIONS[3], accessory: { id: "headset" } });
-		expect(sessionColorMap.size).toBe(mapSizeBefore);
+		const live = appendSprite("bound");
+		const archived = appendSprite("bound", { subject: { kind: "session", id: "archived" } });
+		const currentStaff = appendSprite("bound", { subject: { kind: "staff", id: "staff-a" } });
+		const defaultStaff = appendSprite("bound", { subject: { kind: "staff", id: "staff-no-session" } });
 
-		const foreign = resolveHostBobbitAppearance("bound", { kind: "session", id: "foreign" });
-		const missing = resolveHostBobbitAppearance("bound", { kind: "session", id: "does-not-exist" });
-		const missingBound = resolveHostBobbitAppearance("does-not-exist", { kind: "session", id: "live" });
-		expect(foreign).toMatchObject({ hueRotate: 0, accessory: { id: "none" } });
-		expect(missing).toEqual(foreign);
-		expect(missingBound).toEqual(foreign);
+		expect(blob(live).style.getPropertyValue("--bobbit-hue-rotate")).toBe(`${BOBBIT_HUE_ROTATIONS[7]}deg`);
+		expect(live.querySelector(".bobbit-blob__crown")).not.toBeNull();
+		expect(blob(archived).style.getPropertyValue("--bobbit-hue-rotate")).toBe(`${BOBBIT_HUE_ROTATIONS[5]}deg`);
+		expect(archived.querySelector(".bobbit-blob__wand")).not.toBeNull();
+		expect(blob(currentStaff).style.getPropertyValue("--bobbit-hue-rotate")).toBe(`${BOBBIT_HUE_ROTATIONS[3]}deg`);
+		expect(currentStaff.querySelector(".bobbit-blob__headset")).not.toBeNull();
+		expect(blob(defaultStaff).style.getPropertyValue("--bobbit-hue-rotate")).toBe("0deg");
+		expect(defaultStaff.querySelector(".bobbit-blob__clipboard")).not.toBeNull();
+		expect(sessionColorMap.size).toBe(mapSizeBefore);
 	});
 
-	it("keeps staff accessory while defaulting colour when no same-project current session exists", () => {
-		state.gatewaySessions = [session("bound", "project-a")];
-		state.staffList = [{
-			id: "staff-a",
-			name: "Staff A",
-			description: "",
+	it("maps active, idle, paused, and explicit static presentation to canonical output", () => {
+		installMatchMedia(false);
+		state.gatewaySessions = [session("bound", "project-a"), session("live", "project-a")];
+		const active = appendSprite("bound", { state: "active" });
+		const idle = appendSprite("bound", { state: "idle" });
+		const paused = appendSprite("bound", { state: "paused" });
+		const staticActive = appendSprite("bound", { state: "active", animated: false });
+		const staticIdle = appendSprite("bound", { state: "idle", animated: false });
+
+		expect(blob(active).classList).toContain("bobbit-blob--hosted-active");
+		expect(blob(active).classList).not.toContain("bobbit-blob--hosted-static");
+		expect(blob(idle).classList).toContain("bobbit-blob--hosted-idle");
+		expect(blob(idle).classList).toContain("bobbit-blob--idle");
+		expect(blob(paused).classList).toContain("bobbit-blob--hosted-paused");
+		expect(blob(paused).classList).toContain("bobbit-blob--hosted-static");
+		expect(blob(staticActive).classList).toContain("bobbit-blob--hosted-static");
+		expect(blob(staticActive).classList).not.toContain("bobbit-blob--idle");
+		expect(blob(staticIdle).classList).toContain("bobbit-blob--hosted-static");
+		expect(blob(staticIdle).classList).toContain("bobbit-blob--idle");
+		expect(canvasFingerprint(staticActive)).toBe(canvasFingerprint(paused));
+		expect(canvasFingerprint(staticIdle)).not.toBe(canvasFingerprint(paused));
+	});
+
+	it("honours default and boundary dimensions", () => {
+		installMatchMedia(false);
+		state.gatewaySessions = [session("bound", "project-a"), session("live", "project-a")];
+		for (const [size, expected] of [[undefined, 40], [16, 16], [96, 96]] as const) {
+			const sprite = appendSprite("bound", { ...(size === undefined ? {} : { size }) });
+			expect(sprite.style.width).toBe(`${expected}px`);
+			expect(sprite.style.height).toBe(`${expected}px`);
+			const composition = sprite.querySelector<HTMLElement>(".bobbit-hosted-composition");
+			expect(composition?.style.width).toBe(`${expected}px`);
+			expect(composition?.style.height).toBe(`${expected}px`);
+		}
+	});
+
+	it("uses addsHeight for every tall accessory and never for a normal accessory", () => {
+		installMatchMedia(false);
+		const tallAccessories = Object.values(ACCESSORY_DEFS).filter(accessory => accessory.addsHeight);
+		expect(tallAccessories.map(accessory => accessory.id).sort()).toEqual(["crown", "nurse-cap", "wizard-hat"]);
+		state.gatewaySessions = [
+			session("bound", "project-a"),
+			...tallAccessories.map(accessory => session(accessory.id, "project-a", { accessory: accessory.id })),
+			session("normal", "project-a", { accessory: "bandana" }),
+		];
+
+		for (const accessory of tallAccessories) {
+			const sprite = appendSprite("bound", { subject: { kind: "session", id: accessory.id } });
+			expect(blob(sprite).classList, accessory.id).toContain("bobbit-blob--hosted-tall");
+			expect(sprite.querySelector(`.bobbit-blob__${accessory.id}`), accessory.id).not.toBeNull();
+		}
+		const normal = appendSprite("bound", { subject: { kind: "session", id: "normal" } });
+		expect(blob(normal).classList).not.toContain("bobbit-blob--hosted-tall");
+	});
+
+	it("reacts to reduced-motion changes and removes the media listener on disconnect", () => {
+		const motion = installMatchMedia(true);
+		state.gatewaySessions = [session("bound", "project-a"), session("live", "project-a")];
+		const sprite = appendSprite("bound");
+
+		expect(motion.add).toHaveBeenCalledTimes(1);
+		expect(blob(sprite).classList).toContain("bobbit-blob--hosted-static");
+		motion.setMatches(false);
+		expect(blob(sprite).classList).not.toContain("bobbit-blob--hosted-static");
+		motion.setMatches(true);
+		expect(blob(sprite).classList).toContain("bobbit-blob--hosted-static");
+
+		sprite.remove();
+		expect(motion.remove).toHaveBeenCalledTimes(1);
+		expect(sprite.childElementCount).toBe(0);
+		motion.setMatches(false);
+		expect(sprite.childElementCount).toBe(0);
+	});
+
+	it("stops canvas work on remove and restarts allowed motion once on reappend", () => {
+		vi.useFakeTimers();
+		const motion = installMatchMedia(false);
+		state.gatewaySessions = [session("bound", "project-a"), session("live", "project-a")];
+		const phaseAnimation = {
+			currentTime: 0,
+			effect: { getTiming: () => ({ duration: 10_000, delay: 0 }) },
+		} as unknown as Animation;
+		vi.spyOn(Element.prototype as Element & { getAnimations: () => Animation[] }, "getAnimations")
+			.mockReturnValue([phaseAnimation]);
+		const sprite = appendSprite("bound");
+		expect(vi.getTimerCount()).toBeGreaterThan(0);
+
+		const parking = document.createElement("div");
+		document.body.append(parking);
+		parking.append(sprite);
+		expect(motion.remove).toHaveBeenCalledTimes(1);
+		expect(motion.add).toHaveBeenCalledTimes(2);
+		expect(sprite.querySelector("canvas.bobbit-blob__sprite")).not.toBeNull();
+		expect(vi.getTimerCount()).toBe(1);
+
+		sprite.remove();
+		expect(motion.remove).toHaveBeenCalledTimes(2);
+		expect(sprite.childElementCount).toBe(0);
+		expect(vi.getTimerCount()).toBe(0);
+	});
+
+	it("renders canonical-equivalent fallback without leaking foreign or malformed identity", () => {
+		installMatchMedia(false);
+		state.gatewaySessions = [
+			session("bound", "project-a"),
+			session("foreign-session-secret", "project-b", { colorIndex: 4, accessory: "bandana" }),
+			session("malformed", "project-a", { colorIndex: 999, accessory: "not-an-accessory" }),
+		];
+		state.staffList = [staff("foreign-staff-secret", "project-b", { accessory: "crown" })];
+		const cases: Array<[string, BrowserHostBobbitSpriteOptions["subject"]]> = [
+			["bound", { kind: "session", id: "missing" }],
+			["bound", { kind: "session", id: "" }],
+			["bound", { kind: "session", id: "foreign-session-secret" }],
+			["bound", { kind: "staff", id: "foreign-staff-secret" }],
+			["bound", { kind: "session", id: "malformed" }],
+			["missing-bound", { kind: "session", id: "live" }],
+		];
+		const rendered = cases.map(([bound, subject]) => appendSprite(bound, {
+			subject,
 			state: "paused",
-			currentSessionId: "foreign-session",
-			triggers: [],
-			projectId: "project-a",
-			accessory: "clipboard",
-		}];
-		state.archivedSessions = [session("foreign-session", "project-b", { colorIndex: 8 })];
+			label: "Fallback avatar",
+		}).innerHTML);
+		for (const output of rendered) {
+			expect(output).toBe(rendered[0]);
+			expect(output).not.toContain("secret");
+			expect(output).not.toContain("malformed");
+		}
+	});
 
-		expect(resolveHostBobbitAppearance("bound", { kind: "staff", id: "staff-a" }))
-			.toMatchObject({ hueRotate: 0, accessory: { id: "clipboard" } });
+	it("isolates its selected accessory from conflicting document-level classes", () => {
+		installMatchMedia(false);
+		document.documentElement.classList.add("bobbit-wizard-hat", "bobbit-crowned");
+		state.gatewaySessions = [
+			session("bound", "project-a"),
+			session("live", "project-a", { accessory: "bandana" }),
+		];
+		const sprite = appendSprite("bound");
+		expect(sprite.querySelector(".bobbit-blob__bandana")).not.toBeNull();
+		expect(sprite.querySelector(".bobbit-blob__wizard-hat")).toBeNull();
+		expect(sprite.querySelector(".bobbit-blob__crown")).toBeNull();
+		expect(blob(sprite).classList).not.toContain("bobbit-blob--hosted-tall");
+	});
 
-		const detached = createHostBobbitSprite("bound", {
-			subject: { kind: "staff", id: "staff-a" },
-			state: "idle",
-			label: "Staff A",
-			animated: false,
-			size: 16,
-		});
+	it("keeps the pure resolver non-allocating for same-project and fallback paths", () => {
+		state.gatewaySessions = [
+			session("bound", "project-a"),
+			session("live", "project-a", { colorIndex: 2, accessory: "crown" }),
+			session("foreign", "project-b", { colorIndex: 4, accessory: "bandana" }),
+		];
+		sessionColorMap.set("live", 7);
+		const mapSizeBefore = sessionColorMap.size;
+		expect(resolveHostBobbitAppearance("bound", { kind: "session", id: "live" }))
+			.toMatchObject({ hueRotate: BOBBIT_HUE_ROTATIONS[7], accessory: { id: "crown" } });
+		const foreign = resolveHostBobbitAppearance("bound", { kind: "session", id: "foreign" });
+		expect(resolveHostBobbitAppearance("bound", { kind: "session", id: "missing" })).toEqual(foreign);
+		expect(sessionColorMap.size).toBe(mapSizeBefore);
+	});
+
+	it("does not render while detached", () => {
+		state.gatewaySessions = [session("bound", "project-a")];
+		const detached = createHostBobbitSprite("bound", options({ animated: false, size: 16 }));
 		expect(detached.isConnected).toBe(false);
 		expect(detached.childElementCount).toBe(0);
 	});

--- a/tests2/dom/host-bobbit-sprite.test.ts
+++ b/tests2/dom/host-bobbit-sprite.test.ts
@@ -1,0 +1,144 @@
+import { beforeAll as syncBeforeAll } from "vitest";
+import { syncCustomElements } from "./_setup/custom-elements.js";
+syncBeforeAll(() => syncCustomElements());
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+// Preserve the established host-api module-cycle initialization order.
+import "../../src/app/session-manager.js";
+import { getHostApi } from "../../src/app/host-api.js";
+import {
+	createHostBobbitSprite,
+	resolveHostBobbitAppearance,
+	type BrowserHostBobbitSpriteOptions,
+} from "../../src/app/host-bobbit-sprite.js";
+import { sessionColorMap } from "../../src/app/session-colors.js";
+import { state, type GatewaySession } from "../../src/app/state.js";
+import { BOBBIT_HUE_ROTATIONS } from "../../src/ui/bobbit-render.js";
+
+function session(id: string, projectId: string, overrides: Partial<GatewaySession> = {}): GatewaySession {
+	return {
+		id,
+		projectId,
+		title: id,
+		cwd: "/tmp",
+		status: "idle",
+		createdAt: 1,
+		lastActivity: 1,
+		clientCount: 0,
+		...overrides,
+	};
+}
+
+beforeEach(() => {
+	state.gatewaySessions = [];
+	state.archivedSessions = [];
+	state.staffList = [];
+	sessionColorMap.clear();
+});
+
+afterEach(() => {
+	document.body.replaceChildren();
+	sessionColorMap.clear();
+});
+
+describe("browser Host Bobbit sprite client boundary", () => {
+	it("validates synchronously and returns a labelled framework-neutral element", () => {
+		const host = getHostApi("bound", undefined) as any;
+		const valid: BrowserHostBobbitSpriteOptions = {
+			subject: { kind: "session", id: "missing" },
+			state: "paused",
+			label: "  Missing agent  ",
+		};
+		const element = host.ui.createBobbitSprite(valid);
+
+		expect(element).toBeInstanceOf(HTMLElement);
+		expect(element.getAttribute("role")).toBe("img");
+		expect(element.getAttribute("aria-label")).toBe(valid.label);
+		expect(element.textContent).toBe("");
+
+		const invalidValues: unknown[] = [
+			null,
+			{},
+			{ ...valid, subject: null },
+			{ ...valid, subject: { kind: "goal", id: "x" } },
+			{ ...valid, subject: { kind: "session", id: 1 } },
+			{ ...valid, state: "busy" },
+			{ ...valid, label: " " },
+			{ ...valid, label: "x".repeat(201) },
+			{ ...valid, size: 15 },
+			{ ...valid, size: 97 },
+			{ ...valid, size: 40.5 },
+			{ ...valid, animated: "yes" },
+		];
+		for (const value of invalidValues) {
+			expect(() => host.ui.createBobbitSprite(value)).toThrow(TypeError);
+		}
+	});
+
+	it("resolves only loaded same-project session and staff appearance without allocating colour", () => {
+		state.gatewaySessions = [
+			session("bound", "project-a"),
+			session("live", "project-a", { colorIndex: 2, accessory: "crown" }),
+			session("foreign", "project-b", { colorIndex: 4, accessory: "bandana" }),
+			session("staff-session", "project-a", { colorIndex: 3 }),
+		];
+		state.archivedSessions = [
+			session("archived", "project-a", { colorIndex: 5, accessory: "wand", archived: true }),
+		];
+		state.staffList = [{
+			id: "staff-a",
+			name: "Staff A",
+			description: "",
+			state: "active",
+			currentSessionId: "staff-session",
+			triggers: [],
+			projectId: "project-a",
+			accessory: "headset",
+		}];
+		sessionColorMap.set("live", 7);
+		const mapSizeBefore = sessionColorMap.size;
+
+		expect(resolveHostBobbitAppearance("bound", { kind: "session", id: "live" }))
+			.toMatchObject({ hueRotate: BOBBIT_HUE_ROTATIONS[7], accessory: { id: "crown" } });
+		expect(resolveHostBobbitAppearance("bound", { kind: "session", id: "archived" }))
+			.toMatchObject({ hueRotate: BOBBIT_HUE_ROTATIONS[5], accessory: { id: "wand" } });
+		expect(resolveHostBobbitAppearance("bound", { kind: "staff", id: "staff-a" }))
+			.toMatchObject({ hueRotate: BOBBIT_HUE_ROTATIONS[3], accessory: { id: "headset" } });
+		expect(sessionColorMap.size).toBe(mapSizeBefore);
+
+		const foreign = resolveHostBobbitAppearance("bound", { kind: "session", id: "foreign" });
+		const missing = resolveHostBobbitAppearance("bound", { kind: "session", id: "does-not-exist" });
+		const missingBound = resolveHostBobbitAppearance("does-not-exist", { kind: "session", id: "live" });
+		expect(foreign).toMatchObject({ hueRotate: 0, accessory: { id: "none" } });
+		expect(missing).toEqual(foreign);
+		expect(missingBound).toEqual(foreign);
+	});
+
+	it("keeps staff accessory while defaulting colour when no same-project current session exists", () => {
+		state.gatewaySessions = [session("bound", "project-a")];
+		state.staffList = [{
+			id: "staff-a",
+			name: "Staff A",
+			description: "",
+			state: "paused",
+			currentSessionId: "foreign-session",
+			triggers: [],
+			projectId: "project-a",
+			accessory: "clipboard",
+		}];
+		state.archivedSessions = [session("foreign-session", "project-b", { colorIndex: 8 })];
+
+		expect(resolveHostBobbitAppearance("bound", { kind: "staff", id: "staff-a" }))
+			.toMatchObject({ hueRotate: 0, accessory: { id: "clipboard" } });
+
+		const detached = createHostBobbitSprite("bound", {
+			subject: { kind: "staff", id: "staff-a" },
+			state: "idle",
+			label: "Staff A",
+			animated: false,
+			size: 16,
+		});
+		expect(detached.isConnected).toBe(false);
+		expect(detached.childElementCount).toBe(0);
+	});
+});

--- a/tests2/tests-map.json
+++ b/tests2/tests-map.json
@@ -3643,6 +3643,15 @@
       }
     },
     {
+      "path": "tests2/browser/journeys/host-bobbit-sprite.journey.spec.ts",
+      "reason": "Project-scoped fixture-pack journey proving host.ui.createBobbitSprite directly appends accessible session and staff avatars with persisted colour/accessory fidelity and canonical active, idle, paused, and static presentation before and after reload.",
+      "execution": {
+        "runner": "playwright",
+        "tier": "browser",
+        "project": "browser"
+      }
+    },
+    {
       "path": "tests2/dom/delegate-interaction-mode.test.ts",
       "reason": "Focused DOM coverage for independent lifecycle archive, read-only tool capability, and non-interactive interaction-mode projection.",
       "execution": {

--- a/tests2/tests-map.json
+++ b/tests2/tests-map.json
@@ -3643,6 +3643,15 @@
       }
     },
     {
+      "path": "tests2/dom/host-bobbit-sprite.test.ts",
+      "reason": "DOM coverage for Host Bobbit sprite validation, privacy-bounded session and staff appearance resolution, non-allocating persisted colours, and detached rendering behavior.",
+      "execution": {
+        "runner": "vitest",
+        "tier": "unit",
+        "project": "dom"
+      }
+    },
+    {
       "path": "tests2/browser/journeys/host-bobbit-sprite.journey.spec.ts",
       "reason": "Project-scoped fixture-pack journey proving host.ui.createBobbitSprite directly appends accessible session and staff avatars with persisted colour/accessory fidelity and canonical active, idle, paused, and static presentation before and after reload.",
       "execution": {

--- a/tests2/tests-map.json
+++ b/tests2/tests-map.json
@@ -3644,7 +3644,7 @@
     },
     {
       "path": "tests2/dom/host-bobbit-sprite.test.ts",
-      "reason": "DOM coverage for Host Bobbit sprite validation, privacy-bounded session and staff appearance resolution, non-allocating persisted colours, and detached rendering behavior.",
+      "reason": "DOM coverage for Host Bobbit sprite validation, privacy-bounded session and staff appearance resolution, canonical states and sizing, reduced-motion changes, tall-accessory layout, and disconnect/reconnect cleanup.",
       "execution": {
         "runner": "vitest",
         "tier": "unit",


### PR DESCRIPTION
## Summary
- add the required framework-neutral `host.ui.createBobbitSprite` contract
- reuse canonical Bobbit appearance, rendering, animation, and cleanup behavior
- enforce project-private identity resolution with canonical fallback
- add contract, DOM lifecycle, and reload browser coverage
- document the v6 additive Host contract and extension-author example

## Validation
- `npm run check`
- focused Host API/core/DOM tests
- focused Host Bobbit browser journey
- implementation workflow build, unit, browser, E2E, review, security, and QA gates

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)