### PR TITLE
Strip archived sessions from goal tool output

### DIFF
--- a/defaults/tools/bobbit/bobbit_read.yaml
+++ b/defaults/tools/bobbit/bobbit_read.yaml
@@ -71,10 +71,10 @@ detail_docs: >-
   return archived sessions plus the `archivedDelegates` delegate-chain
   enrichment.
 
-  - `list_goals` — default calls drop any `archived: true` goal rows and strip
-  the `archivedSessions` auxiliary array. Pass `archived: true` to select the
-  archived path, which returns archived goals plus the `archivedSessions`
-  affiliated-session enrichment.
+  - `list_goals` — default calls drop any `archived: true` goal rows. The tool
+  always strips the REST-only `archivedSessions` auxiliary array, including
+  when `archived: true` selects archived goals. Use `list_sessions` with
+  `include: "archived"` to retrieve archived sessions.
 
   - `search` — default calls drop any archived hit from `results`. Pass
   `include: "archived"` (or the REST-style `includeArchived: true`) to include

--- a/defaults/tools/bobbit/compact-projection.ts
+++ b/defaults/tools/bobbit/compact-projection.ts
@@ -457,7 +457,7 @@ export const BOBBIT_COMPACT_PROJECTIONS = {
 	bobbit_read: {
 		health: generic,
 		connection_info: generic,
-		list_goals: { profile: "generic", mode: "list", collections: { goals: "goal", archivedSessions: "session" } },
+		list_goals: { profile: "generic", mode: "list", collections: { goals: "goal" } },
 		get_goal: { profile: "goal", mode: "detail" },
 		goal_cost: identity,
 		goal_git_status: generic,

--- a/defaults/tools/bobbit/extension.ts
+++ b/defaults/tools/bobbit/extension.ts
@@ -309,6 +309,13 @@ function filterArchivedRows(data: unknown, itemKey: string, stripKeys: string[] 
 	return out;
 }
 
+function stripResponseKeys(data: unknown, keys: string[]): unknown {
+	if (!data || typeof data !== "object" || Array.isArray(data)) return data;
+	const out = { ...(data as Record<string, unknown>) };
+	for (const key of keys) delete out[key];
+	return out;
+}
+
 // GET-only maintenance probes for bobbit_read.maintenance_inspect.
 const PROBE_PATHS: Record<string, string> = {
 	orphaned_worktrees: "/api/maintenance/orphaned-worktrees",
@@ -355,7 +362,10 @@ const READ_OPS: Record<string, OpSpec> = {
 			cursor: (params) => isTruthyFlag(params.archived),
 		}),
 		required: [],
-		postProcess: (data, p) => isTruthyFlag(p.archived) ? data : filterArchivedRows(data, "goals", ["archivedSessions"]),
+		postProcess: (data, p) => stripResponseKeys(
+			isTruthyFlag(p.archived) ? data : filterArchivedRows(data, "goals"),
+			["archivedSessions"],
+		),
 		page: (p) => ({ itemKey: "goals", cursor: isTruthyFlag(p.archived) }),
 	},
 	get_goal: { method: "GET", buildPath: (p) => `/api/goals/${p.goalId}`, required: ["goalId"] },

--- a/docs/bobbit-gateway-tool.md
+++ b/docs/bobbit-gateway-tool.md
@@ -157,10 +157,10 @@ auxiliary arrays the REST endpoints attach for the UI:
 - `list_sessions` — drops `archived: true` session rows and strips the
   `archivedDelegates` array. Pass `include=archived` to get archived sessions
   plus the `archivedDelegates` delegate-chain enrichment.
-- `list_goals` — drops `archived: true` goal rows and strips the
-  `archivedSessions` array. Pass `archived=true` to select the archived path,
-  which returns archived goals plus the `archivedSessions` affiliated-session
-  enrichment.
+- `list_goals` — drops `archived: true` goal rows by default. The tool always
+  strips the REST-only `archivedSessions` array, including when `archived=true`
+  selects archived goals. Use `list_sessions(include=archived)` to retrieve
+  archived sessions.
 - `search` — drops archived hits from `results`. Pass `include=archived` (or
   the REST-style `includeArchived=true`) to include archived rows.
 

--- a/docs/design/bobbit-read-pagination.md
+++ b/docs/design/bobbit-read-pagination.md
@@ -14,8 +14,8 @@ Status: **implemented** · Goal: Page Bobbit Tools · Author: coder-861a
 - The tool forwards REST paging only for `list_sessions`, `list_goals`, and `search`. These are the high-volume endpoints where the gateway returns page fields such as `total`, `hasMore`, `nextOffset`, or `nextCursor`.
 - When a gateway response already includes REST paging fields or a `pagination` object, the tool adds normalized `pagination` metadata and marks `pagedBy: "rest"`; it does **not** re-slice the returned array. This matters for responses such as `include=archived` sessions, where the REST payload can include live sessions plus an archived page.
 - Other list-style operations use tool-side fallback paging after the endpoint has applied semantic filters (`projectId`, `goalId`, `view`, `q`, `include`, or `archived` as applicable). Fallback responses are marked `pagedBy: "tool"`.
-- Tool-side fallback preserves ancillary fields such as `generation`, diagnostics, summary counts, and maintenance probe counts — **except** the archive-only auxiliary arrays, which follow the archive-visibility rule below.
-- **Archive visibility (hidden by default).** `list_sessions`, `list_goals`, and `search` are live-only by default. A per-operation `postProcess` step drops any `archived: true` rows from the primary array and strips the archive-only auxiliary arrays before pagination: `archivedDelegates` for `list_sessions` and `archivedSessions` for `list_goals`. These arrays are preserved (and archived rows returned) **only** on the explicit archive path — `include=archived` for `list_sessions`, `archived=true` for `list_goals`, and `include=archived` / `includeArchived=true` for `search`. UI clients that need archived search results explicitly opt REST `/api/search` into that mode with `includeArchived=true`; `bobbit_read.search` remains live-only unless its caller opts in. So the general “ancillary fields are always preserved” rule does not apply to archived side payloads on default calls; they are intentionally removed so archived entities never leak into agent context.
+- Tool-side fallback preserves ancillary fields such as `generation`, diagnostics, summary counts, and maintenance probe counts — **except** archive-only auxiliary arrays, which follow the agent-facing rules below.
+- **Archive visibility (hidden by default).** `list_sessions`, `list_goals`, and `search` are live-only by default. A per-operation `postProcess` step drops any `archived: true` rows from the primary array. Explicit archive paths preserve requested primary rows: `include=archived` for `list_sessions`, `archived=true` for `list_goals`, and `include=archived` / `includeArchived=true` for `search`. `list_sessions` also preserves `archivedDelegates` on its explicit archive path. `list_goals` always strips the REST-only `archivedSessions` side payload; agents retrieve archived sessions through `list_sessions` instead. UI clients retain the unchanged REST behaviour.
 - Cursor inputs use `cursor` as the generic alias and `after` as the gateway query name for archived session/goal paths. Cursor mode wins over offset mode only when the operation is cursor-backed and a cursor value is supplied.
 
 ## 2. Scope
@@ -162,7 +162,7 @@ async function dispatch(ops: Record<string, OpSpec>, params: Params, opts?: { pa
 | operation | primary array | semantic filters | paging behaviour |
 |---|---:|---|---|
 | `list_sessions` | `sessions` | `include`, `q`, `projectId` | Forwards filters plus `limit`; forwards `offset` for offset mode and `after` for archived cursor mode. REST-paged results are not re-sliced. Live-only by default: archived rows + `archivedDelegates` stripped unless `include=archived`. |
-| `list_goals` | `goals` | `archived`, `q`, `projectId` | Forwards filters plus `limit`; forwards `offset` for live/offset mode and `after` for archived cursor mode. REST-paged results are not re-sliced. Live-only by default: archived rows + `archivedSessions` stripped unless `archived=true`. |
+| `list_goals` | `goals` | `archived`, `q`, `projectId` | Forwards filters plus `limit`; forwards `offset` for live/offset mode and `after` for archived cursor mode. REST-paged results are not re-sliced. Live-only by default; `archived=true` returns archived goals. The tool always strips the REST-only `archivedSessions` side payload. |
 | `list_projects` | `projects` or bare array | hidden/system/HQ preference filter inside `listProjectsForApi()` | Tool fallback pages the filtered response and normalizes tool output to `{ projects, pagination }` when needed. |
 | `list_workflows` | `workflows` | `projectId` required | Forwards `projectId`; tool fallback pages after workflow resolution. |
 | `list_roles` | `roles` | `projectId` config scope | Forwards `projectId`; tool fallback pages after config-scope resolution. |
@@ -223,7 +223,7 @@ If a probe returns a bare array, normalize it to `{ items: [...], pagination: { 
 - `include`
   - `include=archived` is the archive opt-in for `list_sessions` **and** `search`. For `list_sessions` it includes live sessions plus the archived page/delegates and preserves the `archivedDelegates` enrichment. For `search` it forwards `includeArchived=true` to `/api/search`; the full search UI uses that REST opt-in deliberately, while `bobbit_read.search` defaults to live-only. Without `include=archived`, both operations are live-only: archived rows are stripped from their primary arrays, and `list_sessions` also strips `archivedDelegates`.
 - `archived`
-  - Only `list_goals`; `archived=true` selects the archived path. Without it, `list_goals` is live-only and archived goal rows / `archivedSessions` are stripped in `postProcess`.
+  - Only `list_goals`; `archived=true` selects the archived-goal path. Without it, archived goal rows are filtered. The `archivedSessions` side payload is stripped in both modes.
 - `view`
   - Only `list_gates`/`list_tasks`; compute summary/full projection first, then page the displayed list.
 
@@ -251,7 +251,7 @@ Backward compatibility rule: REST endpoints must keep their existing response sh
 - Invalid `limit`/`offset` should be clamped, not surfaced as validation errors, matching existing REST style.
 - If a caller asks for `limit` larger than max, return the clamped `limit` in metadata.
 - Cursor and offset should not both drive the same request. If both are supplied for a cursor operation, cursor wins and metadata uses `mode: "cursor"`.
-- Tool-side fallback must preserve ancillary fields (`generation`, diagnostics, counts, summaries). The archive-only auxiliary arrays (`archivedDelegates`, `archivedSessions`) are the exception: they are stripped on default (live-only) calls and preserved only on the explicit archive opt-in (`include=archived` / `archived=true`).
+- Tool-side fallback must preserve ancillary fields (`generation`, diagnostics, counts, summaries). Archive-only auxiliary arrays are exceptions: `archivedDelegates` is stripped from default session calls and preserved with `include=archived`; `archivedSessions` is always stripped from `list_goals` because archived sessions have their own tool path.
 - Avoid exposing `cwd`/`ensure` on `list_mcp_servers` in this goal; `ensure=true` has initialization side effects and `bobbit_read` should stay read-only.
 
 ## 11. Focused test plan

--- a/tests2/core/bobbit-tool-archive-filtering.test.ts
+++ b/tests2/core/bobbit-tool-archive-filtering.test.ts
@@ -2,6 +2,7 @@
 //
 // Archive visibility contract: agent-facing bobbit_read list/search operations
 // hide archived rows by default, while preserving explicit archive opt-ins.
+// list_goals never exposes the REST-only archivedSessions enrichment.
 import { guardProcessEnv } from "./helpers/env-guard.js";
 guardProcessEnv();
 
@@ -110,7 +111,7 @@ describe("bobbit_read — archive-hidden list defaults", () => {
 		expect.soft("archivedSessions" in data).toBe(false);
 	});
 
-	it("list_goals preserves archived goals and archivedSessions when archived=true is explicit", async () => {
+	it("list_goals preserves archived goals but strips archivedSessions when archived=true is explicit", async () => {
 		stubFetch((url) => {
 			expect(new URL(url).searchParams.get("archived")).toBe("true");
 			return {
@@ -129,7 +130,8 @@ describe("bobbit_read — archive-hidden list defaults", () => {
 		const data = json(result);
 
 		expect(ids(data.goals)).toEqual(["archived-goal-explicit"]);
-		expect(ids(data.archivedSessions)).toEqual(["archived-session"]);
+		expect.soft(data.archivedSessions).toBeUndefined();
+		expect.soft("archivedSessions" in data).toBe(false);
 	});
 });
 

--- a/tests2/core/bobbit-tool-verbosity.test.ts
+++ b/tests2/core/bobbit-tool-verbosity.test.ts
@@ -91,15 +91,8 @@ describe("bobbit compact projections", () => {
 		for (const dropped of ["spec", "branch", "mergeTarget", "setupStatus", "team", "paused", "workflow", "worktreePath", "repoPath", "cwd",
 			"sandboxed", "subgoalsAllowed", "autoStartTeam", "generation", "colorIndex"]) expect(data.goals[0][dropped], dropped === "spec" ? "BOBBIT_READ_LIST_GOALS_MUST_OMIT_SPEC" : dropped).toBeUndefined();
 		for (const dropped of ["providerMetadata", "filesystemPath", "workflowSnapshot"]) expect(data[dropped]).toBeUndefined();
-		expect(data.archivedSessions[0]).toMatchObject({
-			id: archivedSession.id,
-			title: archivedSession.title,
-			status: archivedSession.status,
-			role: archivedSession.role,
-			archived: true,
-		});
-		expect(data.archivedSessions[0].cwd).toBeUndefined();
-		expect(data.archivedSessions[0].clientCount).toBeUndefined();
+		expect(data.archivedSessions).toBeUndefined();
+		expect("archivedSessions" in data).toBe(false);
 		expect(data.pagination).toMatchObject({
 			limit: 1,
 			total: 25,

--- a/tests2/tests-map.json
+++ b/tests2/tests-map.json
@@ -2032,7 +2032,7 @@
     },
     {
       "path": "tests2/core/bobbit-tool-archive-filtering.test.ts",
-      "reason": "Reproducing tests for the Hide Archived Lists goal: bobbit_read list_sessions/list_goals/search must hide archived primary rows and archive-only enrichment by default while preserving explicit archive opt-ins; pins SearchService default includeArchived=false.",
+      "reason": "Pins agent-facing archive filtering: default list/search calls hide archived rows, explicit archive paths preserve requested primary rows, and list_goals never passes through the REST-only archivedSessions enrichment.",
       "execution": {
         "runner": "vitest",
         "tier": "unit",


### PR DESCRIPTION
## Summary
- strip the REST-only archivedSessions enrichment from every agent-facing list_goals response
- preserve archived goal pagination and dedicated archived-session access through list_sessions
- update compact projections, documentation, and pinning tests without changing the REST API or UI

## Verification
- focused Bobbit tool tests: 28 passed
- npm run check
- implementation workflow: build, unit, browser, E2E, conformance, integrated review, and security review passed

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)