### PR TITLE
Fix browser test filters

### DIFF
--- a/scripts/testing-v2/run-browser-v2.mjs
+++ b/scripts/testing-v2/run-browser-v2.mjs
@@ -53,14 +53,18 @@ export function createBrowserRunEnvironment(paths, inheritedEnv = process.env, p
 	}, platform);
 }
 
-/** Preserve every caller-provided Playwright flag, including npm's `--retry=0`. */
+/**
+ * Preserve caller arguments ahead of the configured project. Playwright's
+ * `--project` option is variadic, so positional filters after it are parsed as
+ * additional project names instead of test-file filters.
+ */
 export function playwrightCommandArgs(forwardedArgs = []) {
 	return [
 		join(REPO_ROOT, "node_modules", "playwright", "cli.js"),
 		"test",
 		"--config", "playwright-v2.config.ts",
-		"--project", "browser-v2",
 		...forwardedArgs,
+		"--project", "browser-v2",
 	];
 }
 

--- a/tests2/core/browser-run-wrapper.test.ts
+++ b/tests2/core/browser-run-wrapper.test.ts
@@ -94,11 +94,11 @@ describe("browser-v2 coordinator wrapper", () => {
   });
 
   it("does not inject a retry policy while preserving an explicit caller policy", () => {
-    expect(playwrightCommandArgs().filter((arg) => arg.startsWith("--retries"))).toEqual([]);
+    expect(playwrightCommandArgs().filter((arg: string) => arg.startsWith("--retries"))).toEqual([]);
 
     const forwarded = ["--retries=0", "--workers=2"];
     const args = playwrightCommandArgs(forwarded);
-    expect(args.filter((arg) => arg.startsWith("--retries"))).toEqual(["--retries=0"]);
+    expect(args.filter((arg: string) => arg.startsWith("--retries"))).toEqual(["--retries=0"]);
     expect(args.slice(4, -2)).toEqual(forwarded);
   });
 });

--- a/tests2/core/browser-run-wrapper.test.ts
+++ b/tests2/core/browser-run-wrapper.test.ts
@@ -65,15 +65,40 @@ describe("browser-v2 coordinator wrapper", () => {
     }
   });
 
-  it("forwards every caller Playwright flag without injecting a retry policy", () => {
-    const forwarded = ["--grep", "cross-os coordinator", "--retries=0", "--workers=2"];
+  it("places positional test-file filters before Playwright's variadic project option", () => {
+    const forwarded = [
+      "tests2/browser/message-editor.spec.ts",
+      "tests2/browser/workflow-editor.spec.ts",
+    ];
 
     expect(playwrightCommandArgs(forwarded)).toEqual([
       join(REPO_ROOT, "node_modules", "playwright", "cli.js"),
       "test",
       "--config", "playwright-v2.config.ts",
-      "--project", "browser-v2",
       ...forwarded,
+      "--project", "browser-v2",
     ]);
+  });
+
+  it("preserves mixed caller filters and flags in order before the configured project", () => {
+    const forwarded = [
+      "tests2/browser/message-editor.spec.ts",
+      "--grep", "cross-os coordinator",
+      "--workers=2",
+      "--headed",
+    ];
+    const args = playwrightCommandArgs(forwarded);
+
+    expect(args.slice(4, -2)).toEqual(forwarded);
+    expect(args.slice(-2)).toEqual(["--project", "browser-v2"]);
+  });
+
+  it("does not inject a retry policy while preserving an explicit caller policy", () => {
+    expect(playwrightCommandArgs().filter((arg) => arg.startsWith("--retries"))).toEqual([]);
+
+    const forwarded = ["--retries=0", "--workers=2"];
+    const args = playwrightCommandArgs(forwarded);
+    expect(args.filter((arg) => arg.startsWith("--retries"))).toEqual(["--retries=0"]);
+    expect(args.slice(4, -2)).toEqual(forwarded);
   });
 });


### PR DESCRIPTION
## Summary

- forward caller Playwright filters and flags before the variadic `--project browser-v2` option
- preserve caller argument order without injecting retries
- add focused cross-platform wrapper tests for positional filters and retry handling

## Validation

- `npm run test:unit -- tests2/core/browser-run-wrapper.test.ts --project v2-core`
- `npm run check`
- implementation workflow: build, type-check, unit, browser, E2E, conformance, implementation, and security reviews passed

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)