### PR TITLE
Rename context target to soft limit

### DIFF
--- a/src/ui/components/AgentInterface.ts
+++ b/src/ui/components/AgentInterface.ts
@@ -2523,7 +2523,7 @@ export class AgentInterface extends LitElement {
 						<div style="border-bottom:1px solid var(--border);margin-bottom:8px;padding-bottom:8px;">
 							${row("Provider", m.provider)}
 							${hasDistinctCapacity ? html`
-								${row("Context target", formatTokenCount(contextMeter.target!) + " tokens")}
+								${row("Soft limit", formatTokenCount(contextMeter.target!) + " tokens")}
 								${row("Model capacity", formatTokenCount(contextMeter.capacity!) + " tokens")}
 							` : row("Context window", contextMeter.scale ? formatTokenCount(contextMeter.scale) + " tokens" : "—")}
 							${row("Max output", m.maxTokens ? formatTokenCount(m.maxTokens) + " tokens" : "—")}
@@ -2539,7 +2539,7 @@ export class AgentInterface extends LitElement {
 						</div>
 						${hasDistinctCapacity ? html`
 							<div class="context-meter-scale" data-testid="context-meter-scale" aria-hidden="true">
-								<span>Target ${formatTokenCount(contextMeter.target!)}</span>
+								<span>Soft limit ${formatTokenCount(contextMeter.target!)}</span>
 								<span>Capacity ${formatTokenCount(contextMeter.capacity!)}</span>
 							</div>
 						` : nothing}

--- a/src/ui/components/AgentInterface.ts
+++ b/src/ui/components/AgentInterface.ts
@@ -2352,12 +2352,12 @@ export class AgentInterface extends LitElement {
 		const showContext = hasContextScale && (usageStale || lastUsage !== undefined);
 		const contextAccessibleText = usageStale
 			? hasDistinctCapacity
-				? `Context usage refreshing after compaction; model capacity ${formatTokenCount(contextMeter.capacity!)} tokens; target ${formatTokenCount(contextMeter.target!)} tokens`
+				? `Context usage refreshing after compaction; model capacity ${formatTokenCount(contextMeter.capacity!)} tokens; soft limit ${formatTokenCount(contextMeter.target!)} tokens`
 				: `Context usage refreshing after compaction${contextMeter.scale ? `; limit ${formatTokenCount(contextMeter.scale)} tokens` : ""}`
 			: hasDistinctCapacity
-				? `Context: ${formatTokenCount(contextTokens)} / ${formatTokenCount(contextMeter.capacity!)} tokens (${contextPct}% of model capacity); target ${formatTokenCount(contextMeter.target!)} tokens`
+				? `Context: ${formatTokenCount(contextTokens)} / ${formatTokenCount(contextMeter.capacity!)} tokens (${contextPct}% of model capacity); soft limit ${formatTokenCount(contextMeter.target!)} tokens`
 				: contextMeter.scale
-					? `Context: ${formatTokenCount(contextTokens)} / ${formatTokenCount(contextMeter.scale)} tokens (${contextPct}%${contextMeter.target ? " of context target" : " of model capacity"})`
+					? `Context: ${formatTokenCount(contextTokens)} / ${formatTokenCount(contextMeter.scale)} tokens (${contextPct}%${contextMeter.target ? " of soft limit" : " of model capacity"})`
 					: "Context usage unavailable";
 		const renderContextMeter = (variant: "footer" | "popover", stale = false) => {
 			const startPct = (this.session as any)?._compactionStartPct as number | null | undefined;

--- a/tests2/browser/journeys/context-capacity.journey.spec.ts
+++ b/tests2/browser/journeys/context-capacity.journey.spec.ts
@@ -153,12 +153,12 @@ test.describe("Journey: Context target and model capacity", () => {
 			await page.keyboard.press("Enter");
 			await expect(popover(page)).toBeVisible();
 			await expect(trigger).toHaveAttribute("aria-expanded", "true");
-			await expect(popover(page)).toContainText("Context target");
+			await expect(popover(page)).toContainText("Soft limit");
 			await expect(popover(page)).toContainText("100k tokens");
 			await expect(popover(page)).toContainText("Model capacity");
 			await expect(popover(page)).toContainText("400k tokens");
 			await expect(popover(page)).toContainText("50k / 400k tokens");
-			await expect(popover(page).getByTestId("context-meter-scale")).toContainText("Target 100k");
+			await expect(popover(page).getByTestId("context-meter-scale")).toContainText("Soft limit 100k");
 			await expect(popover(page).getByTestId("context-meter-scale")).toContainText("Capacity 400k");
 			await expectTrackUsesInputSurface(footerTrack(page), false);
 			await expectTrackUsesInputSurface(popover(page).getByTestId("context-meter-track"), false);
@@ -188,7 +188,7 @@ test.describe("Journey: Context target and model capacity", () => {
 			await expect(footerTrack(page).getByTestId("context-meter-target-marker")).toHaveCount(0);
 			await contextTrigger(page).click();
 			await expect(popover(page)).toContainText("Context window");
-			await expect(popover(page)).not.toContainText("Context target");
+			await expect(popover(page)).not.toContainText("Soft limit");
 			await expect(popover(page)).not.toContainText("Model capacity");
 			await expect(popover(page).getByTestId("context-meter-scale")).toHaveCount(0);
 			await closeContextPopover(page);

--- a/tests2/browser/journeys/context-capacity.journey.spec.ts
+++ b/tests2/browser/journeys/context-capacity.journey.spec.ts
@@ -140,7 +140,7 @@ test.describe("Journey: Context target and model capacity", () => {
 			await renderContextScenario(page, { usage: 50_000, target: TARGET, capacity: CAPACITY });
 			const trigger = contextTrigger(page);
 			await expect(trigger).toBeVisible();
-			await expect(trigger).toHaveAttribute("aria-label", "Context: 50k / 400k tokens (13% of model capacity); target 100k tokens");
+			await expect(trigger).toHaveAttribute("aria-label", "Context: 50k / 400k tokens (13% of model capacity); soft limit 100k tokens");
 			await expect(trigger).toHaveAttribute("aria-expanded", "false");
 			await expectFooterGeometry(page);
 			await expect(footerTrack(page).getByTestId("context-meter-target-marker")).toHaveAttribute("style", /left:\s*25%/);
@@ -181,7 +181,7 @@ test.describe("Journey: Context target and model capacity", () => {
 			await renderContextScenario(page, { usage: 390_000, target: TARGET, capacity: CAPACITY });
 			await expect(contextTrigger(page)).toContainText("98%");
 			expect(await segmentWidth(footerTrack(page), "context-meter-negative")).toBeCloseTo(72.5, 3);
-			await expect(contextTrigger(page)).toHaveAttribute("aria-label", "Context: 390k / 400k tokens (98% of model capacity); target 100k tokens");
+			await expect(contextTrigger(page)).toHaveAttribute("aria-label", "Context: 390k / 400k tokens (98% of model capacity); soft limit 100k tokens");
 
 			// Equal and absent capacity honestly collapse to the existing single-limit treatment.
 			await renderContextScenario(page, { usage: 50_000, target: TARGET, capacity: TARGET });

--- a/tests2/dom/context-cost-stats.test.ts
+++ b/tests2/dom/context-cost-stats.test.ts
@@ -202,7 +202,7 @@ describe("AgentInterface context target and capacity meter", () => {
 		expect(trigger.type).toBe("button");
 		expect(trigger.getAttribute("aria-expanded")).toBe("false");
 		expect(trigger.getAttribute("aria-controls")).toBe("context-usage-popover");
-		expect(trigger.getAttribute("aria-label")).toBe("Context: 300k / 1050k tokens (29% of model capacity); target 272k tokens");
+		expect(trigger.getAttribute("aria-label")).toBe("Context: 300k / 1050k tokens (29% of model capacity); soft limit 272k tokens");
 		expect(track.getAttribute("role")).toBe("progressbar");
 		expect(track.getAttribute("aria-valuemax")).toBe("1050000");
 		expect(track.getAttribute("aria-valuenow")).toBe("300000");

--- a/tests2/dom/context-cost-stats.test.ts
+++ b/tests2/dom/context-cost-stats.test.ts
@@ -216,11 +216,11 @@ describe("AgentInterface context target and capacity meter", () => {
 
 		const popover = openContextPopover(fixture);
 		expect(popover.getAttribute("role")).toBe("dialog");
-		expect(popover.textContent).toMatch(/Context target\s*272k tokens/);
+		expect(popover.textContent).toMatch(/Soft limit\s*272k tokens/);
 		expect(popover.textContent).toMatch(/Model capacity\s*1050k tokens/);
 		expect(popover.textContent).not.toContain("Context window");
 		expect(popover.textContent).toContain("300k / 1050k tokens");
-		expect(popover.querySelector('[data-testid="context-meter-scale"]')?.textContent).toContain("Target 272k");
+		expect(popover.querySelector('[data-testid="context-meter-scale"]')?.textContent).toContain("Soft limit 272k");
 		expect(popover.querySelector('[data-testid="context-meter-scale"]')?.textContent).toContain("Capacity 1050k");
 
 		const escape = new KeyboardEvent("keydown", { key: "Escape", cancelable: true });
@@ -238,7 +238,7 @@ describe("AgentInterface context target and capacity meter", () => {
 			expect(fixture.container.querySelector('[data-testid="context-meter-target-marker"]')).toBeNull();
 			const popover = openContextPopover(fixture);
 			expect(popover.textContent).toMatch(/Context window\s*272k tokens/);
-			expect(popover.textContent).not.toContain("Context target");
+			expect(popover.textContent).not.toContain("Soft limit");
 			expect(popover.textContent).not.toContain("Model capacity");
 			expect(popover.querySelector('[data-testid="context-meter-scale"]')).toBeNull();
 		}


### PR DESCRIPTION
## Summary
- rename the context popover's target labels to soft limit
- update DOM and browser coverage for the new wording

## Testing
- `npx vitest run tests2/dom/context-cost-stats.test.ts`

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)