### PR TITLE
Trust credentialed PR hosts

### DIFF
--- a/docs/pr-walkthrough-panel.md
+++ b/docs/pr-walkthrough-panel.md
@@ -1018,9 +1018,9 @@ validated YAML submission.
 ### Trusted GitHub hosts
 
 A walkthrough fetches PR metadata and diffs over the network, so Bobbit only contacts
-hosts in one server-authoritative effective set. Centralizing the decision keeps PR
-Walkthrough launch, fetch, and posting aligned with Git status PR polling, permission
-checks, and merge actions.
+hosts in one server-authoritative effective set. Centralizing the listed-host decision
+keeps PR Walkthrough launch, fetch, and posting aligned with permission checks, merge
+actions, and the primary trust path used by PR-status polling.
 
 The effective set is the union of:
 
@@ -1034,6 +1034,14 @@ The effective set is the union of:
 - **Local `gh` configuration.** Host keys explicitly present in the GitHub CLI's
   host-specific auth configuration are trusted automatically. A user who already ran
   `gh auth login --hostname <host>` therefore does not have to configure Bobbit again.
+
+PR status can separately vouch for an otherwise-unlisted, structurally valid enterprise
+host from the operator's local Git credential helpers. That fallback is intentionally
+absent here: it does not add the host to this effective set and cannot authorize
+walkthrough launch, metadata or diff fetches, persistence, or review posting. To use PR
+Walkthrough with such a host, add it through managed preferences or local `gh`
+`hosts.yml`. See
+[Credential-derived PR-status eligibility](remote-state-coordinator.md#credential-derived-pr-status-eligibility).
 
 `GithubTrustedHostResolver` reads only host keys from the local `gh` configuration and
 normalizes them through the same hostname validator used for managed preferences. It

--- a/docs/remote-state-coordinator.md
+++ b/docs/remote-state-coordinator.md
@@ -28,33 +28,78 @@ A repository without `origin` remains valid local state. Its refresh path does n
 
 A pull-request identity combines normalized host, owner, repository, and either a resolved head identity or PR number. Once a head lookup returns a PR number, both selectors alias the same record.
 
-Only complete remotes whose host is in Bobbit's effective GitHub trust set are eligible for PR lookup. The Git transport identity remains port-sensitive, but PR/API authority is derived separately: SSH transport ports are dropped, while explicit HTTP(S) web/API ports remain part of the PR identity and every host-scoped `gh` call. Untrusted hosts, malformed paths, encoded separators, query strings, fragments, and trusted-looking substrings embedded in another URL are rejected rather than falling back to an independent lookup.
+PR lookup separates structural remote parsing from host trust. The structural parser still rejects incomplete or unsafe remotes, including malformed paths, encoded separators, query strings, fragments, and trusted-looking substrings embedded in another URL. A valid candidate becomes eligible only through the listed-host rules below or the narrow PR-status credential check. The Git transport identity remains port-sensitive, but PR/API authority is derived separately: SSH transport ports are dropped, while explicit HTTP(S) web/API ports remain part of the PR identity and every host-scoped `gh` call. Rejection never falls back to an independent lookup.
 
 A repository-scoped head lookup validates every candidate against the exact server-owned head and head repository. It selects the unique open PR when present; otherwise it selects the uniquely newest terminal PR, allowing safe branch reuse without a second external read. Ambiguous, malformed, or cross-repository results fail closed and retain any last-good snapshot. Candidate refs, repository ownership, and ordering fields are validation inputs only and are never published.
 
-### Effective GitHub host trust
+### Listed GitHub host trust
 
-One server-side resolver supplies the same effective trust decision to PR status polling,
+One server-side resolver supplies the listed-host trust decision to PR status polling,
 merge and permission checks, PR Walkthrough, and the browser's trust-prompt preflight.
 The effective set combines Bobbit's built-in GitHub hosts, managed
 `githubTrustedHosts`, and normalized host keys explicitly configured in the local `gh`
-CLI. This lets an existing host-specific `gh` login enable an enterprise host without a
-duplicate Bobbit preference, while preventing individual consumers from drifting onto
-different allowlists.
+`hosts.yml`. This lets an existing host-specific `gh` login enable an enterprise host
+without a duplicate Bobbit preference, while preventing individual consumers from
+drifting onto different allowlists.
 
 Discovery reads only host keys from the local `gh` configuration; it does not run an
 authentication-status or API probe, request tokens, or contact the configured hosts.
 Token data is never returned, persisted, or logged, and environment-only authorization
-cannot authorize an arbitrary remote. Results are briefly cached and concurrent callers
-share the lookup. If `gh` configuration cannot be read, discovery contributes nothing
-and trust falls back to the built-in plus managed set.
+cannot add a host to this set. Results are briefly cached and concurrent callers share
+the lookup. If `gh` configuration cannot be read, discovery contributes nothing and
+trust falls back to the built-in plus managed set.
 
 The browser queries the server for a normalized boolean decision rather than receiving
-or rebuilding the effective list. Unknown hosts therefore remain rejected, while a
-host configured only in `gh` is accepted consistently by status and action routes and
-by the PR Walkthrough launch flow. See
+or rebuilding the effective list. A host configured only in `gh` is therefore accepted
+consistently by status and action routes and by the PR Walkthrough launch flow. See
 [Trusted GitHub hosts](pr-walkthrough-panel.md#trusted-github-hosts) for discovery and
 prompt details.
+
+### Credential-derived PR-status eligibility
+
+PR status has one additional, process-local path for a structurally valid enterprise
+remote absent from the effective set. Bobbit asks the operator's local Git credential
+configuration about the exact normalized host with `git credential fill`. It accepts
+the host only when the bounded reply echoes that exact host authority and contains a
+password-bearing credential. The resulting `gh` reads remain bound to that host and the
+validated owner/repository; the credential result cannot authorize an unqualified or
+different target.
+
+This is **PR-status-only eligibility**, not an addition to the effective host set. It
+does not persist trust, modify `githubTrustedHosts`, widen merge or permission actions,
+or authorize PR Walkthrough launch, fetch, or posting. Built-in, managed, and
+`hosts.yml`-discovered hosts keep their existing behavior.
+
+The probe runs only through the injected command-runner spawn seam, from a neutral
+temporary directory so repository-local helpers cannot grant process-wide host trust.
+Terminal, GUI, and askpass prompting are disabled. Missing spawn support, subprocess or
+input errors, timeout, malformed or mismatched output, and output beyond the inspection
+bounds all fail closed. Output inspection is byte-bounded, and a timed-out process is
+terminated with escalation so a wedged helper cannot accumulate across polls.
+Credential values and helper errors are never returned, persisted, or logged. The
+security boundary is narrower than "no network access": credential helpers are
+operator-configured code and may themselves contact the queried host.
+
+Credential-derived trust is refused before probing when `gh` would prefer a set
+host-class-wide ambient token for the target: `GH_TOKEN` or `GITHUB_TOKEN` for
+`github.com` and `*.ghe.com`, and `GH_ENTERPRISE_TOKEN` or
+`GITHUB_ENTERPRISE_TOKEN` for other enterprise hosts. This prevents admission based on
+a host-specific credential from causing `gh` to send a different class-wide token.
+Bobbit warns once per host, naming the applicable variable but never its value. This
+refusal does not alter trust or ambient-token behavior for listed hosts. Uniform
+ambient-token scrubbing for `gh` calls admitted by existing trust sources is a separate
+follow-up concern.
+
+Verdicts are cached by normalized host with one in-flight probe per host. Positive
+verdicts remain for the gateway process lifetime. Negative verdicts remain until an
+explicit PR-status refresh; that refresh clears negatives and stops callers from joining
+older-generation in-flight probes, while preserving positives. Automatic, visibility,
+and sidebar reads do not re-probe a cached negative.
+
+Trust verdicts are not persisted, but a successful lookup may still populate the
+separate persistent PR-status cache used for startup hydration. Revalidating that cache
+immediately after credential revocation is a follow-up concern; startup hydration can
+therefore display stale PR status before later live processing updates it.
 
 Published PR URLs are reconstructed from the validated server-derived HTTPS authority, owner, repository, and positive PR number. Upstream URLs containing credentials, query strings, fragments, mismatched authorities, non-HTTPS schemes, or non-canonical paths are rejected. Clients apply the same safe-link shape defensively before assigning a URL to a navigation sink.
 

--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -762,6 +762,29 @@ All four routes accept `intent`:
 
 `sidebar` changes cadence only for PR state; a Git route still uses the repository's normal automatic policy. On Git routes, legacy `fetch=true` has the same blocking revalidation role as `intent=explicit`. It may be combined with `untracked=1` so the response reflects newly fetched refs and includes the full untracked-file scan. Without either explicit form, stale revalidation completes asynchronously and is delivered through WebSocket.
 
+#### PR host eligibility
+
+PR-status routes first apply the normal built-in, managed `githubTrustedHosts`, and local
+`gh` `hosts.yml` trust rules. If a structurally valid enterprise remote is otherwise
+unlisted, PR status may additionally derive process-local eligibility from the
+operator's local Git credential configuration. It requires `git credential fill` to
+echo the exact host and return a password-bearing result; failures remain the existing
+ineligible response and do not reach `gh`. This fallback does not persist trust, change
+preferences, or authorize any PR Walkthrough or PR action route.
+
+Credential probes are single-flight per host. Positive verdicts remain until process
+exit; negative verdicts and stale in-flight probes are cleared only by
+`intent=explicit` on a PR-status route. An explicit refresh therefore discovers a newly
+provisioned credential, but does not re-probe a host already vouched for in this process.
+
+The fallback is refused when a set ambient variable would take precedence in `gh` for
+the target's host class: `GH_TOKEN` or `GITHUB_TOKEN` for `github.com` and `*.ghe.com`,
+or `GH_ENTERPRISE_TOKEN` or `GITHUB_ENTERPRISE_TOKEN` for other enterprise hosts. The
+server warns once per host with the variable name, never its value. Listed hosts retain
+their existing behavior. See
+[Credential-derived PR-status eligibility](remote-state-coordinator.md#credential-derived-pr-status-eligibility)
+for the subprocess, output-bound, redaction, and cache security boundary.
+
 #### Response envelopes
 
 The public coordinator metadata is:
@@ -813,7 +836,7 @@ On a cold eligible PR record, `data` and `refreshedAt` are absent while the firs
 
 PR absence has two distinct route outcomes:
 
-- If the target cannot be resolved to an eligible GitHub or trusted GitHub Enterprise repository and head, the default response is `404 { error: "No PR found" }`; `optional=1` returns empty `204`. No independent fallback lookup runs.
+- If the target cannot be resolved to an eligible GitHub repository and head—including when an unlisted enterprise host has no acceptable credential-derived verdict—the default response is `404 { error: "No PR found" }`; `optional=1` returns empty `204`. No `gh` call or independent fallback lookup runs.
 - If the target is eligible and a successful lookup returns `data: null`, the default response is `200` with that envelope; `optional=1` returns empty `204`. Cold and failed eligible snapshots remain `200` envelopes even with `optional=1`, because their freshness/error metadata is meaningful.
 
 Unknown entities, missing host worktrees, no-worktree goals/Headquarters sessions, sandbox resolution, and the existing explicit Git/PR mutation routes retain their endpoint-specific behavior.

--- a/src/server/agent/spawn-tree.ts
+++ b/src/server/agent/spawn-tree.ts
@@ -38,8 +38,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { connect } from "node:net";
 import { randomUUID } from "node:crypto";
-import type { Clock } from "../gateway-deps.js";
-import { realClock } from "../gateway-deps.js";
+import { realClock, type Clock } from "../clock.js";
 
 export interface SpawnTrackedOptions {
 	cwd?: string;

--- a/src/server/clock.ts
+++ b/src/server/clock.ts
@@ -1,0 +1,17 @@
+export type TimerHandle = ReturnType<typeof globalThis.setTimeout>;
+
+export interface Clock {
+	now(): number;
+	setTimeout(handler: () => void, ms: number): TimerHandle;
+	setInterval(handler: () => void, ms: number): TimerHandle;
+	clearTimeout(handle: TimerHandle): void;
+	clearInterval(handle: TimerHandle): void;
+}
+
+export const realClock: Clock = {
+	now: () => Date.now(),
+	setTimeout: (handler, ms) => globalThis.setTimeout(handler, ms),
+	setInterval: (handler, ms) => globalThis.setInterval(handler, ms),
+	clearTimeout: handle => globalThis.clearTimeout(handle),
+	clearInterval: handle => globalThis.clearInterval(handle),
+};

--- a/src/server/clock.ts
+++ b/src/server/clock.ts
@@ -20,8 +20,14 @@ function normalizeRealTimerDelay(ms: number): number {
 
 export const realClock: Clock = {
 	now: () => Date.now(),
-	setTimeout: (handler, ms) => globalThis.setTimeout(handler, normalizeRealTimerDelay(ms)),
-	setInterval: (handler, ms) => globalThis.setInterval(handler, normalizeRealTimerDelay(ms)),
+	setTimeout: (handler, ms) => {
+		// codeql[js/resource-exhaustion] The generic Clock DI boundary receives internal durations, normalized to finite [0, 2^31-1] before this sink.
+		return globalThis.setTimeout(handler, normalizeRealTimerDelay(ms));
+	},
+	setInterval: (handler, ms) => {
+		// codeql[js/resource-exhaustion] The generic Clock DI boundary receives internal durations, normalized to finite [0, 2^31-1] before this sink.
+		return globalThis.setInterval(handler, normalizeRealTimerDelay(ms));
+	},
 	clearTimeout: handle => globalThis.clearTimeout(handle),
 	clearInterval: handle => globalThis.clearInterval(handle),
 };

--- a/src/server/clock.ts
+++ b/src/server/clock.ts
@@ -8,10 +8,20 @@ export interface Clock {
 	clearInterval(handle: TimerHandle): void;
 }
 
+// Node coerces non-finite and out-of-range delays to 1 ms, which can turn a
+// long wait or interval into a tight loop. Keep real timers inside Node's
+// signed 32-bit range; virtual test clocks retain their own delay semantics.
+const MAX_REAL_TIMER_DELAY_MS = 2_147_483_647;
+
+function normalizeRealTimerDelay(ms: number): number {
+	if (!Number.isFinite(ms)) return MAX_REAL_TIMER_DELAY_MS;
+	return Math.min(MAX_REAL_TIMER_DELAY_MS, Math.max(0, ms));
+}
+
 export const realClock: Clock = {
 	now: () => Date.now(),
-	setTimeout: (handler, ms) => globalThis.setTimeout(handler, ms),
-	setInterval: (handler, ms) => globalThis.setInterval(handler, ms),
+	setTimeout: (handler, ms) => globalThis.setTimeout(handler, normalizeRealTimerDelay(ms)),
+	setInterval: (handler, ms) => globalThis.setInterval(handler, normalizeRealTimerDelay(ms)),
 	clearTimeout: handle => globalThis.clearTimeout(handle),
 	clearInterval: handle => globalThis.clearInterval(handle),
 };

--- a/src/server/gateway-deps.ts
+++ b/src/server/gateway-deps.ts
@@ -1,20 +1,15 @@
-import { execFileSync as nodeExecFileSync, spawn as nodeSpawn, type ChildProcess, type ExecFileOptions, type ExecFileSyncOptions, type SpawnOptions } from "node:child_process";
+import { execFileSync as nodeExecFileSync, type ChildProcess, type ExecFileOptions, type ExecFileSyncOptions } from "node:child_process";
 import fs from "node:fs";
 import { execFileSafe } from "./exec-file-safe.js";
 import type { RpcBridgeFactory } from "./agent/rpc-bridge.js";
 import { realVerificationCommandRunner, type VerificationCommandRunner } from "./agent/verification-command-runner.js";
+import { createCommandSpawnAdapter, type CommandSpawnOptions } from "./owned-tree-command-spawn.js";
+import { realClock } from "./clock.js";
 
 export type { ExecFileOptions, ExecFileSyncOptions, SpawnOptions } from "node:child_process";
-
-export type TimerHandle = ReturnType<typeof globalThis.setTimeout>;
-
-export interface Clock {
-	now(): number;
-	setTimeout(handler: () => void, ms: number): TimerHandle;
-	setInterval(handler: () => void, ms: number): TimerHandle;
-	clearTimeout(handle: TimerHandle): void;
-	clearInterval(handle: TimerHandle): void;
-}
+export { realClock } from "./clock.js";
+export type { Clock, TimerHandle } from "./clock.js";
+import type { Clock } from "./clock.js";
 
 export interface ExecFileResult {
 	stdout: string | Buffer;
@@ -24,7 +19,9 @@ export interface ExecFileResult {
 export interface CommandRunner {
 	execFile(file: string, args: readonly string[], options?: ExecFileOptions): Promise<ExecFileResult>;
 	execFileSync?(file: string, args: readonly string[], options?: ExecFileSyncOptions): Buffer | string;
-	spawn?(file: string, args: readonly string[], options?: SpawnOptions): ChildProcess;
+	spawn?(file: string, args: readonly string[], options?: CommandSpawnOptions): ChildProcess;
+	/** The spawn implementation honors branded owned-tree requests synchronously. */
+	supportsOwnedTreeSpawn?: true;
 }
 
 export interface GatewayDeps {
@@ -81,18 +78,11 @@ export interface FsLike extends Pick<typeof fs,
 	>;
 }
 
-export const realClock: Clock = {
-	now: () => Date.now(),
-	setTimeout: (handler, ms) => globalThis.setTimeout(handler, ms),
-	setInterval: (handler, ms) => globalThis.setInterval(handler, ms),
-	clearTimeout: (handle) => globalThis.clearTimeout(handle),
-	clearInterval: (handle) => globalThis.clearInterval(handle),
-};
-
 export const realCommandRunner: CommandRunner = {
 	execFile: (file, args, options) => execFileSafe(file, args, options),
 	execFileSync: (file, args, options) => nodeExecFileSync(file, [...args], options),
-	spawn: (file, args, options) => options === undefined ? nodeSpawn(file, [...args]) : nodeSpawn(file, [...args], options),
+	spawn: createCommandSpawnAdapter(),
+	supportsOwnedTreeSpawn: true,
 };
 
 export const realFetch: typeof fetch = globalThis.fetch;

--- a/src/server/github-host-credential-trust.ts
+++ b/src/server/github-host-credential-trust.ts
@@ -1,0 +1,329 @@
+import type { ChildProcess, SpawnOptions } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { TextDecoder } from "node:util";
+import { realClock, type Clock, type TimerHandle } from "./gateway-deps.js";
+import { normalizeGithubHost } from "./remote-state-coordinator.js";
+
+const PROBE_TIMEOUT_MS = 5_000;
+const PROBE_KILL_GRACE_MS = 500;
+const PROBE_MAX_OUTPUT_BYTES = 8 * 1024;
+const GITHUB_COM_CLASS_TOKENS = ["GH_TOKEN", "GITHUB_TOKEN"] as const;
+const ENTERPRISE_SERVER_CLASS_TOKENS = ["GH_ENTERPRISE_TOKEN", "GITHUB_ENTERPRISE_TOKEN"] as const;
+
+export type CredentialProbe = (host: string) => Promise<boolean>;
+export type SpawnLike = (file: string, args: readonly string[], options: SpawnOptions) => ChildProcess;
+export type SpawnResolver = () => SpawnLike | undefined;
+export type EnvironmentResolver = () => Readonly<Record<string, string | undefined>>;
+
+type VerdictEntry =
+	| { kind: "positive"; generation: number }
+	| { kind: "negative"; generation: number }
+	| { kind: "pending"; generation: number; promise: Promise<boolean> };
+
+export interface GithubHostCredentialTrustOptions {
+	probe?: CredentialProbe;
+	resolveSpawn?: SpawnResolver;
+	clock?: Clock;
+	getEnv?: EnvironmentResolver;
+	warn?: (message: string) => void;
+}
+
+/**
+ * Process-local, PR-only trust derived from the operator's Git credential
+ * configuration. Only boolean verdicts and ambient variable names cross the
+ * credential boundary; credential values are never returned, persisted, or
+ * logged.
+ */
+export class GithubHostCredentialTrust {
+	private readonly states = new Map<string, VerdictEntry>();
+	private readonly probe: CredentialProbe;
+	private readonly getEnv: EnvironmentResolver;
+	private readonly warn: (message: string) => void;
+	private readonly reportedAmbientRefusals = new Set<string>();
+	private generation = 0;
+
+	constructor(options: GithubHostCredentialTrustOptions = {}) {
+		const resolveSpawn = options.resolveSpawn ?? (() => undefined);
+		const clock = options.clock ?? realClock;
+		this.probe = options.probe ?? (host => probeLocalGitCredential(host, resolveSpawn(), clock));
+		this.getEnv = options.getEnv ?? (() => process.env);
+		this.warn = options.warn ?? (message => console.warn(message));
+	}
+
+	async isTrusted(host: string): Promise<boolean> {
+		const key = normalizeCredentialAuthority(host);
+		if (!key) return false;
+
+		// Resolve live, before consulting even a positive cache entry: gh inherits
+		// the live environment and would prefer a host-class-wide token.
+		let ambientVariable: string | undefined;
+		try {
+			ambientVariable = ambientTokenFor(key, this.getEnv());
+		} catch {
+			return false;
+		}
+		if (ambientVariable) {
+			this.reportAmbientRefusal(key, ambientVariable);
+			return false;
+		}
+
+		const existing = this.states.get(key);
+		if (existing?.kind === "positive") return true;
+		if (existing?.kind === "negative") return false;
+		if (existing?.kind === "pending") return existing.promise;
+
+		const generation = this.generation;
+		let pending!: VerdictEntry & { kind: "pending" };
+		const promise = this.resolveVerdict(key, generation, () => pending);
+		pending = { kind: "pending", generation, promise };
+		this.states.set(key, pending);
+		return promise;
+	}
+
+	/** Keep positive trust for the process lifetime; invalidate negative and stale pending work. */
+	forgetUnverified(): void {
+		this.generation++;
+		for (const [host, state] of this.states) {
+			if (state.kind !== "positive") this.states.delete(host);
+		}
+	}
+
+	private async resolveVerdict(
+		host: string,
+		generation: number,
+		entry: () => VerdictEntry,
+	): Promise<boolean> {
+		let trusted = false;
+		try {
+			trusted = (await this.probe(host)) === true;
+		} catch {
+			trusted = false;
+		}
+		const current = this.states.get(host);
+		if (generation === this.generation && current === entry()) {
+			this.states.set(host, { kind: trusted ? "positive" : "negative", generation });
+		}
+		return trusted;
+	}
+
+	private reportAmbientRefusal(host: string, variable: string): void {
+		if (this.reportedAmbientRefusals.has(host)) return;
+		this.reportedAmbientRefusals.add(host);
+		try {
+			this.warn(
+				`[github-trust] Not trusting ${host} from the local Git credential configuration because ${variable} is set. `
+				+ `Trust ${host} explicitly with githubTrustedHosts or unset ${variable}.`,
+			);
+		} catch {
+			// Warning delivery must not turn a fail-closed refusal into an exception.
+		}
+	}
+}
+
+function normalizeCredentialAuthority(host: string): string | undefined {
+	const normalized = normalizeGithubHost(host);
+	// Credential probing is intentionally narrower than structural parsing. The
+	// parser supplies DNS authorities; direct callers cannot inject credential
+	// protocol lines or URL components.
+	if (!/^[a-z0-9._-]+(?::\d+)?$/.test(normalized)) return undefined;
+	const port = /:(\d+)$/.exec(normalized)?.[1];
+	if (port && (Number(port) < 1 || Number(port) > 65_535)) return undefined;
+	return normalized;
+}
+
+function ambientTokenFor(host: string, env: Readonly<Record<string, string | undefined>>): string | undefined {
+	const hostname = host.replace(/:\d+$/, "");
+	const names = hostname === "github.com" || hostname.endsWith(".ghe.com")
+		? GITHUB_COM_CLASS_TOKENS
+		: ENTERPRISE_SERVER_CLASS_TOKENS;
+	return names.find(name => (env[name] ?? "").trim() !== "");
+}
+
+function probeEnvironment(root: string): NodeJS.ProcessEnv {
+	const env: NodeJS.ProcessEnv = {
+		...process.env,
+		GIT_TERMINAL_PROMPT: "0",
+		GCM_INTERACTIVE: "never",
+		// The dedicated child is empty; the ceiling also prevents an operator-
+		// overridden temp root from inheriting repository-local credential config.
+		GIT_CEILING_DIRECTORIES: root,
+	};
+	delete env.GIT_ASKPASS;
+	delete env.SSH_ASKPASS;
+	delete env.DISPLAY;
+	return env;
+}
+
+function unref(handle: TimerHandle): void {
+	(handle as { unref?: () => void }).unref?.();
+}
+
+class CredentialRecordParser {
+	private readonly decoder = new TextDecoder("utf-8", { fatal: true });
+	private pending = "";
+	private bytes = 0;
+	private ended = false;
+	private invalid = false;
+	private host: string | undefined;
+	private hasPassword = false;
+	private readonly keys = new Set<string>();
+
+	constructor(private readonly expectedHost: string) {}
+
+	push(chunk: Buffer | string): boolean {
+		if (this.invalid) return false;
+		const bytes = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+		this.bytes += bytes.length;
+		if (this.bytes > PROBE_MAX_OUTPUT_BYTES) return this.reject();
+		try {
+			this.pending += this.decoder.decode(bytes, { stream: true });
+		} catch {
+			return this.reject();
+		}
+		return this.consumeCompleteLines();
+	}
+
+	finish(): boolean {
+		if (this.invalid) return false;
+		try {
+			this.pending += this.decoder.decode();
+		} catch {
+			return this.reject();
+		}
+		if (!this.consumeCompleteLines()) return false;
+		if (this.pending) {
+			const line = this.pending;
+			this.pending = "";
+			if (!this.consumeLine(line)) return false;
+		}
+		return !this.invalid && this.host === this.expectedHost && this.hasPassword;
+	}
+
+	private consumeCompleteLines(): boolean {
+		for (;;) {
+			const newline = this.pending.indexOf("\n");
+			if (newline < 0) return !this.invalid;
+			const line = this.pending.slice(0, newline);
+			this.pending = this.pending.slice(newline + 1);
+			if (!this.consumeLine(line)) return false;
+		}
+	}
+
+	private consumeLine(rawLine: string): boolean {
+		const line = rawLine.endsWith("\r") ? rawLine.slice(0, -1) : rawLine;
+		if (this.ended) return this.reject();
+		if (line === "") {
+			this.ended = true;
+			return true;
+		}
+		if (/[\u0000-\u001f\u007f]/.test(line)) return this.reject();
+		const separator = line.indexOf("=");
+		if (separator <= 0) return this.reject();
+		const key = line.slice(0, separator);
+		if (!/^[A-Za-z][A-Za-z0-9_-]*$/.test(key) || this.keys.has(key)) return this.reject();
+		this.keys.add(key);
+		const value = line.slice(separator + 1);
+		if (key === "host") {
+			if (value !== this.expectedHost) return this.reject();
+			this.host = value;
+		} else if (key === "password") {
+			if (value.length === 0) return this.reject();
+			this.hasPassword = true;
+		}
+		// All other values, including usernames and future credential fields, are
+		// deliberately discarded rather than retained on the trust object.
+		return true;
+	}
+
+	private reject(): false {
+		this.invalid = true;
+		this.pending = "";
+		return false;
+	}
+}
+
+function probeLocalGitCredential(host: string, spawn: SpawnLike | undefined, clock: Clock): Promise<boolean> {
+	if (!spawn) return Promise.resolve(false);
+
+	let cwd: string;
+	try {
+		cwd = mkdtempSync(join(tmpdir(), "bobbit-git-credential-"));
+	} catch {
+		return Promise.resolve(false);
+	}
+
+	return new Promise<boolean>((resolve) => {
+		let child: ChildProcess;
+		try {
+			child = spawn("git", ["credential", "fill"], {
+				cwd,
+				env: probeEnvironment(tmpdir()),
+				windowsHide: true,
+				stdio: ["pipe", "pipe", "ignore"],
+			});
+		} catch {
+			cleanupProbeDirectory(cwd);
+			resolve(false);
+			return;
+		}
+
+		const parser = new CredentialRecordParser(host);
+		let settled = false;
+		let closed = false;
+		let killTimer: TimerHandle | undefined;
+		const cleanup = () => cleanupProbeDirectory(cwd);
+		const settle = (result: boolean, keepKillTimer = false) => {
+			if (settled) return;
+			settled = true;
+			clock.clearTimeout(timeoutTimer);
+			if (killTimer && !keepKillTimer) clock.clearTimeout(killTimer);
+			cleanup();
+			resolve(result);
+		};
+		const abort = () => {
+			if (settled) return;
+			try { child.kill("SIGTERM"); } catch { /* fail closed below */ }
+			killTimer = clock.setTimeout(() => {
+				if (!closed) {
+					try { child.kill("SIGKILL"); } catch { /* already gone */ }
+				}
+				cleanup();
+			}, PROBE_KILL_GRACE_MS);
+			unref(killTimer);
+			settle(false, true);
+		};
+		const timeoutTimer = clock.setTimeout(abort, PROBE_TIMEOUT_MS);
+		unref(timeoutTimer);
+
+		if (!child.stdout || !child.stdin) {
+			abort();
+			return;
+		}
+		child.stdout.on("data", (chunk: Buffer | string) => {
+			if (!settled && !parser.push(chunk)) abort();
+		});
+		child.stdout.on("error", abort);
+		child.on("error", abort);
+		child.on("close", (code: number | null, signal: NodeJS.Signals | null) => {
+			closed = true;
+			if (killTimer) clock.clearTimeout(killTimer);
+			if (settled) {
+				cleanup();
+				return;
+			}
+			settle(code === 0 && signal == null && parser.finish());
+		});
+		child.stdin.on("error", abort);
+		try {
+			child.stdin.end(`url=https://${host}\n\n`);
+		} catch {
+			abort();
+		}
+	});
+}
+
+function cleanupProbeDirectory(cwd: string): void {
+	try { rmSync(cwd, { recursive: true, force: true }); } catch { /* best-effort retry occurs after kill */ }
+}

--- a/src/server/github-host-credential-trust.ts
+++ b/src/server/github-host-credential-trust.ts
@@ -1,20 +1,22 @@
-import type { ChildProcess, SpawnOptions } from "node:child_process";
+import type { ChildProcess } from "node:child_process";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { TextDecoder } from "node:util";
-import { realClock, type Clock, type TimerHandle } from "./gateway-deps.js";
+import { realClock, type Clock, type CommandRunner, type TimerHandle } from "./gateway-deps.js";
+import { ownedTreeSpawnOptions, type OwnedTreeControl } from "./owned-tree-command-spawn.js";
 import { normalizeGithubHost } from "./remote-state-coordinator.js";
 
 const PROBE_TIMEOUT_MS = 5_000;
 const PROBE_KILL_GRACE_MS = 500;
+const PROBE_TREE_SETTLE_MS = 1_500;
+const PROBE_CLEANUP_RETRY_MS = 100;
 const PROBE_MAX_OUTPUT_BYTES = 8 * 1024;
 const GITHUB_COM_CLASS_TOKENS = ["GH_TOKEN", "GITHUB_TOKEN"] as const;
 const ENTERPRISE_SERVER_CLASS_TOKENS = ["GH_ENTERPRISE_TOKEN", "GITHUB_ENTERPRISE_TOKEN"] as const;
 
 export type CredentialProbe = (host: string) => Promise<boolean>;
-export type SpawnLike = (file: string, args: readonly string[], options: SpawnOptions) => ChildProcess;
-export type SpawnResolver = () => SpawnLike | undefined;
+export type CommandRunnerResolver = () => CommandRunner | undefined;
 export type EnvironmentResolver = () => Readonly<Record<string, string | undefined>>;
 
 type VerdictEntry =
@@ -24,7 +26,7 @@ type VerdictEntry =
 
 export interface GithubHostCredentialTrustOptions {
 	probe?: CredentialProbe;
-	resolveSpawn?: SpawnResolver;
+	resolveCommandRunner?: CommandRunnerResolver;
 	clock?: Clock;
 	getEnv?: EnvironmentResolver;
 	warn?: (message: string) => void;
@@ -45,9 +47,9 @@ export class GithubHostCredentialTrust {
 	private generation = 0;
 
 	constructor(options: GithubHostCredentialTrustOptions = {}) {
-		const resolveSpawn = options.resolveSpawn ?? (() => undefined);
+		const resolveCommandRunner = options.resolveCommandRunner ?? (() => undefined);
 		const clock = options.clock ?? realClock;
-		this.probe = options.probe ?? (host => probeLocalGitCredential(host, resolveSpawn(), clock));
+		this.probe = options.probe ?? (host => probeLocalGitCredential(host, resolveCommandRunner(), clock));
 		this.getEnv = options.getEnv ?? (() => process.env);
 		this.warn = options.warn ?? (message => console.warn(message));
 	}
@@ -254,8 +256,10 @@ class CredentialRecordParser {
 	}
 }
 
-function probeLocalGitCredential(host: string, spawn: SpawnLike | undefined, clock: Clock): Promise<boolean> {
-	if (!spawn) return Promise.resolve(false);
+function probeLocalGitCredential(host: string, runner: CommandRunner | undefined, clock: Clock): Promise<boolean> {
+	// Capability is checked before spawning. A runner that cannot synchronously
+	// hand back an owned tree is never allowed to start a credential helper.
+	if (!runner?.spawn || runner.supportsOwnedTreeSpawn !== true) return Promise.resolve(false);
 
 	let cwd: string;
 	try {
@@ -265,75 +269,123 @@ function probeLocalGitCredential(host: string, spawn: SpawnLike | undefined, clo
 	}
 
 	return new Promise<boolean>((resolve) => {
+		let tree: OwnedTreeControl | undefined;
 		let child: ChildProcess;
 		try {
-			child = spawn("git", ["credential", "fill"], {
+			child = runner.spawn!("git", ["credential", "fill"], ownedTreeSpawnOptions({
 				cwd,
 				env: probeEnvironment(tmpdir()),
 				windowsHide: true,
 				stdio: ["pipe", "pipe", "ignore"],
-			});
+			}, clock, control => {
+				if (tree) throw new Error("Owned tree control was bound more than once");
+				tree = control;
+			}));
 		} catch {
 			cleanupProbeDirectory(cwd);
 			resolve(false);
 			return;
 		}
+		if (!tree) {
+			// A capability-bearing injected runner that ignored the branded handoff is
+			// untrusted. There is no safe root-PID fallback or post-exit tree scan.
+			cleanupProbeDirectory(cwd);
+			resolve(false);
+			return;
+		}
 
+		const ownedTree = tree;
 		const parser = new CredentialRecordParser(host);
 		let settled = false;
-		let closed = false;
-		let killTimer: TimerHandle | undefined;
-		const cleanup = () => cleanupProbeDirectory(cwd);
-		const settle = (result: boolean, keepKillTimer = false) => {
+		let aborting = false;
+		let ownershipEstablished = false;
+		let requestWritten = false;
+		let closeResult: { code: number | null; signal: NodeJS.Signals | null } | undefined;
+		let closeHandled = false;
+		let timeoutTimer: TimerHandle | undefined;
+
+		const cleanupAfterTreeBoundary = () => {
+			if (cleanupProbeDirectory(cwd)) return;
+			const retry = clock.setTimeout(() => { cleanupProbeDirectory(cwd); }, PROBE_CLEANUP_RETRY_MS);
+			unref(retry);
+		};
+		const settle = (result: boolean) => {
 			if (settled) return;
 			settled = true;
-			clock.clearTimeout(timeoutTimer);
-			if (killTimer && !keepKillTimer) clock.clearTimeout(killTimer);
-			cleanup();
+			if (timeoutTimer) clock.clearTimeout(timeoutTimer);
+			cleanupAfterTreeBoundary();
 			resolve(result);
 		};
-		const abort = () => {
-			if (settled) return;
-			try { child.kill("SIGTERM"); } catch { /* fail closed below */ }
-			killTimer = clock.setTimeout(() => {
-				if (!closed) {
-					try { child.kill("SIGKILL"); } catch { /* already gone */ }
-				}
-				cleanup();
-			}, PROBE_KILL_GRACE_MS);
-			unref(killTimer);
-			settle(false, true);
+		const abort = async () => {
+			if (settled || aborting) return;
+			aborting = true;
+			if (timeoutTimer) clock.clearTimeout(timeoutTimer);
+			try { ownedTree.killTree("SIGTERM", PROBE_KILL_GRACE_MS); } catch { /* fail closed */ }
+			let completed = false;
+			try { completed = await ownedTree.waitForTreeExit(PROBE_KILL_GRACE_MS); } catch { /* escalate */ }
+			if (!completed) {
+				try { ownedTree.killTree("SIGKILL"); } catch { /* fail closed */ }
+				try { await ownedTree.waitForTreeExit(PROBE_TREE_SETTLE_MS); } catch { /* bounded failure */ }
+			}
+			settle(false);
 		};
-		const timeoutTimer = clock.setTimeout(abort, PROBE_TIMEOUT_MS);
+		const finishClose = async () => {
+			if (settled || aborting || closeHandled || !ownershipEstablished || !requestWritten || !closeResult) return;
+			closeHandled = true;
+			if (timeoutTimer) clock.clearTimeout(timeoutTimer);
+			const exitedCleanly = closeResult.code === 0 && closeResult.signal == null;
+			if (exitedCleanly && !parser.finish()) {
+				closeHandled = false;
+				await abort();
+				return;
+			}
+			let completed = false;
+			try { completed = await ownedTree.waitForTreeExit(PROBE_TREE_SETTLE_MS); } catch { /* fail closed */ }
+			settle(exitedCleanly && completed);
+		};
+
+		timeoutTimer = clock.setTimeout(() => { void abort(); }, PROBE_TIMEOUT_MS);
 		unref(timeoutTimer);
 
+		child.on("error", () => { void abort(); });
+		child.on("close", (code: number | null, signal: NodeJS.Signals | null) => {
+			closeResult = { code, signal };
+			void finishClose();
+		});
 		if (!child.stdout || !child.stdin) {
-			abort();
+			void abort();
 			return;
 		}
 		child.stdout.on("data", (chunk: Buffer | string) => {
-			if (!settled && !parser.push(chunk)) abort();
+			if (!settled && !aborting && !parser.push(chunk)) void abort();
 		});
-		child.stdout.on("error", abort);
-		child.on("error", abort);
-		child.on("close", (code: number | null, signal: NodeJS.Signals | null) => {
-			closed = true;
-			if (killTimer) clock.clearTimeout(killTimer);
-			if (settled) {
-				cleanup();
+		child.stdout.on("error", () => { void abort(); });
+		child.stdin.on("error", () => { void abort(); });
+
+		void ownedTree.ownershipReady.then(() => {
+			if (settled || aborting) return;
+			ownershipEstablished = true;
+			if (closeResult) {
+				// A helper that completed before receiving our exact request cannot vouch
+				// for the authority, even if its unsolicited output looks well formed.
+				void abort();
 				return;
 			}
-			settle(code === 0 && signal == null && parser.finish());
-		});
-		child.stdin.on("error", abort);
-		try {
-			child.stdin.end(`url=https://${host}\n\n`);
-		} catch {
-			abort();
-		}
+			try {
+				child.stdin!.end(`url=https://${host}\n\n`);
+				requestWritten = true;
+			} catch {
+				void abort();
+			}
+		}, () => { void abort(); });
 	});
 }
 
-function cleanupProbeDirectory(cwd: string): void {
-	try { rmSync(cwd, { recursive: true, force: true }); } catch { /* best-effort retry occurs after kill */ }
+function cleanupProbeDirectory(cwd: string): boolean {
+	try {
+		rmSync(cwd, { recursive: true, force: true });
+		return true;
+	} catch {
+		return false;
+	}
 }

--- a/src/server/github-host-credential-trust.ts
+++ b/src/server/github-host-credential-trust.ts
@@ -84,10 +84,14 @@ export class GithubHostCredentialTrust {
 		if (verdict?.kind === "positive") return true;
 		if (verdict?.kind === "negative") return false;
 
+		const generation = this.generation;
 		const active = this.activeFlights.get(key);
-		if (!active) return this.startFlight(key, this.generation);
-		if (active.generation === this.generation) return active.promise;
-		return this.queueLatestSuccessor(key, active);
+		const promise = !active
+			? this.startFlight(key, generation)
+			: active.generation === generation
+				? active.promise
+				: this.queueLatestSuccessor(key, active, generation);
+		return this.viewForGeneration(promise, generation);
 	}
 
 	/**
@@ -105,9 +109,9 @@ export class GithubHostCredentialTrust {
 	private startFlight(host: string, generation: number): Promise<boolean> {
 		const existing = this.activeFlights.get(host);
 		if (existing) {
-			return existing.generation === this.generation
+			return existing.generation === generation
 				? existing.promise
-				: this.queueLatestSuccessor(host, existing);
+				: this.queueLatestSuccessor(host, existing, generation);
 		}
 
 		let complete!: (trusted: boolean) => void;
@@ -123,10 +127,10 @@ export class GithubHostCredentialTrust {
 		return promise;
 	}
 
-	private queueLatestSuccessor(host: string, active: ActiveFlight): Promise<boolean> {
+	private queueLatestSuccessor(host: string, active: ActiveFlight, generation: number): Promise<boolean> {
 		const existing = this.queuedFlights.get(host);
 		if (existing) {
-			existing.generation = this.generation;
+			existing.generation = generation;
 			return existing.promise;
 		}
 
@@ -140,9 +144,18 @@ export class GithubHostCredentialTrust {
 			if (queued.generation !== this.generation) return false;
 			return this.startFlight(host, queued.generation);
 		})();
-		queued = { generation: this.generation, promise };
+		queued = { generation, promise };
 		this.queuedFlights.set(host, queued);
 		return promise;
+	}
+
+	// Flights and successors are shared for tree ownership, but authorization is
+	// not: every caller observes false once a newer explicit refresh supersedes it.
+	private viewForGeneration(promise: Promise<boolean>, generation: number): Promise<boolean> {
+		return promise.then(
+			trusted => trusted === true && generation === this.generation,
+			() => false,
+		);
 	}
 
 	private async resolveFlight(host: string, flight: ActiveFlight): Promise<boolean> {

--- a/src/server/github-host-credential-trust.ts
+++ b/src/server/github-host-credential-trust.ts
@@ -21,8 +21,10 @@ export type EnvironmentResolver = () => Readonly<Record<string, string | undefin
 
 type VerdictEntry =
 	| { kind: "positive"; generation: number }
-	| { kind: "negative"; generation: number }
-	| { kind: "pending"; generation: number; promise: Promise<boolean> };
+	| { kind: "negative"; generation: number };
+
+type ActiveFlight = { generation: number; promise: Promise<boolean> };
+type QueuedFlight = { generation: number; promise: Promise<boolean> };
 
 export interface GithubHostCredentialTrustOptions {
 	probe?: CredentialProbe;
@@ -39,7 +41,14 @@ export interface GithubHostCredentialTrustOptions {
  * logged.
  */
 export class GithubHostCredentialTrust {
-	private readonly states = new Map<string, VerdictEntry>();
+	private readonly verdicts = new Map<string, VerdictEntry>();
+	// An active flight owns the host's credential-helper tree until the probe has
+	// crossed its owned-tree completion boundary. Refresh invalidation must never
+	// delete this ownership record or another tree could start concurrently.
+	private readonly activeFlights = new Map<string, ActiveFlight>();
+	// At most one successor waits behind the active owner. Its mutable generation
+	// is advanced by later callers so skipped refresh generations never start trees.
+	private readonly queuedFlights = new Map<string, QueuedFlight>();
 	private readonly probe: CredentialProbe;
 	private readonly getEnv: EnvironmentResolver;
 	private readonly warn: (message: string) => void;
@@ -71,42 +80,85 @@ export class GithubHostCredentialTrust {
 			return false;
 		}
 
-		const existing = this.states.get(key);
-		if (existing?.kind === "positive") return true;
-		if (existing?.kind === "negative") return false;
-		if (existing?.kind === "pending") return existing.promise;
+		const verdict = this.verdicts.get(key);
+		if (verdict?.kind === "positive") return true;
+		if (verdict?.kind === "negative") return false;
 
-		const generation = this.generation;
-		let pending!: VerdictEntry & { kind: "pending" };
-		const promise = this.resolveVerdict(key, generation, () => pending);
-		pending = { kind: "pending", generation, promise };
-		this.states.set(key, pending);
-		return promise;
+		const active = this.activeFlights.get(key);
+		if (!active) return this.startFlight(key, this.generation);
+		if (active.generation === this.generation) return active.promise;
+		return this.queueLatestSuccessor(key, active);
 	}
 
-	/** Keep positive trust for the process lifetime; invalidate negative and stale pending work. */
+	/**
+	 * Keep positive trust for the process lifetime and invalidate negative
+	 * verdicts. Active tree ownership remains intact; a later request can queue
+	 * one serialized successor for the newest generation.
+	 */
 	forgetUnverified(): void {
 		this.generation++;
-		for (const [host, state] of this.states) {
-			if (state.kind !== "positive") this.states.delete(host);
+		for (const [host, verdict] of this.verdicts) {
+			if (verdict.kind === "negative") this.verdicts.delete(host);
 		}
 	}
 
-	private async resolveVerdict(
-		host: string,
-		generation: number,
-		entry: () => VerdictEntry,
-	): Promise<boolean> {
+	private startFlight(host: string, generation: number): Promise<boolean> {
+		const existing = this.activeFlights.get(host);
+		if (existing) {
+			return existing.generation === this.generation
+				? existing.promise
+				: this.queueLatestSuccessor(host, existing);
+		}
+
+		let complete!: (trusted: boolean) => void;
+		const promise = new Promise<boolean>(resolve => { complete = resolve; });
+		const flight: ActiveFlight = { generation, promise };
+		this.activeFlights.set(host, flight);
+		// Install ownership before invoking an injected probe: even a runner that
+		// throws synchronously cannot leave an unowned or immortal flight entry.
+		void this.resolveFlight(host, flight).then(complete, () => {
+			if (this.activeFlights.get(host) === flight) this.activeFlights.delete(host);
+			complete(false);
+		});
+		return promise;
+	}
+
+	private queueLatestSuccessor(host: string, active: ActiveFlight): Promise<boolean> {
+		const existing = this.queuedFlights.get(host);
+		if (existing) {
+			existing.generation = this.generation;
+			return existing.promise;
+		}
+
+		let queued!: QueuedFlight;
+		const promise = (async () => {
+			await active.promise;
+			if (this.queuedFlights.get(host) !== queued) return false;
+			this.queuedFlights.delete(host);
+			// A refresh with no subsequent trust request invalidates the queued
+			// intent. Only a caller from the latest generation may start a tree.
+			if (queued.generation !== this.generation) return false;
+			return this.startFlight(host, queued.generation);
+		})();
+		queued = { generation: this.generation, promise };
+		this.queuedFlights.set(host, queued);
+		return promise;
+	}
+
+	private async resolveFlight(host: string, flight: ActiveFlight): Promise<boolean> {
 		let trusted = false;
 		try {
 			trusted = (await this.probe(host)) === true;
 		} catch {
 			trusted = false;
 		}
-		const current = this.states.get(host);
-		if (generation === this.generation && current === entry()) {
-			this.states.set(host, { kind: trusted ? "positive" : "negative", generation });
-		}
+
+		const current = this.activeFlights.get(host);
+		const currentGeneration = flight.generation === this.generation;
+		if (current === flight) this.activeFlights.delete(host);
+		if (!currentGeneration) return false;
+		if (current !== flight) return false;
+		this.verdicts.set(host, { kind: trusted ? "positive" : "negative", generation: flight.generation });
 		return trusted;
 	}
 

--- a/src/server/github-host-credential-trust.ts
+++ b/src/server/github-host-credential-trust.ts
@@ -135,10 +135,13 @@ function normalizeCredentialAuthority(host: string): string | undefined {
 
 function ambientTokenFor(host: string, env: Readonly<Record<string, string | undefined>>): string | undefined {
 	const hostname = host.replace(/:\d+$/, "");
-	const names = hostname === "github.com" || hostname.endsWith(".ghe.com")
-		? GITHUB_COM_CLASS_TOKENS
-		: ENTERPRISE_SERVER_CLASS_TOKENS;
-	return names.find(name => (env[name] ?? "").trim() !== "");
+	const usesGithubClassToken = hostname === "github.com"
+		|| hostname.endsWith(".github.com")
+		|| hostname === "github.localhost"
+		|| hostname.endsWith(".github.localhost")
+		|| hostname.endsWith(".ghe.com");
+	const names = usesGithubClassToken ? GITHUB_COM_CLASS_TOKENS : ENTERPRISE_SERVER_CLASS_TOKENS;
+	return names.find(name => env[name] !== undefined && env[name] !== "");
 }
 
 function probeEnvironment(root: string): NodeJS.ProcessEnv {
@@ -155,6 +158,11 @@ function probeEnvironment(root: string): NodeJS.ProcessEnv {
 		GIT_CEILING_DIRECTORIES: root,
 	};
 	delete env.DISPLAY;
+	// A neutral cwd is not sufficient when Git's repository-selection variables
+	// point back to a repository with local credential configuration.
+	delete env.GIT_DIR;
+	delete env.GIT_WORK_TREE;
+	delete env.GIT_COMMON_DIR;
 	return env;
 }
 

--- a/src/server/github-host-credential-trust.ts
+++ b/src/server/github-host-credential-trust.ts
@@ -146,12 +146,14 @@ function probeEnvironment(root: string): NodeJS.ProcessEnv {
 		...process.env,
 		GIT_TERMINAL_PROMPT: "0",
 		GCM_INTERACTIVE: "never",
+		// Empty overrides are intentional: deleting these variables would let Git
+		// fall back to core.askPass or SSH_ASKPASS and execute a configured prompt.
+		GIT_ASKPASS: "",
+		SSH_ASKPASS: "",
 		// The dedicated child is empty; the ceiling also prevents an operator-
 		// overridden temp root from inheriting repository-local credential config.
 		GIT_CEILING_DIRECTORIES: root,
 	};
-	delete env.GIT_ASKPASS;
-	delete env.SSH_ASKPASS;
 	delete env.DISPLAY;
 	return env;
 }

--- a/src/server/owned-tree-command-spawn.ts
+++ b/src/server/owned-tree-command-spawn.ts
@@ -1,0 +1,83 @@
+import { spawn as nodeSpawn, type ChildProcess, type SpawnOptions } from "node:child_process";
+import type { Clock } from "./clock.js";
+import { spawnTracked, type TrackedChild } from "./agent/spawn-tree.js";
+
+const OWNED_TREE_REQUEST = Symbol("bobbit.owned-tree-command-spawn");
+
+export type OwnedTreeControl = Pick<TrackedChild,
+	| "ownershipReady"
+	| "killTree"
+	| "waitForTreeExit"
+	| "killed"
+	| "timedOut"
+>;
+
+interface OwnedTreeRequest {
+	clock: Clock;
+	bind(control: OwnedTreeControl): void;
+}
+
+export type CommandSpawnOptions = SpawnOptions & {
+	[OWNED_TREE_REQUEST]?: OwnedTreeRequest;
+};
+
+/**
+ * Brand one logical CommandRunner spawn as requiring platform-owned process-tree
+ * containment. The symbol stays private so only this module can translate the
+ * request into the lower-level sentinel/Job supervisor.
+ */
+export function ownedTreeSpawnOptions(
+	options: {
+		cwd?: string;
+		env?: NodeJS.ProcessEnv;
+		stdio?: SpawnOptions["stdio"];
+		windowsHide?: boolean;
+	},
+	clock: Clock,
+	bind: (control: OwnedTreeControl) => void,
+): CommandSpawnOptions {
+	return Object.assign({}, options, {
+		[OWNED_TREE_REQUEST]: { clock, bind } satisfies OwnedTreeRequest,
+	});
+}
+
+export function hasOwnedTreeSpawnRequest(options: CommandSpawnOptions | undefined): boolean {
+	return options?.[OWNED_TREE_REQUEST] !== undefined;
+}
+
+type DirectSpawn = (file: string, args: readonly string[], options?: SpawnOptions) => ChildProcess;
+type OwnedSpawn = typeof spawnTracked;
+
+/** Production CommandRunner spawn adapter. Ordinary calls retain direct-spawn behavior. */
+export function createCommandSpawnAdapter(
+	directSpawn: DirectSpawn = (file, args, options) => options === undefined
+		? nodeSpawn(file, [...args])
+		: nodeSpawn(file, [...args], options),
+	ownedSpawn: OwnedSpawn = spawnTracked,
+): NonNullable<import("./gateway-deps.js").CommandRunner["spawn"]> {
+	return (file, args, options) => {
+		const request = options?.[OWNED_TREE_REQUEST];
+		if (!request) return directSpawn(file, args, options);
+
+		const { [OWNED_TREE_REQUEST]: _request, ...spawnOptions } = options;
+		if (spawnOptions.cwd != null && typeof spawnOptions.cwd !== "string") {
+			throw new Error("Owned-tree command cwd must be a filesystem path string");
+		}
+		const tracked = ownedSpawn(file, args, {
+			cwd: spawnOptions.cwd,
+			env: spawnOptions.env,
+			stdio: spawnOptions.stdio,
+			windowsHide: spawnOptions.windowsHide,
+			clock: request.clock,
+		});
+		try {
+			request.bind(tracked);
+		} catch (error) {
+			// Binding is part of the synchronous ownership handoff. If a caller cannot
+			// retain the control, do not leave the newly owned tree running.
+			tracked.killTree("SIGKILL");
+			throw error;
+		}
+		return tracked.child;
+	};
+}

--- a/src/server/remote-state-coordinator.ts
+++ b/src/server/remote-state-coordinator.ts
@@ -223,14 +223,11 @@ export interface TrustedGithubRemote {
 }
 
 /**
- * Parse a complete Git remote and trust-gate its actual host. URL and scp forms
- * are deliberately separate so a trusted-looking suffix embedded in an
- * attacker-controlled URL can never become the canonical PR identity.
+ * Structurally parse a complete GitHub-shaped remote without deciding whether
+ * its host is trusted. Callers must apply an independent host trust decision
+ * before using the result for any external operation.
  */
-export function parseTrustedGithubRemote(
-	remote: string,
-	configuredEnterpriseHosts: readonly string[] = [],
-): TrustedGithubRemote | undefined {
+export function parseUntrustedGithubRemoteCandidate(remote: string): TrustedGithubRemote | undefined {
 	const value = remote.trim();
 	if (!value || /[\u0000-\u001f\u007f]/.test(value)) return undefined;
 
@@ -244,7 +241,6 @@ export function parseTrustedGithubRemote(
 		if (url.search || url.hash) return undefined;
 		if (url.protocol === "ssh:" && url.password) return undefined;
 		if (url.protocol === "ssh:" && url.username && url.username !== "git") return undefined;
-		if (!isTrustedGithubRemoteHost(url.hostname, configuredEnterpriseHosts)) return undefined;
 		// An SSH port belongs to Git transport, not to the GitHub web/API
 		// authority used by `gh` and host-scoped credentials. HTTPS/HTTP ports do
 		// identify a distinct API authority and therefore remain canonical.
@@ -258,7 +254,7 @@ export function parseTrustedGithubRemote(
 		[, host, rawOwner, rawRepository] = scp;
 	}
 
-	if (!host || !isTrustedGithubRemoteHost(host, configuredEnterpriseHosts)) return undefined;
+	if (!host) return undefined;
 	const owner = decodeGithubPathSegment(rawOwner);
 	const decodedRepository = decodeGithubPathSegment(rawRepository);
 	if (!owner || !decodedRepository) return undefined;
@@ -269,6 +265,16 @@ export function parseTrustedGithubRemote(
 		owner: owner.toLowerCase(),
 		repository: repository.toLowerCase(),
 	};
+}
+
+/** Parse a complete Git remote and trust-gate its actual host against the existing list. */
+export function parseTrustedGithubRemote(
+	remote: string,
+	configuredEnterpriseHosts: readonly string[] = [],
+): TrustedGithubRemote | undefined {
+	const candidate = parseUntrustedGithubRemoteCandidate(remote);
+	if (!candidate) return undefined;
+	return isTrustedGithubRemoteHost(candidate.host, configuredEnterpriseHosts) ? candidate : undefined;
 }
 
 function decodeGithubPathSegment(value: string): string | undefined {

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -2,8 +2,9 @@ import { exec } from "node:child_process";
 import { isDeepStrictEqual, promisify } from "node:util";
 import { getRegisteredRpcBridgeFactory, registerRpcBridgeFactory, tryHostPathToContainer } from "./agent/rpc-bridge.js";
 import { resolveGatewayDeps, realCommandRunner, type Clock, type CommandRunner, type FsLike, type GatewayDeps } from "./gateway-deps.js";
-import { parseTrustedGithubRemote, RemoteStateCoordinator, type PullRequestIdentity, type RemoteStateAddress, type RemoteStateIntent, type RemoteStateTelemetryEvent, type RepositorySnapshotBinding, type TrustedGithubRemote } from "./remote-state-coordinator.js";
+import { parseTrustedGithubRemote, parseUntrustedGithubRemoteCandidate, RemoteStateCoordinator, type PullRequestIdentity, type RemoteStateAddress, type RemoteStateIntent, type RemoteStateTelemetryEvent, type RepositorySnapshotBinding, type TrustedGithubRemote } from "./remote-state-coordinator.js";
 import { GithubTrustedHostResolver } from "./github-trusted-hosts.js";
+import { GithubHostCredentialTrust } from "./github-host-credential-trust.js";
 import { resolveLegacyTestRuntimeFlags } from "./legacy-test-runtime-flags.js";
 import { parseStrictBody, STRICT_UPDATE_BODY_KEYS, type StrictBody, type StrictBodyOptions } from "./strict-body.js";
 export type { Clock, CommandRunner, ExecFileResult, FsLike, GatewayDeps, ResolvedGatewayDeps, TimerHandle } from "./gateway-deps.js";
@@ -1268,6 +1269,10 @@ export function buildGhPrMergePermissionsArgs(remote: TrustedGithubRemote, numbe
 	];
 }
 
+export function buildGhRepoPermissionArgs(remote: TrustedGithubRemote): string[] {
+	return ["repo", "view", "--repo", githubRepositorySelector(remote), "--json", "viewerPermission"];
+}
+
 export function buildGhBranchRulesArgs(remote: TrustedGithubRemote, branch: string): string[] {
 	return [
 		"api", ...ghApiHostnameArgs(remote),
@@ -1309,20 +1314,26 @@ export function __resetPrStatusCachesForTests(): void {
 	_repoPermCache.clear();
 }
 
-// Cache viewer permission per repo (rarely changes, long TTL)
+// Cache viewer permission per exact repository (rarely changes, long TTL).
+// The cwd alone is not an authority: a remote can change while the process runs.
 const _repoPermCache = new Map<string, { perm: string; ts: number }>();
 const REPO_PERM_CACHE_TTL_MS = 300_000; // 5 minutes
 
-async function getViewerIsAdmin(cwd: string): Promise<boolean> {
-	const cached = _repoPermCache.get(cwd);
+function repoPermissionCacheKey(cwd: string, remote: TrustedGithubRemote): string {
+	return `${cwd}\0${githubRepositorySelector(remote)}`;
+}
+
+async function getViewerIsAdmin(cwd: string, remote: TrustedGithubRemote): Promise<boolean> {
+	const cacheKey = repoPermissionCacheKey(cwd, remote);
+	const cached = _repoPermCache.get(cacheKey);
 	if (cached && Date.now() - cached.ts < REPO_PERM_CACHE_TTL_MS) return cached.perm === "ADMIN";
 	try {
-		const stdout = await execGh(["repo", "view", "--json", "viewerPermission"], cwd);
+		const stdout = await execGh(buildGhRepoPermissionArgs(remote), cwd);
 		const perm = JSON.parse(stdout).viewerPermission ?? "";
-		_repoPermCache.set(cwd, { perm, ts: Date.now() });
+		_repoPermCache.set(cacheKey, { perm, ts: Date.now() });
 		return perm === "ADMIN";
 	} catch {
-		_repoPermCache.set(cwd, { perm: "", ts: Date.now() });
+		_repoPermCache.set(cacheKey, { perm: "", ts: Date.now() });
 		return false;
 	}
 }
@@ -1352,7 +1363,7 @@ async function getViewerMergePermissions(
 			const parsed = JSON.parse(stdout);
 			const repository = parsed?.data?.repository;
 			const perm = repository?.viewerPermission ?? "";
-			_repoPermCache.set(cwd, { perm, ts: Date.now() });
+			_repoPermCache.set(repoPermissionCacheKey(cwd, remote), { perm, ts: Date.now() });
 
 			let viewerCanMergeAsAdmin = repository?.pullRequest?.viewerCanMergeAsAdmin === true;
 			if (!viewerCanMergeAsAdmin && typeof pr.baseRefName === "string" && pr.baseRefName) {
@@ -1364,7 +1375,10 @@ async function getViewerMergePermissions(
 			// Fall through to legacy permission probe.
 		}
 	}
-	return { viewerIsAdmin: await getViewerIsAdmin(cwd), viewerCanMergeAsAdmin: false };
+	return {
+		viewerIsAdmin: remote ? await getViewerIsAdmin(cwd, remote) : false,
+		viewerCanMergeAsAdmin: false,
+	};
 }
 
 async function getViewerCanBypassBranchRules(
@@ -2708,6 +2722,15 @@ export function createGateway(config: GatewayConfig, deps?: GatewayDeps) {
 		getManagedHosts: () => normalizeTrustedHosts(preferencesStore.get("githubTrustedHosts")),
 		env: process.env,
 	});
+	// This fallback is deliberately separate from the configured/discovered host
+	// resolver: it grants process-local admission only to PR operations and never
+	// persists or broadens githubTrustedHosts. Resolve spawn and environment per
+	// probe so injected runners and live ambient-token refusal remain authoritative.
+	const githubHostCredentialTrust = new GithubHostCredentialTrust({
+		resolveSpawn: () => gatewayDeps.commandRunner.spawn,
+		clock: gatewayDeps.clock,
+		getEnv: () => process.env,
+	});
 	const reviewAnnotationStore = new ReviewAnnotationStore(stateDir, gatewayDeps.fsImpl);
 	const savedCwd = preferencesStore.get("defaultCwd");
 	if (savedCwd && typeof savedCwd === "string") {
@@ -3438,7 +3461,15 @@ export function createGateway(config: GatewayConfig, deps?: GatewayDeps) {
 	const parsePrRemote = async (cwd: string): Promise<{ host: string; owner: string; repository: string } | undefined> => {
 		try {
 			const origin = stripTokenFromGitUrl(await execGit("git remote get-url origin", cwd, 5_000, undefined, gatewayDeps.commandRunner));
-			return parseTrustedGithubRemote(origin, await githubTrustedHostResolver.resolve());
+			const listed = parseTrustedGithubRemote(origin, await githubTrustedHostResolver.resolve());
+			if (listed) return listed;
+
+			// Structural parsing remains the sole authority for malformed/unsafe remote
+			// rejection. Only an otherwise-valid, unlisted candidate reaches the local
+			// credential probe, and the exact candidate is returned only when vouched.
+			const candidate = parseUntrustedGithubRemoteCandidate(origin);
+			if (!candidate) return undefined;
+			return await githubHostCredentialTrust.isTrusted(candidate.host) ? candidate : undefined;
 		} catch {
 			return undefined;
 		}
@@ -3769,6 +3800,7 @@ export function createGateway(config: GatewayConfig, deps?: GatewayDeps) {
 	};
 	const remoteStateRoutes = {
 		resolveGithubTrustedHosts: () => githubTrustedHostResolver.resolve(),
+		forgetUnverifiedGithubHosts: () => githubHostCredentialTrust.forgetUnverified(),
 		publicSnapshot: publicRemoteSnapshot,
 		publicGitSnapshot,
 		gitSnapshotFor,
@@ -14641,6 +14673,7 @@ async function handleApiRoute(
 		if (!goal) { json({ error: "Goal not found" }, 404); return; }
 		if (!hasGoalGitWorktree(goal)) { json(goalGitUnavailablePayload(goal, "PR status"), 409); return; }
 		const optional = url.searchParams.get("optional") === "1";
+		if (url.searchParams.get("intent") === "explicit") remoteState.forgetUnverifiedGithubHosts();
 		const target = await remoteState.resolvePrSnapshotTarget(goal, goal.branch);
 		const snapshot = target
 			? await remoteState.prSnapshotFor(target, { kind: "goal", id: goalId }, url.searchParams.get("intent"))
@@ -18243,6 +18276,7 @@ async function handleApiRoute(
 		const session = sessionManager.getSession(id);
 		if (!session) { json({ error: "Session not found" }, 404); return; }
 		if (isHeadquartersSession(session)) { json(sessionGitUnavailablePayload(session, "PR status"), 409); return; }
+		if (url.searchParams.get("intent") === "explicit") remoteState.forgetUnverifiedGithubHosts();
 		const selector = await resolveSessionPrRouteSelector(id, session);
 		const optional = url.searchParams.get("optional") === "1";
 		const snapshot = selector.target

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -2729,7 +2729,7 @@ export function createGateway(config: GatewayConfig, deps?: GatewayDeps) {
 	// persists or broadens githubTrustedHosts. Resolve spawn and environment per
 	// probe so injected runners and live ambient-token refusal remain authoritative.
 	const githubHostCredentialTrust = new GithubHostCredentialTrust({
-		resolveSpawn: () => gatewayDeps.commandRunner.spawn,
+		resolveCommandRunner: () => gatewayDeps.commandRunner,
 		clock: gatewayDeps.clock,
 		getEnv: () => process.env,
 	});

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -3526,10 +3526,7 @@ export function createGateway(config: GatewayConfig, deps?: GatewayDeps) {
 		/** Multi-repo candidates stay bound to the authoritative source remote. */
 		remote?: TrustedGithubRemote;
 	};
-	const resolveOwnedPrRepositoryIdentity = async (
-		cwd: string,
-		trustMode: PrRemoteTrustMode,
-	): Promise<OwnedPrRepositoryIdentity | undefined> => {
+	const resolveOwnedPrRepositoryCommonDir = async (cwd: string): Promise<string | undefined> => {
 		let rawCommonDir: string;
 		try {
 			rawCommonDir = (await execGitArgs(
@@ -3553,13 +3550,30 @@ export function createGateway(config: GatewayConfig, deps?: GatewayDeps) {
 			}
 		}
 		if (!rawCommonDir) return undefined;
-		const remote = await parsePrRemote(cwd, trustMode);
-		if (!remote) return undefined;
 		const absoluteCommonDir = path.isAbsolute(rawCommonDir) ? rawCommonDir : path.resolve(cwd, rawCommonDir);
-		return {
-			commonDir: comparableOwnedPath(absoluteCommonDir),
-			remote,
-		};
+		return comparableOwnedPath(absoluteCommonDir);
+	};
+	const resolveOwnedPrRepositoryIdentity = async (
+		cwd: string,
+		trustMode: PrRemoteTrustMode,
+	): Promise<OwnedPrRepositoryIdentity | undefined> => {
+		const commonDir = await resolveOwnedPrRepositoryCommonDir(cwd);
+		if (!commonDir) return undefined;
+		const remote = await parsePrRemote(cwd, trustMode);
+		return remote ? { commonDir, remote } : undefined;
+	};
+	const resolveStructuralPrSiblingIdentity = async (cwd: string): Promise<OwnedPrRepositoryIdentity | undefined> => {
+		const commonDir = await resolveOwnedPrRepositoryCommonDir(cwd);
+		if (!commonDir) return undefined;
+		try {
+			// This candidate is consumed only by duplicate-source rejection. It does
+			// not make the sibling eligible for PR routing or credential probing.
+			const origin = stripTokenFromGitUrl(await execGit("git remote get-url origin", cwd, 5_000, undefined, gatewayDeps.commandRunner));
+			const remote = parseUntrustedGithubRemoteCandidate(origin);
+			return remote ? { commonDir, remote } : undefined;
+		} catch {
+			return undefined;
+		}
 	};
 	const sameOwnedPrRepository = (left: OwnedPrRepositoryIdentity, right: OwnedPrRepositoryIdentity): boolean => (
 		left.commonDir === right.commonDir
@@ -3693,10 +3707,9 @@ export function createGateway(config: GatewayConfig, deps?: GatewayDeps) {
 				const siblingTopLevel = await resolveConfiguredPrTopLevel(siblingSource);
 				if (!siblingTopLevel) continue;
 				if (comparableOwnedPath(siblingTopLevel) !== comparableOwnedPath(siblingSource)) return [];
-				// Siblings are inspected only for pre-existing listed-host aliases. A status
-				// request may credential-vouch its selected source, but must not invoke an
-				// operator's credential helpers for unrelated configured repositories.
-				const siblingIdentity = await resolveOwnedPrRepositoryIdentity(siblingSource, "listed-only");
+				// Structural sibling inspection preserves fail-closed duplicate-source
+				// rejection without trusting the sibling host or consulting credentials.
+				const siblingIdentity = await resolveStructuralPrSiblingIdentity(siblingSource);
 				if (siblingIdentity && sameOwnedPrRepository(sourceIdentity, siblingIdentity)) return [];
 			}
 			const addMatchingRepository = async (candidate: unknown, allowedRoots: readonly string[]) => {

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -1482,6 +1482,8 @@ export type CoordinatedPrLookupTarget = {
 	selector: CoordinatedPrSelector;
 };
 
+type PrRemoteTrustMode = "listed-only" | "credential-status";
+
 type NormalizedCoordinatedPr = {
 	data: any;
 	updatedAt?: number;
@@ -3458,15 +3460,19 @@ export function createGateway(config: GatewayConfig, deps?: GatewayDeps) {
 			// was never registered or identity lookup is temporarily unavailable.
 		}
 	};
-	const parsePrRemote = async (cwd: string): Promise<{ host: string; owner: string; repository: string } | undefined> => {
+	const parsePrRemote = async (
+		cwd: string,
+		trustMode: PrRemoteTrustMode = "listed-only",
+	): Promise<{ host: string; owner: string; repository: string } | undefined> => {
 		try {
 			const origin = stripTokenFromGitUrl(await execGit("git remote get-url origin", cwd, 5_000, undefined, gatewayDeps.commandRunner));
 			const listed = parseTrustedGithubRemote(origin, await githubTrustedHostResolver.resolve());
 			if (listed) return listed;
+			if (trustMode === "listed-only") return undefined;
 
 			// Structural parsing remains the sole authority for malformed/unsafe remote
 			// rejection. Only an otherwise-valid, unlisted candidate reaches the local
-			// credential probe, and the exact candidate is returned only when vouched.
+			// credential probe, and the exact candidate is returned only for status reads.
 			const candidate = parseUntrustedGithubRemoteCandidate(origin);
 			if (!candidate) return undefined;
 			return await githubHostCredentialTrust.isTrusted(candidate.host) ? candidate : undefined;
@@ -3520,7 +3526,10 @@ export function createGateway(config: GatewayConfig, deps?: GatewayDeps) {
 		/** Multi-repo candidates stay bound to the authoritative source remote. */
 		remote?: TrustedGithubRemote;
 	};
-	const resolveOwnedPrRepositoryIdentity = async (cwd: string): Promise<OwnedPrRepositoryIdentity | undefined> => {
+	const resolveOwnedPrRepositoryIdentity = async (
+		cwd: string,
+		trustMode: PrRemoteTrustMode,
+	): Promise<OwnedPrRepositoryIdentity | undefined> => {
 		let rawCommonDir: string;
 		try {
 			rawCommonDir = (await execGitArgs(
@@ -3544,7 +3553,7 @@ export function createGateway(config: GatewayConfig, deps?: GatewayDeps) {
 			}
 		}
 		if (!rawCommonDir) return undefined;
-		const remote = await parsePrRemote(cwd);
+		const remote = await parsePrRemote(cwd, trustMode);
 		if (!remote) return undefined;
 		const absoluteCommonDir = path.isAbsolute(rawCommonDir) ? rawCommonDir : path.resolve(cwd, rawCommonDir);
 		return {
@@ -3574,14 +3583,20 @@ export function createGateway(config: GatewayConfig, deps?: GatewayDeps) {
 		if (!rawTopLevel) return undefined;
 		return canonicalOwnedPath(path.isAbsolute(rawTopLevel) ? rawTopLevel : path.resolve(source, rawTopLevel));
 	};
-	const resolveConfiguredPrSourceIdentity = async (source: string): Promise<OwnedPrRepositoryIdentity | undefined> => {
+	const resolveConfiguredPrSourceIdentity = async (
+		source: string,
+		trustMode: PrRemoteTrustMode,
+	): Promise<OwnedPrRepositoryIdentity | undefined> => {
 		const topLevel = await resolveConfiguredPrTopLevel(source);
 		// A selected nested component must be a repository root in its own right.
 		// Merely resolving Git through an enclosing repository is not ownership.
 		if (!topLevel || comparableOwnedPath(topLevel) !== comparableOwnedPath(source)) return undefined;
-		return resolveOwnedPrRepositoryIdentity(source);
+		return resolveOwnedPrRepositoryIdentity(source, trustMode);
 	};
-	const ownedPrCandidates = async (owner: PrRouteOwner): Promise<OwnedPrCandidate[]> => {
+	const ownedPrCandidates = async (
+		owner: PrRouteOwner,
+		trustMode: PrRemoteTrustMode,
+	): Promise<OwnedPrCandidate[]> => {
 		// Project scope comes from the store that owns the entity, never from its
 		// mutable/persisted projectId or repository metadata.
 		const owningContext = projectContextManager.getContextForGoal(owner.id)
@@ -3671,14 +3686,14 @@ export function createGateway(config: GatewayConfig, deps?: GatewayDeps) {
 			// routing, but any observable top-level/identity alias still fails closed.
 			const selectedConfiguredSource = configuredSources.get(selected.repo);
 			if (!selectedConfiguredSource || comparableOwnedPath(selectedConfiguredSource) !== comparableOwnedPath(selectedSource)) return [];
-			const sourceIdentity = await resolveConfiguredPrSourceIdentity(selectedConfiguredSource);
+			const sourceIdentity = await resolveConfiguredPrSourceIdentity(selectedConfiguredSource, trustMode);
 			if (!sourceIdentity) return [];
 			for (const [repo, siblingSource] of configuredSources) {
 				if (repo === selected.repo) continue;
 				const siblingTopLevel = await resolveConfiguredPrTopLevel(siblingSource);
 				if (!siblingTopLevel) continue;
 				if (comparableOwnedPath(siblingTopLevel) !== comparableOwnedPath(siblingSource)) return [];
-				const siblingIdentity = await resolveOwnedPrRepositoryIdentity(siblingSource);
+				const siblingIdentity = await resolveOwnedPrRepositoryIdentity(siblingSource, trustMode);
 				if (siblingIdentity && sameOwnedPrRepository(sourceIdentity, siblingIdentity)) return [];
 			}
 			const addMatchingRepository = async (candidate: unknown, allowedRoots: readonly string[]) => {
@@ -3686,7 +3701,7 @@ export function createGateway(config: GatewayConfig, deps?: GatewayDeps) {
 				add(candidate, allowedRoots);
 				if (candidates.length === before) return;
 				const added = candidates[candidates.length - 1];
-				const identity = await resolveOwnedPrRepositoryIdentity(added);
+				const identity = await resolveOwnedPrRepositoryIdentity(added, trustMode);
 				if (!identity || !sameOwnedPrRepository(sourceIdentity, identity)) {
 					candidates.pop();
 					seen.delete(comparableOwnedPath(added));
@@ -3716,12 +3731,13 @@ export function createGateway(config: GatewayConfig, deps?: GatewayDeps) {
 		owner: PrRouteOwner,
 		branch: string | undefined,
 		identitySource?: { cwd: string; containerId?: string },
+		trustMode: PrRemoteTrustMode = "listed-only",
 	): Promise<PrSnapshotTarget | undefined> => {
 		// Selection is local-only and restricted to entity/project-owned candidates.
 		// A broken worktree can recover through its persisted repoPath or registered
 		// project root, but a merely Git-valid ambient directory is never eligible.
 		let selectedCandidate: OwnedPrCandidate | undefined;
-		for (const candidate of await ownedPrCandidates(owner)) {
+		for (const candidate of await ownedPrCandidates(owner, trustMode)) {
 			try {
 				await execGitArgs(["rev-parse", "--git-dir"], candidate.cwd, 5_000, undefined, gatewayDeps.commandRunner);
 				selectedCandidate = candidate;
@@ -3732,7 +3748,7 @@ export function createGateway(config: GatewayConfig, deps?: GatewayDeps) {
 		const executionCwd = selectedCandidate.cwd;
 
 		const [remote, head] = await Promise.all([
-			selectedCandidate.remote ? Promise.resolve(selectedCandidate.remote) : parsePrRemote(executionCwd),
+			selectedCandidate.remote ? Promise.resolve(selectedCandidate.remote) : parsePrRemote(executionCwd, trustMode),
 			resolvePullRequestHeadIdentity(
 				identitySource?.cwd ?? executionCwd,
 				branch,
@@ -14674,7 +14690,7 @@ async function handleApiRoute(
 		if (!hasGoalGitWorktree(goal)) { json(goalGitUnavailablePayload(goal, "PR status"), 409); return; }
 		const optional = url.searchParams.get("optional") === "1";
 		if (url.searchParams.get("intent") === "explicit") remoteState.forgetUnverifiedGithubHosts();
-		const target = await remoteState.resolvePrSnapshotTarget(goal, goal.branch);
+		const target = await remoteState.resolvePrSnapshotTarget(goal, goal.branch, undefined, "credential-status");
 		const snapshot = target
 			? await remoteState.prSnapshotFor(target, { kind: "goal", id: goalId }, url.searchParams.get("intent"))
 			: undefined;
@@ -18235,7 +18251,11 @@ async function handleApiRoute(
 		}
 		return;
 	}
-	const resolveSessionPrRouteSelector = async (id: string, session: any) => {
+	const resolveSessionPrRouteSelector = async (
+		id: string,
+		session: any,
+		trustMode: PrRemoteTrustMode = "listed-only",
+	) => {
 		const cwd = session.cwd as string;
 		const cid = session.sandboxed ? session.containerId as string | undefined : undefined;
 		const persisted = sessionManager.getPersistedSession(id);
@@ -18266,7 +18286,7 @@ async function handleApiRoute(
 			cwd,
 			cid,
 			branch,
-			target: await remoteState.resolvePrSnapshotTarget(owner, branch, identitySource),
+			target: await remoteState.resolvePrSnapshotTarget(owner, branch, identitySource, trustMode),
 		};
 	};
 
@@ -18277,7 +18297,7 @@ async function handleApiRoute(
 		if (!session) { json({ error: "Session not found" }, 404); return; }
 		if (isHeadquartersSession(session)) { json(sessionGitUnavailablePayload(session, "PR status"), 409); return; }
 		if (url.searchParams.get("intent") === "explicit") remoteState.forgetUnverifiedGithubHosts();
-		const selector = await resolveSessionPrRouteSelector(id, session);
+		const selector = await resolveSessionPrRouteSelector(id, session, "credential-status");
 		const optional = url.searchParams.get("optional") === "1";
 		const snapshot = selector.target
 			? await remoteState.prSnapshotFor(selector.target, { kind: "session", id }, url.searchParams.get("intent"))

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -3693,7 +3693,10 @@ export function createGateway(config: GatewayConfig, deps?: GatewayDeps) {
 				const siblingTopLevel = await resolveConfiguredPrTopLevel(siblingSource);
 				if (!siblingTopLevel) continue;
 				if (comparableOwnedPath(siblingTopLevel) !== comparableOwnedPath(siblingSource)) return [];
-				const siblingIdentity = await resolveOwnedPrRepositoryIdentity(siblingSource, trustMode);
+				// Siblings are inspected only for pre-existing listed-host aliases. A status
+				// request may credential-vouch its selected source, but must not invoke an
+				// operator's credential helpers for unrelated configured repositories.
+				const siblingIdentity = await resolveOwnedPrRepositoryIdentity(siblingSource, "listed-only");
 				if (siblingIdentity && sameOwnedPrRepository(sourceIdentity, siblingIdentity)) return [];
 			}
 			const addMatchingRepository = async (candidate: unknown, allowedRoots: readonly string[]) => {

--- a/tests2/core/clock.test.ts
+++ b/tests2/core/clock.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { realClock, type TimerHandle } from "../../src/server/clock.js";
+
+const MAX_REAL_TIMER_DELAY_MS = 2_147_483_647;
+
+function timerHandle(): TimerHandle {
+	return { unref: vi.fn() } as unknown as TimerHandle;
+}
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe("realClock timer delay bounds", () => {
+	it("passes ordinary and zero timeout delays through unchanged", () => {
+		const handle = timerHandle();
+		const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout").mockReturnValue(handle);
+		const handler = vi.fn();
+
+		expect(realClock.setTimeout(handler, 125.5)).toBe(handle);
+		realClock.setTimeout(handler, 0);
+
+		expect(setTimeoutSpy).toHaveBeenNthCalledWith(1, handler, 125.5);
+		expect(setTimeoutSpy).toHaveBeenNthCalledWith(2, handler, 0);
+	});
+
+	it.each([
+		[Number.MAX_SAFE_INTEGER, MAX_REAL_TIMER_DELAY_MS],
+		[Number.POSITIVE_INFINITY, MAX_REAL_TIMER_DELAY_MS],
+		[Number.NaN, MAX_REAL_TIMER_DELAY_MS],
+		[Number.NEGATIVE_INFINITY, MAX_REAL_TIMER_DELAY_MS],
+		[-10, 0],
+	])("normalizes timeout delay %s to %s", (input, expected) => {
+		const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout").mockReturnValue(timerHandle());
+		const handler = vi.fn();
+
+		realClock.setTimeout(handler, input);
+
+		expect(setTimeoutSpy).toHaveBeenCalledWith(handler, expected);
+	});
+
+	it("applies the same bounds to intervals", () => {
+		const setIntervalSpy = vi.spyOn(globalThis, "setInterval").mockReturnValue(timerHandle());
+		const handler = vi.fn();
+
+		realClock.setInterval(handler, Number.POSITIVE_INFINITY);
+		realClock.setInterval(handler, -1);
+		realClock.setInterval(handler, 250);
+
+		expect(setIntervalSpy).toHaveBeenNthCalledWith(1, handler, MAX_REAL_TIMER_DELAY_MS);
+		expect(setIntervalSpy).toHaveBeenNthCalledWith(2, handler, 0);
+		expect(setIntervalSpy).toHaveBeenNthCalledWith(3, handler, 250);
+	});
+
+	it("forwards timer handles unchanged when clearing", () => {
+		const clearTimeoutSpy = vi.spyOn(globalThis, "clearTimeout").mockImplementation(() => undefined);
+		const clearIntervalSpy = vi.spyOn(globalThis, "clearInterval").mockImplementation(() => undefined);
+		const handle = timerHandle();
+
+		realClock.clearTimeout(handle);
+		realClock.clearInterval(handle);
+
+		expect(clearTimeoutSpy).toHaveBeenCalledWith(handle);
+		expect(clearIntervalSpy).toHaveBeenCalledWith(handle);
+	});
+});

--- a/tests2/core/command-runner-fence.test.ts
+++ b/tests2/core/command-runner-fence.test.ts
@@ -1,3 +1,4 @@
+import os from "node:os";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -95,6 +96,42 @@ describe("fenced command runner", () => {
 		expect(() => runnerWithoutSpawn.spawn!("git.cmd", ["--no-pager", "credential", "fill"])).toThrow(expected);
 	});
 
+	it("blocks alias and config-include injection on every runner path without delegation", async () => {
+		const delegations: string[] = [];
+		const delegate: CommandRunner = {
+			execFile: async () => { delegations.push("async"); return { stdout: "", stderr: "" }; },
+			execFileSync: () => { delegations.push("sync"); return ""; },
+			spawn: () => { delegations.push("spawn"); return {} as any; },
+		};
+		const runner = createFencedCommandRunner(delegate);
+		const expected = new Error("[fenced-command-runner] blocked unsafe git configuration");
+		const bypasses: Array<{ args: string[]; env?: NodeJS.ProcessEnv }> = [
+			{ args: ["-c", "alias.readcreds=!git credential fill", "readcreds"] },
+			{ args: ["-cALIAS.readcreds=!git credential fill", "readcreds"] },
+			{ args: ["--config-env", "alias.readcreds=FIXTURE_ALIAS", "readcreds"], env: { FIXTURE_ALIAS: "!git credential fill" } },
+			{ args: ["--config-env=Alias.readcreds=FIXTURE_ALIAS", "readcreds"], env: { FIXTURE_ALIAS: "!git credential fill" } },
+			{ args: ["-c", "include.path=/developer/.gitconfig", "status"] },
+			{ args: ["-cIncludeIf.gitdir:/fixture/.path=/developer/.gitconfig", "status"] },
+			{ args: ["--config-env=includeIf.onbranch:main.path=INCLUDE_FILE", "status"], env: { INCLUDE_FILE: "/developer/.gitconfig" } },
+			{
+				args: ["readcreds"],
+				env: { GIT_CONFIG_COUNT: "1", GIT_CONFIG_KEY_0: "alias.readcreds", GIT_CONFIG_VALUE_0: "!git credential fill" },
+			},
+			{
+				args: ["status"],
+				env: { git_config_count: "1", git_config_key_0: "INCLUDE.path", git_config_value_0: "/developer/.gitconfig" },
+			},
+			{ args: ["status"], env: { GIT_CONFIG_PARAMETERS: "'alias.readcreds'='!git credential fill'" } },
+		];
+
+		for (const { args, env } of bypasses) {
+			await expect(runner.execFile("git", args, { env })).rejects.toThrow(expected);
+			expect(() => runner.execFileSync!("git.cmd", args, { env })).toThrow(expected);
+			expect(() => runner.spawn!("git.exe", args, { env })).toThrow(expected);
+		}
+		expect(delegations).toEqual([]);
+	});
+
 	it("fails closed on unknown or malformed Git global options before delegation", async () => {
 		const delegations: string[] = [];
 		const delegate: CommandRunner = {
@@ -104,49 +141,83 @@ describe("fenced command runner", () => {
 		};
 		const runner = createFencedCommandRunner(delegate);
 		const expected = new Error("[fenced-command-runner] blocked unclassified git invocation");
-		for (const args of [
-			[],
-			["--unknown-global", "credential", "fill"],
-			["-C"],
-			["--config-env"],
-			["--git-dir=", "status"],
-			["--", "--not-a-command"],
-		]) {
-			await expect(runner.execFile("git", args)).rejects.toThrow(expected);
-			expect(() => runner.execFileSync!("git.cmd", args)).toThrow(expected);
-			expect(() => runner.spawn!("git.bat", args)).toThrow(expected);
+		for (const { args, env } of [
+			{ args: [] },
+			{ args: ["--unknown-global", "credential", "fill"] },
+			{ args: ["-C"] },
+			{ args: ["--config-env"] },
+			{ args: ["--config-env=core.filemode="] },
+			{ args: ["--config-env=core.filemode=INVALID-NAME", "status"] },
+			{ args: ["--git-dir=", "status"] },
+			{ args: ["--", "--not-a-command"] },
+			{ args: ["status"], env: { GIT_CONFIG_COUNT: "one" } },
+			{ args: ["status"], env: { GIT_CONFIG_KEY_0: "user.name", GIT_CONFIG_VALUE_0: "Fixture" } },
+			{ args: ["status"], env: { GIT_CONFIG_COUNT: "1", GIT_CONFIG_KEY_0: "user.name" } },
+			{ args: ["status"], env: { GIT_CONFIG_COUNT: "0", GIT_CONFIG_KEY_extra: "user.name" } },
+		] as Array<{ args: string[]; env?: NodeJS.ProcessEnv }>) {
+			await expect(runner.execFile("git", args, { env })).rejects.toThrow(expected);
+			expect(() => runner.execFileSync!("git.cmd", args, { env })).toThrow(expected);
+			expect(() => runner.spawn!("git.bat", args, { env })).toThrow(expected);
 		}
 		expect(delegations).toEqual([]);
 	});
 
-	it("allows classified non-credential global options through every runner path", async () => {
+	it("delegates safe config while isolating global and system Git configuration", async () => {
 		const { repo } = makeRepositoryMetadata(makeFixtureRoot("bobbit-fenced-global-options-"));
 		const calls: string[] = [];
+		const environments: NodeJS.ProcessEnv[] = [];
 		const fakeChild = { pid: 4321 };
 		const delegate: CommandRunner = {
-			execFile: async (file, args) => {
+			execFile: async (file, args, options) => {
 				calls.push(`async ${file} ${args.join(" ")}`);
+				environments.push(options?.env ?? {});
 				return { stdout: "clean", stderr: "" };
 			},
-			execFileSync: (file, args) => {
+			execFileSync: (file, args, options) => {
 				calls.push(`sync ${file} ${args.join(" ")}`);
+				environments.push(options?.env ?? {});
 				return "clean";
 			},
-			spawn: (file, args) => {
+			spawn: (file, args, options) => {
 				calls.push(`spawn ${file} ${args.join(" ")}`);
+				environments.push(options?.env ?? {});
 				return fakeChild as any;
 			},
 		};
 		const runner = createFencedCommandRunner(delegate);
+		const developerConfig = {
+			GIT_CONFIG: "/developer/selected.gitconfig",
+			GIT_CONFIG_GLOBAL: "/developer/.gitconfig",
+			GIT_CONFIG_SYSTEM: "/etc/gitconfig",
+			GIT_CONFIG_NOSYSTEM: "0",
+		};
 
-		await expect(runner.execFile("git.cmd", ["--no-pager", "status", "--short"], { cwd: repo })).resolves.toEqual({ stdout: "clean", stderr: "" });
-		expect(runner.execFileSync!("git.bat", ["-c", "color.ui=false", "status", "--short"], { cwd: repo })).toBe("clean");
-		expect(runner.spawn!("git.exe", [`--git-dir=${path.join(repo, ".git")}`, "status", "--short"], { cwd: repo })).toBe(fakeChild);
+		await expect(runner.execFile("git.cmd", ["-c", "user.name=Fixture", "status", "--short"], { cwd: repo, env: developerConfig })).resolves.toEqual({ stdout: "clean", stderr: "" });
+		expect(runner.execFileSync!("git.bat", ["-ccore.filemode=false", "status", "--short"], {
+			cwd: repo,
+			env: { ...developerConfig, GIT_CONFIG_COUNT: "1", GIT_CONFIG_KEY_0: "user.email", GIT_CONFIG_VALUE_0: "fixture@example.test" },
+		})).toBe("clean");
+		expect(runner.spawn!("git.exe", ["--config-env=core.filemode=FIXTURE_FILEMODE", "status", "--short"], {
+			cwd: repo,
+			env: { ...developerConfig, FIXTURE_FILEMODE: "false" },
+		})).toBe(fakeChild);
 		expect(calls).toEqual([
-			"async git.cmd --no-pager status --short",
-			"sync git.bat -c color.ui=false status --short",
-			`spawn git.exe --git-dir=${path.join(repo, ".git")} status --short`,
+			"async git.cmd -c user.name=Fixture status --short",
+			"sync git.bat -ccore.filemode=false status --short",
+			"spawn git.exe --config-env=core.filemode=FIXTURE_FILEMODE status --short",
 		]);
+		for (const env of environments) {
+			expect(env.GIT_CONFIG).toBeUndefined();
+			expect(env.GIT_CONFIG_GLOBAL).toBe(os.devNull);
+			expect(env.GIT_CONFIG_SYSTEM).toBe(os.devNull);
+			expect(env.GIT_CONFIG_NOSYSTEM).toBe("1");
+		}
+		expect(environments[1]).toMatchObject({
+			GIT_CONFIG_COUNT: "1",
+			GIT_CONFIG_KEY_0: "user.email",
+			GIT_CONFIG_VALUE_0: "fixture@example.test",
+		});
+		expect(environments[2]?.FIXTURE_FILEMODE).toBe("false");
 	});
 
 	it("allows explicit async fakes to stand in for fenced Git credential forms", async () => {
@@ -155,12 +226,14 @@ describe("fenced command runner", () => {
 			fakes: {
 				"git credential fill": response,
 				"git --no-pager credential fill": response,
+				"git -c alias.readcreds=!git credential fill readcreds": response,
 			},
 		});
 
 		for (const [file, args] of [
 			["git", ["credential", "fill"]],
 			["git.cmd", ["--no-pager", "credential", "fill"]],
+			["git.exe", ["-c", "alias.readcreds=!git credential fill", "readcreds"]],
 		] as const) {
 			await expect(runner.execFile(file, args)).resolves.toEqual({
 				stdout: response.stdout,

--- a/tests2/core/command-runner-fence.test.ts
+++ b/tests2/core/command-runner-fence.test.ts
@@ -1,5 +1,6 @@
 import type { ChildProcess } from "node:child_process";
-import { EventEmitter } from "node:events";
+import { EventEmitter, once } from "node:events";
+import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
@@ -16,6 +17,34 @@ import { VerificationHarness } from "../../src/server/agent/verification-harness
 import { createFencedCommandRunner } from "../harness/fenced-command-runner.js";
 import { installMemoryFs } from "./helpers/memory-fs-spies.js";
 import type { MemFs } from "../harness/mem-fs.js";
+
+const nativeExistsSync = fs.existsSync.bind(fs);
+const nativeMkdtempSync = fs.mkdtempSync.bind(fs);
+const nativeRmSync = fs.rmSync.bind(fs);
+const nativeUnlinkSync = fs.unlinkSync.bind(fs);
+const nativeWriteFileSync = fs.writeFileSync.bind(fs);
+
+type NativeExecFile = typeof import("node:child_process").execFile;
+type NativeExecFileSync = typeof import("node:child_process").execFileSync;
+type NativeSpawn = typeof import("node:child_process").spawn;
+type SpawnGuardState = { originals?: { execFile?: NativeExecFile; execFileSync?: NativeExecFileSync; spawn?: NativeSpawn } };
+const SPAWN_GUARD_STATE = Symbol.for("bobbit.tests2.tier1-spawn-guard-state");
+
+/** Narrow real-process delegate for this fence's own end-to-end containment regression. */
+function preservedNativeCommandRunner(): CommandRunner {
+	const originals = (process as NodeJS.Process & { [SPAWN_GUARD_STATE]?: SpawnGuardState })[SPAWN_GUARD_STATE]?.originals;
+	if (!originals?.execFile || !originals.execFileSync || !originals.spawn) throw new Error("tier-1 spawn guard originals unavailable");
+	return {
+		execFile: (file, args, options) => new Promise((resolve, reject) => {
+			originals.execFile!(file, [...args], options as any, (error, stdout, stderr) => {
+				if (error) return reject(Object.assign(error, { stdout, stderr }));
+				resolve({ stdout, stderr });
+			});
+		}),
+		execFileSync: (file, args, options) => originals.execFileSync!(file, [...args], options),
+		spawn: (file, args, options) => originals.spawn!(file, [...args], options as any),
+	};
+}
 
 let memoryFs: MemFs;
 let restoreFs: () => void;
@@ -143,9 +172,12 @@ describe("fenced command runner", () => {
 		expect(hasOwnedTreeSpawnRequest(delegatedOptions)).toBe(true);
 		expect(delegatedOptions).not.toBe(options);
 		expect(delegatedOptions?.env).toMatchObject({
-			GIT_CONFIG_GLOBAL: os.devNull,
-			GIT_CONFIG_SYSTEM: os.devNull,
+			GIT_CONFIG_GLOBAL: process.platform === "win32" ? "NUL" : os.devNull,
+			GIT_CONFIG_SYSTEM: process.platform === "win32" ? "NUL" : os.devNull,
 			GIT_CONFIG_NOSYSTEM: "1",
+			GIT_CONFIG_COUNT: "1",
+			GIT_CONFIG_KEY_0: "credential.helper",
+			GIT_CONFIG_VALUE_0: "",
 		});
 		expect(bound).toBe(control);
 		expect(directSpawn).not.toHaveBeenCalled();
@@ -290,18 +322,75 @@ describe("fenced command runner", () => {
 			"sync git.bat -ccore.filemode=false status --short",
 			"spawn git.exe --config-env=core.filemode=FIXTURE_FILEMODE status --short",
 		]);
+		const expectedNullConfig = process.platform === "win32" ? "NUL" : os.devNull;
 		for (const env of environments) {
 			expect(env.GIT_CONFIG).toBeUndefined();
-			expect(env.GIT_CONFIG_GLOBAL).toBe(os.devNull);
-			expect(env.GIT_CONFIG_SYSTEM).toBe(os.devNull);
+			expect(env.GIT_CONFIG_GLOBAL).toBe(expectedNullConfig);
+			expect(env.GIT_CONFIG_SYSTEM).toBe(expectedNullConfig);
 			expect(env.GIT_CONFIG_NOSYSTEM).toBe("1");
+			expect(env[`GIT_CONFIG_KEY_${Number(env.GIT_CONFIG_COUNT) - 1}`]).toBe("credential.helper");
+			expect(env[`GIT_CONFIG_VALUE_${Number(env.GIT_CONFIG_COUNT) - 1}`]).toBe("");
 		}
 		expect(environments[1]).toMatchObject({
-			GIT_CONFIG_COUNT: "1",
+			GIT_CONFIG_COUNT: "2",
 			GIT_CONFIG_KEY_0: "user.email",
 			GIT_CONFIG_VALUE_0: "fixture@example.test",
+			GIT_CONFIG_KEY_1: "credential.helper",
+			GIT_CONFIG_VALUE_1: "",
 		});
 		expect(environments[2]?.FIXTURE_FILEMODE).toBe("false");
+	});
+
+	it("keeps repository alias/include credential helpers inert through every real delegate path", async () => {
+		const root = nativeMkdtempSync(path.join(os.tmpdir(), "bobbit-fenced-real-helper-"));
+		const repo = path.join(root, "repo");
+		const includePath = path.join(root, "included.gitconfig");
+		const helperPath = path.join(root, "marker-helper.cjs");
+		const markerPath = path.join(root, "helper-called");
+		const nullConfig = process.platform === "win32" ? "NUL" : os.devNull;
+		const env = { ...process.env };
+		for (const name of Object.keys(env)) {
+			if (name.toUpperCase().startsWith("GIT_CONFIG")) delete env[name];
+		}
+		Object.assign(env, {
+			GIT_CONFIG_GLOBAL: nullConfig,
+			GIT_CONFIG_SYSTEM: nullConfig,
+			GIT_CONFIG_NOSYSTEM: "1",
+			GIT_TERMINAL_PROMPT: "0",
+		});
+
+		const realDelegate = preservedNativeCommandRunner();
+		const gitSync = (args: string[]) => realDelegate.execFileSync!("git", args, { cwd: root, env, encoding: "utf8" });
+		const slash = (value: string) => value.replaceAll("\\", "/");
+		try {
+			nativeWriteFileSync(helperPath, [
+				'const fs = require("node:fs");',
+				'fs.writeFileSync(process.argv[2], "called");',
+				"process.stdin.resume();",
+			].join("\n"));
+			gitSync(["init", repo]);
+			gitSync(["config", "--file", includePath, "credential.helper", `!node "${slash(helperPath)}" "${slash(markerPath)}"`]);
+			realDelegate.execFileSync!("git", ["config", "include.path", slash(includePath)], { cwd: repo, env, encoding: "utf8" });
+			realDelegate.execFileSync!("git", ["config", "alias.nested-creds", "!printf 'protocol=https\\nhost=marker.invalid\\n\\n' | git credential fill"], { cwd: repo, env, encoding: "utf8" });
+
+			// Prove the controlled fixture is live without exposing or returning a credential.
+			try { realDelegate.execFileSync!("git", ["nested-creds"], { cwd: repo, env, encoding: "utf8" }); } catch { /* expected: marker helper returns no password */ }
+			expect(nativeExistsSync(markerPath)).toBe(true);
+			nativeUnlinkSync(markerPath);
+
+			const runner = createFencedCommandRunner(realDelegate);
+			await runner.execFile("git", ["nested-creds"], { cwd: repo, env, encoding: "utf8" }).catch(() => undefined);
+			expect(nativeExistsSync(markerPath)).toBe(false);
+
+			try { runner.execFileSync!("git", ["nested-creds"], { cwd: repo, env, encoding: "utf8" }); } catch { /* expected: no helper can answer */ }
+			expect(nativeExistsSync(markerPath)).toBe(false);
+
+			const child = runner.spawn!("git", ["nested-creds"], { cwd: repo, env, stdio: "ignore" });
+			await once(child, "close");
+			expect(nativeExistsSync(markerPath)).toBe(false);
+		} finally {
+			nativeRmSync(root, { recursive: true, force: true });
+		}
 	});
 
 	it("allows explicit async fakes to stand in for fenced Git credential forms", async () => {

--- a/tests2/core/command-runner-fence.test.ts
+++ b/tests2/core/command-runner-fence.test.ts
@@ -1,8 +1,16 @@
+import type { ChildProcess } from "node:child_process";
+import { EventEmitter } from "node:events";
 import os from "node:os";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import type { CommandRunner } from "../../src/server/gateway-deps.js";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { realClock, type CommandRunner } from "../../src/server/gateway-deps.js";
+import {
+	createCommandSpawnAdapter,
+	hasOwnedTreeSpawnRequest,
+	ownedTreeSpawnOptions,
+	type OwnedTreeControl,
+} from "../../src/server/owned-tree-command-spawn.js";
 import { resolveWorktreeSupport } from "../../src/server/agent/worktree-support.js";
 import { VerificationHarness } from "../../src/server/agent/verification-harness.js";
 import { createFencedCommandRunner } from "../harness/fenced-command-runner.js";
@@ -94,6 +102,82 @@ describe("fenced command runner", () => {
 			execFile: async () => ({ stdout: "", stderr: "" }),
 		});
 		expect(() => runnerWithoutSpawn.spawn!("git.cmd", ["--no-pager", "credential", "fill"])).toThrow(expected);
+	});
+
+	it("forwards owned-tree capability and branded safe Git spawns through the fence", () => {
+		const { repo } = makeRepositoryMetadata(makeFixtureRoot("bobbit-fenced-owned-tree-"));
+		const child = new EventEmitter() as ChildProcess;
+		const control: OwnedTreeControl & { child: ChildProcess } = {
+			child,
+			ownershipReady: Promise.resolve(),
+			killTree: vi.fn(),
+			waitForTreeExit: vi.fn(async () => true),
+			killed: () => false,
+			timedOut: () => false,
+		};
+		const directSpawn = vi.fn();
+		const ownedSpawn = vi.fn(() => control);
+		const capableSpawn = createCommandSpawnAdapter(directSpawn as any, ownedSpawn as any);
+		let delegatedOptions: Parameters<typeof capableSpawn>[2];
+		const delegate: CommandRunner = {
+			execFile: async () => ({ stdout: "", stderr: "" }),
+			spawn: (file, args, options) => {
+				delegatedOptions = options;
+				return capableSpawn(file, args, options);
+			},
+			supportsOwnedTreeSpawn: true,
+		};
+		const runner = createFencedCommandRunner(delegate);
+		let bound: OwnedTreeControl | undefined;
+		const options = ownedTreeSpawnOptions({
+			cwd: repo,
+			env: {
+				GIT_CONFIG_GLOBAL: "/developer/.gitconfig",
+				GIT_CONFIG_SYSTEM: "/etc/gitconfig",
+			},
+			stdio: "ignore",
+		}, realClock, value => { bound = value; });
+
+		expect(runner.supportsOwnedTreeSpawn).toBe(true);
+		expect(runner.spawn!("git", ["status", "--short"], options)).toBe(child);
+		expect(hasOwnedTreeSpawnRequest(delegatedOptions)).toBe(true);
+		expect(delegatedOptions).not.toBe(options);
+		expect(delegatedOptions?.env).toMatchObject({
+			GIT_CONFIG_GLOBAL: os.devNull,
+			GIT_CONFIG_SYSTEM: os.devNull,
+			GIT_CONFIG_NOSYSTEM: "1",
+		});
+		expect(bound).toBe(control);
+		expect(directSpawn).not.toHaveBeenCalled();
+		expect(ownedSpawn).toHaveBeenCalledTimes(1);
+	});
+
+	it("does not advertise owned-tree spawning when its delegate lacks the capability", () => {
+		const runner = createFencedCommandRunner({
+			execFile: async () => ({ stdout: "", stderr: "" }),
+			spawn: () => new EventEmitter() as ChildProcess,
+		});
+
+		expect(runner.supportsOwnedTreeSpawn).toBeUndefined();
+		expect(Object.hasOwn(runner, "supportsOwnedTreeSpawn")).toBe(false);
+	});
+
+	it("blocks branded Git credential requests before capable delegate activity", () => {
+		const delegateSpawn = vi.fn(() => new EventEmitter() as ChildProcess);
+		const delegate: CommandRunner = {
+			execFile: async () => ({ stdout: "", stderr: "" }),
+			spawn: delegateSpawn,
+			supportsOwnedTreeSpawn: true,
+		};
+		const runner = createFencedCommandRunner(delegate);
+		const bind = vi.fn();
+		const options = ownedTreeSpawnOptions({ cwd: makeFixtureRoot("bobbit-fenced-owned-credential-") }, realClock, bind);
+
+		expect(runner.supportsOwnedTreeSpawn).toBe(true);
+		expect(() => runner.spawn!("git.cmd", ["--no-pager", "credential", "fill"], options))
+			.toThrow("[fenced-command-runner] blocked git credential invocation");
+		expect(delegateSpawn).not.toHaveBeenCalled();
+		expect(bind).not.toHaveBeenCalled();
 	});
 
 	it("blocks alias and config-include injection on every runner path without delegation", async () => {

--- a/tests2/core/command-runner-fence.test.ts
+++ b/tests2/core/command-runner-fence.test.ts
@@ -45,11 +45,12 @@ describe("fenced command runner", () => {
 	it("rejects network and host-control commands", async () => {
 		const runner = createFencedCommandRunner(unexpectedDelegate());
 		await expect(runner.execFile("git", ["push", "https://github.com/example/repo.git", "HEAD"])).rejects.toThrow(/blocked git push/);
-		await expect(runner.execFile("gh", ["pr", "list"])).rejects.toThrow(/blocked gh/);
-		await expect(runner.execFile("docker", ["ps"])).rejects.toThrow(/blocked docker/);
+		await expect(runner.execFile("git.cmd", ["--no-pager", "push", "https://github.com/example/repo.git", "HEAD"])).rejects.toThrow(/blocked git push/);
+		await expect(runner.execFile("gh.cmd", ["pr", "list"])).rejects.toThrow(/blocked gh/);
+		await expect(runner.execFile("docker.bat", ["ps"])).rejects.toThrow(/blocked docker/);
 	});
 
-	it("blocks git credential across async, sync, and spawn paths before delegation", async () => {
+	it("blocks credential subcommands behind Git global options on every runner path", async () => {
 		const delegations: string[] = [];
 		const delegate: CommandRunner = {
 			execFile: async (file, args) => {
@@ -66,33 +67,106 @@ describe("fenced command runner", () => {
 			},
 		};
 		const runner = createFencedCommandRunner(delegate);
-		const expected = "[fenced-command-runner] blocked git credential invocation";
+		const expected = new Error("[fenced-command-runner] blocked git credential invocation");
+		const fixture = makeFixtureRoot("bobbit-fenced-credential-options-");
+		const bypasses = [
+			{ file: "git", args: ["credential", "fill"] },
+			{ file: "git.exe", args: ["--no-pager", "credential", "fill"] },
+			{ file: "git.cmd", args: ["-C", fixture, "credential", "fill"] },
+			{ file: "git.bat", args: [`-C${fixture}`, "credential", "fill"] },
+			{ file: "git", args: ["-c", "credential.helper=fixture", "credential", "fill"] },
+			{ file: "git.exe", args: ["-ccredential.helper=fixture", "credential", "fill"] },
+			{ file: "git.cmd", args: ["--config-env", "credential.helper=FIXTURE_HELPER", "credential", "fill"] },
+			{ file: "git.bat", args: ["--config-env=credential.helper=FIXTURE_HELPER", "credential", "fill"] },
+			{ file: "git", args: [`--git-dir=${fixture}`, "credential", "fill"] },
+			{ file: "git.exe", args: ["--", "credential", "fill"] },
+		];
 
-		const asyncMessage = await runner.execFile("git", ["credential", "fill", "fixture-secret"])
-			.then(() => "unexpected success", error => String(error.message));
-		expect(asyncMessage).toBe(expected);
-		expect(() => runner.execFileSync!("git.exe", ["credential", "approve", "fixture-secret"])).toThrow(new Error(expected));
-		expect(() => runner.spawn!("git", ["credential", "reject", "fixture-secret"])).toThrow(new Error(expected));
+		for (const { file, args } of bypasses) {
+			await expect(runner.execFile(file, args)).rejects.toThrow(expected);
+			expect(() => runner.execFileSync!(file, args)).toThrow(expected);
+			expect(() => runner.spawn!(file, args)).toThrow(expected);
+		}
 		expect(delegations).toEqual([]);
 
-		const delegateWithoutSpawn: CommandRunner = {
+		const runnerWithoutSpawn = createFencedCommandRunner({
 			execFile: async () => ({ stdout: "", stderr: "" }),
-		};
-		const runnerWithoutSpawn = createFencedCommandRunner(delegateWithoutSpawn);
-		expect(() => runnerWithoutSpawn.spawn!("git", ["credential", "fill"])).toThrow(expected);
+		});
+		expect(() => runnerWithoutSpawn.spawn!("git.cmd", ["--no-pager", "credential", "fill"])).toThrow(expected);
 	});
 
-	it("allows an explicit async fake to stand in for git credential without delegation", async () => {
+	it("fails closed on unknown or malformed Git global options before delegation", async () => {
+		const delegations: string[] = [];
+		const delegate: CommandRunner = {
+			execFile: async () => { delegations.push("async"); return { stdout: "", stderr: "" }; },
+			execFileSync: () => { delegations.push("sync"); return ""; },
+			spawn: () => { delegations.push("spawn"); return {} as any; },
+		};
+		const runner = createFencedCommandRunner(delegate);
+		const expected = new Error("[fenced-command-runner] blocked unclassified git invocation");
+		for (const args of [
+			[],
+			["--unknown-global", "credential", "fill"],
+			["-C"],
+			["--config-env"],
+			["--git-dir=", "status"],
+			["--", "--not-a-command"],
+		]) {
+			await expect(runner.execFile("git", args)).rejects.toThrow(expected);
+			expect(() => runner.execFileSync!("git.cmd", args)).toThrow(expected);
+			expect(() => runner.spawn!("git.bat", args)).toThrow(expected);
+		}
+		expect(delegations).toEqual([]);
+	});
+
+	it("allows classified non-credential global options through every runner path", async () => {
+		const { repo } = makeRepositoryMetadata(makeFixtureRoot("bobbit-fenced-global-options-"));
+		const calls: string[] = [];
+		const fakeChild = { pid: 4321 };
+		const delegate: CommandRunner = {
+			execFile: async (file, args) => {
+				calls.push(`async ${file} ${args.join(" ")}`);
+				return { stdout: "clean", stderr: "" };
+			},
+			execFileSync: (file, args) => {
+				calls.push(`sync ${file} ${args.join(" ")}`);
+				return "clean";
+			},
+			spawn: (file, args) => {
+				calls.push(`spawn ${file} ${args.join(" ")}`);
+				return fakeChild as any;
+			},
+		};
+		const runner = createFencedCommandRunner(delegate);
+
+		await expect(runner.execFile("git.cmd", ["--no-pager", "status", "--short"], { cwd: repo })).resolves.toEqual({ stdout: "clean", stderr: "" });
+		expect(runner.execFileSync!("git.bat", ["-c", "color.ui=false", "status", "--short"], { cwd: repo })).toBe("clean");
+		expect(runner.spawn!("git.exe", [`--git-dir=${path.join(repo, ".git")}`, "status", "--short"], { cwd: repo })).toBe(fakeChild);
+		expect(calls).toEqual([
+			"async git.cmd --no-pager status --short",
+			"sync git.bat -c color.ui=false status --short",
+			`spawn git.exe --git-dir=${path.join(repo, ".git")} status --short`,
+		]);
+	});
+
+	it("allows explicit async fakes to stand in for fenced Git credential forms", async () => {
+		const response = { stdout: "protocol=https\nhost=git.example.test\n\n" };
 		const runner = createFencedCommandRunner(unexpectedDelegate(), {
 			fakes: {
-				"git credential fill": { stdout: "protocol=https\nhost=git.example.test\n\n" },
+				"git credential fill": response,
+				"git --no-pager credential fill": response,
 			},
 		});
 
-		await expect(runner.execFile("git", ["credential", "fill"])).resolves.toEqual({
-			stdout: "protocol=https\nhost=git.example.test\n\n",
-			stderr: "",
-		});
+		for (const [file, args] of [
+			["git", ["credential", "fill"]],
+			["git.cmd", ["--no-pager", "credential", "fill"]],
+		] as const) {
+			await expect(runner.execFile(file, args)).resolves.toEqual({
+				stdout: response.stdout,
+				stderr: "",
+			});
+		}
 	});
 
 	it("short-circuits read-only discovery outside repositories without delegating or mutating git", async () => {
@@ -215,6 +289,7 @@ describe("fenced command runner", () => {
 			["fetch", "https://github.com/example/repo.git"],
 			["clone", "https://github.com/example/repo.git", path.join(repo, "clone")],
 			["push", "https://github.com/example/repo.git", "HEAD"],
+			["--no-pager", "push", "https://github.com/example/repo.git", "HEAD"],
 		]) {
 			expect(() => runner.execFileSync!("git", args, { cwd: repo })).toThrow(/blocked git/);
 			expect(() => runner.spawn!("git", args, { cwd: repo })).toThrow(/blocked git/);

--- a/tests2/core/command-runner-fence.test.ts
+++ b/tests2/core/command-runner-fence.test.ts
@@ -49,6 +49,52 @@ describe("fenced command runner", () => {
 		await expect(runner.execFile("docker", ["ps"])).rejects.toThrow(/blocked docker/);
 	});
 
+	it("blocks git credential across async, sync, and spawn paths before delegation", async () => {
+		const delegations: string[] = [];
+		const delegate: CommandRunner = {
+			execFile: async (file, args) => {
+				delegations.push(`async ${file} ${args.join(" ")}`);
+				return { stdout: "", stderr: "" };
+			},
+			execFileSync: (file, args) => {
+				delegations.push(`sync ${file} ${args.join(" ")}`);
+				return "";
+			},
+			spawn: (file, args) => {
+				delegations.push(`spawn ${file} ${args.join(" ")}`);
+				return {} as any;
+			},
+		};
+		const runner = createFencedCommandRunner(delegate);
+		const expected = "[fenced-command-runner] blocked git credential invocation";
+
+		const asyncMessage = await runner.execFile("git", ["credential", "fill", "fixture-secret"])
+			.then(() => "unexpected success", error => String(error.message));
+		expect(asyncMessage).toBe(expected);
+		expect(() => runner.execFileSync!("git.exe", ["credential", "approve", "fixture-secret"])).toThrow(new Error(expected));
+		expect(() => runner.spawn!("git", ["credential", "reject", "fixture-secret"])).toThrow(new Error(expected));
+		expect(delegations).toEqual([]);
+
+		const delegateWithoutSpawn: CommandRunner = {
+			execFile: async () => ({ stdout: "", stderr: "" }),
+		};
+		const runnerWithoutSpawn = createFencedCommandRunner(delegateWithoutSpawn);
+		expect(() => runnerWithoutSpawn.spawn!("git", ["credential", "fill"])).toThrow(expected);
+	});
+
+	it("allows an explicit async fake to stand in for git credential without delegation", async () => {
+		const runner = createFencedCommandRunner(unexpectedDelegate(), {
+			fakes: {
+				"git credential fill": { stdout: "protocol=https\nhost=git.example.test\n\n" },
+			},
+		});
+
+		await expect(runner.execFile("git", ["credential", "fill"])).resolves.toEqual({
+			stdout: "protocol=https\nhost=git.example.test\n\n",
+			stderr: "",
+		});
+	});
+
 	it("short-circuits read-only discovery outside repositories without delegating or mutating git", async () => {
 		const cwd = makeFixtureRoot("bobbit-fenced-nonrepo-");
 		let asyncDelegations = 0;

--- a/tests2/core/github-host-credential-trust.test.ts
+++ b/tests2/core/github-host-credential-trust.test.ts
@@ -144,10 +144,16 @@ describe("Git credential probe", () => {
 			GIT_ASKPASS: process.env.GIT_ASKPASS,
 			SSH_ASKPASS: process.env.SSH_ASKPASS,
 			DISPLAY: process.env.DISPLAY,
+			GIT_DIR: process.env.GIT_DIR,
+			GIT_WORK_TREE: process.env.GIT_WORK_TREE,
+			GIT_COMMON_DIR: process.env.GIT_COMMON_DIR,
 		};
 		process.env.GIT_ASKPASS = "configured-core-askpass-sentinel";
 		process.env.SSH_ASKPASS = "configured-ssh-askpass-sentinel";
 		process.env.DISPLAY = "gui-prompt-sentinel";
+		process.env.GIT_DIR = "/repository/.git";
+		process.env.GIT_WORK_TREE = "/repository";
+		process.env.GIT_COMMON_DIR = "/repository/.git";
 		try {
 			const helper = fakeHelper(credential());
 			await expect(subject(helper).isTrusted("git.example.com")).resolves.toBe(true);
@@ -169,6 +175,9 @@ describe("Git credential probe", () => {
 			expect(env.GIT_ASKPASS).toBe("");
 			expect(env.SSH_ASKPASS).toBe("");
 			expect(env.DISPLAY).toBeUndefined();
+			expect(env.GIT_DIR).toBeUndefined();
+			expect(env.GIT_WORK_TREE).toBeUndefined();
+			expect(env.GIT_COMMON_DIR).toBeUndefined();
 			expect(helper.requests.join("")).toBe("url=https://git.example.com\n\n");
 			expect(helper.kills).toEqual([]);
 		} finally {
@@ -295,12 +304,18 @@ describe("ambient gh token refusal", () => {
 		await expect(trust.isTrusted("git.example.com")).resolves.toBe(true);
 	});
 
-	it("uses GitHub-class tokens only for github.com and proper ghe.com subdomains", async () => {
+	it("matches gh GitHub-token host classes without admitting near-misses", async () => {
 		for (const [host, variable] of [
 			["github.com", "GH_TOKEN"],
+			["pages.github.com", "GH_TOKEN"],
+			["github.localhost", "GITHUB_TOKEN"],
+			["api.github.localhost", "GH_TOKEN"],
+			["api.github.localhost:8443", "GITHUB_TOKEN"],
 			["tenant.ghe.com", "GITHUB_TOKEN"],
 			["tenant.ghe.com:8443", "GH_TOKEN"],
 			["ghe.com", "GH_ENTERPRISE_TOKEN"],
+			["notgithub.com", "GITHUB_ENTERPRISE_TOKEN"],
+			["github.com.evil.test", "GH_ENTERPRISE_TOKEN"],
 			["notghe.com", "GITHUB_ENTERPRISE_TOKEN"],
 			["ghe.com.evil.test", "GH_ENTERPRISE_TOKEN"],
 		] as const) {
@@ -313,6 +328,24 @@ describe("ambient gh token refusal", () => {
 			await expect(trust.isTrusted(host), host).resolves.toBe(false);
 			expect(probe, host).not.toHaveBeenCalled();
 		}
+	});
+
+	it("treats a whitespace-only gh token as set and redacts its value", async () => {
+		const warnings: string[] = [];
+		const probe = vi.fn(async () => true);
+		const trust = new GithubHostCredentialTrust({
+			probe,
+			getEnv: () => ({ GH_ENTERPRISE_TOKEN: " \t" }),
+			warn: line => warnings.push(line),
+		});
+
+		await expect(trust.isTrusted("git.example.com")).resolves.toBe(false);
+		expect(probe).not.toHaveBeenCalled();
+		expect(warnings).toEqual([
+			"[github-trust] Not trusting git.example.com from the local Git credential configuration because GH_ENTERPRISE_TOKEN is set. "
+			+ "Trust git.example.com explicitly with githubTrustedHosts or unset GH_ENTERPRISE_TOKEN.",
+		]);
+		expect(warnings[0]).not.toContain("\t");
 	});
 
 	it("keeps token classes independent and honors variable precedence", async () => {

--- a/tests2/core/github-host-credential-trust.test.ts
+++ b/tests2/core/github-host-credential-trust.test.ts
@@ -127,28 +127,70 @@ describe("GithubHostCredentialTrust cache", () => {
 		expect(probe).toHaveBeenCalledTimes(1);
 	});
 
-	it("clears negatives only on refresh and fences stale pending completions", async () => {
-		let firstRelease!: (value: boolean) => void;
-		let calls = 0;
-		const probe = vi.fn(async () => {
-			calls++;
-			if (calls === 1) return new Promise<boolean>(resolve => { firstRelease = resolve; });
-			return true;
+	it("serializes repeated refresh generations and never authorizes from stale flights", async () => {
+		const releases: Array<(value: boolean) => void> = [];
+		let active = 0;
+		let maxActive = 0;
+		const probe = vi.fn(() => {
+			active++;
+			maxActive = Math.max(maxActive, active);
+			return new Promise<boolean>(resolve => {
+				releases.push(value => {
+					active--;
+					resolve(value);
+				});
+			});
 		});
 		const trust = new GithubHostCredentialTrust({ probe, getEnv: () => ({}) });
 
-		const stale = trust.isTrusted("git.example.com");
+		const first = trust.isTrusted("git.example.com");
+		for (let refresh = 0; refresh < 4; refresh++) {
+			trust.forgetUnverified();
+			void trust.isTrusted("git.example.com");
+			expect(probe, `refresh ${refresh} must join one queued successor`).toHaveBeenCalledTimes(1);
+		}
+
+		// The old tree may return a credential, but its generation is stale. Only
+		// one successor for the latest requested generation starts after it exits.
+		releases[0](true);
+		await expect(first).resolves.toBe(false);
+		await vi.waitFor(() => expect(probe).toHaveBeenCalledTimes(2));
+		expect(active).toBe(1);
+		expect(maxActive).toBe(1);
+
+		const beforeLatestRefresh = trust.isTrusted("git.example.com");
 		trust.forgetUnverified();
-		const fresh = trust.isTrusted("git.example.com");
-		firstRelease(false);
-		await expect(stale).resolves.toBe(false);
-		await expect(fresh).resolves.toBe(true);
+		const latest = trust.isTrusted("git.example.com");
+		expect(probe).toHaveBeenCalledTimes(2);
+		releases[1](true);
+		await expect(beforeLatestRefresh).resolves.toBe(false);
+		await vi.waitFor(() => expect(probe).toHaveBeenCalledTimes(3));
+		expect(active).toBe(1);
+		expect(maxActive).toBe(1);
+
+		releases[2](true);
+		await expect(latest).resolves.toBe(true);
+		await expect(trust.isTrusted("git.example.com")).resolves.toBe(true);
+		expect(probe).toHaveBeenCalledTimes(3);
+		expect(active).toBe(0);
+	});
+
+	it("clears cached negatives only on explicit refresh", async () => {
+		const probe = vi.fn()
+			.mockResolvedValueOnce(false)
+			.mockResolvedValueOnce(true);
+		const trust = new GithubHostCredentialTrust({ probe, getEnv: () => ({}) });
+
+		await expect(trust.isTrusted("git.example.com")).resolves.toBe(false);
+		await expect(trust.isTrusted("git.example.com")).resolves.toBe(false);
+		expect(probe).toHaveBeenCalledTimes(1);
+		trust.forgetUnverified();
 		await expect(trust.isTrusted("git.example.com")).resolves.toBe(true);
 		expect(probe).toHaveBeenCalledTimes(2);
 	});
 
 	it("caches thrown probes as negative until refresh and rejects malformed authorities", async () => {
-		const probe = vi.fn(async () => { throw new Error("secret-bearing helper failure"); });
+		const probe = vi.fn(() => { throw new Error("secret-bearing helper failure"); });
 		const trust = new GithubHostCredentialTrust({ probe, getEnv: () => ({}) });
 		await expect(trust.isTrusted("git.example.com")).resolves.toBe(false);
 		await expect(trust.isTrusted("git.example.com")).resolves.toBe(false);

--- a/tests2/core/github-host-credential-trust.test.ts
+++ b/tests2/core/github-host-credential-trust.test.ts
@@ -1,0 +1,290 @@
+import type { ChildProcess, SpawnOptions } from "node:child_process";
+import { EventEmitter } from "node:events";
+import { existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { PassThrough } from "node:stream";
+import { describe, expect, it, vi } from "vitest";
+import type { Clock, TimerHandle } from "../../src/server/gateway-deps.js";
+import {
+	GithubHostCredentialTrust,
+	type SpawnLike,
+} from "../../src/server/github-host-credential-trust.js";
+
+interface FakeHelper {
+	spawn: SpawnLike;
+	calls: Array<{ file: string; args: string[]; options: SpawnOptions }>;
+	requests: string[];
+	kills: string[];
+}
+
+function fakeHelper(
+	output: string | Buffer | readonly (string | Buffer)[],
+	options: { close?: boolean; code?: number; spawnError?: Error } = {},
+): FakeHelper {
+	const calls: FakeHelper["calls"] = [];
+	const requests: string[] = [];
+	const kills: string[] = [];
+	return {
+		calls,
+		requests,
+		kills,
+		spawn(file, args, spawnOptions) {
+			if (options.spawnError) throw options.spawnError;
+			calls.push({ file, args: [...args], options: spawnOptions });
+			const child = new EventEmitter() as ChildProcess;
+			const stdout = new PassThrough();
+			const stdin = new PassThrough();
+			stdin.on("data", chunk => requests.push(String(chunk)));
+			Object.assign(child, {
+				stdout,
+				stdin,
+				kill(signal?: string) {
+					kills.push(signal ?? "SIGTERM");
+					return true;
+				},
+			});
+			setImmediate(() => {
+				for (const chunk of Array.isArray(output) ? output : [output]) stdout.write(chunk);
+				if (options.close === false) return;
+				stdout.end();
+				child.emit("close", options.code ?? 0, null);
+			});
+			return child;
+		},
+	};
+}
+
+function subject(helper: FakeHelper, clock?: Clock): GithubHostCredentialTrust {
+	return new GithubHostCredentialTrust({ resolveSpawn: () => helper.spawn, clock, getEnv: () => ({}) });
+}
+
+function credential(host = "git.example.com", password = "fixture-secret"): string {
+	return `protocol=https\nhost=${host}\nusername=operator\npassword=${password}\n`;
+}
+
+function manualClock(): Clock & { runPending(): void } {
+	let next = 1;
+	let pending: Array<{ handle: TimerHandle; handler: () => void }> = [];
+	return {
+		now: () => 0,
+		setTimeout(handler) {
+			const handle = next++ as unknown as TimerHandle;
+			pending.push({ handle, handler });
+			return handle;
+		},
+		setInterval: () => 0 as unknown as TimerHandle,
+		clearTimeout(handle) { pending = pending.filter(item => item.handle !== handle); },
+		clearInterval() {},
+		runPending() {
+			const due = pending;
+			pending = [];
+			for (const item of due) item.handler();
+		},
+	};
+}
+
+describe("GithubHostCredentialTrust cache", () => {
+	it("single-flights normalized hosts and retains positive verdicts across refresh", async () => {
+		let release!: (value: boolean) => void;
+		const probe = vi.fn(() => new Promise<boolean>(resolve => { release = resolve; }));
+		const trust = new GithubHostCredentialTrust({ probe, getEnv: () => ({}) });
+
+		const first = trust.isTrusted(" GIT.Example.Com. ");
+		const joined = trust.isTrusted("git.example.com");
+		expect(probe).toHaveBeenCalledTimes(1);
+		release(true);
+		await expect(Promise.all([first, joined])).resolves.toEqual([true, true]);
+
+		trust.forgetUnverified();
+		await expect(trust.isTrusted("git.example.com")).resolves.toBe(true);
+		expect(probe).toHaveBeenCalledTimes(1);
+	});
+
+	it("clears negatives only on refresh and fences stale pending completions", async () => {
+		let firstRelease!: (value: boolean) => void;
+		let calls = 0;
+		const probe = vi.fn(async () => {
+			calls++;
+			if (calls === 1) return new Promise<boolean>(resolve => { firstRelease = resolve; });
+			return true;
+		});
+		const trust = new GithubHostCredentialTrust({ probe, getEnv: () => ({}) });
+
+		const stale = trust.isTrusted("git.example.com");
+		trust.forgetUnverified();
+		const fresh = trust.isTrusted("git.example.com");
+		firstRelease(false);
+		await expect(stale).resolves.toBe(false);
+		await expect(fresh).resolves.toBe(true);
+		await expect(trust.isTrusted("git.example.com")).resolves.toBe(true);
+		expect(probe).toHaveBeenCalledTimes(2);
+	});
+
+	it("caches thrown probes as negative until refresh and rejects malformed authorities", async () => {
+		const probe = vi.fn(async () => { throw new Error("secret-bearing helper failure"); });
+		const trust = new GithubHostCredentialTrust({ probe, getEnv: () => ({}) });
+		await expect(trust.isTrusted("git.example.com")).resolves.toBe(false);
+		await expect(trust.isTrusted("git.example.com")).resolves.toBe(false);
+		expect(probe).toHaveBeenCalledTimes(1);
+		for (const host of ["", "bad.example\nhost=evil", "user@host", "host/path", "host:99999"]) {
+			await expect(trust.isTrusted(host)).resolves.toBe(false);
+		}
+		expect(probe).toHaveBeenCalledTimes(1);
+	});
+});
+
+describe("Git credential probe", () => {
+	it("uses only injected spawn from a dedicated neutral directory with prompting disabled, then cleans up", async () => {
+		const helper = fakeHelper(credential());
+		await expect(subject(helper).isTrusted("git.example.com")).resolves.toBe(true);
+		expect(helper.calls).toHaveLength(1);
+		const call = helper.calls[0];
+		expect(call.file).toBe("git");
+		expect(call.args).toEqual(["credential", "fill"]);
+		expect(call.options.cwd).not.toBe(tmpdir());
+		expect(String(call.options.cwd).startsWith(tmpdir())).toBe(true);
+		expect(existsSync(String(call.options.cwd))).toBe(false);
+		expect(call.options.stdio).toEqual(["pipe", "pipe", "ignore"]);
+		expect(call.options.windowsHide).toBe(true);
+		const env = call.options.env as NodeJS.ProcessEnv;
+		expect(env.GIT_TERMINAL_PROMPT).toBe("0");
+		expect(env.GCM_INTERACTIVE).toBe("never");
+		expect(env.GIT_CEILING_DIRECTORIES).toBe(tmpdir());
+		expect(env.GIT_ASKPASS).toBeUndefined();
+		expect(env.SSH_ASKPASS).toBeUndefined();
+		expect(env.DISPLAY).toBeUndefined();
+		expect(helper.requests.join("")).toBe("url=https://git.example.com\n\n");
+		expect(helper.kills).toEqual([]);
+	});
+
+	it("fails closed without spawn support or when injected spawn throws", async () => {
+		await expect(new GithubHostCredentialTrust({ getEnv: () => ({}) }).isTrusted("git.example.com")).resolves.toBe(false);
+		const helper = fakeHelper("", { spawnError: new Error("fenced") });
+		await expect(subject(helper).isTrusted("git.example.com")).resolves.toBe(false);
+	});
+
+	it("requires one exact echoed normalized authority and a non-empty password", async () => {
+		const cases: Array<[string, string | Buffer, boolean]> = [
+			["exact record", credential(), true],
+			["authority with exact port", credential("git.example.com:8443"), true],
+			["wrong host", credential("other.example.com"), false],
+			["missing host", "protocol=https\npassword=secret\n", false],
+			["missing password", "protocol=https\nhost=git.example.com\n", false],
+			["empty password", "host=git.example.com\npassword=\n", false],
+			["duplicate host", "host=git.example.com\nhost=git.example.com\npassword=secret\n", false],
+			["contradictory host", "host=git.example.com\nhost=other.example.com\npassword=secret\n", false],
+			["duplicate password", "host=git.example.com\npassword=one\npassword=two\n", false],
+			["malformed line", "host=git.example.com\nnot-a-field\npassword=secret\n", false],
+			["trailing record", "host=git.example.com\npassword=secret\n\nhost=git.example.com\npassword=other\n", false],
+			["malformed UTF-8", Buffer.from([0x68, 0x6f, 0x73, 0x74, 0x3d, 0xff]), false],
+		];
+		for (const [label, output, expected] of cases) {
+			const helper = fakeHelper(output);
+			await expect(subject(helper).isTrusted(label.includes("port") ? "git.example.com:8443" : "git.example.com"), label)
+				.resolves.toBe(expected);
+		}
+	});
+
+	it("waits for successful close and rejects nonzero exit or malformed trailing output", async () => {
+		const nonzero = fakeHelper(credential(), { code: 1 });
+		await expect(subject(nonzero).isTrusted("git.example.com")).resolves.toBe(false);
+		expect(nonzero.kills).toEqual([]);
+
+		const trailing = fakeHelper([credential(), "\nmalformed"]);
+		await expect(subject(trailing).isTrusted("git.example.com")).resolves.toBe(false);
+	});
+
+	it("rejects output beyond the byte cap in one chunk or across chunks", async () => {
+		const padding = "field=" + "x".repeat(9 * 1024);
+		for (const output of [
+			`${credential()}${padding}\n`,
+			["host=git.example.com\npassword=secret\n", "field=", "x".repeat(9 * 1024)],
+		]) {
+			const helper = fakeHelper(output);
+			await expect(subject(helper).isTrusted("git.example.com")).resolves.toBe(false);
+			expect(helper.kills).toEqual(["SIGTERM"]);
+		}
+	});
+
+	it("times out, sends TERM, escalates a wedged process to KILL, and never kills normal success", async () => {
+		const clock = manualClock();
+		const wedged = fakeHelper("host=git.example.com\n", { close: false });
+		const verdict = subject(wedged, clock).isTrusted("git.example.com");
+		await new Promise(resolve => setImmediate(resolve));
+		clock.runPending();
+		await expect(verdict).resolves.toBe(false);
+		expect(wedged.kills).toEqual(["SIGTERM"]);
+		clock.runPending();
+		expect(wedged.kills).toEqual(["SIGTERM", "SIGKILL"]);
+
+		const normalClock = manualClock();
+		const normal = fakeHelper(credential());
+		await expect(subject(normal, normalClock).isTrusted("git.example.com")).resolves.toBe(true);
+		normalClock.runPending();
+		expect(normal.kills).toEqual([]);
+	});
+});
+
+describe("ambient gh token refusal", () => {
+	it("resolves the live environment before cache/probe and warns once without retaining the value", async () => {
+		const secret = "ghp_secret_must_not_escape";
+		let env: Record<string, string | undefined> = {};
+		const warnings: string[] = [];
+		const probe = vi.fn(async () => true);
+		const trust = new GithubHostCredentialTrust({ probe, getEnv: () => env, warn: line => warnings.push(line) });
+
+		await expect(trust.isTrusted("git.example.com")).resolves.toBe(true);
+		env = { GH_ENTERPRISE_TOKEN: secret };
+		await expect(trust.isTrusted("git.example.com")).resolves.toBe(false);
+		await expect(trust.isTrusted("git.example.com")).resolves.toBe(false);
+		expect(probe).toHaveBeenCalledTimes(1);
+		expect(warnings).toHaveLength(1);
+		expect(warnings[0]).toContain("git.example.com");
+		expect(warnings[0]).toContain("GH_ENTERPRISE_TOKEN");
+		expect(warnings[0]).not.toContain(secret);
+		expect(JSON.stringify(trust)).not.toContain(secret);
+
+		env = {};
+		await expect(trust.isTrusted("git.example.com")).resolves.toBe(true);
+	});
+
+	it("uses GitHub-class tokens only for github.com and proper ghe.com subdomains", async () => {
+		for (const [host, variable] of [
+			["github.com", "GH_TOKEN"],
+			["tenant.ghe.com", "GITHUB_TOKEN"],
+			["tenant.ghe.com:8443", "GH_TOKEN"],
+			["ghe.com", "GH_ENTERPRISE_TOKEN"],
+			["notghe.com", "GITHUB_ENTERPRISE_TOKEN"],
+			["ghe.com.evil.test", "GH_ENTERPRISE_TOKEN"],
+		] as const) {
+			const probe = vi.fn(async () => true);
+			const trust = new GithubHostCredentialTrust({
+				probe,
+				getEnv: () => ({ [variable]: "secret" }),
+				warn: () => {},
+			});
+			await expect(trust.isTrusted(host), host).resolves.toBe(false);
+			expect(probe, host).not.toHaveBeenCalled();
+		}
+	});
+
+	it("keeps token classes independent and honors variable precedence", async () => {
+		const warnings: string[] = [];
+		const enterprise = new GithubHostCredentialTrust({
+			probe: async () => true,
+			getEnv: () => ({ GH_TOKEN: "github-only" }),
+			warn: line => warnings.push(line),
+		});
+		await expect(enterprise.isTrusted("git.example.com")).resolves.toBe(true);
+
+		const refused = new GithubHostCredentialTrust({
+			probe: async () => true,
+			getEnv: () => ({ GH_ENTERPRISE_TOKEN: "first", GITHUB_ENTERPRISE_TOKEN: "second" }),
+			warn: line => warnings.push(line),
+		});
+		await expect(refused.isTrusted("git.example.com")).resolves.toBe(false);
+		expect(warnings.at(-1)).toContain("GH_ENTERPRISE_TOKEN");
+		expect(warnings.at(-1)).not.toContain("first");
+		expect(warnings.at(-1)).not.toContain("second");
+	});
+});

--- a/tests2/core/github-host-credential-trust.test.ts
+++ b/tests2/core/github-host-credential-trust.test.ts
@@ -19,7 +19,7 @@ interface FakeHelper {
 
 function fakeHelper(
 	output: string | Buffer | readonly (string | Buffer)[],
-	options: { close?: boolean; code?: number; spawnError?: Error } = {},
+	options: { close?: boolean; code?: number; spawnError?: Error; stdoutError?: Error } = {},
 ): FakeHelper {
 	const calls: FakeHelper["calls"] = [];
 	const requests: string[] = [];
@@ -45,6 +45,11 @@ function fakeHelper(
 			});
 			setImmediate(() => {
 				for (const chunk of Array.isArray(output) ? output : [output]) stdout.write(chunk);
+				if (options.stdoutError) {
+					stdout.emit("error", options.stdoutError);
+					child.emit("close", 1, null);
+					return;
+				}
 				if (options.close === false) return;
 				stdout.end();
 				child.emit("close", options.code ?? 0, null);
@@ -135,32 +140,74 @@ describe("GithubHostCredentialTrust cache", () => {
 
 describe("Git credential probe", () => {
 	it("uses only injected spawn from a dedicated neutral directory with prompting disabled, then cleans up", async () => {
-		const helper = fakeHelper(credential());
-		await expect(subject(helper).isTrusted("git.example.com")).resolves.toBe(true);
-		expect(helper.calls).toHaveLength(1);
-		const call = helper.calls[0];
-		expect(call.file).toBe("git");
-		expect(call.args).toEqual(["credential", "fill"]);
-		expect(call.options.cwd).not.toBe(tmpdir());
-		expect(String(call.options.cwd).startsWith(tmpdir())).toBe(true);
-		expect(existsSync(String(call.options.cwd))).toBe(false);
-		expect(call.options.stdio).toEqual(["pipe", "pipe", "ignore"]);
-		expect(call.options.windowsHide).toBe(true);
-		const env = call.options.env as NodeJS.ProcessEnv;
-		expect(env.GIT_TERMINAL_PROMPT).toBe("0");
-		expect(env.GCM_INTERACTIVE).toBe("never");
-		expect(env.GIT_CEILING_DIRECTORIES).toBe(tmpdir());
-		expect(env.GIT_ASKPASS).toBeUndefined();
-		expect(env.SSH_ASKPASS).toBeUndefined();
-		expect(env.DISPLAY).toBeUndefined();
-		expect(helper.requests.join("")).toBe("url=https://git.example.com\n\n");
-		expect(helper.kills).toEqual([]);
+		const inherited = {
+			GIT_ASKPASS: process.env.GIT_ASKPASS,
+			SSH_ASKPASS: process.env.SSH_ASKPASS,
+			DISPLAY: process.env.DISPLAY,
+		};
+		process.env.GIT_ASKPASS = "configured-core-askpass-sentinel";
+		process.env.SSH_ASKPASS = "configured-ssh-askpass-sentinel";
+		process.env.DISPLAY = "gui-prompt-sentinel";
+		try {
+			const helper = fakeHelper(credential());
+			await expect(subject(helper).isTrusted("git.example.com")).resolves.toBe(true);
+			expect(helper.calls).toHaveLength(1);
+			const call = helper.calls[0];
+			expect(call.file).toBe("git");
+			expect(call.args).toEqual(["credential", "fill"]);
+			expect(call.options.cwd).not.toBe(tmpdir());
+			expect(String(call.options.cwd).startsWith(tmpdir())).toBe(true);
+			expect(existsSync(String(call.options.cwd))).toBe(false);
+			expect(call.options.stdio).toEqual(["pipe", "pipe", "ignore"]);
+			expect(call.options.windowsHide).toBe(true);
+			const env = call.options.env as NodeJS.ProcessEnv;
+			expect(env.GIT_TERMINAL_PROMPT).toBe("0");
+			expect(env.GCM_INTERACTIVE).toBe("never");
+			expect(env.GIT_CEILING_DIRECTORIES).toBe(tmpdir());
+			// Empty values override both inherited variables and Git's core.askPass;
+			// deleting GIT_ASKPASS here would allow the configured fallback to run.
+			expect(env.GIT_ASKPASS).toBe("");
+			expect(env.SSH_ASKPASS).toBe("");
+			expect(env.DISPLAY).toBeUndefined();
+			expect(helper.requests.join("")).toBe("url=https://git.example.com\n\n");
+			expect(helper.kills).toEqual([]);
+		} finally {
+			for (const [name, value] of Object.entries(inherited)) {
+				if (value === undefined) delete process.env[name];
+				else process.env[name] = value;
+			}
+		}
 	});
 
 	it("fails closed without spawn support or when injected spawn throws", async () => {
 		await expect(new GithubHostCredentialTrust({ getEnv: () => ({}) }).isTrusted("git.example.com")).resolves.toBe(false);
 		const helper = fakeHelper("", { spawnError: new Error("fenced") });
 		await expect(subject(helper).isTrusted("git.example.com")).resolves.toBe(false);
+	});
+
+	it("never logs credential output or helper error values", async () => {
+		const stdoutSecret = "stdout-password-must-not-escape";
+		const errorSecret = "helper-error-must-not-escape";
+		const spies = [
+			vi.spyOn(console, "log").mockImplementation(() => {}),
+			vi.spyOn(console, "warn").mockImplementation(() => {}),
+			vi.spyOn(console, "error").mockImplementation(() => {}),
+		];
+		try {
+			await expect(subject(fakeHelper(credential("git.example.com", stdoutSecret))).isTrusted("git.example.com"))
+				.resolves.toBe(true);
+			await expect(subject(fakeHelper("host=git.example.com\npassword=partial-secret", {
+				stdoutError: new Error(errorSecret),
+			})).isTrusted("git.example.com")).resolves.toBe(false);
+
+			const logged = JSON.stringify(spies.flatMap(spy => spy.mock.calls));
+			expect(logged).not.toContain(stdoutSecret);
+			expect(logged).not.toContain("partial-secret");
+			expect(logged).not.toContain(errorSecret);
+			expect(spies.every(spy => spy.mock.calls.length === 0)).toBe(true);
+		} finally {
+			for (const spy of spies) spy.mockRestore();
+		}
 	});
 
 	it("requires one exact echoed normalized authority and a non-empty password", async () => {

--- a/tests2/core/github-host-credential-trust.test.ts
+++ b/tests2/core/github-host-credential-trust.test.ts
@@ -4,63 +4,85 @@ import { existsSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { PassThrough } from "node:stream";
 import { describe, expect, it, vi } from "vitest";
-import type { Clock, TimerHandle } from "../../src/server/gateway-deps.js";
-import {
-	GithubHostCredentialTrust,
-	type SpawnLike,
-} from "../../src/server/github-host-credential-trust.js";
+import type { Clock, CommandRunner, TimerHandle } from "../../src/server/gateway-deps.js";
+import { GithubHostCredentialTrust } from "../../src/server/github-host-credential-trust.js";
+import { createCommandSpawnAdapter, type OwnedTreeControl } from "../../src/server/owned-tree-command-spawn.js";
 
 interface FakeHelper {
-	spawn: SpawnLike;
+	runner: CommandRunner;
 	calls: Array<{ file: string; args: string[]; options: SpawnOptions }>;
 	requests: string[];
 	kills: string[];
+	waits: number[];
 }
 
 function fakeHelper(
 	output: string | Buffer | readonly (string | Buffer)[],
-	options: { close?: boolean; code?: number; spawnError?: Error; stdoutError?: Error } = {},
+	options: {
+		close?: boolean;
+		code?: number;
+		spawnError?: Error;
+		stdoutError?: Error;
+		ownershipReady?: Promise<void>;
+		waitResults?: Array<boolean | Promise<boolean>>;
+	} = {},
 ): FakeHelper {
 	const calls: FakeHelper["calls"] = [];
 	const requests: string[] = [];
 	const kills: string[] = [];
+	const waits: number[] = [];
+	const waitResults = [...(options.waitResults ?? [true])];
+	const ownedSpawn = ((file: string, args: readonly string[], spawnOptions: SpawnOptions & { clock?: Clock }) => {
+		if (options.spawnError) throw options.spawnError;
+		calls.push({ file, args: [...args], options: spawnOptions });
+		const child = new EventEmitter() as ChildProcess;
+		const stdout = new PassThrough();
+		const stdin = new PassThrough();
+		stdin.on("data", chunk => requests.push(String(chunk)));
+		Object.assign(child, {
+			stdout,
+			stdin,
+			kill() { throw new Error("credential probe must never kill the root directly"); },
+		});
+		const control: OwnedTreeControl = {
+			child,
+			ownershipReady: options.ownershipReady ?? Promise.resolve(),
+			killTree(signal = "SIGTERM") { kills.push(signal); },
+			async waitForTreeExit(timeoutMs?: number) {
+				waits.push(timeoutMs ?? -1);
+				return await (waitResults.shift() ?? true);
+			},
+			killed: () => kills.length > 0,
+			timedOut: () => false,
+		} as OwnedTreeControl & { child: ChildProcess };
+		setImmediate(() => {
+			for (const chunk of Array.isArray(output) ? output : [output]) stdout.write(chunk);
+			if (options.stdoutError) {
+				stdout.emit("error", options.stdoutError);
+				child.emit("close", 1, null);
+				return;
+			}
+			if (options.close === false) return;
+			stdout.end();
+			child.emit("close", options.code ?? 0, null);
+		});
+		return control;
+	}) as any;
 	return {
 		calls,
 		requests,
 		kills,
-		spawn(file, args, spawnOptions) {
-			if (options.spawnError) throw options.spawnError;
-			calls.push({ file, args: [...args], options: spawnOptions });
-			const child = new EventEmitter() as ChildProcess;
-			const stdout = new PassThrough();
-			const stdin = new PassThrough();
-			stdin.on("data", chunk => requests.push(String(chunk)));
-			Object.assign(child, {
-				stdout,
-				stdin,
-				kill(signal?: string) {
-					kills.push(signal ?? "SIGTERM");
-					return true;
-				},
-			});
-			setImmediate(() => {
-				for (const chunk of Array.isArray(output) ? output : [output]) stdout.write(chunk);
-				if (options.stdoutError) {
-					stdout.emit("error", options.stdoutError);
-					child.emit("close", 1, null);
-					return;
-				}
-				if (options.close === false) return;
-				stdout.end();
-				child.emit("close", options.code ?? 0, null);
-			});
-			return child;
+		waits,
+		runner: {
+			execFile: async () => { throw new Error("unexpected execFile"); },
+			spawn: createCommandSpawnAdapter(() => { throw new Error("unexpected direct spawn"); }, ownedSpawn),
+			supportsOwnedTreeSpawn: true,
 		},
 	};
 }
 
 function subject(helper: FakeHelper, clock?: Clock): GithubHostCredentialTrust {
-	return new GithubHostCredentialTrust({ resolveSpawn: () => helper.spawn, clock, getEnv: () => ({}) });
+	return new GithubHostCredentialTrust({ resolveCommandRunner: () => helper.runner, clock, getEnv: () => ({}) });
 }
 
 function credential(host = "git.example.com", password = "fixture-secret"): string {
@@ -188,10 +210,61 @@ describe("Git credential probe", () => {
 		}
 	});
 
-	it("fails closed without spawn support or when injected spawn throws", async () => {
+	it("does not write the credential request before ownership is established", async () => {
+		let establishOwnership!: () => void;
+		const helper = fakeHelper(credential(), {
+			ownershipReady: new Promise<void>(resolve => { establishOwnership = resolve; }),
+		});
+		const verdict = subject(helper).isTrusted("git.example.com");
+		expect(helper.requests).toEqual([]);
+		establishOwnership();
+		await expect(verdict).resolves.toBe(true);
+		expect(helper.requests).toEqual(["url=https://git.example.com\n\n"]);
+	});
+
+	it("rejects unsolicited credential output from a helper that closes before ownership readiness", async () => {
+		let establishOwnership!: () => void;
+		const helper = fakeHelper(credential(), {
+			ownershipReady: new Promise<void>(resolve => { establishOwnership = resolve; }),
+		});
+		const verdict = subject(helper).isTrusted("git.example.com");
+		await new Promise(resolve => setImmediate(resolve));
+		expect(helper.requests).toEqual([]);
+		establishOwnership();
+		await expect(verdict).resolves.toBe(false);
+		expect(helper.requests).toEqual([]);
+		expect(helper.kills).toEqual(["SIGTERM"]);
+	});
+
+	it("fails closed without spawn, capability, synchronous binding, or ownership readiness", async () => {
 		await expect(new GithubHostCredentialTrust({ getEnv: () => ({}) }).isTrusted("git.example.com")).resolves.toBe(false);
 		const helper = fakeHelper("", { spawnError: new Error("fenced") });
 		await expect(subject(helper).isTrusted("git.example.com")).resolves.toBe(false);
+
+		const noCapability: CommandRunner = {
+			execFile: async () => ({ stdout: "", stderr: "" }),
+			spawn: helper.runner.spawn,
+		};
+		await expect(new GithubHostCredentialTrust({
+			resolveCommandRunner: () => noCapability,
+			getEnv: () => ({}),
+		}).isTrusted("git.example.com")).resolves.toBe(false);
+		expect(helper.calls).toHaveLength(0);
+
+		const unbound: CommandRunner = {
+			execFile: async () => ({ stdout: "", stderr: "" }),
+			spawn: () => new EventEmitter() as ChildProcess,
+			supportsOwnedTreeSpawn: true,
+		};
+		await expect(new GithubHostCredentialTrust({
+			resolveCommandRunner: () => unbound,
+			getEnv: () => ({}),
+		}).isTrusted("git.example.com")).resolves.toBe(false);
+
+		const rejected = fakeHelper(credential(), { ownershipReady: Promise.reject(new Error("ownership secret")) });
+		await expect(subject(rejected).isTrusted("git.example.com")).resolves.toBe(false);
+		expect(rejected.requests).toEqual([]);
+		expect(rejected.kills).toEqual(["SIGTERM"]);
 	});
 
 	it("never logs credential output or helper error values", async () => {
@@ -250,34 +323,56 @@ describe("Git credential probe", () => {
 		await expect(subject(trailing).isTrusted("git.example.com")).resolves.toBe(false);
 	});
 
-	it("rejects output beyond the byte cap in one chunk or across chunks", async () => {
+	it("rejects bounded output only after the owned descendant tree is reaped", async () => {
 		const padding = "field=" + "x".repeat(9 * 1024);
 		for (const output of [
 			`${credential()}${padding}\n`,
 			["host=git.example.com\npassword=secret\n", "field=", "x".repeat(9 * 1024)],
 		]) {
-			const helper = fakeHelper(output);
+			const helper = fakeHelper(output, { waitResults: [false, true] });
 			await expect(subject(helper).isTrusted("git.example.com")).resolves.toBe(false);
-			expect(helper.kills).toEqual(["SIGTERM"]);
+			expect(helper.kills).toEqual(["SIGTERM", "SIGKILL"]);
+			expect(helper.waits).toEqual([500, 1_500]);
 		}
 	});
 
-	it("times out, sends TERM, escalates a wedged process to KILL, and never kills normal success", async () => {
+	it("waits for tree completion, escalates wedged descendants, and never kills normal success", async () => {
 		const clock = manualClock();
-		const wedged = fakeHelper("host=git.example.com\n", { close: false });
+		const wedged = fakeHelper("host=git.example.com\n", { close: false, waitResults: [false, true] });
 		const verdict = subject(wedged, clock).isTrusted("git.example.com");
 		await new Promise(resolve => setImmediate(resolve));
 		clock.runPending();
 		await expect(verdict).resolves.toBe(false);
-		expect(wedged.kills).toEqual(["SIGTERM"]);
-		clock.runPending();
 		expect(wedged.kills).toEqual(["SIGTERM", "SIGKILL"]);
+		expect(wedged.waits).toEqual([500, 1_500]);
 
 		const normalClock = manualClock();
 		const normal = fakeHelper(credential());
 		await expect(subject(normal, normalClock).isTrusted("git.example.com")).resolves.toBe(true);
 		normalClock.runPending();
 		expect(normal.kills).toEqual([]);
+		expect(normal.waits).toEqual([1_500]);
+	});
+
+	it("keeps the verdict and temporary directory pending until the owned tree completes", async () => {
+		let completeTree!: (completed: boolean) => void;
+		const helper = fakeHelper(credential(), {
+			waitResults: [new Promise<boolean>(resolve => { completeTree = resolve; })],
+		});
+		let settled = false;
+		const verdict = subject(helper).isTrusted("git.example.com").finally(() => { settled = true; });
+		await new Promise(resolve => setImmediate(resolve));
+		expect(settled).toBe(false);
+		expect(existsSync(String(helper.calls[0].options.cwd))).toBe(true);
+		completeTree(true);
+		await expect(verdict).resolves.toBe(true);
+		expect(existsSync(String(helper.calls[0].options.cwd))).toBe(false);
+	});
+
+	it("fails closed when the owned-tree completion boundary cannot be confirmed", async () => {
+		const helper = fakeHelper(credential(), { waitResults: [false] });
+		await expect(subject(helper).isTrusted("git.example.com")).resolves.toBe(false);
+		expect(helper.kills).toEqual([]);
 	});
 });
 

--- a/tests2/core/github-host-credential-trust.test.ts
+++ b/tests2/core/github-host-credential-trust.test.ts
@@ -144,9 +144,10 @@ describe("GithubHostCredentialTrust cache", () => {
 		const trust = new GithubHostCredentialTrust({ probe, getEnv: () => ({}) });
 
 		const first = trust.isTrusted("git.example.com");
+		const queuedCallers: Promise<boolean>[] = [];
 		for (let refresh = 0; refresh < 4; refresh++) {
 			trust.forgetUnverified();
-			void trust.isTrusted("git.example.com");
+			queuedCallers.push(trust.isTrusted("git.example.com"));
 			expect(probe, `refresh ${refresh} must join one queued successor`).toHaveBeenCalledTimes(1);
 		}
 
@@ -163,7 +164,9 @@ describe("GithubHostCredentialTrust cache", () => {
 		const latest = trust.isTrusted("git.example.com");
 		expect(probe).toHaveBeenCalledTimes(2);
 		releases[1](true);
-		await expect(beforeLatestRefresh).resolves.toBe(false);
+		await expect(Promise.all([...queuedCallers, beforeLatestRefresh])).resolves.toEqual([
+			false, false, false, false, false,
+		]);
 		await vi.waitFor(() => expect(probe).toHaveBeenCalledTimes(3));
 		expect(active).toBe(1);
 		expect(maxActive).toBe(1);

--- a/tests2/core/owned-tree-command-spawn.test.ts
+++ b/tests2/core/owned-tree-command-spawn.test.ts
@@ -1,0 +1,83 @@
+import type { ChildProcess, SpawnOptions } from "node:child_process";
+import { EventEmitter } from "node:events";
+import { describe, expect, it, vi } from "vitest";
+import { realClock } from "../../src/server/clock.js";
+import {
+	createCommandSpawnAdapter,
+	hasOwnedTreeSpawnRequest,
+	ownedTreeSpawnOptions,
+	type OwnedTreeControl,
+} from "../../src/server/owned-tree-command-spawn.js";
+
+function fakeChild(): ChildProcess {
+	return new EventEmitter() as ChildProcess;
+}
+
+describe("owned-tree CommandRunner spawn adapter", () => {
+	it("keeps ordinary spawn direct and byte-compatible", () => {
+		const child = fakeChild();
+		const options: SpawnOptions = { cwd: "fixture", windowsHide: false };
+		const direct = vi.fn(() => child);
+		const owned = vi.fn();
+		const spawn = createCommandSpawnAdapter(direct, owned as any);
+
+		expect(spawn("git", ["status"], options)).toBe(child);
+		expect(direct).toHaveBeenCalledWith("git", ["status"], options);
+		expect(owned).not.toHaveBeenCalled();
+	});
+
+	it("translates only a branded logical spawn through spawnTracked defaults and binds control synchronously", () => {
+		const child = fakeChild();
+		const control: OwnedTreeControl & { child: ChildProcess } = {
+			child,
+			ownershipReady: Promise.resolve(),
+			killTree: vi.fn(),
+			waitForTreeExit: vi.fn(async () => true),
+			killed: () => false,
+			timedOut: () => false,
+		};
+		const direct = vi.fn();
+		const owned = vi.fn((_file: string, _args: readonly string[], options: Record<string, unknown>) => {
+			// Absence of both overrides is the security invariant: spawnTracked chooses
+			// its production POSIX sentinel or pre-resume Windows Job itself.
+			expect(options.spawnImpl).toBeUndefined();
+			expect(options.platform).toBeUndefined();
+			return control;
+		});
+		const spawn = createCommandSpawnAdapter(direct as any, owned as any);
+		let bound: OwnedTreeControl | undefined;
+		const options = ownedTreeSpawnOptions({
+			cwd: "neutral",
+			env: { GIT_TERMINAL_PROMPT: "0" },
+			stdio: ["pipe", "pipe", "ignore"],
+			windowsHide: true,
+		}, realClock, value => { bound = value; });
+
+		expect(hasOwnedTreeSpawnRequest(options)).toBe(true);
+		expect(spawn("git", ["credential", "fill"], options)).toBe(child);
+		expect(bound).toBe(control);
+		expect(direct).not.toHaveBeenCalled();
+		expect(owned).toHaveBeenCalledTimes(1);
+		expect(owned.mock.calls[0]?.[0]).toBe("git");
+		expect(owned.mock.calls[0]?.[1]).toEqual(["credential", "fill"]);
+		expect(hasOwnedTreeSpawnRequest(owned.mock.calls[0]?.[2] as SpawnOptions)).toBe(false);
+	});
+
+	it("force-kills the owned tree when synchronous binding fails", () => {
+		const child = fakeChild();
+		const killTree = vi.fn();
+		const owned = vi.fn(() => ({
+			child,
+			ownershipReady: Promise.resolve(),
+			killTree,
+			waitForTreeExit: async () => true,
+			killed: () => false,
+			timedOut: () => false,
+		}));
+		const spawn = createCommandSpawnAdapter(vi.fn() as any, owned as any);
+		const options = ownedTreeSpawnOptions({}, realClock, () => { throw new Error("bind failed"); });
+
+		expect(() => spawn("git", ["credential", "fill"], options)).toThrow("bind failed");
+		expect(killTree).toHaveBeenCalledWith("SIGKILL");
+	});
+});

--- a/tests2/core/pr-status-lookup.test.ts
+++ b/tests2/core/pr-status-lookup.test.ts
@@ -15,6 +15,7 @@ import {
 	buildGhPrMergeArgs,
 	buildGhPrMergePermissionsArgs,
 	buildGhPrViewArgs,
+	buildGhRepoPermissionArgs,
 	buildGhRulesetArgs,
 	selectCoordinatedPrResult,
 	shouldLogRemoteStateTelemetry,
@@ -332,16 +333,17 @@ describe("PR status GitHub CLI lookup", () => {
 		assert.equal(status?.viewerCanMergeAsAdmin, false);
 	});
 
-	it("falls back to legacy repo permission lookup when GraphQL cannot be used", async () => {
+	it("keeps the permission fallback bound to the exact repository when GraphQL cannot be used", async () => {
 		const branch = "feature/sidebar-actions && node -e \"throw new Error('shell executed')\"";
 		const calls: Array<{ args: string[]; cwd: string; timeout: number }> = [];
+		const remote = { host: "github.com", owner: "acme", repository: "widget" };
 
 		__setGhExecFileForPrStatusTests(async (args, opts) => {
 			calls.push({ args: [...args], cwd: opts.cwd, timeout: opts.timeout });
 			if (args[0] === "pr" && args[1] === "view") {
 				return JSON.stringify({
 					state: "OPEN",
-					url: "https://example.com/acme/widget/pull/7",
+					url: "https://github.com/acme/widget/pull/7",
 					number: 7,
 					title: "Sidebar actions",
 					mergeable: "MERGEABLE",
@@ -350,6 +352,7 @@ describe("PR status GitHub CLI lookup", () => {
 					reviewDecision: "APPROVED",
 				});
 			}
+			if (args[0] === "api") throw new Error("GraphQL unavailable");
 			if (args[0] === "repo" && args[1] === "view") {
 				return JSON.stringify({ viewerPermission: "ADMIN" });
 			}
@@ -360,7 +363,7 @@ describe("PR status GitHub CLI lookup", () => {
 
 		assert.deepEqual(status, {
 			number: 7,
-			url: "https://example.com/acme/widget/pull/7",
+			url: "https://github.com/acme/widget/pull/7",
 			title: "Sidebar actions",
 			state: "OPEN",
 			mergeable: "MERGEABLE",
@@ -372,8 +375,16 @@ describe("PR status GitHub CLI lookup", () => {
 		});
 		assert.deepEqual(calls.map((call) => call.args), [
 			["pr", "view", branch, "--json", PR_FIELDS],
-			["repo", "view", "--json", "viewerPermission"],
+			buildGhPrMergePermissionsArgs(remote, 7),
+			buildGhRepoPermissionArgs(remote),
 		]);
 		assert.equal(calls[0].args[2], branch);
+	});
+
+	it("builds the permission fallback for an exact enterprise host and repository", () => {
+		assert.deepEqual(
+			buildGhRepoPermissionArgs({ host: "ghe.example.test:8443", owner: "acme", repository: "widget" }),
+			["repo", "view", "--repo", "ghe.example.test:8443/acme/widget", "--json", "viewerPermission"],
+		);
 	});
 });

--- a/tests2/core/remote-state-identity.test.ts
+++ b/tests2/core/remote-state-identity.test.ts
@@ -7,6 +7,7 @@ import {
 	normalizePullRequestIdentity,
 	normalizeRemoteIdentity,
 	parseTrustedGithubRemote,
+	parseUntrustedGithubRemoteCandidate,
 	RemoteStateCoordinator,
 } from "../../src/server/remote-state-coordinator.ts";
 
@@ -78,7 +79,20 @@ describe("remote state canonical identity", () => {
 		);
 	});
 
-	it("rejects trusted-looking substrings, extra paths, and encoded separators", () => {
+	it("separates structural parsing from the unchanged list trust gate", () => {
+		assert.deepEqual(parseUntrustedGithubRemoteCandidate("https://GHE.Example.Test/Acme/Widget.git"), {
+			host: "ghe.example.test",
+			owner: "acme",
+			repository: "widget",
+		});
+		assert.equal(parseTrustedGithubRemote("https://ghe.example.test/acme/widget.git"), undefined);
+		assert.deepEqual(
+			parseTrustedGithubRemote("https://ghe.example.test/acme/widget.git", ["ghe.example.test"]),
+			parseUntrustedGithubRemoteCandidate("https://ghe.example.test/acme/widget.git"),
+		);
+	});
+
+	it("preserves every malformed remote rejection for structural candidates", () => {
 		const rejected = [
 			"https://evil.example/a/https://github.com/acme/widget.git",
 			"ssh://git@evil.example/a/git@github.com:acme/widget.git",
@@ -89,8 +103,24 @@ describe("remote state canonical identity", () => {
 			"https://github.com/acme/widget%252Fother.git",
 			"https://github.com/acme/widget.git?token=secret",
 			"git@github.com:acme%2Fother/widget.git",
+			"ssh://root@ghe.example.test/acme/widget.git",
+			"file:///tmp/acme/widget.git",
+			"https://ghe.example.test/acme/..",
 		];
-		for (const remote of rejected) assert.equal(parseTrustedGithubRemote(remote), undefined, remote);
+		for (const remote of rejected) {
+			assert.equal(parseUntrustedGithubRemoteCandidate(remote), undefined, remote);
+			assert.equal(parseTrustedGithubRemote(remote, ["ghe.example.test"]), undefined, remote);
+		}
+	});
+
+	it("continues rejecting structurally valid but unlisted hosts on the list path", () => {
+		const remote = "https://evil.example/acme/widget.git";
+		assert.deepEqual(parseUntrustedGithubRemoteCandidate(remote), {
+			host: "evil.example",
+			owner: "acme",
+			repository: "widget",
+		});
+		assert.equal(parseTrustedGithubRemote(remote), undefined);
 	});
 
 	it("canonicalizes Windows local paths", () => {

--- a/tests2/harness/fenced-command-runner.ts
+++ b/tests2/harness/fenced-command-runner.ts
@@ -153,6 +153,16 @@ function assertGitRemoteAllowedSync(realCommandRunner: CommandRunner, args: read
 	}
 }
 
+/**
+ * `git credential` reads the developer's real credential configuration, so
+ * letting it through would make host trust — and the security assertions that
+ * depend on it — vary by machine. Applied to every invocation path, not just the
+ * one that has a caller today. Callers fail closed on a throw.
+ */
+function assertNotGitCredential(args: readonly string[]): void {
+	if (args[0] === "credential") throw new Error("[fenced-command-runner] blocked git credential invocation");
+}
+
 export function createFencedCommandRunner(realCommandRunner: CommandRunner, opts: FencedCommandRunnerOptions = {}): CommandRunner {
 	return {
 		async execFile(file: string, args: readonly string[], options?: ExecFileOptions): Promise<ExecFileResult> {
@@ -166,6 +176,7 @@ export function createFencedCommandRunner(realCommandRunner: CommandRunner, opts
 			if (name === "gh") throw new Error("[fenced-command-runner] blocked gh invocation");
 			if (name === "docker" || name === "podman") throw new Error(`[fenced-command-runner] blocked ${name} invocation`);
 			if (name === "git") {
+				assertNotGitCredential(args);
 				if (shouldShortCircuitGitDiscovery(args, options)) throw nonRepositoryGitError(args, options);
 				await assertGitRemoteAllowed(realCommandRunner, args, options);
 			}
@@ -176,6 +187,7 @@ export function createFencedCommandRunner(realCommandRunner: CommandRunner, opts
 			if (name === "gh") throw new Error("[fenced-command-runner] blocked gh invocation");
 			if (name === "docker" || name === "podman") throw new Error(`[fenced-command-runner] blocked ${name} invocation`);
 			if (name === "git") {
+				assertNotGitCredential(args);
 				if (shouldShortCircuitGitDiscovery(args, options)) throw nonRepositoryGitError(args, options);
 				assertGitRemoteAllowedSync(realCommandRunner, args, options);
 			}
@@ -185,7 +197,10 @@ export function createFencedCommandRunner(realCommandRunner: CommandRunner, opts
 			const name = commandName(file);
 			if (name === "gh") throw new Error("[fenced-command-runner] blocked gh invocation");
 			if (name === "docker" || name === "podman") throw new Error(`[fenced-command-runner] blocked ${name} invocation`);
-			if (name === "git") assertGitRemoteAllowedSync(realCommandRunner, args, options);
+			if (name === "git") {
+				assertNotGitCredential(args);
+				assertGitRemoteAllowedSync(realCommandRunner, args, options);
+			}
 			return realCommandRunner.spawn!(file, args, options);
 		},
 	};

--- a/tests2/harness/fenced-command-runner.ts
+++ b/tests2/harness/fenced-command-runner.ts
@@ -15,7 +15,7 @@ export interface FencedCommandRunnerOptions {
 const NETWORK_GIT_COMMANDS = new Set(["push", "fetch", "clone", "ls-remote"]);
 
 function commandName(file: string): string {
-	return path.basename(file).replace(/\.exe$/i, "").toLowerCase();
+	return path.basename(file).replace(/\.(?:exe|cmd|bat)$/i, "").toLowerCase();
 }
 
 function fakeKey(file: string, args: readonly string[]): string {
@@ -63,8 +63,12 @@ function hasGitMetadataAtOrAbove(candidate: string): boolean {
 	}
 }
 
-function shouldShortCircuitGitDiscovery(args: readonly string[], options?: ExecFileOptions | ExecFileSyncOptions): boolean {
-	if (!isReadOnlyGitDiscovery(args) || hasExplicitGitDirectory(args, options)) return false;
+function shouldShortCircuitGitDiscovery(
+	commandArgs: readonly string[],
+	invocationArgs: readonly string[],
+	options?: ExecFileOptions | ExecFileSyncOptions,
+): boolean {
+	if (!isReadOnlyGitDiscovery(commandArgs) || hasExplicitGitDirectory(invocationArgs, options)) return false;
 	const cwd = gitProbeCwd(options);
 	return cwd !== null && !hasGitMetadataAtOrAbove(cwd);
 }
@@ -153,14 +157,101 @@ function assertGitRemoteAllowedSync(realCommandRunner: CommandRunner, args: read
 	}
 }
 
+const GIT_GLOBAL_FLAGS = new Set([
+	"--version",
+	"--help",
+	"-h",
+	"-p",
+	"--paginate",
+	"-P",
+	"--no-pager",
+	"--no-replace-objects",
+	"--bare",
+	"--no-lazy-fetch",
+	"--no-optional-locks",
+	"--no-advice",
+	"--literal-pathspecs",
+	"--glob-pathspecs",
+	"--noglob-pathspecs",
+	"--icase-pathspecs",
+	"--html-path",
+	"--man-path",
+	"--info-path",
+	"--exec-path",
+]);
+
+const GIT_GLOBAL_OPTIONS_WITH_VALUE = new Set([
+	"-C",
+	"-c",
+	"--git-dir",
+	"--work-tree",
+	"--namespace",
+	"--config-env",
+	"--attr-source",
+	"--super-prefix",
+]);
+
+const GIT_GLOBAL_LONG_OPTIONS_WITH_EQUALS = new Set([
+	"--git-dir",
+	"--work-tree",
+	"--namespace",
+	"--config-env",
+	"--attr-source",
+	"--super-prefix",
+	"--exec-path",
+]);
+
+const MALFORMED_GIT_INVOCATION = "[fenced-command-runner] blocked unclassified git invocation";
+const GIT_CREDENTIAL_INVOCATION = "[fenced-command-runner] blocked git credential invocation";
+
+/**
+ * Find the Git subcommand without consulting Git or host configuration. Unknown
+ * and incomplete leading options are rejected rather than guessed at: this is a
+ * test security boundary, not a general-purpose Git argument parser.
+ */
+function classifyGitCommand(args: readonly string[]): readonly string[] {
+	let index = 0;
+	while (index < args.length) {
+		const arg = args[index];
+		if (arg === "--") {
+			index++;
+			break;
+		}
+		if (arg.length > 0 && !arg.startsWith("-")) return args.slice(index);
+		if (GIT_GLOBAL_FLAGS.has(arg)) {
+			index++;
+			continue;
+		}
+		if (GIT_GLOBAL_OPTIONS_WITH_VALUE.has(arg)) {
+			const value = args[index + 1];
+			if (value === undefined || value.length === 0) throw new Error(MALFORMED_GIT_INVOCATION);
+			index += 2;
+			continue;
+		}
+		if ((arg.startsWith("-C") || arg.startsWith("-c")) && arg.length > 2) {
+			index++;
+			continue;
+		}
+		const equals = arg.indexOf("=");
+		if (equals > 0 && GIT_GLOBAL_LONG_OPTIONS_WITH_EQUALS.has(arg.slice(0, equals)) && equals < arg.length - 1) {
+			index++;
+			continue;
+		}
+		throw new Error(MALFORMED_GIT_INVOCATION);
+	}
+	const commandArgs = args.slice(index);
+	if (!commandArgs[0] || commandArgs[0].startsWith("-")) throw new Error(MALFORMED_GIT_INVOCATION);
+	return commandArgs;
+}
+
 /**
  * `git credential` reads the developer's real credential configuration, so
  * letting it through would make host trust — and the security assertions that
  * depend on it — vary by machine. Applied to every invocation path, not just the
  * one that has a caller today. Callers fail closed on a throw.
  */
-function assertNotGitCredential(args: readonly string[]): void {
-	if (args[0] === "credential") throw new Error("[fenced-command-runner] blocked git credential invocation");
+function assertNotGitCredential(commandArgs: readonly string[]): void {
+	if (commandArgs[0] === "credential") throw new Error(GIT_CREDENTIAL_INVOCATION);
 }
 
 export function createFencedCommandRunner(realCommandRunner: CommandRunner, opts: FencedCommandRunnerOptions = {}): CommandRunner {
@@ -176,9 +267,10 @@ export function createFencedCommandRunner(realCommandRunner: CommandRunner, opts
 			if (name === "gh") throw new Error("[fenced-command-runner] blocked gh invocation");
 			if (name === "docker" || name === "podman") throw new Error(`[fenced-command-runner] blocked ${name} invocation`);
 			if (name === "git") {
-				assertNotGitCredential(args);
-				if (shouldShortCircuitGitDiscovery(args, options)) throw nonRepositoryGitError(args, options);
-				await assertGitRemoteAllowed(realCommandRunner, args, options);
+				const commandArgs = classifyGitCommand(args);
+				assertNotGitCredential(commandArgs);
+				if (shouldShortCircuitGitDiscovery(commandArgs, args, options)) throw nonRepositoryGitError(commandArgs, options);
+				await assertGitRemoteAllowed(realCommandRunner, commandArgs, options);
 			}
 			return realCommandRunner.execFile(file, args, options);
 		},
@@ -187,9 +279,10 @@ export function createFencedCommandRunner(realCommandRunner: CommandRunner, opts
 			if (name === "gh") throw new Error("[fenced-command-runner] blocked gh invocation");
 			if (name === "docker" || name === "podman") throw new Error(`[fenced-command-runner] blocked ${name} invocation`);
 			if (name === "git") {
-				assertNotGitCredential(args);
-				if (shouldShortCircuitGitDiscovery(args, options)) throw nonRepositoryGitError(args, options);
-				assertGitRemoteAllowedSync(realCommandRunner, args, options);
+				const commandArgs = classifyGitCommand(args);
+				assertNotGitCredential(commandArgs);
+				if (shouldShortCircuitGitDiscovery(commandArgs, args, options)) throw nonRepositoryGitError(commandArgs, options);
+				assertGitRemoteAllowedSync(realCommandRunner, commandArgs, options);
 			}
 			return realCommandRunner.execFileSync!(file, args, options);
 		},
@@ -198,8 +291,9 @@ export function createFencedCommandRunner(realCommandRunner: CommandRunner, opts
 			if (name === "gh") throw new Error("[fenced-command-runner] blocked gh invocation");
 			if (name === "docker" || name === "podman") throw new Error(`[fenced-command-runner] blocked ${name} invocation`);
 			if (name === "git") {
-				assertNotGitCredential(args);
-				assertGitRemoteAllowedSync(realCommandRunner, args, options);
+				const commandArgs = classifyGitCommand(args);
+				assertNotGitCredential(commandArgs);
+				assertGitRemoteAllowedSync(realCommandRunner, commandArgs, options);
 			}
 			return realCommandRunner.spawn!(file, args, options);
 		},

--- a/tests2/harness/fenced-command-runner.ts
+++ b/tests2/harness/fenced-command-runner.ts
@@ -344,7 +344,7 @@ function assertNotGitCredential(commandArgs: readonly string[]): void {
 }
 
 export function createFencedCommandRunner(realCommandRunner: CommandRunner, opts: FencedCommandRunnerOptions = {}): CommandRunner {
-	return {
+	const runner: CommandRunner = {
 		async execFile(file: string, args: readonly string[], options?: ExecFileOptions): Promise<ExecFileResult> {
 			const name = commandName(file);
 			const key = fakeKey(file, args);
@@ -393,4 +393,6 @@ export function createFencedCommandRunner(realCommandRunner: CommandRunner, opts
 			return realCommandRunner.spawn!(file, args, delegatedOptions);
 		},
 	};
+	if (realCommandRunner.supportsOwnedTreeSpawn === true) runner.supportsOwnedTreeSpawn = true;
+	return runner;
 }

--- a/tests2/harness/fenced-command-runner.ts
+++ b/tests2/harness/fenced-command-runner.ts
@@ -248,7 +248,12 @@ function normalizedConfigEnvironment(env: NodeJS.ProcessEnv): Map<string, { name
 	return normalized;
 }
 
-function assertSafeGitConfigEnvironment(env: NodeJS.ProcessEnv): void {
+interface GitConfigEnvironmentEntry {
+	key: string;
+	value: string;
+}
+
+function safeGitConfigEnvironmentEntries(env: NodeJS.ProcessEnv): GitConfigEnvironmentEntry[] {
 	const normalized = normalizedConfigEnvironment(env);
 	if (normalized.has("GIT_CONFIG_PARAMETERS")) throw new Error(UNSAFE_GIT_CONFIGURATION);
 
@@ -258,30 +263,50 @@ function assertSafeGitConfigEnvironment(env: NodeJS.ProcessEnv): void {
 	const indexed = injectionNames;
 	if (!countEntry) {
 		if (indexed.length > 0) throw new Error(MALFORMED_GIT_INVOCATION);
-		return;
+		return [];
 	}
 	if (!/^(?:0|[1-9]\d*)$/.test(countEntry.value)) throw new Error(MALFORMED_GIT_INVOCATION);
 	const count = Number(countEntry.value);
 	if (!Number.isSafeInteger(count) || count > MAX_GIT_CONFIG_ENV_ENTRIES || indexed.length !== count * 2) {
 		throw new Error(MALFORMED_GIT_INVOCATION);
 	}
+	const entries: GitConfigEnvironmentEntry[] = [];
 	for (let index = 0; index < count; index++) {
 		const key = normalized.get(`GIT_CONFIG_KEY_${index}`)?.value;
 		const value = normalized.get(`GIT_CONFIG_VALUE_${index}`)?.value;
 		if (key === undefined || value === undefined) throw new Error(MALFORMED_GIT_INVOCATION);
 		assertSafeGitConfigKey(gitConfigName(key));
+		entries.push({ key, value });
 	}
+	return entries;
 }
+
+const GIT_NULL_CONFIG_PATH = process.platform === "win32" ? "NUL" : os.devNull;
 
 function fencedGitOptions<T extends ExecFileOptions | ExecFileSyncOptions | SpawnOptions>(options: T | undefined): T {
 	const env = { ...(options?.env ?? process.env) };
-	assertSafeGitConfigEnvironment(env);
+	const configEntries = safeGitConfigEnvironmentEntries(env);
 	for (const name of Object.keys(env)) {
-		if (["GIT_CONFIG", "GIT_CONFIG_GLOBAL", "GIT_CONFIG_SYSTEM", "GIT_CONFIG_NOSYSTEM"].includes(name.toUpperCase())) delete env[name];
+		const upper = name.toUpperCase();
+		if (
+			["GIT_CONFIG", "GIT_CONFIG_GLOBAL", "GIT_CONFIG_SYSTEM", "GIT_CONFIG_NOSYSTEM", "GIT_CONFIG_COUNT"].includes(upper)
+			|| /^GIT_CONFIG_(?:KEY|VALUE)_\d+$/.test(upper)
+		) delete env[name];
 	}
-	env.GIT_CONFIG_GLOBAL = os.devNull;
-	env.GIT_CONFIG_SYSTEM = os.devNull;
+	env.GIT_CONFIG_GLOBAL = GIT_NULL_CONFIG_PATH;
+	env.GIT_CONFIG_SYSTEM = GIT_NULL_CONFIG_PATH;
 	env.GIT_CONFIG_NOSYSTEM = "1";
+
+	// An empty helper entry resets every helper loaded from repository-local
+	// config (including transitive includes). GIT_CONFIG_COUNT is inherited by
+	// shell aliases and their nested Git processes, unlike a root-only command
+	// check, so no unfaked runner path can consult a developer credential helper.
+	configEntries.push({ key: "credential.helper", value: "" });
+	env.GIT_CONFIG_COUNT = String(configEntries.length);
+	for (const [index, entry] of configEntries.entries()) {
+		env[`GIT_CONFIG_KEY_${index}`] = entry.key;
+		env[`GIT_CONFIG_VALUE_${index}`] = entry.value;
+	}
 	return { ...(options ?? {}), env } as T;
 }
 

--- a/tests2/harness/fenced-command-runner.ts
+++ b/tests2/harness/fenced-command-runner.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import type { CommandRunner, ExecFileOptions, ExecFileResult, ExecFileSyncOptions, SpawnOptions } from "../../src/server/gateway-deps.js";
@@ -96,20 +97,20 @@ function isAllowedLocalRemote(remote: string, cwd?: string): boolean {
 	return !!localPath && isBareGitRepo(localPath);
 }
 
-async function resolveRemoteName(realCommandRunner: CommandRunner, remote: string, cwd: string | undefined): Promise<string | null> {
+async function resolveRemoteName(realCommandRunner: CommandRunner, remote: string, cwd: string | undefined, env: NodeJS.ProcessEnv | undefined): Promise<string | null> {
 	if (!cwd || !/^[A-Za-z0-9_.-]+$/.test(remote) || !hasGitMetadataAtOrAbove(path.resolve(cwd))) return null;
 	try {
-		const { stdout } = await realCommandRunner.execFile("git", ["remote", "get-url", remote], { cwd, encoding: "utf-8", timeout: 5_000 });
+		const { stdout } = await realCommandRunner.execFile("git", ["remote", "get-url", remote], { cwd, env, encoding: "utf-8", timeout: 5_000 });
 		return String(stdout).trim() || null;
 	} catch {
 		return null;
 	}
 }
 
-function resolveRemoteNameSync(realCommandRunner: CommandRunner, remote: string, cwd: string | undefined): string | null {
+function resolveRemoteNameSync(realCommandRunner: CommandRunner, remote: string, cwd: string | undefined, env: NodeJS.ProcessEnv | undefined): string | null {
 	if (!cwd || !/^[A-Za-z0-9_.-]+$/.test(remote) || !hasGitMetadataAtOrAbove(path.resolve(cwd))) return null;
 	try {
-		const stdout = realCommandRunner.execFileSync!("git", ["remote", "get-url", remote], { cwd, encoding: "utf-8", timeout: 5_000 });
+		const stdout = realCommandRunner.execFileSync!("git", ["remote", "get-url", remote], { cwd, env, encoding: "utf-8", timeout: 5_000 });
 		return String(stdout).trim() || null;
 	} catch {
 		return null;
@@ -139,7 +140,7 @@ async function assertGitRemoteAllowed(realCommandRunner: CommandRunner, args: re
 	const cwd = typeof options?.cwd === "string" ? options.cwd : undefined;
 	const candidate = remoteCandidate(subcommand, args);
 	if (!candidate) throw new Error(`[fenced-command-runner] blocked git ${subcommand}: remote is required`);
-	const resolved = (await resolveRemoteName(realCommandRunner, candidate, cwd)) ?? candidate;
+	const resolved = (await resolveRemoteName(realCommandRunner, candidate, cwd, options?.env)) ?? candidate;
 	if (!isAllowedLocalRemote(resolved, cwd)) {
 		throw new Error(`[fenced-command-runner] blocked git ${subcommand} to non-local remote: ${candidate}`);
 	}
@@ -151,7 +152,7 @@ function assertGitRemoteAllowedSync(realCommandRunner: CommandRunner, args: read
 	const cwd = typeof options?.cwd === "string" ? options.cwd : undefined;
 	const candidate = remoteCandidate(subcommand, args);
 	if (!candidate) throw new Error(`[fenced-command-runner] blocked git ${subcommand}: remote is required`);
-	const resolved = resolveRemoteNameSync(realCommandRunner, candidate, cwd) ?? candidate;
+	const resolved = resolveRemoteNameSync(realCommandRunner, candidate, cwd, options?.env) ?? candidate;
 	if (!isAllowedLocalRemote(resolved, cwd)) {
 		throw new Error(`[fenced-command-runner] blocked git ${subcommand} to non-local remote: ${candidate}`);
 	}
@@ -203,6 +204,86 @@ const GIT_GLOBAL_LONG_OPTIONS_WITH_EQUALS = new Set([
 
 const MALFORMED_GIT_INVOCATION = "[fenced-command-runner] blocked unclassified git invocation";
 const GIT_CREDENTIAL_INVOCATION = "[fenced-command-runner] blocked git credential invocation";
+const UNSAFE_GIT_CONFIGURATION = "[fenced-command-runner] blocked unsafe git configuration";
+const MAX_GIT_CONFIG_ENV_ENTRIES = 128;
+
+function gitConfigName(key: string): string {
+	if (!key || key.includes("=") || /[\s\0]/.test(key) || !key.includes(".")) throw new Error(MALFORMED_GIT_INVOCATION);
+	return key;
+}
+
+function gitConfigKey(value: string): string {
+	const equals = value.indexOf("=");
+	return gitConfigName(equals < 0 ? value : value.slice(0, equals));
+}
+
+function assertSafeGitConfigKey(key: string): void {
+	if (/^alias\./i.test(key) || /^include\.path$/i.test(key) || /^includeif\..+\.path$/i.test(key)) {
+		throw new Error(UNSAFE_GIT_CONFIGURATION);
+	}
+}
+
+function assertSafeInlineGitConfig(value: string): void {
+	assertSafeGitConfigKey(gitConfigKey(value));
+}
+
+function assertSafeConfigEnv(value: string): void {
+	const equals = value.indexOf("=");
+	if (equals <= 0 || equals === value.length - 1 || value.indexOf("=", equals + 1) !== -1) {
+		throw new Error(MALFORMED_GIT_INVOCATION);
+	}
+	const variable = value.slice(equals + 1);
+	if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(variable)) throw new Error(MALFORMED_GIT_INVOCATION);
+	assertSafeGitConfigKey(gitConfigKey(value.slice(0, equals)));
+}
+
+function normalizedConfigEnvironment(env: NodeJS.ProcessEnv): Map<string, { name: string; value: string }> {
+	const normalized = new Map<string, { name: string; value: string }>();
+	for (const [name, value] of Object.entries(env)) {
+		if (value === undefined || !name.toUpperCase().startsWith("GIT_CONFIG")) continue;
+		const upper = name.toUpperCase();
+		if (normalized.has(upper)) throw new Error(MALFORMED_GIT_INVOCATION);
+		normalized.set(upper, { name, value });
+	}
+	return normalized;
+}
+
+function assertSafeGitConfigEnvironment(env: NodeJS.ProcessEnv): void {
+	const normalized = normalizedConfigEnvironment(env);
+	if (normalized.has("GIT_CONFIG_PARAMETERS")) throw new Error(UNSAFE_GIT_CONFIGURATION);
+
+	const countEntry = normalized.get("GIT_CONFIG_COUNT");
+	const injectionNames = [...normalized.keys()].filter(name => name.startsWith("GIT_CONFIG_KEY_") || name.startsWith("GIT_CONFIG_VALUE_"));
+	if (injectionNames.some(name => !/^GIT_CONFIG_(?:KEY|VALUE)_\d+$/.test(name))) throw new Error(MALFORMED_GIT_INVOCATION);
+	const indexed = injectionNames;
+	if (!countEntry) {
+		if (indexed.length > 0) throw new Error(MALFORMED_GIT_INVOCATION);
+		return;
+	}
+	if (!/^(?:0|[1-9]\d*)$/.test(countEntry.value)) throw new Error(MALFORMED_GIT_INVOCATION);
+	const count = Number(countEntry.value);
+	if (!Number.isSafeInteger(count) || count > MAX_GIT_CONFIG_ENV_ENTRIES || indexed.length !== count * 2) {
+		throw new Error(MALFORMED_GIT_INVOCATION);
+	}
+	for (let index = 0; index < count; index++) {
+		const key = normalized.get(`GIT_CONFIG_KEY_${index}`)?.value;
+		const value = normalized.get(`GIT_CONFIG_VALUE_${index}`)?.value;
+		if (key === undefined || value === undefined) throw new Error(MALFORMED_GIT_INVOCATION);
+		assertSafeGitConfigKey(gitConfigName(key));
+	}
+}
+
+function fencedGitOptions<T extends ExecFileOptions | ExecFileSyncOptions | SpawnOptions>(options: T | undefined): T {
+	const env = { ...(options?.env ?? process.env) };
+	assertSafeGitConfigEnvironment(env);
+	for (const name of Object.keys(env)) {
+		if (["GIT_CONFIG", "GIT_CONFIG_GLOBAL", "GIT_CONFIG_SYSTEM", "GIT_CONFIG_NOSYSTEM"].includes(name.toUpperCase())) delete env[name];
+	}
+	env.GIT_CONFIG_GLOBAL = os.devNull;
+	env.GIT_CONFIG_SYSTEM = os.devNull;
+	env.GIT_CONFIG_NOSYSTEM = "1";
+	return { ...(options ?? {}), env } as T;
+}
 
 /**
  * Find the Git subcommand without consulting Git or host configuration. Unknown
@@ -225,15 +306,23 @@ function classifyGitCommand(args: readonly string[]): readonly string[] {
 		if (GIT_GLOBAL_OPTIONS_WITH_VALUE.has(arg)) {
 			const value = args[index + 1];
 			if (value === undefined || value.length === 0) throw new Error(MALFORMED_GIT_INVOCATION);
+			if (arg === "-c") assertSafeInlineGitConfig(value);
+			if (arg === "--config-env") assertSafeConfigEnv(value);
 			index += 2;
 			continue;
 		}
-		if ((arg.startsWith("-C") || arg.startsWith("-c")) && arg.length > 2) {
+		if (arg.startsWith("-C") && arg.length > 2) {
+			index++;
+			continue;
+		}
+		if (arg.startsWith("-c") && arg.length > 2) {
+			assertSafeInlineGitConfig(arg.slice(2));
 			index++;
 			continue;
 		}
 		const equals = arg.indexOf("=");
 		if (equals > 0 && GIT_GLOBAL_LONG_OPTIONS_WITH_EQUALS.has(arg.slice(0, equals)) && equals < arg.length - 1) {
+			if (arg.slice(0, equals) === "--config-env") assertSafeConfigEnv(arg.slice(equals + 1));
 			index++;
 			continue;
 		}
@@ -266,36 +355,42 @@ export function createFencedCommandRunner(realCommandRunner: CommandRunner, opts
 			}
 			if (name === "gh") throw new Error("[fenced-command-runner] blocked gh invocation");
 			if (name === "docker" || name === "podman") throw new Error(`[fenced-command-runner] blocked ${name} invocation`);
+			let delegatedOptions = options;
 			if (name === "git") {
 				const commandArgs = classifyGitCommand(args);
 				assertNotGitCredential(commandArgs);
-				if (shouldShortCircuitGitDiscovery(commandArgs, args, options)) throw nonRepositoryGitError(commandArgs, options);
-				await assertGitRemoteAllowed(realCommandRunner, commandArgs, options);
+				delegatedOptions = fencedGitOptions(options);
+				if (shouldShortCircuitGitDiscovery(commandArgs, args, delegatedOptions)) throw nonRepositoryGitError(commandArgs, delegatedOptions);
+				await assertGitRemoteAllowed(realCommandRunner, commandArgs, delegatedOptions);
 			}
-			return realCommandRunner.execFile(file, args, options);
+			return realCommandRunner.execFile(file, args, delegatedOptions);
 		},
 		execFileSync(file, args, options) {
 			const name = commandName(file);
 			if (name === "gh") throw new Error("[fenced-command-runner] blocked gh invocation");
 			if (name === "docker" || name === "podman") throw new Error(`[fenced-command-runner] blocked ${name} invocation`);
+			let delegatedOptions = options;
 			if (name === "git") {
 				const commandArgs = classifyGitCommand(args);
 				assertNotGitCredential(commandArgs);
-				if (shouldShortCircuitGitDiscovery(commandArgs, args, options)) throw nonRepositoryGitError(commandArgs, options);
-				assertGitRemoteAllowedSync(realCommandRunner, commandArgs, options);
+				delegatedOptions = fencedGitOptions(options);
+				if (shouldShortCircuitGitDiscovery(commandArgs, args, delegatedOptions)) throw nonRepositoryGitError(commandArgs, delegatedOptions);
+				assertGitRemoteAllowedSync(realCommandRunner, commandArgs, delegatedOptions);
 			}
-			return realCommandRunner.execFileSync!(file, args, options);
+			return realCommandRunner.execFileSync!(file, args, delegatedOptions);
 		},
 		spawn(file, args, options) {
 			const name = commandName(file);
 			if (name === "gh") throw new Error("[fenced-command-runner] blocked gh invocation");
 			if (name === "docker" || name === "podman") throw new Error(`[fenced-command-runner] blocked ${name} invocation`);
+			let delegatedOptions = options;
 			if (name === "git") {
 				const commandArgs = classifyGitCommand(args);
 				assertNotGitCredential(commandArgs);
-				assertGitRemoteAllowedSync(realCommandRunner, commandArgs, options);
+				delegatedOptions = fencedGitOptions(options);
+				assertGitRemoteAllowedSync(realCommandRunner, commandArgs, delegatedOptions);
 			}
-			return realCommandRunner.spawn!(file, args, options);
+			return realCommandRunner.spawn!(file, args, delegatedOptions);
 		},
 	};
 }

--- a/tests2/integration/remote-state-routes.test.ts
+++ b/tests2/integration/remote-state-routes.test.ts
@@ -483,6 +483,147 @@ test.describe("remote-state coordinator routes", () => {
 		}
 	});
 
+	test("credential-vouches only the selected repository in a multi-repository PR status lookup", async ({ gateway }) => {
+		test.setTimeout(30_000);
+		const projectRoot = mkdtempSync(join(tmpdir(), "bobbit-pr-credential-selected-"));
+		const selectedSource = join(projectRoot, "selected");
+		const siblingSource = join(projectRoot, "sibling");
+		mkdirSync(selectedSource, { recursive: true });
+		mkdirSync(siblingSource, { recursive: true });
+		const selectedHost = `selected-credential-${Date.now()}.invalid`;
+		const siblingHost = `unrelated-sibling-${Date.now()}.invalid`;
+		const branch = `fixture/selected-credential-${Date.now()}`;
+		const project = await registerProject({
+			name: `Selected credential repository ${Date.now()}`,
+			rootPath: projectRoot,
+			components: [
+				{ name: "selected", repo: "selected" },
+				{ name: "sibling", repo: "sibling" },
+			],
+			seedWorkflows: false,
+		});
+		const sessionId = await createRemoteStateSession(gateway, selectedSource, project.id);
+		gateway.sessionManager.updateSessionMeta(sessionId, { branch, repoPath: projectRoot });
+		const session = gateway.sessionManager.getSession(sessionId) as any;
+		session.cwd = selectedSource;
+		session.repoPath = projectRoot;
+
+		const runner = (gateway.sessionManager as any).commandRunner;
+		const originalExecFile = runner.execFile;
+		const originalSpawn = runner.spawn;
+		const previousEnterpriseTokens = new Map<string, string | undefined>(
+			["GH_ENTERPRISE_TOKEN", "GITHUB_ENTERPRISE_TOKEN"].map(name => [name, process.env[name]] as const),
+		);
+		const probes: Array<{ request: string; cwd: string }> = [];
+		const ghCalls: Array<{ args: string[]; cwd: string }> = [];
+		const repositoryFor = (cwd: string) => {
+			if (cwd === selectedSource) return {
+				host: selectedHost,
+				slug: "acme/selected-repository",
+				commonDir: join(selectedSource, ".git"),
+			};
+			if (cwd === siblingSource) return {
+				host: siblingHost,
+				slug: "acme/unrelated-sibling",
+				commonDir: join(siblingSource, ".git"),
+			};
+			return undefined;
+		};
+
+		try {
+			delete process.env.GH_ENTERPRISE_TOKEN;
+			delete process.env.GITHUB_ENTERPRISE_TOKEN;
+			runner.spawn = (_file: string, _args: readonly string[], options?: any) => {
+				const child = credentialHelperResult(
+					`protocol=https\nhost=${selectedHost}\nusername=route-fixture\npassword=fixture-secret\n`,
+				);
+				const probe = { request: "", cwd: String(options?.cwd ?? "") };
+				probes.push(probe);
+				child.stdin.on("data", (chunk: Buffer) => { probe.request += chunk.toString("utf8"); });
+				return child;
+			};
+			runner.execFile = async (file: string, args: readonly string[], options?: any) => {
+				const command = commandName(file);
+				const cwd = String(options?.cwd ?? "");
+				const repository = repositoryFor(cwd);
+				if (command === "git" && args.join(" ") === "rev-parse --show-toplevel") {
+					if (!repository) throw new Error("not a configured repository source");
+					return { stdout: `${cwd}\n`, stderr: "" };
+				}
+				if (command === "git" && args.join(" ") === "rev-parse --path-format=absolute --git-common-dir") {
+					if (!repository) throw new Error("unknown repository identity");
+					return { stdout: `${repository.commonDir}\n`, stderr: "" };
+				}
+				if (command === "git" && args.join(" ") === "rev-parse --git-dir") {
+					if (cwd !== selectedSource) throw new Error("PR execution escaped selected repository");
+					return { stdout: ".git\n", stderr: "" };
+				}
+				if (command === "git" && args.join(" ") === "remote get-url origin") {
+					if (!repository) throw new Error("unknown repository remote");
+					return { stdout: `https://${repository.host}/${repository.slug}.git\n`, stderr: "" };
+				}
+				if (command === "git" && args.join(" ") === `check-ref-format --branch ${branch}`) {
+					return { stdout: `${branch}\n`, stderr: "" };
+				}
+				if (command === "gh") {
+					ghCalls.push({ args: [...args], cwd });
+					if (cwd !== selectedSource) throw new Error("gh escaped selected repository");
+					if (args[0] === "pr" && args[1] === "list") {
+						return { stdout: JSON.stringify([{
+							number: 119,
+							url: `https://${selectedHost}/acme/selected-repository/pull/119`,
+							title: "selected credential repository",
+							state: "OPEN",
+							mergeable: "MERGEABLE",
+							headRefName: branch,
+							baseRefName: "main",
+							...ownedHeadEvidence("acme", "selected-repository"),
+						}]), stderr: "" };
+					}
+					if (args[0] === "api") {
+						return {
+							stdout: JSON.stringify({ data: { repository: { viewerPermission: "WRITE", pullRequest: { viewerCanMergeAsAdmin: false } } } }),
+							stderr: "",
+						};
+					}
+				}
+				return unexpectedRunnerCommand(file, args, options);
+			};
+
+			const status = await apiFetch(`/api/sessions/${sessionId}/pr-status?intent=explicit`);
+			expect(status.status).toBe(200);
+			expect(await status.json()).toMatchObject({
+				stale: false,
+				data: { number: 119, title: "selected credential repository" },
+			});
+			expect(probes).toEqual([expect.objectContaining({
+				request: `url=https://${selectedHost}\n\n`,
+			})]);
+			expect(probes[0].cwd).not.toBe(selectedSource);
+			expect(probes[0].request).not.toContain(siblingHost);
+			const listCall = ghCalls.find(call => call.args[0] === "pr" && call.args[1] === "list");
+			expect(listCall).toMatchObject({ cwd: selectedSource });
+			expect(listCall?.args.slice(0, 6)).toEqual([
+				"pr", "list", "--repo", `${selectedHost}/acme/selected-repository`, "--head", branch,
+			]);
+			expect(ghCalls.filter(call => call.args[0] === "api").every(call => (
+				call.args[1] === "--hostname" && call.args[2] === selectedHost
+			))).toBe(true);
+			expect(JSON.stringify(ghCalls)).not.toContain(siblingHost);
+		} finally {
+			runner.execFile = originalExecFile;
+			runner.spawn = originalSpawn;
+			for (const [name, value] of previousEnterpriseTokens) {
+				if (value === undefined) delete process.env[name];
+				else process.env[name] = value;
+			}
+			await deleteSession(sessionId);
+			await apiFetch(`/api/projects/${project.id}`, { method: "DELETE" }).catch(() => {});
+			const cleanup = await awaitableRm(projectRoot, { maxAttempts: 5, backoffMs: 50 });
+			expect(cleanup.removed, `selected credential fixture cleanup failed: ${String(cleanup.lastError ?? "unknown error")}`).toBe(true);
+		}
+	});
+
 	test("coalesces session Git and PR reads and only broadcasts redacted snapshot envelopes", async ({ gateway }) => {
 		test.setTimeout(30_000);
 		const sessionId = await createRemoteStateSession(gateway, gitCwd());

--- a/tests2/integration/remote-state-routes.test.ts
+++ b/tests2/integration/remote-state-routes.test.ts
@@ -320,6 +320,7 @@ test.describe("remote-state coordinator routes", () => {
 		);
 		let remoteHost = vouchedHost;
 		let sessionId: string | undefined;
+		let goalId: string | undefined;
 		let originalTrustedHosts: unknown = [];
 		const ghCalls: string[][] = [];
 		const probes: Array<{ file: string; args: string[]; cwd: string; env: NodeJS.ProcessEnv; request: string }> = [];
@@ -331,6 +332,21 @@ test.describe("remote-state coordinator routes", () => {
 			delete process.env.GITHUB_ENTERPRISE_TOKEN;
 			sessionId = await createRemoteStateSession(gateway, gitCwd());
 			gateway.sessionManager.updateSessionMeta(sessionId, { branch });
+			const goal = await createGoal({
+				title: `credential trust merge boundary ${Date.now()}`,
+				cwd: gitCwd(),
+				worktree: false,
+				autoStartTeam: false,
+			});
+			goalId = String(goal.id);
+			if (typeof goal.projectId !== "string") throw new Error("fixture goal project unavailable");
+			gateway.sessionManager.getGoalStoreForProject(goal.projectId).update(goalId, {
+				cwd: gitCwd(),
+				repoPath: gitCwd(),
+				worktreePath: gitCwd(),
+				branch,
+				setupStatus: "ready",
+			});
 
 			runner.spawn = (file: string, args: readonly string[], options?: any) => {
 				const child = credentialHelperResult(remoteHost === vouchedHost
@@ -420,6 +436,24 @@ test.describe("remote-state coordinator routes", () => {
 			expect((await apiFetch(`/api/sessions/${sessionId}/pr-status?intent=explicit`)).status).toBe(200);
 			expect(probes).toHaveLength(1);
 
+			// Credential-derived trust is status-only. Both destructive routes must use
+			// listed-host admission and fail before another probe or any gh operation.
+			const probesBeforeMerge = probes.length;
+			const ghCallsBeforeMerge = ghCalls.length;
+			for (const mergeUrl of [
+				`/api/sessions/${sessionId}/pr-merge`,
+				`/api/goals/${goalId}/pr-merge`,
+			]) {
+				const merge = await apiFetch(mergeUrl, {
+					method: "POST",
+					body: JSON.stringify({ method: "squash", branch }),
+				});
+				expect(merge.status, mergeUrl).toBe(409);
+				expect(await merge.json()).toEqual({ error: "PR repository unavailable" });
+			}
+			expect(probes).toHaveLength(probesBeforeMerge);
+			expect(ghCalls).toHaveLength(ghCallsBeforeMerge);
+
 			remoteHost = unvouchedHost;
 			const ghCallsBeforeUnvouched = ghCalls.length;
 			const unavailable = await apiFetch(`/api/sessions/${sessionId}/pr-status?intent=explicit&optional=1`);
@@ -436,7 +470,10 @@ test.describe("remote-state coordinator routes", () => {
 			}
 			gateway.clock.advance(60_000);
 			try {
-				if (sessionId) await deleteSession(sessionId);
+				await Promise.all([
+					sessionId ? deleteSession(sessionId) : Promise.resolve(),
+					goalId ? deleteGoal(goalId) : Promise.resolve(),
+				]);
 			} finally {
 				await apiFetch("/api/preferences", {
 					method: "PUT",

--- a/tests2/integration/remote-state-routes.test.ts
+++ b/tests2/integration/remote-state-routes.test.ts
@@ -635,7 +635,9 @@ test.describe("remote-state coordinator routes", () => {
 
 			probes[1].complete(true);
 			const responses = await Promise.all(routeRequests);
-			expect(responses.map(response => response.status).sort()).toEqual([200, 200, 204]);
+			// Each route keeps its own refresh-generation view even though G1 and G2
+			// share one successor internally. Only the latest caller may authorize.
+			expect(responses.map(response => response.status)).toEqual([204, 204, 200]);
 			expect(activeTrees).toBe(0);
 			expect(maxActiveTrees).toBe(1);
 			expect(probes).toHaveLength(2);

--- a/tests2/integration/remote-state-routes.test.ts
+++ b/tests2/integration/remote-state-routes.test.ts
@@ -828,6 +828,105 @@ test.describe("remote-state coordinator routes", () => {
 		}
 	});
 
+	test("rejects an unlisted configured sibling alias without probing it or invoking gh", async ({ gateway }) => {
+		test.setTimeout(30_000);
+		const projectRoot = mkdtempSync(join(tmpdir(), "bobbit-pr-credential-alias-"));
+		const selectedSource = join(projectRoot, "selected");
+		const siblingSource = join(projectRoot, "sibling");
+		mkdirSync(selectedSource, { recursive: true });
+		mkdirSync(siblingSource, { recursive: true });
+		const host = `credential-alias-${Date.now()}.invalid`;
+		const branch = `fixture/credential-alias-${Date.now()}`;
+		const commonDir = join(projectRoot, ".git", "shared");
+		const project = await registerProject({
+			name: `Credential repository alias ${Date.now()}`,
+			rootPath: projectRoot,
+			components: [
+				{ name: "selected", repo: "selected" },
+				{ name: "sibling", repo: "sibling" },
+			],
+			seedWorkflows: false,
+		});
+		const sessionId = await createRemoteStateSession(gateway, selectedSource, project.id);
+		gateway.sessionManager.updateSessionMeta(sessionId, { branch, repoPath: projectRoot });
+		const session = gateway.sessionManager.getSession(sessionId) as any;
+		session.cwd = selectedSource;
+		session.repoPath = projectRoot;
+
+		const runner = (gateway.sessionManager as any).commandRunner;
+		const originalExecFile = runner.execFile;
+		const originalSpawn = runner.spawn;
+		const originalOwnedTreeCapability = runner.supportsOwnedTreeSpawn;
+		const previousEnterpriseTokens = new Map<string, string | undefined>(
+			["GH_ENTERPRISE_TOKEN", "GITHUB_ENTERPRISE_TOKEN"].map(name => [name, process.env[name]] as const),
+		);
+		const probes: Array<{ request: string; cwd: string }> = [];
+		let ghCalls = 0;
+
+		try {
+			delete process.env.GH_ENTERPRISE_TOKEN;
+			delete process.env.GITHUB_ENTERPRISE_TOKEN;
+			runner.spawn = createCommandSpawnAdapter(
+				() => { throw new Error("credential alias fixture received an ordinary spawn"); },
+				((_file: string, _args: readonly string[], options?: any) => {
+					const tracked = credentialHelperResult(
+						`protocol=https\nhost=${host}\nusername=route-fixture\npassword=fixture-secret\n`,
+					);
+					const probe = { request: "", cwd: String(options?.cwd ?? "") };
+					probes.push(probe);
+					tracked.child.stdin.on("data", (chunk: Buffer) => { probe.request += chunk.toString("utf8"); });
+					return tracked;
+				}) as any,
+			);
+			runner.supportsOwnedTreeSpawn = true;
+			runner.execFile = async (file: string, args: readonly string[], options?: any) => {
+				const command = commandName(file);
+				const cwd = String(options?.cwd ?? "");
+				const configuredSource = cwd === selectedSource || cwd === siblingSource;
+				if (command === "git" && args.join(" ") === "rev-parse --show-toplevel") {
+					if (!configuredSource) throw new Error("not a configured repository source");
+					return { stdout: `${cwd}\n`, stderr: "" };
+				}
+				if (command === "git" && args.join(" ") === "rev-parse --path-format=absolute --git-common-dir") {
+					if (!configuredSource) throw new Error("unknown repository identity");
+					return { stdout: `${commonDir}\n`, stderr: "" };
+				}
+				if (command === "git" && args.join(" ") === "remote get-url origin") {
+					if (!configuredSource) throw new Error("unknown repository remote");
+					return { stdout: `https://${host}/acme/shared-repository.git\n`, stderr: "" };
+				}
+				if (command === "gh") {
+					ghCalls += 1;
+					throw new Error("ambiguous configured repository reached gh");
+				}
+				return unexpectedRunnerCommand(file, args, options);
+			};
+
+			const status = await apiFetch(`/api/sessions/${sessionId}/pr-status?intent=explicit&optional=1`);
+			expect(status.status).toBe(204);
+			expect(await status.text()).toBe("");
+			expect(probes).toEqual([expect.objectContaining({
+				request: `url=https://${host}\n\n`,
+			})]);
+			expect(probes[0].cwd).not.toBe(selectedSource);
+			expect(probes[0].request).not.toContain(siblingSource);
+			expect(ghCalls).toBe(0);
+		} finally {
+			runner.execFile = originalExecFile;
+			runner.spawn = originalSpawn;
+			if (originalOwnedTreeCapability === undefined) delete runner.supportsOwnedTreeSpawn;
+			else runner.supportsOwnedTreeSpawn = originalOwnedTreeCapability;
+			for (const [name, value] of previousEnterpriseTokens) {
+				if (value === undefined) delete process.env[name];
+				else process.env[name] = value;
+			}
+			await deleteSession(sessionId);
+			await apiFetch(`/api/projects/${project.id}`, { method: "DELETE" }).catch(() => {});
+			const cleanup = await awaitableRm(projectRoot, { maxAttempts: 5, backoffMs: 50 });
+			expect(cleanup.removed, `credential alias fixture cleanup failed: ${String(cleanup.lastError ?? "unknown error")}`).toBe(true);
+		}
+	});
+
 	test("coalesces session Git and PR reads and only broadcasts redacted snapshot envelopes", async ({ gateway }) => {
 		test.setTimeout(30_000);
 		const sessionId = await createRemoteStateSession(gateway, gitCwd());

--- a/tests2/integration/remote-state-routes.test.ts
+++ b/tests2/integration/remote-state-routes.test.ts
@@ -498,6 +498,186 @@ test.describe("remote-state coordinator routes", () => {
 		}
 	});
 
+	test("serializes staggered explicit credential refreshes before exact-bound PR lookup", async ({ gateway }) => {
+		test.setTimeout(30_000);
+		const host = `credential-serialized-${Date.now()}.invalid`;
+		const branch = `fixture/credential-serialized-${Date.now()}`;
+		const runner = (gateway.sessionManager as any).commandRunner;
+		const originalExecFile = runner.execFile;
+		const originalSpawn = runner.spawn;
+		const originalOwnedTreeCapability = runner.supportsOwnedTreeSpawn;
+		const previousEnterpriseTokens = new Map<string, string | undefined>(
+			["GH_ENTERPRISE_TOKEN", "GITHUB_ENTERPRISE_TOKEN"].map(name => [name, process.env[name]] as const),
+		);
+		let sessionId: string | undefined;
+		let originalTrustedHosts: unknown = [];
+		let activeTrees = 0;
+		let maxActiveTrees = 0;
+		let remoteReads = 0;
+		const ghCalls: string[][] = [];
+		const probes: Array<{
+			request: string;
+			complete: (trusted: boolean) => void;
+		}> = [];
+		const routeRequests: Array<Promise<Response>> = [];
+		const waitForCount = async (read: () => number, expected: number) => {
+			for (let attempt = 0; attempt < 100 && read() < expected; attempt++) {
+				await new Promise<void>(resolve => setImmediate(resolve));
+			}
+			expect(read()).toBe(expected);
+		};
+
+		try {
+			delete process.env.GH_ENTERPRISE_TOKEN;
+			delete process.env.GITHUB_ENTERPRISE_TOKEN;
+			sessionId = await createRemoteStateSession(gateway, gitCwd());
+			gateway.sessionManager.updateSessionMeta(sessionId, { branch });
+
+			runner.spawn = createCommandSpawnAdapter(
+				() => { throw new Error("credential serialization fixture received an ordinary spawn"); },
+				((_file: string, _args: readonly string[]) => {
+					const child: any = new EventEmitter();
+					child.stdout = new PassThrough();
+					child.stdin = new PassThrough();
+					child.kill = () => { throw new Error("credential serialization fixture must use owned-tree control"); };
+					activeTrees++;
+					maxActiveTrees = Math.max(maxActiveTrees, activeTrees);
+					let reaped = false;
+					let completed = false;
+					const probe = {
+						request: "",
+						complete: (trusted: boolean) => {
+							if (completed) return;
+							completed = true;
+							child.stdout.end(trusted
+								? `protocol=https\nhost=${host}\nusername=route-fixture\npassword=fixture-secret\n`
+								: `protocol=https\nhost=${host}\nusername=route-fixture\n`);
+							child.emit("close", 0, null);
+						},
+					};
+					child.stdin.on("data", (chunk: Buffer) => { probe.request += chunk.toString("utf8"); });
+					probes.push(probe);
+					return {
+						child,
+						ownershipReady: Promise.resolve(),
+						killTree: () => {},
+						waitForTreeExit: async () => {
+							if (!reaped) { reaped = true; activeTrees--; }
+							return true;
+						},
+						killed: () => false,
+						timedOut: () => false,
+					};
+				}) as any,
+			);
+			runner.supportsOwnedTreeSpawn = true;
+			runner.execFile = async (file: string, args: readonly string[], options?: any) => {
+				const command = commandName(file);
+				if (command === "git" && args.join(" ") === "remote get-url origin") {
+					remoteReads++;
+					return { stdout: `https://${host}/acme/widget.git\n`, stderr: "" };
+				}
+				if (command === "gh") {
+					ghCalls.push([...args]);
+					if (args[0] === "pr" && args[1] === "list") {
+						return {
+							stdout: JSON.stringify([{
+								number: 93,
+								url: `https://${host}/acme/widget/pull/93`,
+								title: "Serialized credential refresh",
+								state: "OPEN",
+								mergeable: "MERGEABLE",
+								headRefName: branch,
+								baseRefName: "main",
+								...ownedHeadEvidence("acme", "widget"),
+							}]),
+							stderr: "",
+						};
+					}
+					if (args[0] === "api") throw new Error("fixture GraphQL unavailable");
+					if (args[0] === "repo" && args[1] === "view") {
+						return { stdout: JSON.stringify({ viewerPermission: "ADMIN" }), stderr: "" };
+					}
+				}
+				const standard = standardSingleRepositoryProbe(file, args, gitCwd());
+				if (standard) return standard;
+				return unexpectedRunnerCommand(file, args, options);
+			};
+
+			const originalPreferences = await apiFetch("/api/preferences");
+			if (originalPreferences.ok) originalTrustedHosts = (await originalPreferences.json()).githubTrustedHosts ?? [];
+			expect((await apiFetch("/api/preferences", {
+				method: "PUT",
+				body: JSON.stringify({ githubTrustedHosts: [] }),
+			})).status).toBe(200);
+			gateway.clock.advance(60_000);
+
+			routeRequests.push(apiFetch(`/api/sessions/${sessionId}/pr-status?intent=explicit&optional=1`));
+			await waitForCount(() => probes.length, 1);
+			expect(activeTrees).toBe(1);
+
+			// Each request advances the refresh generation after the prior helper tree
+			// has started. They must update one queued successor, not spawn siblings.
+			routeRequests.push(apiFetch(`/api/sessions/${sessionId}/pr-status?intent=explicit&optional=1`));
+			await waitForCount(() => remoteReads, 2);
+			routeRequests.push(apiFetch(`/api/sessions/${sessionId}/pr-status?intent=explicit&optional=1`));
+			await waitForCount(() => remoteReads, 3);
+			expect(probes).toHaveLength(1);
+			expect(activeTrees).toBe(1);
+			expect(ghCalls).toHaveLength(0);
+
+			probes[0].complete(true);
+			await waitForCount(() => probes.length, 2);
+			expect(probes[1].request).toBe(`url=https://${host}\n\n`);
+			expect(activeTrees).toBe(1);
+			expect(maxActiveTrees).toBe(1);
+			expect(ghCalls).toHaveLength(0);
+
+			probes[1].complete(true);
+			const responses = await Promise.all(routeRequests);
+			expect(responses.map(response => response.status).sort()).toEqual([200, 200, 204]);
+			expect(activeTrees).toBe(0);
+			expect(maxActiveTrees).toBe(1);
+			expect(probes).toHaveLength(2);
+			const prLookups = ghCalls.filter(args => args[0] === "pr" && args[1] === "list");
+			expect(prLookups).toHaveLength(1);
+			expect(prLookups[0].slice(0, 6)).toEqual([
+				"pr", "list", "--repo", `${host}/acme/widget`, "--head", branch,
+			]);
+			expect(ghCalls.filter(args => args[0] === "api").every(args => (
+				args[1] === "--hostname" && args[2] === host
+			))).toBe(true);
+			expect(ghCalls.find(args => args[0] === "repo" && args[1] === "view")).toEqual([
+				"repo", "view", "--repo", `${host}/acme/widget`, "--json", "viewerPermission",
+			]);
+		} finally {
+			// Completing one stale tree may schedule its serialized successor in a
+			// microtask, so drain twice before awaiting any still-pending routes.
+			for (let pass = 0; pass < 3; pass++) {
+				for (const probe of probes) probe.complete(false);
+				await new Promise<void>(resolve => setImmediate(resolve));
+			}
+			await Promise.allSettled(routeRequests);
+			runner.execFile = originalExecFile;
+			runner.spawn = originalSpawn;
+			if (originalOwnedTreeCapability === undefined) delete runner.supportsOwnedTreeSpawn;
+			else runner.supportsOwnedTreeSpawn = originalOwnedTreeCapability;
+			for (const [name, value] of previousEnterpriseTokens) {
+				if (value === undefined) delete process.env[name];
+				else process.env[name] = value;
+			}
+			gateway.clock.advance(60_000);
+			try {
+				if (sessionId) await deleteSession(sessionId);
+			} finally {
+				await apiFetch("/api/preferences", {
+					method: "PUT",
+					body: JSON.stringify({ githubTrustedHosts: originalTrustedHosts }),
+				}).catch(() => {});
+			}
+		}
+	});
+
 	test("credential-vouches only the selected repository in a multi-repository PR status lookup", async ({ gateway }) => {
 		test.setTimeout(30_000);
 		const projectRoot = mkdtempSync(join(tmpdir(), "bobbit-pr-credential-selected-"));

--- a/tests2/integration/remote-state-routes.test.ts
+++ b/tests2/integration/remote-state-routes.test.ts
@@ -7,6 +7,7 @@ import { awaitableRm } from "../../tests/e2e/test-utils/cleanup.js";
 import { test, expect } from "./_e2e/in-process-harness.js";
 import { apiFetch, connectWs, createGoal, defaultProjectId, deleteGoal, deleteSession, gitCwd, nonGitCwd, registerProject } from "./_e2e/e2e-setup.js";
 import { loadServerTestRuntime } from "../harness/server-runtime.js";
+import { createCommandSpawnAdapter } from "../../src/server/owned-tree-command-spawn.js";
 
 let serverModule: any;
 let forceRequestedAt = 1_000;
@@ -78,12 +79,19 @@ function credentialHelperResult(output: string): any {
 	const child: any = new EventEmitter();
 	child.stdout = new PassThrough();
 	child.stdin = new PassThrough();
-	child.kill = () => true;
+	child.kill = () => { throw new Error("credential route fixture must use owned-tree control"); };
 	setImmediate(() => {
 		child.stdout.end(output);
 		child.emit("close", 0, null);
 	});
-	return child;
+	return {
+		child,
+		ownershipReady: Promise.resolve(),
+		killTree: () => {},
+		waitForTreeExit: async () => true,
+		killed: () => false,
+		timedOut: () => false,
+	};
 }
 
 function ownedHeadEvidence(owner: string, repository: string): Record<string, unknown> {
@@ -315,6 +323,7 @@ test.describe("remote-state coordinator routes", () => {
 		const runner = (gateway.sessionManager as any).commandRunner;
 		const originalExecFile = runner.execFile;
 		const originalSpawn = runner.spawn;
+		const originalOwnedTreeCapability = runner.supportsOwnedTreeSpawn;
 		const previousEnterpriseTokens = new Map<string, string | undefined>(
 			["GH_ENTERPRISE_TOKEN", "GITHUB_ENTERPRISE_TOKEN"].map(name => [name, process.env[name]] as const),
 		);
@@ -348,21 +357,25 @@ test.describe("remote-state coordinator routes", () => {
 				setupStatus: "ready",
 			});
 
-			runner.spawn = (file: string, args: readonly string[], options?: any) => {
-				const child = credentialHelperResult(remoteHost === vouchedHost
-					? `protocol=https\nhost=${vouchedHost}\nusername=route-fixture\npassword=fixture-secret\n`
-					: `protocol=https\nhost=${unvouchedHost}\nusername=route-fixture\n`);
-				const probe = {
-					file: commandName(file),
-					args: [...args],
-					cwd: String(options?.cwd ?? ""),
-					env: options?.env ?? {},
-					request: "",
-				};
-				probes.push(probe);
-				child.stdin.on("data", (chunk: Buffer) => { probe.request += chunk.toString("utf8"); });
-				return child;
-			};
+			runner.spawn = createCommandSpawnAdapter(
+				() => { throw new Error("credential fixture received an ordinary spawn"); },
+				((file: string, args: readonly string[], options?: any) => {
+					const tracked = credentialHelperResult(remoteHost === vouchedHost
+						? `protocol=https\nhost=${vouchedHost}\nusername=route-fixture\npassword=fixture-secret\n`
+						: `protocol=https\nhost=${unvouchedHost}\nusername=route-fixture\n`);
+					const probe = {
+						file: commandName(file),
+						args: [...args],
+						cwd: String(options?.cwd ?? ""),
+						env: options?.env ?? {},
+						request: "",
+					};
+					probes.push(probe);
+					tracked.child.stdin.on("data", (chunk: Buffer) => { probe.request += chunk.toString("utf8"); });
+					return tracked;
+				}) as any,
+			);
+			runner.supportsOwnedTreeSpawn = true;
 			runner.execFile = async (file: string, args: readonly string[], options?: any) => {
 				const command = commandName(file);
 				if (command === "git" && args.join(" ") === "remote get-url origin") {
@@ -464,6 +477,8 @@ test.describe("remote-state coordinator routes", () => {
 		} finally {
 			runner.execFile = originalExecFile;
 			runner.spawn = originalSpawn;
+			if (originalOwnedTreeCapability === undefined) delete runner.supportsOwnedTreeSpawn;
+			else runner.supportsOwnedTreeSpawn = originalOwnedTreeCapability;
 			for (const [name, value] of previousEnterpriseTokens) {
 				if (value === undefined) delete process.env[name];
 				else process.env[name] = value;
@@ -511,6 +526,7 @@ test.describe("remote-state coordinator routes", () => {
 		const runner = (gateway.sessionManager as any).commandRunner;
 		const originalExecFile = runner.execFile;
 		const originalSpawn = runner.spawn;
+		const originalOwnedTreeCapability = runner.supportsOwnedTreeSpawn;
 		const previousEnterpriseTokens = new Map<string, string | undefined>(
 			["GH_ENTERPRISE_TOKEN", "GITHUB_ENTERPRISE_TOKEN"].map(name => [name, process.env[name]] as const),
 		);
@@ -533,15 +549,19 @@ test.describe("remote-state coordinator routes", () => {
 		try {
 			delete process.env.GH_ENTERPRISE_TOKEN;
 			delete process.env.GITHUB_ENTERPRISE_TOKEN;
-			runner.spawn = (_file: string, _args: readonly string[], options?: any) => {
-				const child = credentialHelperResult(
-					`protocol=https\nhost=${selectedHost}\nusername=route-fixture\npassword=fixture-secret\n`,
-				);
-				const probe = { request: "", cwd: String(options?.cwd ?? "") };
-				probes.push(probe);
-				child.stdin.on("data", (chunk: Buffer) => { probe.request += chunk.toString("utf8"); });
-				return child;
-			};
+			runner.spawn = createCommandSpawnAdapter(
+				() => { throw new Error("credential fixture received an ordinary spawn"); },
+				((_file: string, _args: readonly string[], options?: any) => {
+					const tracked = credentialHelperResult(
+						`protocol=https\nhost=${selectedHost}\nusername=route-fixture\npassword=fixture-secret\n`,
+					);
+					const probe = { request: "", cwd: String(options?.cwd ?? "") };
+					probes.push(probe);
+					tracked.child.stdin.on("data", (chunk: Buffer) => { probe.request += chunk.toString("utf8"); });
+					return tracked;
+				}) as any,
+			);
+			runner.supportsOwnedTreeSpawn = true;
 			runner.execFile = async (file: string, args: readonly string[], options?: any) => {
 				const command = commandName(file);
 				const cwd = String(options?.cwd ?? "");
@@ -613,6 +633,8 @@ test.describe("remote-state coordinator routes", () => {
 		} finally {
 			runner.execFile = originalExecFile;
 			runner.spawn = originalSpawn;
+			if (originalOwnedTreeCapability === undefined) delete runner.supportsOwnedTreeSpawn;
+			else runner.supportsOwnedTreeSpawn = originalOwnedTreeCapability;
 			for (const [name, value] of previousEnterpriseTokens) {
 				if (value === undefined) delete process.env[name];
 				else process.env[name] = value;

--- a/tests2/integration/remote-state-routes.test.ts
+++ b/tests2/integration/remote-state-routes.test.ts
@@ -1,5 +1,7 @@
 import { mkdirSync, mkdtempSync, realpathSync, symlinkSync, writeFileSync } from "node:fs";
+import { EventEmitter } from "node:events";
 import { tmpdir } from "node:os";
+import { PassThrough } from "node:stream";
 import { basename, dirname, join } from "node:path";
 import { awaitableRm } from "../../tests/e2e/test-utils/cleanup.js";
 import { test, expect } from "./_e2e/in-process-harness.js";
@@ -70,6 +72,18 @@ function standardSingleRepositoryProbe(
 
 function commandName(file: string): string {
 	return basename(file).toLowerCase().replace(/\.(?:cmd|exe)$/, "");
+}
+
+function credentialHelperResult(output: string): any {
+	const child: any = new EventEmitter();
+	child.stdout = new PassThrough();
+	child.stdin = new PassThrough();
+	child.kill = () => true;
+	setImmediate(() => {
+		child.stdout.end(output);
+		child.emit("close", 0, null);
+	});
+	return child;
 }
 
 function ownedHeadEvidence(owner: string, repository: string): Record<string, unknown> {
@@ -289,6 +303,145 @@ test.describe("remote-state coordinator routes", () => {
 				}).catch(() => {});
 				const cleanup = await awaitableRm(ghConfigDir, { maxAttempts: 5, backoffMs: 50 });
 				expect(cleanup.removed, `GH_CONFIG_DIR fixture cleanup failed: ${String(cleanup.lastError ?? "unknown error")}`).toBe(true);
+			}
+		}
+	});
+
+	test("admits only credential-vouched unlisted enterprise hosts to exact-bound PR lookup", async ({ gateway }) => {
+		test.setTimeout(30_000);
+		const vouchedHost = `credential-vouched-${Date.now()}.invalid`;
+		const unvouchedHost = `credential-unvouched-${Date.now()}.invalid`;
+		const branch = `fixture/credential-vouched-${Date.now()}`;
+		const runner = (gateway.sessionManager as any).commandRunner;
+		const originalExecFile = runner.execFile;
+		const originalSpawn = runner.spawn;
+		const previousEnterpriseTokens = new Map<string, string | undefined>(
+			["GH_ENTERPRISE_TOKEN", "GITHUB_ENTERPRISE_TOKEN"].map(name => [name, process.env[name]] as const),
+		);
+		let remoteHost = vouchedHost;
+		let sessionId: string | undefined;
+		let originalTrustedHosts: unknown = [];
+		const ghCalls: string[][] = [];
+		const probes: Array<{ file: string; args: string[]; cwd: string; env: NodeJS.ProcessEnv; request: string }> = [];
+
+		try {
+			// The production trust object reads the environment at admission time. Clear
+			// host-class ambient tokens for this fixture only, then restore them exactly.
+			delete process.env.GH_ENTERPRISE_TOKEN;
+			delete process.env.GITHUB_ENTERPRISE_TOKEN;
+			sessionId = await createRemoteStateSession(gateway, gitCwd());
+			gateway.sessionManager.updateSessionMeta(sessionId, { branch });
+
+			runner.spawn = (file: string, args: readonly string[], options?: any) => {
+				const child = credentialHelperResult(remoteHost === vouchedHost
+					? `protocol=https\nhost=${vouchedHost}\nusername=route-fixture\npassword=fixture-secret\n`
+					: `protocol=https\nhost=${unvouchedHost}\nusername=route-fixture\n`);
+				const probe = {
+					file: commandName(file),
+					args: [...args],
+					cwd: String(options?.cwd ?? ""),
+					env: options?.env ?? {},
+					request: "",
+				};
+				probes.push(probe);
+				child.stdin.on("data", (chunk: Buffer) => { probe.request += chunk.toString("utf8"); });
+				return child;
+			};
+			runner.execFile = async (file: string, args: readonly string[], options?: any) => {
+				const command = commandName(file);
+				if (command === "git" && args.join(" ") === "remote get-url origin") {
+					return { stdout: `https://${remoteHost}/acme/widget.git\n`, stderr: "" };
+				}
+				if (command === "gh") {
+					ghCalls.push([...args]);
+					if (args[0] === "pr" && args[1] === "list") {
+						return {
+							stdout: JSON.stringify([{
+								number: 91,
+								url: `https://${vouchedHost}/acme/widget/pull/91`,
+								title: "Credential-vouched enterprise host",
+								state: "OPEN",
+								mergeable: "MERGEABLE",
+								headRefName: branch,
+								baseRefName: "main",
+								...ownedHeadEvidence("acme", "widget"),
+							}]),
+							stderr: "",
+						};
+					}
+					if (args[0] === "api") throw new Error("fixture GraphQL unavailable");
+					if (args[0] === "repo" && args[1] === "view") {
+						return { stdout: JSON.stringify({ viewerPermission: "ADMIN" }), stderr: "" };
+					}
+				}
+				const standard = standardSingleRepositoryProbe(file, args, gitCwd());
+				if (standard) return standard;
+				return unexpectedRunnerCommand(file, args, options);
+			};
+
+			const originalPreferences = await apiFetch("/api/preferences");
+			if (originalPreferences.ok) originalTrustedHosts = (await originalPreferences.json()).githubTrustedHosts ?? [];
+			expect((await apiFetch("/api/preferences", {
+				method: "PUT",
+				body: JSON.stringify({ githubTrustedHosts: [] }),
+			})).status).toBe(200);
+			gateway.clock.advance(60_000);
+			expect(await (await apiFetch(`/api/github/trusted-hosts/check?host=${vouchedHost}`)).json())
+				.toEqual({ host: vouchedHost, trusted: false });
+
+			const vouched = await apiFetch(`/api/sessions/${sessionId}/pr-status?intent=explicit`);
+			expect(vouched.status).toBe(200);
+			expect(await vouched.json()).toMatchObject({
+				source: "pr",
+				stale: false,
+				data: { number: 91, viewerIsAdmin: true },
+			});
+			expect(ghCalls.find(args => args[0] === "pr" && args[1] === "list")?.slice(0, 6)).toEqual([
+				"pr", "list", "--repo", `${vouchedHost}/acme/widget`, "--head", branch,
+			]);
+			expect(ghCalls.filter(args => args[0] === "api").every(args => (
+				args[1] === "--hostname" && args[2] === vouchedHost
+			))).toBe(true);
+			expect(ghCalls.find(args => args[0] === "repo" && args[1] === "view")).toEqual([
+				"repo", "view", "--repo", `${vouchedHost}/acme/widget`, "--json", "viewerPermission",
+			]);
+			expect(probes).toHaveLength(1);
+			expect(probes[0]).toMatchObject({
+				file: "git",
+				args: ["credential", "fill"],
+				request: `url=https://${vouchedHost}\n\n`,
+			});
+			expect(probes[0].cwd).not.toBe(gitCwd());
+			expect(probes[0].cwd.startsWith(tmpdir())).toBe(true);
+			expect(probes[0].env.GIT_TERMINAL_PROMPT).toBe("0");
+			expect(probes[0].env.GCM_INTERACTIVE).toBe("never");
+
+			crossForceCoalescingWindow();
+			expect((await apiFetch(`/api/sessions/${sessionId}/pr-status?intent=explicit`)).status).toBe(200);
+			expect(probes).toHaveLength(1);
+
+			remoteHost = unvouchedHost;
+			const ghCallsBeforeUnvouched = ghCalls.length;
+			const unavailable = await apiFetch(`/api/sessions/${sessionId}/pr-status?intent=explicit&optional=1`);
+			expect(unavailable.status).toBe(204);
+			expect(probes).toHaveLength(2);
+			expect(probes[1].request).toBe(`url=https://${unvouchedHost}\n\n`);
+			expect(ghCalls).toHaveLength(ghCallsBeforeUnvouched);
+		} finally {
+			runner.execFile = originalExecFile;
+			runner.spawn = originalSpawn;
+			for (const [name, value] of previousEnterpriseTokens) {
+				if (value === undefined) delete process.env[name];
+				else process.env[name] = value;
+			}
+			gateway.clock.advance(60_000);
+			try {
+				if (sessionId) await deleteSession(sessionId);
+			} finally {
+				await apiFetch("/api/preferences", {
+					method: "PUT",
+					body: JSON.stringify({ githubTrustedHosts: originalTrustedHosts }),
+				}).catch(() => {});
 			}
 		}
 	});

--- a/tests2/tests-map.json
+++ b/tests2/tests-map.json
@@ -167,6 +167,15 @@
       }
     },
     {
+      "path": "tests2/core/clock.test.ts",
+      "reason": "Deterministic core coverage proving the real Clock visibly bounds overflow and non-finite timeout and interval delays while preserving ordinary, zero, negative, and clear-handle behavior.",
+      "execution": {
+        "runner": "vitest",
+        "tier": "unit",
+        "project": "core"
+      }
+    },
+    {
       "path": "tests2/core/github-host-credential-trust.test.ts",
       "reason": "Core security coverage for PR-only credential-derived host trust: exact bounded credential records, injected owned-tree spawning, neutral temporary directories, prompt suppression, tree-completion kill escalation, per-host refresh generations, live ambient-token refusal, and secret-redacted failure behavior.",
       "execution": {

--- a/tests2/tests-map.json
+++ b/tests2/tests-map.json
@@ -168,7 +168,16 @@
     },
     {
       "path": "tests2/core/github-host-credential-trust.test.ts",
-      "reason": "Core security coverage for PR-only credential-derived host trust: exact bounded credential records, injected spawn isolation, neutral temporary directories, prompt suppression, timeout kill escalation, per-host refresh generations, live ambient-token refusal, and secret-redacted failure behavior.",
+      "reason": "Core security coverage for PR-only credential-derived host trust: exact bounded credential records, injected owned-tree spawning, neutral temporary directories, prompt suppression, tree-completion kill escalation, per-host refresh generations, live ambient-token refusal, and secret-redacted failure behavior.",
+      "execution": {
+        "runner": "vitest",
+        "tier": "unit",
+        "project": "core"
+      }
+    },
+    {
+      "path": "tests2/core/owned-tree-command-spawn.test.ts",
+      "reason": "Core process-boundary coverage proving branded logical commands select spawnTracked ownership defaults with synchronous control binding while ordinary CommandRunner spawns remain direct.",
       "execution": {
         "runner": "vitest",
         "tier": "unit",

--- a/tests2/tests-map.json
+++ b/tests2/tests-map.json
@@ -167,6 +167,15 @@
       }
     },
     {
+      "path": "tests2/core/github-host-credential-trust.test.ts",
+      "reason": "Core security coverage for PR-only credential-derived host trust: exact bounded credential records, injected spawn isolation, neutral temporary directories, prompt suppression, timeout kill escalation, per-host refresh generations, live ambient-token refusal, and secret-redacted failure behavior.",
+      "execution": {
+        "runner": "vitest",
+        "tier": "unit",
+        "project": "core"
+      }
+    },
+    {
       "path": "tests2/core/github-trusted-host-resolver.test.ts",
       "reason": "Core security and caching coverage for token-free gh-config GitHub host discovery, environment stripping, normalization, failure fallback, and single-flight refreshes.",
       "execution": {


### PR DESCRIPTION
## Summary
- allow PR-status reads for structurally valid unlisted GitHub Enterprise remotes vouched for by local Git credentials
- keep credential-derived trust process-local, prompt-free, bounded, ambient-token-aware, and limited to PR status
- preserve exact host/repository binding, existing listed-host behavior, and destructive merge trust gates
- fence tests from real credential helpers and document the security boundary

## Validation
- implementation workflow passed build, type-check, unit, browser, E2E, conformance, integrated review, and security review
- focused credential trust and remote-state route coverage passed

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)