### PR TITLE
Add marketplace pack hot reload

### DIFF
--- a/docs/extension-host-authoring.md
+++ b/docs/extension-host-authoring.md
@@ -2427,12 +2427,15 @@ gateway restart or full-page reload for renderer and panel edits.
 The watcher is an addition to the normal development stack, not an installer or server launcher:
 
 1. Add the pack to the `PACKS` declarations in `scripts/build-market-packs.mjs` as described
-   below. A directory or committed bundle alone does not make a pack watchable.
+   below. A declaration makes the pack watchable but does not create its serving target; a directory
+   or committed bundle alone does not make a pack watchable either.
 2. Install and activate the pack in the scope you are testing, if it is not a shipped first-party
    pack. The open client must already have resolved that pack as the winning contribution.
-3. Start `npm run dev:harness` in one terminal. Its initial server build creates the declared
-   default serving roots and it runs the Vite development server. If using another development
-   launcher, run `npm run build:server` once before watching and ensure Vite is running.
+3. Start `npm run dev:harness` in one terminal so Vite and the gateway are running. Its initial
+   `npm run build:server` creates a default serving root only for a pack copied by the explicit
+   first-party allowlist in `scripts/copy-builtin-packs.mjs`. For any other declared pack, create or
+   install an existing repository-relative served pack root with a matching `pack.yaml`, then pass
+   that root with `--target`.
 4. Start the watcher in another terminal:
 
 ```bash
@@ -2494,11 +2497,14 @@ A serving target must already:
 - expose a stable, non-zero filesystem identity. Every traversed output directory and existing
   output file must expose the same kind of identity.
 
-The default target is not discovered or created. If it is missing, the command directs you to run
-`npm run build:server` or pass an explicit `--target`. Explicit targets are canonicalized,
-deduplicated, and processed in deterministic order. Parent directories for declared output files
-are created only after all targets pass validation. Static symlinks or junctions in an output path,
-output-file symlinks, and entries replaced after validation are rejected.
+The watcher never discovers or creates a serving target. `npm run build:server` creates the
+`defaultServingRoot` only when `scripts/copy-builtin-packs.mjs` copies that pack through its explicit
+first-party allowlist; a `PACKS` declaration alone does not create one. A non-allowlisted declared
+pack therefore needs an existing repository-relative, matching-manifest `--target`. Explicit targets
+are canonicalized, deduplicated, and processed in deterministic order. Parent directories for
+declared output files are created only after all targets pass validation. Static symlinks or
+junctions in an output path, output-file symlinks, and entries replaced after validation are
+rejected.
 
 Run the watcher unprivileged and only against serving trees controlled by the same trusted
 developer. Its pathname and identity checks reduce accidental or racy redirection, but are not a

--- a/docs/extension-host-authoring.md
+++ b/docs/extension-host-authoring.md
@@ -2415,6 +2415,137 @@ Two hard rules keep a bundle loadable by the Blob-URL loader:
 2. **One self-contained file per entry — NO code splitting / dynamic chunks.** A Blob-URL
    module has no resolvable base for `import("./chunk.js")`, so every dep is inlined eagerly.
 
+### Hot-reload an authored pack during development
+
+Use the pack watcher when iterating on a declared bundle. It rebuilds one pack, mirrors only that
+pack's declared outputs into the tree the gateway already serves, and asks Vite to invalidate the
+matching browser modules. This keeps the normal pack build as the source of truth while avoiding a
+gateway restart or full-page reload for renderer and panel edits.
+
+#### Prerequisites and command
+
+The watcher is an addition to the normal development stack, not an installer or server launcher:
+
+1. Add the pack to the `PACKS` declarations in `scripts/build-market-packs.mjs` as described
+   below. A directory or committed bundle alone does not make a pack watchable.
+2. Install and activate the pack in the scope you are testing, if it is not a shipped first-party
+   pack. The open client must already have resolved that pack as the winning contribution.
+3. Start `npm run dev:harness` in one terminal. Its initial server build creates the declared
+   default serving roots and it runs the Vite development server. If using another development
+   launcher, run `npm run build:server` once before watching and ensure Vite is running.
+4. Start the watcher in another terminal:
+
+```bash
+npm run dev:pack -- <pack>
+```
+
+The full syntax is:
+
+```text
+npm run dev:pack -- <pack> [--target <served-pack-root>]... [--vite-url <http(s)-url>]
+```
+
+- `<pack>` is one exact, lower-case structural pack id from `PACKS`.
+- Repeat `--target` to mirror into more than one existing served pack root. Paths are relative to
+  the repository root. With no target, the declaration's `defaultServingRoot` is the only target.
+- `--vite-url` changes the notification origin from `http://127.0.0.1:5173`. Any path on the
+  supplied URL is ignored; the watcher posts to Vite's fixed development endpoint.
+- `npm run dev:pack -- --help` prints the compact usage form.
+
+The watcher starts observing `<authorRoot>/src` recursively and performs one full
+build/mirror/notification cycle before reporting readiness. Each cycle rebuilds every declared
+entry for the selected pack, sequentially. Changes arriving during a build are coalesced into one
+trailing cycle, so builds and publishes never overlap.
+
+#### Build declaration and target mapping
+
+Each watchable pack has one explicit declaration:
+
+```js
+{
+  pack: "sample-pack",
+  authorRoot: "market-packs/sample-pack",
+  defaultServingRoot: "dist/server/builtin-packs/market-packs/sample-pack",
+  entries: [
+    { in: "sample-panel.ts", out: "lib/sample-panel.js" },
+    { in: "sample-routes.ts", out: "lib/sample-routes.mjs", platform: "node" },
+    { in: "sample-renderer.ts", out: "tools/sample/SampleRenderer.js" },
+  ],
+}
+```
+
+For each entry, `in` resolves from `<authorRoot>/src`, while `out` is relative to the pack root.
+The authoritative bundle is written to `<authorRoot>/<out>` and copied to each
+`<served-pack-root>/<out>`. Nested output paths are retained exactly; the watcher never flattens
+paths or discovers outputs from existing files. Omit `platform` for a browser bundle; use
+`platform: "node"` for a Node ESM bundle.
+
+Pack ids, roots, inputs, outputs, and targets are validated as structural repository-relative
+values. Absolute paths, empty or dot segments, traversal, and unsafe ids fail before watching. The
+CLI also rejects a missing or extra pack positional, unknown options, missing option values, and a
+`--vite-url` that is not HTTP(S). Unknown pack ids fail deterministically and print the sorted set
+of declared ids; unrelated pack directories and stale committed output do not affect resolution.
+
+A serving target must already:
+
+- exist as a directory inside the repository;
+- contain a readable `pack.yaml` whose `name` exactly matches the selected pack; and
+- resolve to a location other than `authorRoot`, including through filesystem aliases.
+
+The default target is not discovered or created. If it is missing, the command directs you to run
+`npm run build:server` or pass an explicit `--target`. Explicit targets are canonicalized,
+deduplicated, and processed in deterministic order. Parent directories for declared output files
+are created only after all targets pass validation.
+
+#### Reload lifecycle and preserved identity
+
+After a successful build, the watcher copies the declared outputs and sends a monotonic,
+watcher-local reload token to Vite. Vite forwards one `bobbit:pack-rebuilt` HMR event. The client
+then invalidates only renderer and panel module caches owned by that pack, fetches current bytes
+through the existing authenticated gateway routes, and imports them with fresh module identity.
+Stale in-flight loads cannot overwrite a later generation.
+
+Mounted renderers and the active panel repaint through their normal render paths. An inactive panel
+loads the fresh module when it is next selected. The reload does not recreate the workspace or
+navigate the page: session binding, tab ids, tab order, active selection, panel parameters, and
+parameterized `instanceKey` values remain unchanged. Module-local renderer or panel state does
+reset because the code is evaluated as a new module; persist state that must survive in
+`host.store` or another durable host surface.
+
+The notification bridge exists only in Vite serve mode. It accepts only a local `POST` to
+`/__bobbit_dev/pack-rebuilt`, with an at-most 8 KiB JSON body containing exactly a structural
+`pack` id and positive safe-integer `reloadToken`. Pack code should not call this internal bridge.
+It has no gateway or production counterpart: production builds contain neither the endpoint nor
+the HMR listener, and `npm run build:packs` continues to build all declarations using the normal
+production path.
+
+Stop the watcher with `Ctrl+C` or a normal `SIGTERM`. Cleanup is idempotent: it closes the filesystem
+watcher, clears pending debounce work, removes signal listeners, prevents new cycles, and lets an
+already-running cycle settle.
+
+#### Limitations and failure recovery
+
+- Only changes under the selected `<authorRoot>/src` trigger a cycle. An edit to imported shared
+  source outside that directory needs a touch inside the selected `src/` tree or a watcher restart;
+  restarting runs the initial full cycle again.
+- Only declared `entries[].out` files are mirrored. Hand-authored modules and other pack files are
+  not copied, and YAML, manifests, contribution additions, entrypoints, actions, routes, channels,
+  and providers are not reconciled by this browser hot-reload path. Use their existing marketplace
+  and gateway lifecycle.
+- Copying is deterministic but in-place, not a staged atomic directory swap. A build failure skips
+  all mirroring and notification; a copy failure suppresses notification. A later source event
+  retries a complete cycle.
+- If Vite is unavailable, rejects the POST, or does not answer before the bounded timeout, the new
+  bytes may already be mirrored but no client token is delivered. There is deliberately no idle
+  backoff loop: fix Vite and make another edit (or restart the watcher) to rebuild, mirror, and send
+  a newer token.
+- A client-side module fetch or evaluation failure is logged and does not poison later HMR events.
+  A later successful source edit can recover the renderer or panel.
+- The watcher does not remove outputs when an entry is deleted from a declaration. Clean obsolete
+  authored and served artifacts explicitly.
+- Built bundles remain marketplace production artifacts. Run the normal pack build as needed and
+  commit regenerated outputs; hot reload does not replace that release workflow.
+
 **Web Workers (the pdfjs wrinkle).** A library that spins up a Web Worker can't resolve a
 sibling worker file from a `blob:` URL. Pre-bundle the worker SOURCE to a string and create a
 Blob-URL `workerSrc` at runtime — see `market-packs/artifacts/src/binary-render.ts` + the

--- a/docs/extension-host-authoring.md
+++ b/docs/extension-host-authoring.md
@@ -2489,13 +2489,21 @@ of declared ids; unrelated pack directories and stale committed output do not af
 A serving target must already:
 
 - exist as a directory inside the repository;
-- contain a readable `pack.yaml` whose `name` exactly matches the selected pack; and
-- resolve to a location other than `authorRoot`, including through filesystem aliases.
+- contain a readable `pack.yaml` whose `name` exactly matches the selected pack;
+- resolve to a location other than `authorRoot`, including through filesystem aliases; and
+- expose a stable, non-zero filesystem identity. Every traversed output directory and existing
+  output file must expose the same kind of identity.
 
 The default target is not discovered or created. If it is missing, the command directs you to run
 `npm run build:server` or pass an explicit `--target`. Explicit targets are canonicalized,
 deduplicated, and processed in deterministic order. Parent directories for declared output files
-are created only after all targets pass validation.
+are created only after all targets pass validation. Static symlinks or junctions in an output path,
+output-file symlinks, and entries replaced after validation are rejected.
+
+Run the watcher unprivileged and only against serving trees controlled by the same trusted
+developer. Its pathname and identity checks reduce accidental or racy redirection, but are not a
+security boundary against a hostile concurrent local principal: portable Node does not provide
+descriptor-relative publication for this workflow.
 
 #### Reload lifecycle and preserved identity
 
@@ -2512,12 +2520,11 @@ parameterized `instanceKey` values remain unchanged. Module-local renderer or pa
 reset because the code is evaluated as a new module; persist state that must survive in
 `host.store` or another durable host surface.
 
-The notification bridge exists only in Vite serve mode. It accepts only a local `POST` to
-`/__bobbit_dev/pack-rebuilt`, with an at-most 8 KiB JSON body containing exactly a structural
-`pack` id and positive safe-integer `reloadToken`. Pack code should not call this internal bridge.
-It has no gateway or production counterpart: production builds contain neither the endpoint nor
-the HMR listener, and `npm run build:packs` continues to build all declarations using the normal
-production path.
+The notification bridge exists only in Vite serve mode. The watcher supplies its required internal,
+non-simple `X-Bobbit-Pack-Reload: 1` header when posting the bounded reload payload; pack code and
+other callers should not use this bridge directly. It has no gateway or production counterpart:
+production builds contain neither the endpoint nor the HMR listener, and `npm run build:packs`
+continues to build all declarations using the normal production path.
 
 Stop the watcher with `Ctrl+C` or a normal `SIGTERM`. Cleanup is idempotent: it closes the filesystem
 watcher, clears pending debounce work, removes signal listeners, prevents new cycles, and lets an

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "build": "npm run build:packs && npm run build:server && npm run build:ui",
     "audit:packed-consumer": "node scripts/release-packed-consumer-audit.mjs",
     "dev": "concurrently -n gw,ui -c blue,green \"node dist/server/cli.js --cwd . --no-ui\" \"node scripts/dev-vite.mjs\"",
+    "dev:pack": "node scripts/build-market-packs.mjs --watch",
     "dev:harness": "node src/server/harness-deps.ts && node scripts/harness-bootstrap.mjs recover && npm run build:server && concurrently -n harness,ui -c yellow,green \"node scripts/harness-bootstrap.mjs harness -- --cwd . --no-ui\" \"node scripts/dev-vite.mjs\"",
     "dev:nord": "node src/server/harness-deps.ts && node scripts/harness-bootstrap.mjs recover && npm run build:server && node scripts/dev-nord.mjs",
     "dev:watchdog": "node src/server/harness-deps.ts && node scripts/harness-bootstrap.mjs recover && npm run build:server && concurrently -n watchdog,ui -c red,green \"node scripts/harness-bootstrap.mjs watchdog -- --cwd . --no-ui\" \"node scripts/dev-vite.mjs\"",

--- a/scripts/build-market-packs.mjs
+++ b/scripts/build-market-packs.mjs
@@ -400,6 +400,10 @@ async function cleanupOwnedTemporary(tempPath, tempStats, fsImpl) {
 	}
 }
 
+function isWindowsReplacementCollision(error) {
+	return process.platform === "win32" && (error?.code === "EPERM" || error?.code === "EEXIST");
+}
+
 async function publishDeclaredOutput(source, destination, target, claims, fsImpl) {
 	const expectedDestination = await captureDestinationFile(destination, target, claims, fsImpl);
 	const tempPath = path.join(path.dirname(destination), `.bobbit-pack-publish-${randomUUID()}`);
@@ -424,10 +428,9 @@ async function publishDeclaredOutput(source, destination, target, claims, fsImpl
 		try {
 			await fsImpl.rename(tempPath, destination);
 		} catch (error) {
-			// Windows rename does not replace an existing file. Remove only the exact
-			// regular file claimed above, then publish by a same-parent rename. A raced
-			// replacement makes rename fail closed rather than following it.
-			if (process.platform !== "win32" || expectedDestination === undefined) throw error;
+			// Windows rename can report EPERM or EEXIST when it cannot replace an
+			// existing file. Never remove the previous output for unrelated failures.
+			if (expectedDestination === undefined || !isWindowsReplacementCollision(error)) throw error;
 			await assertDestinationUnchanged(destination, expectedDestination, target, claims, fsImpl);
 			await fsImpl.unlink(destination);
 			if (await lstatIfPresent(destination, fsImpl) !== undefined) throw staleTargetError(destination);

--- a/scripts/build-market-packs.mjs
+++ b/scripts/build-market-packs.mjs
@@ -1,54 +1,220 @@
 #!/usr/bin/env node
 /**
- * Market-pack bundler — the command behind `npm run build:packs` (wired into
- * `npm run build`, so CI/E2E always get fresh bundles).
+ * Marketplace-pack bundler and development watcher.
  *
- * CONVENTION (Extension Host Phase 2, Slice D1 parity hardening): a pack's CLIENT
- * contributions (renderers, panels) may now `import` npm deps in their SOURCE
- * (`market-packs/<pack>/src/*`). esbuild bundles each entry into a single,
- * self-contained ESM written to the pack's SERVED location. Each entry declares
- * its `out` path RELATIVE TO THE PACK ROOT (V1 schema), so tool renderers may
- * stay tool-local (`tools/<group>/<entry>.js`) while panels and other shared
- * bundles emit to the pack's `lib/` dir (`lib/<entry>.js`) — the new home for
- * shared implementation modules. The marketplace ships the BUILT assets as-is.
- * The built bundles are committed.
- *
- * Two hard rules make a bundle loadable by the Phase-1/2 client loader, which
- * imports the module via a Blob URL and hands it the host toolkit as a FACTORY
- * parameter (see src/app/pack-renderers.ts / pack-panels.ts):
- *   1. NEVER bundle `lit` — it is injected (`{ html, nothing, renderHeader }`).
- *      `lit`/`lit/*` are marked EXTERNAL; pack source must not import them.
- *   2. SINGLE self-contained file per entry — NO code splitting / dynamic chunks.
- *      A Blob-URL module has no resolvable base for `import("./chunk.js")`, so
- *      every dep (highlight.js, pdfjs-dist, docx-preview) is inlined eagerly.
- *
- * pdfjs WORKER: pdfjs needs a worker but a Blob-URL module cannot resolve a
- * sibling worker file and there is no pack-asset endpoint. We pre-bundle the
- * worker SOURCE to a string and expose it as the `virtual:pdf-worker` module; the
- * pack creates a Blob-URL `workerSrc` from it at runtime (see binary-render.ts).
+ * Production (`npm run build:packs`) still bundles every declared entry into its
+ * authored pack. Development (`npm run dev:pack -- <pack>`) rebuilds one exact
+ * declaration, mirrors only its declared outputs, and notifies the local Vite
+ * server after a complete successful publish.
  */
+import { watch as watchFs } from "node:fs";
+import { copyFile, lstat, mkdir, readFile, realpath } from "node:fs/promises";
 import { build } from "esbuild";
 import { createRequire } from "node:module";
 import path from "node:path";
+import process from "node:process";
 import { fileURLToPath } from "node:url";
+import { parse as parseYaml } from "yaml";
 
 const require = createRequire(import.meta.url);
-const projectRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+export const projectRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const PACK_ID = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+const DEFAULT_VITE_URL = "http://127.0.0.1:5173";
+const DEV_RELOAD_PATH = "/__bobbit_dev/pack-rebuilt";
 
-/** Resolve a dep entry from the repo's node_modules (so the worker bundle below
- *  uses the SAME pdfjs the panel bundle does). */
+/** The sole source of truth for authored bundle inputs and serving outputs. */
+export const PACKS = [
+	{
+		pack: "artifacts",
+		authorRoot: "market-packs/artifacts",
+		defaultServingRoot: "dist/server/builtin-packs/market-packs/artifacts",
+		entries: [
+			{ in: "ArtifactRenderer.ts", out: "tools/artifact_demo/ArtifactRenderer.js" },
+			{ in: "ArtifactViewerPanel.ts", out: "lib/ArtifactViewerPanel.js" },
+		],
+	},
+	{
+		pack: "pr-walkthrough",
+		authorRoot: "market-packs/pr-walkthrough",
+		defaultServingRoot: "dist/server/builtin-packs/market-packs/pr-walkthrough",
+		entries: [
+			{ in: "panel.js", out: "lib/panel.js" },
+			{ in: "yaml-to-cards.js", out: "lib/yaml-to-cards.mjs", platform: "node" },
+		],
+	},
+	{
+		pack: "hindsight",
+		authorRoot: "market-packs/hindsight",
+		defaultServingRoot: "dist/server/builtin-packs/market-packs/hindsight",
+		entries: [
+			{ in: "hindsight-client.ts", out: "lib/hindsight-client.mjs", platform: "node" },
+			{ in: "provider.ts", out: "lib/provider.mjs", platform: "node" },
+			{ in: "routes.ts", out: "lib/routes.mjs", platform: "node" },
+		],
+	},
+	{
+		pack: "terminal",
+		authorRoot: "market-packs/terminal",
+		defaultServingRoot: "dist/server/builtin-packs/market-packs/terminal",
+		entries: [
+			{ in: "terminal-panel.ts", out: "lib/terminal-panel.js" },
+			{ in: "terminal-channel.ts", out: "lib/terminal-channel.mjs", platform: "node" },
+		],
+	},
+	{
+		pack: "file-explorer",
+		authorRoot: "market-packs/file-explorer",
+		defaultServingRoot: "dist/server/builtin-packs/market-packs/file-explorer",
+		entries: [
+			{ in: "file-explorer-panel.ts", out: "lib/file-explorer-panel.js" },
+			{ in: "explorer-routes.ts", out: "lib/explorer-routes.mjs", platform: "node" },
+		],
+	},
+];
+
+function normalizeRepoRelative(value, label) {
+	if (typeof value !== "string" || value.length === 0 || value.includes("\0")) {
+		throw new Error(`${label} must be a non-empty repository-relative path`);
+	}
+	if (path.posix.isAbsolute(value) || path.win32.isAbsolute(value)) {
+		throw new Error(`${label} must be repository-relative: ${value}`);
+	}
+	const normalized = value.replaceAll("\\", "/");
+	const segments = normalized.split("/");
+	if (segments.some((segment) => segment === "" || segment === "." || segment === "..")) {
+		throw new Error(`${label} contains an unsafe path segment: ${value}`);
+	}
+	return segments.join("/");
+}
+
+function validateDeclaration(declaration) {
+	if (!declaration || !PACK_ID.test(declaration.pack)) throw new Error(`Invalid pack declaration id: ${declaration?.pack ?? ""}`);
+	const authorRoot = normalizeRepoRelative(declaration.authorRoot, `${declaration.pack} authorRoot`);
+	const defaultServingRoot = normalizeRepoRelative(declaration.defaultServingRoot, `${declaration.pack} defaultServingRoot`);
+	if (!Array.isArray(declaration.entries) || declaration.entries.length === 0) {
+		throw new Error(`${declaration.pack} must declare at least one bundle entry`);
+	}
+	const entries = declaration.entries.map((entry) => {
+		const input = normalizeRepoRelative(entry.in, `${declaration.pack} entry input`);
+		const output = normalizeRepoRelative(entry.out, `${declaration.pack} entry output`);
+		if (entry.platform !== undefined && entry.platform !== "browser" && entry.platform !== "node") {
+			throw new Error(`${declaration.pack} entry platform must be browser or node`);
+		}
+		return { ...entry, in: input, out: output };
+	});
+	return { ...declaration, authorRoot, defaultServingRoot, entries };
+}
+
+for (const declaration of PACKS) validateDeclaration(declaration);
+
+export function parseArgs(argv) {
+	const result = { watch: false, pack: undefined, targets: [], viteUrl: DEFAULT_VITE_URL, help: false };
+	for (let index = 0; index < argv.length; index += 1) {
+		const argument = argv[index];
+		if (argument === "--watch") {
+			if (result.watch) throw new Error("Duplicate option: --watch");
+			result.watch = true;
+			continue;
+		}
+		if (argument === "--help" || argument === "-h") {
+			result.help = true;
+			continue;
+		}
+		if (argument === "--target" || argument === "--vite-url") {
+			const value = argv[index + 1];
+			if (!value || value.startsWith("--")) throw new Error(`Missing value for ${argument}`);
+			index += 1;
+			if (argument === "--target") result.targets.push(normalizeRepoRelative(value, "--target"));
+			else {
+				let parsed;
+				try {
+					parsed = new URL(value);
+				} catch {
+					throw new Error(`--vite-url must be an HTTP(S) URL: ${value}`);
+				}
+				if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+					throw new Error(`--vite-url must be an HTTP(S) URL: ${value}`);
+				}
+				result.viteUrl = parsed.href;
+			}
+			continue;
+		}
+		if (argument.startsWith("-")) throw new Error(`Unknown option: ${argument}`);
+		if (result.pack !== undefined) throw new Error(`Unexpected extra pack argument: ${argument}`);
+		if (!PACK_ID.test(argument)) throw new Error(`Pack id must be a safe structural id: ${argument}`);
+		result.pack = argument;
+	}
+	if (!result.help && result.watch && !result.pack) throw new Error("Missing pack id for --watch");
+	if (!result.help && !result.watch && (result.pack || result.targets.length > 0 || result.viteUrl !== DEFAULT_VITE_URL)) {
+		throw new Error("Pack selection, --target, and --vite-url require --watch");
+	}
+	return result;
+}
+
+export function resolvePackBuild(packName) {
+	if (typeof packName !== "string" || !PACK_ID.test(packName)) throw new Error(`Invalid pack id: ${packName ?? ""}`);
+	const declaration = PACKS.find((candidate) => candidate.pack === packName);
+	if (declaration) return validateDeclaration(declaration);
+	throw new Error(`Unknown pack "${packName}". Declared packs: ${PACKS.map(({ pack }) => pack).sort().join(", ")}`);
+}
+
+function isWithin(root, candidate) {
+	const relative = path.relative(root, candidate);
+	return relative === "" || (!relative.startsWith(`..${path.sep}`) && relative !== ".." && !path.isAbsolute(relative));
+}
+
+/** Resolve, validate and deterministically order already-existing served pack roots. */
+export async function servingTargets(declaration, explicitTargets = [], options = {}) {
+	const validated = validateDeclaration(declaration);
+	const root = path.resolve(options.projectRoot ?? projectRoot);
+	const canonicalRoot = await realpath(root);
+	const authorPath = path.resolve(root, validated.authorRoot);
+	const canonicalAuthor = await realpath(authorPath);
+	const requested = explicitTargets.length > 0 ? explicitTargets : [validated.defaultServingRoot];
+	const usingDefault = explicitTargets.length === 0;
+	const targets = [];
+	for (const supplied of requested) {
+		const relative = normalizeRepoRelative(supplied, "Serving target");
+		const lexical = path.resolve(root, relative);
+		let stats;
+		let canonical;
+		try {
+			await lstat(lexical);
+			canonical = await realpath(lexical);
+			stats = await lstat(canonical);
+		} catch {
+			if (usingDefault) {
+				throw new Error(`Default serving target "${relative}" does not exist; run npm run build:server or pass --target <served-pack-root>`);
+			}
+			throw new Error(`Serving target "${relative}" does not exist`);
+		}
+		if (!stats.isDirectory()) throw new Error(`Serving target "${relative}" is not a directory`);
+		if (!isWithin(canonicalRoot, canonical)) throw new Error(`Serving target "${relative}" escapes the repository root`);
+		if (canonical === canonicalAuthor) throw new Error(`Serving target "${relative}" aliases the authored pack root`);
+		let manifest;
+		try {
+			manifest = parseYaml(await readFile(path.join(canonical, "pack.yaml"), "utf8"));
+		} catch {
+			throw new Error(`Serving target "${relative}" has no readable pack.yaml`);
+		}
+		if (!manifest || manifest.name !== validated.pack) {
+			throw new Error(`Serving target "${relative}" manifest name must be "${validated.pack}"`);
+		}
+		targets.push(canonical);
+	}
+	const caseInsensitive = options.caseInsensitive ?? process.platform === "win32";
+	const unique = new Map();
+	for (const target of targets) unique.set(caseInsensitive ? target.toLowerCase() : target, target);
+	return [...unique.values()].sort((left, right) => left.localeCompare(right));
+}
+
 function resolveDep(spec) {
 	return require.resolve(spec, { paths: [projectRoot] });
 }
 
-// ── Pre-bundle the pdf.worker source to a string for `virtual:pdf-worker`. ──
-async function bundlePdfWorker() {
-	const workerEntry = resolveDep("pdfjs-dist/build/pdf.worker.min.mjs");
-	// ESM (not IIFE) so BOTH worker-load paths resolve from the Blob URL: pdfjs's
-	// `new Worker(workerSrc, { type: "module" })` AND its fake-worker fallback
-	// `import(workerSrc)`. The worker is fully self-contained (no internal chunks).
-	const result = await build({
-		entryPoints: [workerEntry],
+async function bundlePdfWorker(buildImpl = build) {
+	const result = await buildImpl({
+		entryPoints: [resolveDep("pdfjs-dist/build/pdf.worker.min.mjs")],
 		bundle: true,
 		format: "esm",
 		platform: "browser",
@@ -60,16 +226,12 @@ async function bundlePdfWorker() {
 	return result.outputFiles[0].text;
 }
 
-/** esbuild plugin exposing the inlined pdf.worker source as `virtual:pdf-worker`. */
 function pdfWorkerPlugin(workerSource) {
 	return {
 		name: "virtual-pdf-worker",
-		setup(b) {
-			b.onResolve({ filter: /^virtual:pdf-worker$/ }, () => ({
-				path: "virtual:pdf-worker",
-				namespace: "pdf-worker",
-			}));
-			b.onLoad({ filter: /.*/, namespace: "pdf-worker" }, () => ({
+		setup(builder) {
+			builder.onResolve({ filter: /^virtual:pdf-worker$/ }, () => ({ path: "virtual:pdf-worker", namespace: "pdf-worker" }));
+			builder.onLoad({ filter: /.*/, namespace: "pdf-worker" }, () => ({
 				contents: `export default ${JSON.stringify(workerSource)};`,
 				loader: "js",
 			}));
@@ -77,115 +239,222 @@ function pdfWorkerPlugin(workerSource) {
 	};
 }
 
-/**
- * Pack manifest: each entry's SOURCE (`market-packs/<pack>/src/<in>`) is bundled
- * to its SERVED path `market-packs/<pack>/<out>`, where `out` is RELATIVE TO THE
- * PACK ROOT. Tool renderers stay tool-local (`tools/<group>/<entry>.js`); panels
- * and other shared client bundles emit to `lib/`. Extend this when a pack adds a
- * bundled contribution.
- *
- * NOTE: a pack's hand-authored `.mjs` server modules (e.g. pr-walkthrough's
- * `lib/routes.mjs`) are NOT bundled — they are committed source served as-is and
- * are simply relocated to `lib/`; only CLIENT contributions go through esbuild.
- */
-const PACKS = [
-	{
-		pack: "artifacts",
-		entries: [
-			// renderer stays tool-local (served as a PACK renderer by the tool endpoint).
-			{ in: "ArtifactRenderer.ts", out: "tools/artifact_demo/ArtifactRenderer.js" },
-			// panel bundle emits to the shared lib/ dir (auto-discovered panel entry).
-			{ in: "ArtifactViewerPanel.ts", out: "lib/ArtifactViewerPanel.js" },
-		],
-	},
-	{
-		pack: "pr-walkthrough",
-		entries: [
-			// no-tools pack: the viewer panel bundle emits to lib/ (auto-discovered
-			// from panels/pr-walkthrough-panel.yaml). routes.mjs is hand-authored and
-			// relocated to lib/ — NOT bundled here.
-			{ in: "panel.js", out: "lib/panel.js" },
-			// SERVER-side synthesis bundle: the pure shared YAML→cards mapper (with its
-			// `yaml` dep inlined), imported by the hand-authored routes.mjs `publish`
-			// route in the confined NODE worker. platform:"node" so Buffer + node:* stay
-			// node globals/builtins and are NOT browser-polyfilled. Emits `.mjs`.
-			{ in: "yaml-to-cards.js", out: "lib/yaml-to-cards.mjs", platform: "node" },
-		],
-	},
-	{
-		pack: "hindsight",
-		entries: [
-			// SERVER-side modules for the confined NODE worker (provider hooks + pack
-			// routes), each authored in TS and bundled to lib/*.mjs with the REST client
-			// inlined (provider.ts / routes.ts dynamic-import ./hindsight-client.js, which
-			// esbuild inlines into each single self-contained file). platform:"node" so
-			// Buffer + node:* stay node globals/builtins. No CLIENT contributions yet
-			// (panel + tools land in G2.3).
-			{ in: "hindsight-client.ts", out: "lib/hindsight-client.mjs", platform: "node" },
-			{ in: "provider.ts", out: "lib/provider.mjs", platform: "node" },
-			{ in: "routes.ts", out: "lib/routes.mjs", platform: "node" },
-		],
-	},
-	{
-		pack: "terminal",
-		entries: [
-			{ in: "terminal-panel.ts", out: "lib/terminal-panel.js" },
-			{ in: "terminal-channel.ts", out: "lib/terminal-channel.mjs", platform: "node" },
-		],
-	},
-	{
-		pack: "file-explorer",
-		entries: [
-			{ in: "file-explorer-panel.ts", out: "lib/file-explorer-panel.js" },
-			{ in: "explorer-routes.ts", out: "lib/explorer-routes.mjs", platform: "node" },
-		],
-	},
-];
+/** Build every declared entry for one pack, sequentially. */
+export async function buildSelectedPack(declaration, options = {}) {
+	const validated = validateDeclaration(declaration);
+	const root = path.resolve(options.projectRoot ?? projectRoot);
+	const buildImpl = options.build ?? build;
+	const plugin = options.plugin ?? pdfWorkerPlugin(await bundlePdfWorker(buildImpl));
+	const log = options.log ?? ((message) => console.log(message));
+	for (const entry of validated.entries) {
+		const inFile = path.join(root, validated.authorRoot, "src", entry.in);
+		const outFile = path.join(root, validated.authorRoot, entry.out);
+		await buildImpl({
+			entryPoints: [inFile],
+			outfile: outFile,
+			bundle: true,
+			format: "esm",
+			platform: entry.platform ?? "browser",
+			target: "es2022",
+			minify: true,
+			legalComments: "none",
+			external: ["lit", "lit/*"],
+			splitting: false,
+			define: { "process.env.NODE_ENV": '"production"' },
+			...(entry.platform === "node"
+				? { banner: { js: "import { createRequire as __bbCreateRequire } from 'node:module';\nconst require = __bbCreateRequire(import.meta.url);" } }
+				: {}),
+			plugins: [plugin],
+			logLevel: "info",
+		});
+		log(`[build:packs] ${validated.pack}/src/${entry.in} → ${validated.pack}/${entry.out}`);
+	}
+}
 
-async function main() {
-	const workerSource = await bundlePdfWorker();
-	const plugin = pdfWorkerPlugin(workerSource);
-
-	for (const { pack, entries } of PACKS) {
-		const packRoot = path.join(projectRoot, "market-packs", pack);
-		const srcDir = path.join(packRoot, "src");
-		for (const entry of entries) {
-			const inFile = path.join(srcDir, entry.in);
-			const outFile = path.join(packRoot, entry.out);
-			await build({
-				entryPoints: [inFile],
-				outfile: outFile,
-				bundle: true,
-				format: "esm",
-				// Most entries are CLIENT panels (browser); a server-side bundle (e.g.
-				// pr-walkthrough's yaml-to-cards, run in the confined Node worker) opts
-				// into platform:"node" so Buffer/node:* stay node globals/builtins.
-				platform: entry.platform ?? "browser",
-				target: "es2022",
-				minify: true,
-				legalComments: "none",
-				// RULE 1 — lit is host-injected, never bundled.
-				external: ["lit", "lit/*"],
-				// RULE 2 — single self-contained file (no splitting).
-				splitting: false,
-				define: { "process.env.NODE_ENV": '"production"' },
-				// platform:"node" ESM bundles need a real `require` so a bundled CJS dep
-				// (e.g. `yaml`) that lazily `require("process")` resolves — ESM has no
-				// implicit `require`, so esbuild's dynamic-require shim throws without this.
-				...(entry.platform === "node"
-					? { banner: { js: "import { createRequire as __bbCreateRequire } from 'node:module';\nconst require = __bbCreateRequire(import.meta.url);" } }
-					: {}),
-				plugins: [plugin],
-				logLevel: "info",
-			});
-			// eslint-disable-next-line no-console
-			console.log(`[build:packs] ${pack}/src/${entry.in} → ${pack}/${entry.out}`);
+/** Mirror only declared outputs, retaining their pack-relative nested paths. */
+export async function mirrorDeclaredOutputs(declaration, targets, options = {}) {
+	const validated = validateDeclaration(declaration);
+	const root = path.resolve(options.projectRoot ?? projectRoot);
+	for (const target of targets) {
+		for (const entry of validated.entries) {
+			const source = path.join(root, validated.authorRoot, entry.out);
+			const destination = path.join(target, entry.out);
+			await mkdir(path.dirname(destination), { recursive: true });
+			await copyFile(source, destination);
 		}
 	}
 }
 
-main().catch((err) => {
-	// eslint-disable-next-line no-console
-	console.error("[build:packs] failed:", err);
-	process.exit(1);
-});
+/** Notify Vite after a complete mirror. Only HTTP 204 is success. */
+export async function notifyVite(viteUrl, payload, options = {}) {
+	if (!PACK_ID.test(payload?.pack) || !Number.isSafeInteger(payload?.reloadToken) || payload.reloadToken <= 0) {
+		throw new Error("Invalid pack rebuild notification payload");
+	}
+	const controller = new AbortController();
+	const timeoutMs = options.timeoutMs ?? 2_000;
+	const timer = setTimeout(() => controller.abort(), timeoutMs);
+	try {
+		const endpoint = new URL(DEV_RELOAD_PATH, viteUrl);
+		const response = await (options.fetch ?? fetch)(endpoint, {
+			method: "POST",
+			headers: { "content-type": "application/json" },
+			body: JSON.stringify(payload),
+			signal: controller.signal,
+		});
+		if (response.status !== 204) throw new Error(`Vite pack reload endpoint returned HTTP ${response.status}`);
+	} catch (error) {
+		if (controller.signal.aborted) throw new Error(`Vite pack reload notification timed out after ${timeoutMs}ms`, { cause: error });
+		throw error;
+	} finally {
+		clearTimeout(timer);
+	}
+}
+
+/**
+ * Serialize pack-level build/mirror/notify cycles. File events debounce while
+ * idle and coalesce to exactly one trailing cycle while work is active.
+ */
+export function createSerializedRebuilder(options) {
+	const debounceMs = options.debounceMs ?? 60;
+	const reportError = options.onError ?? ((error) => console.error("[dev:pack] rebuild failed:", error));
+	let running = null;
+	let dirty = false;
+	let closed = false;
+	let debounceTimer = null;
+	let watcher = null;
+	let nextReloadToken = 1;
+	let lastError = null;
+	const signalSource = options.signalSource ?? process;
+
+	const cycle = async () => {
+		await options.build();
+		await options.mirror();
+		const reloadToken = nextReloadToken;
+		nextReloadToken += 1;
+		await options.notify({ pack: options.pack, reloadToken });
+	};
+
+	const drain = () => {
+		if (running || closed || !dirty) return running ?? Promise.resolve();
+		running = (async () => {
+			while (dirty && !closed) {
+				dirty = false;
+				try {
+					await cycle();
+					lastError = null;
+				} catch (error) {
+					lastError = error;
+					reportError(error);
+				}
+			}
+		})().finally(() => {
+			running = null;
+			if (dirty && !closed) drain();
+		});
+		return running;
+	};
+
+	const flush = async () => {
+		if (debounceTimer) {
+			clearTimeout(debounceTimer);
+			debounceTimer = null;
+		}
+		if (dirty && !running) drain();
+		while (running) await running;
+	};
+
+	const schedule = (immediate = false) => {
+		if (closed) return;
+		dirty = true;
+		if (running) return;
+		if (debounceTimer) clearTimeout(debounceTimer);
+		if (immediate) {
+			debounceTimer = null;
+			drain();
+		} else {
+			debounceTimer = setTimeout(() => {
+				debounceTimer = null;
+				drain();
+			}, debounceMs);
+		}
+	};
+
+	const onSignal = () => { void dispose(); };
+	const attachWatcher = (nextWatcher) => {
+		if (closed) {
+			nextWatcher.close();
+			return;
+		}
+		if (watcher) throw new Error("A watcher is already attached");
+		watcher = nextWatcher;
+		signalSource.on?.("SIGINT", onSignal);
+		signalSource.on?.("SIGTERM", onSignal);
+	};
+	const dispose = async () => {
+		if (!closed) {
+			closed = true;
+			dirty = false;
+			if (debounceTimer) clearTimeout(debounceTimer);
+			debounceTimer = null;
+			watcher?.close();
+			watcher = null;
+			signalSource.removeListener?.("SIGINT", onSignal);
+			signalSource.removeListener?.("SIGTERM", onSignal);
+		}
+		if (running) await running;
+	};
+
+	return {
+		schedule,
+		flush,
+		attachWatcher,
+		dispose,
+		get state() { return { running: running !== null, dirty, closed, nextReloadToken, lastError }; },
+	};
+}
+
+async function buildAllPacks() {
+	const plugin = pdfWorkerPlugin(await bundlePdfWorker());
+	for (const declaration of PACKS) await buildSelectedPack(declaration, { plugin });
+}
+
+async function runWatcher(parsed) {
+	const declaration = resolvePackBuild(parsed.pack);
+	const targets = await servingTargets(declaration, parsed.targets);
+	const plugin = pdfWorkerPlugin(await bundlePdfWorker());
+	const rebuilder = createSerializedRebuilder({
+		pack: declaration.pack,
+		build: () => buildSelectedPack(declaration, { plugin }),
+		mirror: () => mirrorDeclaredOutputs(declaration, targets),
+		notify: (payload) => notifyVite(parsed.viteUrl, payload),
+	});
+	const sourceRoot = path.join(projectRoot, declaration.authorRoot, "src");
+	const watcher = watchFs(sourceRoot, { recursive: true }, () => rebuilder.schedule());
+	rebuilder.attachWatcher(watcher);
+	rebuilder.schedule(true);
+	await rebuilder.flush();
+	console.log(`[dev:pack] watching ${declaration.pack} at ${sourceRoot}`);
+	return rebuilder;
+}
+
+function printHelp() {
+	console.log("Usage: npm run dev:pack -- <pack> [--target <served-pack-root>]... [--vite-url <http(s)-url>]");
+}
+
+async function main(argv = process.argv.slice(2)) {
+	const parsed = parseArgs(argv);
+	if (parsed.help) {
+		printHelp();
+		return;
+	}
+	if (parsed.watch) await runWatcher(parsed);
+	else await buildAllPacks();
+}
+
+const isEntrypoint = process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+if (isEntrypoint) {
+	main().catch((error) => {
+		console.error(`[${process.argv.includes("--watch") ? "dev:pack" : "build:packs"}] failed:`, error);
+		process.exitCode = 1;
+	});
+}

--- a/scripts/build-market-packs.mjs
+++ b/scripts/build-market-packs.mjs
@@ -324,6 +324,8 @@ export function createSerializedRebuilder(options) {
 	let watcher = null;
 	let nextReloadToken = 1;
 	let lastError = null;
+	let lastFailure = null;
+	let failureCount = 0;
 	const signalSource = options.signalSource ?? process;
 
 	const cycle = async () => {
@@ -344,6 +346,8 @@ export function createSerializedRebuilder(options) {
 					lastError = null;
 				} catch (error) {
 					lastError = error;
+					lastFailure = error;
+					failureCount += 1;
 					reportError(error);
 				}
 			}
@@ -354,13 +358,15 @@ export function createSerializedRebuilder(options) {
 		return running;
 	};
 
-	const flush = async () => {
+	const flush = async ({ throwOnError = false } = {}) => {
+		const startingFailureCount = failureCount;
 		if (debounceTimer) {
 			clearTimeout(debounceTimer);
 			debounceTimer = null;
 		}
 		if (dirty && !running) drain();
 		while (running) await running;
+		if (throwOnError && failureCount > startingFailureCount) throw lastFailure;
 	};
 
 	const schedule = (immediate = false) => {
@@ -418,22 +424,30 @@ async function buildAllPacks() {
 	for (const declaration of PACKS) await buildSelectedPack(declaration, { plugin });
 }
 
-async function runWatcher(parsed) {
+export async function runWatcher(parsed, options = {}) {
+	const root = path.resolve(options.projectRoot ?? projectRoot);
 	const declaration = resolvePackBuild(parsed.pack);
-	const targets = await servingTargets(declaration, parsed.targets);
-	const plugin = pdfWorkerPlugin(await bundlePdfWorker());
+	const targets = await servingTargets(declaration, parsed.targets, { projectRoot: root });
+	const plugin = options.plugin ?? (options.build ? undefined : pdfWorkerPlugin(await bundlePdfWorker()));
 	const rebuilder = createSerializedRebuilder({
 		pack: declaration.pack,
-		build: () => buildSelectedPack(declaration, { plugin }),
-		mirror: () => mirrorDeclaredOutputs(declaration, targets),
-		notify: (payload) => notifyVite(parsed.viteUrl, payload),
+		build: options.build ?? (() => buildSelectedPack(declaration, { projectRoot: root, plugin })),
+		mirror: options.mirror ?? (() => mirrorDeclaredOutputs(declaration, targets, { projectRoot: root })),
+		notify: options.notify ?? ((payload) => notifyVite(parsed.viteUrl, payload)),
+		signalSource: options.signalSource,
+		onError: options.onError,
 	});
-	const sourceRoot = path.join(projectRoot, declaration.authorRoot, "src");
-	const watcher = watchFs(sourceRoot, { recursive: true }, () => rebuilder.schedule());
+	const sourceRoot = path.join(root, declaration.authorRoot, "src");
+	const watcher = (options.watch ?? watchFs)(sourceRoot, { recursive: true }, () => rebuilder.schedule());
 	rebuilder.attachWatcher(watcher);
-	rebuilder.schedule(true);
-	await rebuilder.flush();
-	console.log(`[dev:pack] watching ${declaration.pack} at ${sourceRoot}`);
+	try {
+		rebuilder.schedule(true);
+		await rebuilder.flush({ throwOnError: true });
+	} catch (error) {
+		await rebuilder.dispose();
+		throw error;
+	}
+	(options.log ?? console.log)(`[dev:pack] watching ${declaration.pack} at ${sourceRoot}`);
 	return rebuilder;
 }
 

--- a/scripts/build-market-packs.mjs
+++ b/scripts/build-market-packs.mjs
@@ -7,8 +7,9 @@
  * declaration, mirrors only its declared outputs, and notifies the local Vite
  * server after a complete successful publish.
  */
-import { watch as watchFs } from "node:fs";
-import { copyFile, lstat, mkdir, readFile, realpath } from "node:fs/promises";
+import { constants as fsConstants, watch as watchFs } from "node:fs";
+import { randomUUID } from "node:crypto";
+import { copyFile, lstat, mkdir, readFile, realpath, rename, unlink } from "node:fs/promises";
 import { build } from "esbuild";
 import { createRequire } from "node:module";
 import path from "node:path";
@@ -163,6 +164,47 @@ function isWithin(root, candidate) {
 	return relative === "" || (!relative.startsWith(`..${path.sep}`) && relative !== ".." && !path.isAbsolute(relative));
 }
 
+function stableIdentity(stats) {
+	if (stats.dev === undefined || stats.ino === undefined || String(stats.ino) === "0") return undefined;
+	return `${String(stats.dev)}:${String(stats.ino)}`;
+}
+
+function sameStableIdentity(expected, current) {
+	const expectedIdentity = stableIdentity(expected);
+	return expectedIdentity !== undefined && expectedIdentity === stableIdentity(current);
+}
+
+function staleTargetError(targetPath) {
+	const error = new Error(`Serving target changed or is unsafe: ${targetPath}`);
+	error.code = "ESTALE";
+	return error;
+}
+
+function assertStableDirectory(stats, targetPath) {
+	if (!stats.isDirectory() || stats.isSymbolicLink() || stableIdentity(stats) === undefined) {
+		throw staleTargetError(targetPath);
+	}
+}
+
+async function assertDirectoryClaimCurrent(claim, fsImpl) {
+	const current = await fsImpl.lstat(claim.path);
+	assertStableDirectory(current, claim.path);
+	if (claim.identity !== stableIdentity(current)) throw staleTargetError(claim.path);
+}
+
+async function captureDirectoryClaim(directoryPath, canonicalRoot, fsImpl) {
+	const stats = await fsImpl.lstat(directoryPath);
+	assertStableDirectory(stats, directoryPath);
+	const canonical = await fsImpl.realpath(directoryPath);
+	if (!isWithin(canonicalRoot, canonical)) throw new Error(`Mirror destination escapes its serving target: ${directoryPath}`);
+	const canonicalStats = await fsImpl.lstat(canonical);
+	assertStableDirectory(canonicalStats, canonical);
+	if (!sameStableIdentity(stats, canonicalStats)) throw staleTargetError(directoryPath);
+	return { path: directoryPath, identity: stableIdentity(stats) };
+}
+
+const realMirrorFs = { copyFile, lstat, mkdir, realpath, rename, unlink };
+
 /** Resolve, validate and deterministically order already-existing served pack roots. */
 export async function servingTargets(declaration, explicitTargets = [], options = {}) {
 	const validated = validateDeclaration(declaration);
@@ -176,10 +218,9 @@ export async function servingTargets(declaration, explicitTargets = [], options 
 	for (const supplied of requested) {
 		const relative = normalizeRepoRelative(supplied, "Serving target");
 		const lexical = path.resolve(root, relative);
-		let stats;
 		let canonical;
+		let stats;
 		try {
-			await lstat(lexical);
 			canonical = await realpath(lexical);
 			stats = await lstat(canonical);
 		} catch {
@@ -189,23 +230,30 @@ export async function servingTargets(declaration, explicitTargets = [], options 
 			throw new Error(`Serving target "${relative}" does not exist`);
 		}
 		if (!stats.isDirectory()) throw new Error(`Serving target "${relative}" is not a directory`);
+		if (stats.isSymbolicLink() || stableIdentity(stats) === undefined) {
+			throw new Error(`Serving target "${relative}" is not a stable directory`);
+		}
 		if (!isWithin(canonicalRoot, canonical)) throw new Error(`Serving target "${relative}" escapes the repository root`);
 		if (canonical === canonicalAuthor) throw new Error(`Serving target "${relative}" aliases the authored pack root`);
+		const claim = Object.freeze({ path: canonical, canonicalPath: canonical, identity: stableIdentity(stats) });
 		let manifest;
 		try {
+			await assertDirectoryClaimCurrent(claim, realMirrorFs);
 			manifest = parseYaml(await readFile(path.join(canonical, "pack.yaml"), "utf8"));
-		} catch {
+			await assertDirectoryClaimCurrent(claim, realMirrorFs);
+		} catch (error) {
+			if (error?.code === "ESTALE") throw error;
 			throw new Error(`Serving target "${relative}" has no readable pack.yaml`);
 		}
 		if (!manifest || manifest.name !== validated.pack) {
 			throw new Error(`Serving target "${relative}" manifest name must be "${validated.pack}"`);
 		}
-		targets.push(canonical);
+		targets.push(claim);
 	}
 	const caseInsensitive = options.caseInsensitive ?? process.platform === "win32";
 	const unique = new Map();
-	for (const target of targets) unique.set(caseInsensitive ? target.toLowerCase() : target, target);
-	return [...unique.values()].sort((left, right) => left.localeCompare(right));
+	for (const target of targets) unique.set(caseInsensitive ? target.path.toLowerCase() : target.path, target);
+	return [...unique.values()].sort((left, right) => left.path.localeCompare(right.path));
 }
 
 function resolveDep(spec) {
@@ -271,16 +319,148 @@ export async function buildSelectedPack(declaration, options = {}) {
 	}
 }
 
+function isMissing(error) {
+	return error?.code === "ENOENT";
+}
+
+async function lstatIfPresent(filePath, fsImpl) {
+	try {
+		return await fsImpl.lstat(filePath);
+	} catch (error) {
+		if (isMissing(error)) return undefined;
+		throw error;
+	}
+}
+
+async function assertClaimsCurrent(claims, fsImpl) {
+	for (const claim of claims) await assertDirectoryClaimCurrent(claim, fsImpl);
+}
+
+async function prepareDestinationParent(target, output, fsImpl) {
+	if (!target || typeof target.path !== "string" || typeof target.canonicalPath !== "string" || typeof target.identity !== "string") {
+		throw new Error("Mirror target must be a validated serving target claim");
+	}
+	const rootClaim = { path: target.path, identity: target.identity };
+	await assertDirectoryClaimCurrent(rootClaim, fsImpl);
+	const claims = [rootClaim];
+	const parentSegments = path.posix.dirname(output) === "." ? [] : path.posix.dirname(output).split("/");
+	let currentPath = target.path;
+	for (const segment of parentSegments) {
+		currentPath = path.join(currentPath, segment);
+		await assertClaimsCurrent(claims, fsImpl);
+		let stats = await lstatIfPresent(currentPath, fsImpl);
+		if (stats === undefined) {
+			await fsImpl.mkdir(currentPath, { recursive: false });
+			stats = await fsImpl.lstat(currentPath);
+		}
+		assertStableDirectory(stats, currentPath);
+		const claim = await captureDirectoryClaim(currentPath, target.canonicalPath, fsImpl);
+		claims.push(claim);
+		await assertClaimsCurrent(claims, fsImpl);
+	}
+	return claims;
+}
+
+async function captureDestinationFile(destination, target, claims, fsImpl) {
+	await assertClaimsCurrent(claims, fsImpl);
+	const stats = await lstatIfPresent(destination, fsImpl);
+	if (stats === undefined) return undefined;
+	if (!stats.isFile() || stats.isSymbolicLink() || stableIdentity(stats) === undefined) {
+		throw new Error(`Mirror destination is not a stable regular file: ${destination}`);
+	}
+	const canonical = await fsImpl.realpath(destination);
+	if (!isWithin(target.canonicalPath, canonical)) {
+		throw new Error(`Mirror destination escapes its serving target: ${destination}`);
+	}
+	const canonicalStats = await fsImpl.lstat(canonical);
+	if (!canonicalStats.isFile() || canonicalStats.isSymbolicLink() || !sameStableIdentity(stats, canonicalStats)) {
+		throw staleTargetError(destination);
+	}
+	await assertClaimsCurrent(claims, fsImpl);
+	return stats;
+}
+
+async function assertDestinationUnchanged(destination, expected, target, claims, fsImpl) {
+	const current = await captureDestinationFile(destination, target, claims, fsImpl);
+	if (expected === undefined) {
+		if (current !== undefined) throw staleTargetError(destination);
+		return;
+	}
+	if (current === undefined || !sameStableIdentity(expected, current)) throw staleTargetError(destination);
+}
+
+async function cleanupOwnedTemporary(tempPath, tempStats, fsImpl) {
+	try {
+		const current = await fsImpl.lstat(tempPath);
+		if (current.isFile() && !current.isSymbolicLink() && sameStableIdentity(tempStats, current)) {
+			await fsImpl.unlink(tempPath);
+		}
+	} catch {
+		// Preserve the publication error. Never unlink an identity we do not own.
+	}
+}
+
+async function publishDeclaredOutput(source, destination, target, claims, fsImpl) {
+	const expectedDestination = await captureDestinationFile(destination, target, claims, fsImpl);
+	const tempPath = path.join(path.dirname(destination), `.bobbit-pack-publish-${randomUUID()}`);
+	let tempStats;
+	try {
+		await assertClaimsCurrent(claims, fsImpl);
+		await fsImpl.copyFile(source, tempPath, fsConstants.COPYFILE_EXCL);
+		tempStats = await fsImpl.lstat(tempPath);
+		if (!tempStats.isFile() || tempStats.isSymbolicLink() || stableIdentity(tempStats) === undefined) {
+			throw new Error(`Mirror temporary output is not a stable regular file: ${tempPath}`);
+		}
+		const canonicalTemp = await fsImpl.realpath(tempPath);
+		if (!isWithin(target.canonicalPath, canonicalTemp)) {
+			throw new Error(`Mirror temporary output escapes its serving target: ${tempPath}`);
+		}
+		const canonicalTempStats = await fsImpl.lstat(canonicalTemp);
+		if (!canonicalTempStats.isFile() || !sameStableIdentity(tempStats, canonicalTempStats)) {
+			throw staleTargetError(tempPath);
+		}
+		await assertClaimsCurrent(claims, fsImpl);
+		await assertDestinationUnchanged(destination, expectedDestination, target, claims, fsImpl);
+		try {
+			await fsImpl.rename(tempPath, destination);
+		} catch (error) {
+			// Windows rename does not replace an existing file. Remove only the exact
+			// regular file claimed above, then publish by a same-parent rename. A raced
+			// replacement makes rename fail closed rather than following it.
+			if (process.platform !== "win32" || expectedDestination === undefined) throw error;
+			await assertDestinationUnchanged(destination, expectedDestination, target, claims, fsImpl);
+			await fsImpl.unlink(destination);
+			if (await lstatIfPresent(destination, fsImpl) !== undefined) throw staleTargetError(destination);
+			await assertClaimsCurrent(claims, fsImpl);
+			await fsImpl.rename(tempPath, destination);
+		}
+		const published = await fsImpl.lstat(destination);
+		if (!published.isFile() || published.isSymbolicLink() || !sameStableIdentity(tempStats, published)) {
+			throw staleTargetError(destination);
+		}
+		const canonicalPublished = await fsImpl.realpath(destination);
+		if (!isWithin(target.canonicalPath, canonicalPublished)) throw staleTargetError(destination);
+		const canonicalPublishedStats = await fsImpl.lstat(canonicalPublished);
+		if (!sameStableIdentity(tempStats, canonicalPublishedStats)) throw staleTargetError(destination);
+		await assertClaimsCurrent(claims, fsImpl);
+		tempStats = undefined;
+	} catch (error) {
+		if (tempStats) await cleanupOwnedTemporary(tempPath, tempStats, fsImpl);
+		throw error;
+	}
+}
+
 /** Mirror only declared outputs, retaining their pack-relative nested paths. */
 export async function mirrorDeclaredOutputs(declaration, targets, options = {}) {
 	const validated = validateDeclaration(declaration);
 	const root = path.resolve(options.projectRoot ?? projectRoot);
+	const fsImpl = options.fs ?? realMirrorFs;
 	for (const target of targets) {
 		for (const entry of validated.entries) {
 			const source = path.join(root, validated.authorRoot, entry.out);
-			const destination = path.join(target, entry.out);
-			await mkdir(path.dirname(destination), { recursive: true });
-			await copyFile(source, destination);
+			const destination = path.join(target.path, ...entry.out.split("/"));
+			const claims = await prepareDestinationParent(target, entry.out, fsImpl);
+			await publishDeclaredOutput(source, destination, target, claims, fsImpl);
 		}
 	}
 }

--- a/scripts/build-market-packs.mjs
+++ b/scripts/build-market-packs.mjs
@@ -480,7 +480,10 @@ export async function notifyVite(viteUrl, payload, options = {}) {
 		const endpoint = new URL(DEV_RELOAD_PATH, viteUrl);
 		const response = await (options.fetch ?? fetch)(endpoint, {
 			method: "POST",
-			headers: { "content-type": "application/json" },
+			headers: {
+				"content-type": "application/json",
+				"X-Bobbit-Pack-Reload": "1",
+			},
 			body: JSON.stringify(payload),
 			signal: controller.signal,
 		});

--- a/src/app/main.ts
+++ b/src/app/main.ts
@@ -1167,4 +1167,55 @@ if (import.meta.hot) {
 		// Flush any pending draft so the message editor content survives the reload
 		flushPendingDraft();
 	});
+
+	// Pack rebuilds arrive independently of Vite's module graph: the gateway serves
+	// their bytes and the client imports them through fresh Blob URLs. Serialize the
+	// invalidations so a slower event cannot repaint over a newer one, and recover the
+	// chain after every failure so one bad module never poisons later rebuilds.
+	let packReloadChain = Promise.resolve();
+	import.meta.hot.on("bobbit:pack-rebuilt", (payload: unknown) => {
+		packReloadChain = packReloadChain
+			.catch((error) => {
+				console.error("Pack hot reload failed", error);
+			})
+			.then(async () => {
+				const data = payload && typeof payload === "object" && !Array.isArray(payload)
+					? payload as Record<string, unknown>
+					: undefined;
+				const keys = data ? Object.keys(data) : [];
+				if (
+					!data ||
+					keys.length !== 2 ||
+					!keys.includes("pack") ||
+					!keys.includes("reloadToken") ||
+					typeof data.pack !== "string" ||
+					!/^[a-z0-9][a-z0-9-]*$/.test(data.pack) ||
+					typeof data.reloadToken !== "number" ||
+					!Number.isSafeInteger(data.reloadToken) ||
+					data.reloadToken <= 0
+				) {
+					throw new Error("Invalid bobbit:pack-rebuilt payload");
+				}
+
+				const [rendererModule, panelModule, registryModule] = await Promise.all([
+					import("./pack-renderers.js"),
+					import("./pack-panels.js"),
+					import("../ui/tools/renderer-registry.js"),
+				]);
+				const { invalidatePackRendererModules } = rendererModule as unknown as {
+					invalidatePackRendererModules(packId: string, reloadToken: number): string[];
+				};
+				const { invalidatePackPanelModules } = panelModule as unknown as {
+					invalidatePackPanelModules(packId: string, reloadToken: number): number;
+				};
+
+				const rendererNames = invalidatePackRendererModules(data.pack, data.reloadToken);
+				invalidatePackPanelModules(data.pack, data.reloadToken);
+				if (rendererNames.length > 0) registryModule.requestToolRender();
+				renderApp();
+			})
+			.catch((error) => {
+				console.error("Pack hot reload failed", error);
+			});
+	});
 }

--- a/src/app/pack-panels.ts
+++ b/src/app/pack-panels.ts
@@ -181,6 +181,11 @@ const loadedPanels = new Map<string, PackPanel>();
 /** key → in-flight load promise (so concurrent opens share one fetch). */
 const inFlight = new Map<string, Promise<PackPanel | undefined>>();
 
+/** Development-only successful rebuild token for a registered panel key. The
+ *  token is appended only to the authenticated module-byte request; it does not
+ *  participate in contribution or workspace identity. */
+const developmentReloadTokens = new Map<string, number>();
+
 /** Per-panel load-generation token. Bumped by {@link invalidatePanel} whenever a
  *  registration supersedes prior intent for the key (uninstall, or a project
  *  change that must re-fetch under the new scope). A load captures the generation
@@ -196,6 +201,22 @@ function invalidatePanel(key: string): void {
 	loadGeneration.set(key, (loadGeneration.get(key) ?? 0) + 1);
 	loadedPanels.delete(key);
 	inFlight.delete(key);
+}
+
+/** Invalidate the fetched panel modules owned by one rebuilt pack without
+ *  touching registrations or the durable side-panel workspace. Existing tab
+ *  ids, instance keys, params, order, and selection therefore remain unchanged;
+ *  mounted panels repaint through the normal render path while inactive panels
+ *  reload lazily when next selected. */
+export function invalidatePackPanelModules(packId: string, reloadToken: number): number {
+	let invalidated = 0;
+	for (const [key, panel] of panels) {
+		if (panel.packId !== packId) continue;
+		developmentReloadTokens.set(key, reloadToken);
+		invalidatePanel(key);
+		invalidated += 1;
+	}
+	return invalidated;
 }
 
 /**
@@ -235,6 +256,7 @@ export function registerPackPanels(
 		if (!incoming) {
 			// Uninstall / precedence change → invalidate + drop its tab.
 			invalidatePanel(key);
+			developmentReloadTokens.delete(key);
 			removePackPanelTab(prev.packId, prev.panelId);
 		} else if (incoming.projectId !== prev.projectId || opts?.invalidateLoaded) {
 			// Project change OR a forced pack-mutation re-register (update/reinstall):
@@ -321,7 +343,11 @@ function loadPanelModule(key: string, reg: RegisteredPanel): Promise<PackPanel |
 	if (existing) return existing;
 	if (loadedPanels.has(key)) return Promise.resolve(loadedPanels.get(key));
 	const gen = loadGeneration.get(key) ?? 0;
-	const qs = reg.projectId ? `?projectId=${encodeURIComponent(reg.projectId)}` : "";
+	const params = new URLSearchParams();
+	if (reg.projectId) params.set("projectId", reg.projectId);
+	const developmentReloadToken = developmentReloadTokens.get(key);
+	if (developmentReloadToken !== undefined) params.set("devReload", String(developmentReloadToken));
+	const qs = params.size > 0 ? `?${params.toString()}` : "";
 	const p: Promise<PackPanel | undefined> = (async () => {
 		const url = `/api/ext/packs/${encodeURIComponent(reg.packId)}/panels/${encodeURIComponent(reg.panelId)}${qs}`;
 		const resp = await gatewayFetch(url); // authed (admin bearer); static-asset-equivalent

--- a/src/app/pack-renderers.ts
+++ b/src/app/pack-renderers.ts
@@ -52,8 +52,29 @@ let packRegistered = new Set<string>();
  *  must resolve within its OWN pack; {@link packIdForTool} supplies that packId to
  *  the surface ref the tool renderer binds (see Messages.ts / ToolGroup.ts). */
 let toolPackIds = new Map<string, string>();
+/** Latest applied registration scope for each pack-renderer tool. Hot reload
+ *  replaces only the lazy loader, so it must retain the same project that
+ *  selected the winning renderer bytes. Rebuilt alongside {@link toolPackIds}. */
+let packRendererProjects = new Map<string, string | undefined>();
 /** Tool names whose current winning pack declares project local data. */
 let localDataTools = new Set<string>();
+
+function createPackRendererLoader(toolName: string, projectId?: string, devReload?: number) {
+	return async () => {
+		const params = new URLSearchParams();
+		if (projectId) params.set("projectId", projectId);
+		if (devReload !== undefined) params.set("devReload", String(devReload));
+		const query = params.toString();
+		const url = `/api/tools/${encodeURIComponent(toolName)}/renderer${query ? `?${query}` : ""}`;
+		const resp = await gatewayFetch(url); // authed (admin bearer); no session binding needed
+		if (!resp.ok) throw new Error(`renderer ${toolName} HTTP ${resp.status}`);
+		const blob = await resp.blob();
+		const mod = await importJavaScriptModuleBlob(blob);
+		const factory = (mod as any).default ?? (mod as any).createRenderer;
+		if (typeof factory !== "function") throw new Error("renderer module has no factory export");
+		return factory(HOST_TOOLKIT); // → ToolRenderer
+	};
+}
 
 /** The structural `packId` that contributed `toolName` (a pack renderer tool), or
  *  `undefined` for a built-in / unknown tool. Used to bind the tool renderer's
@@ -86,27 +107,15 @@ export function registerPackRenderers(
 ): void {
 	const next = new Set<string>();
 	const nextPackIds = new Map<string, string>();
+	const nextProjects = new Map<string, string | undefined>();
 	const nextLocalDataTools = new Set<string>();
 	for (const t of tools) {
 		if (t.rendererKind !== "pack") continue;
 		next.add(t.name);
 		if (typeof t.packId === "string" && t.packId) nextPackIds.set(t.name, t.packId);
+		nextProjects.set(t.name, projectId);
 		if (t.hasLocalData === true) nextLocalDataTools.add(t.name);
-		const qs = projectId ? `?projectId=${encodeURIComponent(projectId)}` : "";
-		registerLazyToolRenderer(
-			t.name,
-			async () => {
-				const url = `/api/tools/${encodeURIComponent(t.name)}/renderer${qs}`;
-				const resp = await gatewayFetch(url); // authed (admin bearer); no session binding needed
-				if (!resp.ok) throw new Error(`renderer ${t.name} HTTP ${resp.status}`);
-				const blob = await resp.blob();
-				const mod = await importJavaScriptModuleBlob(blob);
-				const factory = (mod as any).default ?? (mod as any).createRenderer;
-				if (typeof factory !== "function") throw new Error("renderer module has no factory export");
-				return factory(HOST_TOOLKIT); // → ToolRenderer
-			},
-			{ override: true },
-		);
+		registerLazyToolRenderer(t.name, createPackRendererLoader(t.name, projectId), { override: true });
 	}
 	// RECONCILE: any name we previously registered as a pack renderer but that is
 	// no longer pack-owned in the fresh metadata (uninstall / precedence change)
@@ -119,7 +128,27 @@ export function registerPackRenderers(
 	// Rebuild the tool→packId map from the fresh metadata (drops uninstalled tools'
 	// entries) so `packIdForTool` always reflects the current winning providers.
 	toolPackIds = nextPackIds;
+	packRendererProjects = nextProjects;
 	localDataTools = nextLocalDataTools;
+}
+
+/**
+ * Replace the lazy loaders owned by one pack after a successful development
+ * rebuild. Re-registering through the renderer registry's existing override
+ * chokepoint invalidates loaded and in-flight modules while preserving displaced
+ * built-ins. Ownership maps and project scope remain unchanged.
+ *
+ * @returns the affected tool names for the caller to repaint.
+ */
+export function invalidatePackRendererModules(packId: string, reloadToken: number): string[] {
+	const affected: string[] = [];
+	for (const [toolName, ownerPackId] of toolPackIds) {
+		if (ownerPackId !== packId) continue;
+		const projectId = packRendererProjects.get(toolName);
+		registerLazyToolRenderer(toolName, createPackRendererLoader(toolName, projectId, reloadToken), { override: true });
+		affected.push(toolName);
+	}
+	return affected;
 }
 
 /** Sentinel: no reconcile has run yet. Distinct from `undefined` (reconciled

--- a/tests2/browser/fixtures/pack-hot-reload/pack-hot-reload-fixture/lib/nested/hot-reload/panel.js
+++ b/tests2/browser/fixtures/pack-hot-reload/pack-hot-reload-fixture/lib/nested/hot-reload/panel.js
@@ -1,0 +1,17 @@
+export default function createPanel({ html }) {
+	const version = "v1";
+	return {
+		render(params) {
+			return html`
+				<section
+					data-testid="pack-hot-reload-panel"
+					data-version=${version}
+					data-artifact-id=${String(params?.artifactId ?? "")}
+					data-marker=${String(params?.marker ?? "")}
+				>
+					<span data-testid="pack-hot-reload-panel-version">panel ${version}</span>
+				</section>
+			`;
+		},
+	};
+}

--- a/tests2/browser/fixtures/pack-hot-reload/pack-hot-reload-fixture/lib/nested/hot-reload/renderer.js
+++ b/tests2/browser/fixtures/pack-hot-reload/pack-hot-reload-fixture/lib/nested/hot-reload/renderer.js
@@ -1,0 +1,20 @@
+export default function createRenderer({ html }) {
+	const version = "v1";
+	return {
+		render(_params, _result, _isStreaming, ctx) {
+			const openPanel = () => ctx?.host?.ui?.openPanel({
+				panelId: "hot-reload-fixture.detail",
+				params: { artifactId: "artifact-42", marker: "stable-marker" },
+			});
+			return {
+				isCustom: false,
+				content: html`
+					<section data-testid="pack-hot-reload-renderer" data-version=${version}>
+						<span data-testid="pack-hot-reload-renderer-version">renderer ${version}</span>
+						<button type="button" data-testid="pack-hot-reload-open-panel" @click=${openPanel}>Open fixture panel</button>
+					</section>
+				`,
+			};
+		},
+	};
+}

--- a/tests2/browser/fixtures/pack-hot-reload/pack-hot-reload-fixture/pack.yaml
+++ b/tests2/browser/fixtures/pack-hot-reload/pack-hot-reload-fixture/pack.yaml
@@ -1,0 +1,9 @@
+name: pack-hot-reload-fixture
+schema: 2
+description: Browser journey fixture for generic marketplace-pack development hot reload.
+version: 1.0.0
+contents:
+  roles: []
+  tools: [hot-reload]
+  skills: []
+  entrypoints: []

--- a/tests2/browser/fixtures/pack-hot-reload/pack-hot-reload-fixture/panels/hot-reload-panel.yaml
+++ b/tests2/browser/fixtures/pack-hot-reload/pack-hot-reload-fixture/panels/hot-reload-panel.yaml
@@ -1,0 +1,5 @@
+id: hot-reload-fixture.detail
+title: Hot Reload Fixture
+entry: ../lib/nested/hot-reload/panel.js
+instanceMode: parameterized
+instanceParam: artifactId

--- a/tests2/browser/fixtures/pack-hot-reload/pack-hot-reload-fixture/tools/hot-reload/pack_hot_reload_probe.yaml
+++ b/tests2/browser/fixtures/pack-hot-reload/pack-hot-reload-fixture/tools/hot-reload/pack_hot_reload_probe.yaml
@@ -1,0 +1,5 @@
+name: pack_hot_reload_probe
+description: Browser fixture tool whose nested renderer opens the parameterized hot-reload panel.
+group: Test Fixtures
+summary: Exercises development-only marketplace-pack module reconciliation.
+renderer: ../../lib/nested/hot-reload/renderer.js

--- a/tests2/browser/journeys/pack-hot-reload.journey.spec.ts
+++ b/tests2/browser/journeys/pack-hot-reload.journey.spec.ts
@@ -1,5 +1,4 @@
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { cpSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import type { Page } from "@playwright/test";
@@ -78,14 +77,14 @@ async function responseText(response: Response): Promise<string> {
 	return response.clone().text().catch(() => "");
 }
 
-async function addFixtureSource(): Promise<string> {
+async function addFixtureSource(sourceRoot: string): Promise<string> {
 	const response = await apiFetch("/api/marketplace/sources", {
 		method: "POST",
-		body: JSON.stringify({ url: SOURCE_DIR }),
+		body: JSON.stringify({ url: sourceRoot }),
 	});
 	if (response.status === 409) {
 		const list = await apiFetch("/api/marketplace/sources");
-		const source = ((await list.json()).sources ?? []).find((item: { id: string; url: string }) => item.url === SOURCE_DIR);
+		const source = ((await list.json()).sources ?? []).find((item: { id: string; url: string }) => item.url === sourceRoot);
 		expect(source, "the existing hot-reload fixture source should be discoverable").toBeTruthy();
 		return source.id;
 	}
@@ -99,6 +98,14 @@ async function installFixturePack(sourceId: string, projectId: string): Promise<
 		body: JSON.stringify({ sourceId, dirName: PACK_NAME, scope: "project", projectId }),
 	});
 	expect(response.status, `fixture pack installation failed: ${await responseText(response)}`).toBe(201);
+}
+
+async function updateFixturePack(projectId: string): Promise<void> {
+	const response = await apiFetch("/api/marketplace/update", {
+		method: "POST",
+		body: JSON.stringify({ scope: "project", packName: PACK_NAME, projectId }),
+	});
+	expect(response.status, `fixture pack update failed: ${await responseText(response)}`).toBe(200);
 }
 
 async function uninstallFixturePack(projectId: string): Promise<void> {
@@ -184,7 +191,13 @@ function isPanelRequest(raw: string): boolean {
 test.describe("Journey: marketplace-pack development hot reload", () => {
 	test("repaints nested renderer and parameterized panel while preserving page and workspace identity", async ({ page, gateway }) => {
 		test.setTimeout(150_000);
-		const projectRoot = mkdtempSync(join(tmpdir(), "bobbit-pack-hot-reload-"));
+		const runRoot = process.env.BOBBIT_E2E_TMP_ROOT;
+		if (!runRoot) throw new Error("BOBBIT_E2E_TMP_ROOT must identify the browser run root");
+		const tempRoot = mkdtempSync(join(runRoot, "pack-hot-reload-"));
+		const projectRoot = join(tempRoot, "project");
+		const marketplaceSourceRoot = join(tempRoot, "marketplace-source");
+		mkdirSync(projectRoot, { recursive: true });
+		cpSync(SOURCE_DIR, marketplaceSourceRoot, { recursive: true });
 		let projectId: string | undefined;
 		let sessionId: string | undefined;
 		let sourceId: string | undefined;
@@ -198,7 +211,7 @@ test.describe("Journey: marketplace-pack development hot reload", () => {
 				rootPath: projectRoot,
 				seedWorkflows: false,
 			})).id;
-			sourceId = await addFixtureSource();
+			sourceId = await addFixtureSource(marketplaceSourceRoot);
 			await installFixturePack(sourceId, projectId);
 			sessionId = await createSession({ projectId, cwd: projectRoot });
 			await waitForSessionStatus(sessionId, "idle", 30_000);
@@ -247,9 +260,10 @@ test.describe("Journey: marketplace-pack development hot reload", () => {
 				stateParams: { artifactId: "artifact-42", marker: "stable-marker" },
 			});
 
-			const installedPackRoot = join(projectRoot, ".bobbit", "config", "market-packs", PACK_NAME);
-			writeFileSync(join(installedPackRoot, "lib", "nested", "hot-reload", "renderer.js"), rendererBundle("v2"), "utf8");
-			writeFileSync(join(installedPackRoot, "lib", "nested", "hot-reload", "panel.js"), panelBundle("v2"), "utf8");
+			const authoredPackRoot = join(marketplaceSourceRoot, PACK_NAME);
+			writeFileSync(join(authoredPackRoot, "lib", "nested", "hot-reload", "renderer.js"), rendererBundle("v2"), "utf8");
+			writeFileSync(join(authoredPackRoot, "lib", "nested", "hot-reload", "panel.js"), panelBundle("v2"), "utf8");
+			await updateFixturePack(projectId);
 
 			const rebuilt = await fetch(`${viteBaseUrl}/__bobbit_dev/pack-rebuilt`, {
 				method: "POST",
@@ -293,7 +307,7 @@ test.describe("Journey: marketplace-pack development hot reload", () => {
 			if (projectId) await uninstallFixturePack(projectId).catch((error) => cleanupFailures.push(error));
 			if (sourceId) await apiFetch(`/api/marketplace/sources/${encodeURIComponent(sourceId)}`, { method: "DELETE" }).catch((error) => cleanupFailures.push(error));
 			if (projectId) await apiFetch(`/api/projects/${encodeURIComponent(projectId)}`, { method: "DELETE" }).catch((error) => cleanupFailures.push(error));
-			try { rmSync(projectRoot, { recursive: true, force: true }); } catch (error) { cleanupFailures.push(error); }
+			try { rmSync(tempRoot, { recursive: true, force: true }); } catch (error) { cleanupFailures.push(error); }
 			if (cleanupFailures.length > 0) throw new AggregateError(cleanupFailures, "hot-reload journey cleanup failed");
 		}
 	});

--- a/tests2/browser/journeys/pack-hot-reload.journey.spec.ts
+++ b/tests2/browser/journeys/pack-hot-reload.journey.spec.ts
@@ -267,7 +267,10 @@ test.describe("Journey: marketplace-pack development hot reload", () => {
 
 			const rebuilt = await fetch(`${viteBaseUrl}/__bobbit_dev/pack-rebuilt`, {
 				method: "POST",
-				headers: { "Content-Type": "application/json" },
+				headers: {
+					"Content-Type": "application/json",
+					"X-Bobbit-Pack-Reload": "1",
+				},
 				body: JSON.stringify({ pack: PACK_NAME, reloadToken: RELOAD_TOKEN }),
 			});
 			expect(rebuilt.status, `Vite pack rebuild bridge failed: ${await rebuilt.clone().text()}`).toBe(204);

--- a/tests2/browser/journeys/pack-hot-reload.journey.spec.ts
+++ b/tests2/browser/journeys/pack-hot-reload.journey.spec.ts
@@ -1,0 +1,300 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import type { Page } from "@playwright/test";
+import {
+	apiFetch,
+	createSession,
+	deleteSession,
+	expect,
+	navigateToHash,
+	registerProject,
+	test,
+	waitForSessionStatus,
+} from "../_helpers/journey-fixture.js";
+import { readE2EToken } from "../e2e-setup.js";
+import { getFreePort } from "../e2e/packaged-runtime-helpers.js";
+import {
+	startSourceVite,
+	stopSourceProcess,
+	waitForSourceVite,
+	type RunningSourceProcess,
+} from "../e2e/source-vite-runtime-helpers.js";
+
+const REPO_ROOT = resolve(import.meta.dirname, "..", "..", "..");
+const SOURCE_DIR = fileURLToPath(new URL("../fixtures/pack-hot-reload", import.meta.url));
+const PACK_NAME = "pack-hot-reload-fixture";
+const TOOL_NAME = "pack_hot_reload_probe";
+const PANEL_ID = "hot-reload-fixture.detail";
+const RELOAD_TOKEN = 42;
+
+function rendererBundle(version: "v2"): string {
+	return `export default function createRenderer({ html }) {
+\tconst version = ${JSON.stringify(version)};
+\treturn {
+\t\trender(_params, _result, _isStreaming, ctx) {
+\t\t\tconst openPanel = () => ctx?.host?.ui?.openPanel({
+\t\t\t\tpanelId: "${PANEL_ID}",
+\t\t\t\tparams: { artifactId: "artifact-42", marker: "stable-marker" },
+\t\t\t});
+\t\t\treturn {
+\t\t\t\tisCustom: false,
+\t\t\t\tcontent: html\`
+\t\t\t\t\t<section data-testid="pack-hot-reload-renderer" data-version=\${version}>
+\t\t\t\t\t\t<span data-testid="pack-hot-reload-renderer-version">renderer \${version}</span>
+\t\t\t\t\t\t<button type="button" data-testid="pack-hot-reload-open-panel" @click=\${openPanel}>Open fixture panel</button>
+\t\t\t\t\t</section>
+\t\t\t\t\`,
+\t\t\t};
+\t\t},
+\t};
+}
+`;
+}
+
+function panelBundle(version: "v2"): string {
+	return `export default function createPanel({ html }) {
+\tconst version = ${JSON.stringify(version)};
+\treturn {
+\t\trender(params) {
+\t\t\treturn html\`
+\t\t\t\t<section
+\t\t\t\t\tdata-testid="pack-hot-reload-panel"
+\t\t\t\t\tdata-version=\${version}
+\t\t\t\t\tdata-artifact-id=\${String(params?.artifactId ?? "")}
+\t\t\t\t\tdata-marker=\${String(params?.marker ?? "")}
+\t\t\t\t>
+\t\t\t\t\t<span data-testid="pack-hot-reload-panel-version">panel \${version}</span>
+\t\t\t\t</section>
+\t\t\t\`;
+\t\t},
+\t};
+}
+`;
+}
+
+async function responseText(response: Response): Promise<string> {
+	return response.clone().text().catch(() => "");
+}
+
+async function addFixtureSource(): Promise<string> {
+	const response = await apiFetch("/api/marketplace/sources", {
+		method: "POST",
+		body: JSON.stringify({ url: SOURCE_DIR }),
+	});
+	if (response.status === 409) {
+		const list = await apiFetch("/api/marketplace/sources");
+		const source = ((await list.json()).sources ?? []).find((item: { id: string; url: string }) => item.url === SOURCE_DIR);
+		expect(source, "the existing hot-reload fixture source should be discoverable").toBeTruthy();
+		return source.id;
+	}
+	expect(response.status, `fixture source registration failed: ${await responseText(response)}`).toBe(201);
+	return (await response.json()).source.id;
+}
+
+async function installFixturePack(sourceId: string, projectId: string): Promise<void> {
+	const response = await apiFetch("/api/marketplace/install", {
+		method: "POST",
+		body: JSON.stringify({ sourceId, dirName: PACK_NAME, scope: "project", projectId }),
+	});
+	expect(response.status, `fixture pack installation failed: ${await responseText(response)}`).toBe(201);
+}
+
+async function uninstallFixturePack(projectId: string): Promise<void> {
+	await apiFetch("/api/marketplace/installed", {
+		method: "DELETE",
+		body: JSON.stringify({ scope: "project", projectId, packName: PACK_NAME }),
+	}).catch(() => {});
+}
+
+function seedToolTranscript(gateway: any, sessionId: string): void {
+	const agent = gateway.sessionManager?.getSession(sessionId)?.rpcClient?._agent;
+	if (!Array.isArray(agent?.conversationMessages)) throw new Error("hot-reload journey requires the in-process mock agent transcript");
+	const toolCallId = "pack-hot-reload-tool-call";
+	agent.conversationMessages = [
+		{
+			id: `${toolCallId}-assistant`,
+			role: "assistant",
+			content: [{ type: "toolCall", id: toolCallId, name: TOOL_NAME, arguments: { artifactId: "artifact-42" } }],
+			timestamp: 1,
+		},
+		{
+			id: `${toolCallId}-result`,
+			role: "toolResult",
+			toolCallId,
+			toolName: TOOL_NAME,
+			isError: false,
+			content: [{ type: "text", text: "fixture result" }],
+			timestamp: 2,
+		},
+	];
+}
+
+interface WorkspaceSnapshot {
+	tabCount: number;
+	tabOrder: string[];
+	activeId: string;
+	packTab: {
+		id: string;
+		kind: string;
+		packId: string;
+		panelId: string;
+		instanceKey: string;
+		params: Record<string, unknown> | null;
+		stateInstanceKey: string;
+		stateParams: Record<string, unknown> | null;
+	};
+}
+
+async function workspaceSnapshot(page: Page, sessionId: string): Promise<WorkspaceSnapshot> {
+	return page.evaluate(({ sessionId, packName, panelId }) => {
+		const state = (window as any).__bobbitState;
+		const tabs = Array.isArray(state?.panelTabsBySession?.[sessionId]) ? state.panelTabsBySession[sessionId] : [];
+		const tab = tabs.find((candidate: any) => candidate?.source?.type === "pack"
+			&& candidate.source.packId === packName
+			&& candidate.source.panelId === panelId);
+		if (!tab) throw new Error("parameterized hot-reload panel tab was not present in the workspace");
+		return {
+			tabCount: tabs.length,
+			tabOrder: tabs.map((candidate: any) => String(candidate.id)),
+			activeId: String(state.panelWorkspaceActiveBySession?.[sessionId] ?? state.activePanelTabId ?? ""),
+			packTab: {
+				id: String(tab.id),
+				kind: String(tab.kind),
+				packId: String(tab.source.packId),
+				panelId: String(tab.source.panelId),
+				instanceKey: String(tab.source.instanceKey),
+				params: tab.source.params ? structuredClone(tab.source.params) : null,
+				stateInstanceKey: String(tab.state?.instanceKey),
+				stateParams: tab.state?.params ? structuredClone(tab.state.params) : null,
+			},
+		};
+	}, { sessionId, packName: PACK_NAME, panelId: PANEL_ID });
+}
+
+function isRendererRequest(raw: string): boolean {
+	return new URL(raw).pathname === `/api/tools/${TOOL_NAME}/renderer`;
+}
+
+function isPanelRequest(raw: string): boolean {
+	return new URL(raw).pathname === `/api/ext/packs/${PACK_NAME}/panels/${PANEL_ID}`;
+}
+
+test.describe("Journey: marketplace-pack development hot reload", () => {
+	test("repaints nested renderer and parameterized panel while preserving page and workspace identity", async ({ page, gateway }) => {
+		test.setTimeout(150_000);
+		const projectRoot = mkdtempSync(join(tmpdir(), "bobbit-pack-hot-reload-"));
+		let projectId: string | undefined;
+		let sessionId: string | undefined;
+		let sourceId: string | undefined;
+		let vite: RunningSourceProcess | undefined;
+		const moduleRequests: string[] = [];
+		const cleanupFailures: unknown[] = [];
+
+		try {
+			projectId = (await registerProject({
+				name: `pack-hot-reload-${Date.now()}`,
+				rootPath: projectRoot,
+				seedWorkflows: false,
+			})).id;
+			sourceId = await addFixtureSource();
+			await installFixturePack(sourceId, projectId);
+			sessionId = await createSession({ projectId, cwd: projectRoot });
+			await waitForSessionStatus(sessionId, "idle", 30_000);
+			seedToolTranscript(gateway, sessionId);
+
+			const vitePort = await getFreePort();
+			const viteBaseUrl = `http://127.0.0.1:${vitePort}`;
+			vite = startSourceVite({
+				repoRoot: REPO_ROOT,
+				tempRoot: projectRoot,
+				gatewayUrl: gateway.baseURL,
+				port: vitePort,
+			});
+			await waitForSourceVite(viteBaseUrl, vite);
+
+			page.on("request", (request) => {
+				if (isRendererRequest(request.url()) || isPanelRequest(request.url())) moduleRequests.push(request.url());
+			});
+			const token = readE2EToken();
+			await page.goto(`${viteBaseUrl}/?token=${encodeURIComponent(token)}`, { waitUntil: "domcontentloaded" });
+			await navigateToHash(page, `#/session/${sessionId}`);
+			await expect(page.locator("message-editor textarea").first()).toBeVisible({ timeout: 25_000 });
+
+			const renderer = page.getByTestId("pack-hot-reload-renderer");
+			await expect(renderer).toHaveAttribute("data-version", "v1", { timeout: 25_000 });
+			await page.getByTestId("pack-hot-reload-open-panel").click();
+			const panel = page.getByTestId("pack-hot-reload-panel");
+			await expect(panel).toHaveAttribute("data-version", "v1", { timeout: 25_000 });
+			await expect(panel).toHaveAttribute("data-artifact-id", "artifact-42");
+			await expect(panel).toHaveAttribute("data-marker", "stable-marker");
+
+			await page.evaluate(() => {
+				(window as any).__packHotReloadPageIdentity = { nonce: crypto.randomUUID() };
+				(window as any).__packHotReloadOriginalPageIdentity = (window as any).__packHotReloadPageIdentity;
+			});
+			const urlBefore = page.url();
+			const workspaceBefore = await workspaceSnapshot(page, sessionId);
+			expect(workspaceBefore.activeId).toBe(workspaceBefore.packTab.id);
+			expect(workspaceBefore.packTab).toMatchObject({
+				kind: "pack",
+				packId: PACK_NAME,
+				panelId: PANEL_ID,
+				instanceKey: "artifact-42",
+				stateInstanceKey: "artifact-42",
+				params: { artifactId: "artifact-42", marker: "stable-marker" },
+				stateParams: { artifactId: "artifact-42", marker: "stable-marker" },
+			});
+
+			const installedPackRoot = join(projectRoot, ".bobbit", "config", "market-packs", PACK_NAME);
+			writeFileSync(join(installedPackRoot, "lib", "nested", "hot-reload", "renderer.js"), rendererBundle("v2"), "utf8");
+			writeFileSync(join(installedPackRoot, "lib", "nested", "hot-reload", "panel.js"), panelBundle("v2"), "utf8");
+
+			const rebuilt = await fetch(`${viteBaseUrl}/__bobbit_dev/pack-rebuilt`, {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ pack: PACK_NAME, reloadToken: RELOAD_TOKEN }),
+			});
+			expect(rebuilt.status, `Vite pack rebuild bridge failed: ${await rebuilt.clone().text()}`).toBe(204);
+
+			await expect(renderer).toHaveAttribute("data-version", "v2", { timeout: 25_000 });
+			await expect(panel).toHaveAttribute("data-version", "v2", { timeout: 25_000 });
+			await expect(panel).toHaveAttribute("data-artifact-id", "artifact-42");
+			await expect(panel).toHaveAttribute("data-marker", "stable-marker");
+			expect(page.url(), "pack reload must not navigate the page").toBe(urlBefore);
+			expect(await page.evaluate(() => (window as any).__packHotReloadPageIdentity === (window as any).__packHotReloadOriginalPageIdentity),
+				"custom pack reconciliation must preserve the live page realm").toBe(true);
+			expect(await workspaceSnapshot(page, sessionId), "hot reload must preserve tab order, active selection, params, and instance identity").toEqual(workspaceBefore);
+
+			await expect.poll(() => moduleRequests.some((raw) => isRendererRequest(raw) && new URL(raw).searchParams.get("devReload") === String(RELOAD_TOKEN)), {
+				timeout: 20_000,
+				message: "renderer reload must use the successful-cycle token on the authenticated byte fetch",
+			}).toBe(true);
+			await expect.poll(() => moduleRequests.some((raw) => isPanelRequest(raw) && new URL(raw).searchParams.get("devReload") === String(RELOAD_TOKEN)), {
+				timeout: 20_000,
+				message: "panel reload must use the successful-cycle token on the authenticated byte fetch",
+			}).toBe(true);
+
+			const requestsBeforeReload = moduleRequests.length;
+			await page.reload({ waitUntil: "domcontentloaded" });
+			await expect(page.getByTestId("pack-hot-reload-renderer")).toHaveAttribute("data-version", "v2", { timeout: 30_000 });
+			await expect(page.getByTestId("pack-hot-reload-panel")).toHaveAttribute("data-version", "v2", { timeout: 30_000 });
+			expect(await page.evaluate(() => typeof (window as any).__packHotReloadPageIdentity), "ordinary reload must create a new page realm").toBe("undefined");
+			expect(await workspaceSnapshot(page, sessionId), "ordinary reload must restore the same durable parameterized tab").toEqual(workspaceBefore);
+			const ordinaryReloadRequests = moduleRequests.slice(requestsBeforeReload);
+			expect(ordinaryReloadRequests.some((raw) => isRendererRequest(raw) && !new URL(raw).searchParams.has("devReload")),
+				"ordinary reload must restore v2 through the normal renderer byte URL").toBe(true);
+			expect(ordinaryReloadRequests.some((raw) => isPanelRequest(raw) && !new URL(raw).searchParams.has("devReload")),
+				"ordinary reload must restore v2 through the normal panel byte URL").toBe(true);
+		} finally {
+			if (vite) await stopSourceProcess(vite).catch((error) => cleanupFailures.push(error));
+			if (sessionId) await deleteSession(sessionId).catch((error) => cleanupFailures.push(error));
+			if (projectId) await uninstallFixturePack(projectId).catch((error) => cleanupFailures.push(error));
+			if (sourceId) await apiFetch(`/api/marketplace/sources/${encodeURIComponent(sourceId)}`, { method: "DELETE" }).catch((error) => cleanupFailures.push(error));
+			if (projectId) await apiFetch(`/api/projects/${encodeURIComponent(projectId)}`, { method: "DELETE" }).catch((error) => cleanupFailures.push(error));
+			try { rmSync(projectRoot, { recursive: true, force: true }); } catch (error) { cleanupFailures.push(error); }
+			if (cleanupFailures.length > 0) throw new AggregateError(cleanupFailures, "hot-reload journey cleanup failed");
+		}
+	});
+});

--- a/tests2/core/market-pack-dev.test.ts
+++ b/tests2/core/market-pack-dev.test.ts
@@ -564,7 +564,14 @@ describe("Vite notification", () => {
 		expect(fetchMock).toHaveBeenCalledOnce();
 		const [url, init] = fetchMock.mock.calls[0];
 		expect(String(url)).toBe("http://127.0.0.1:5173/__bobbit_dev/pack-rebuilt");
-		expect(init).toMatchObject({ method: "POST", body: '{"pack":"fixture","reloadToken":7}' });
+		expect(init).toMatchObject({
+			method: "POST",
+			headers: {
+				"content-type": "application/json",
+				"X-Bobbit-Pack-Reload": "1",
+			},
+			body: '{"pack":"fixture","reloadToken":7}',
+		});
 		await expect(notifyVite("http://127.0.0.1:5173", { pack: "fixture", reloadToken: 8 }, {
 			fetch: async () => ({ status: 200 }),
 		})).rejects.toThrow("HTTP 200");

--- a/tests2/core/market-pack-dev.test.ts
+++ b/tests2/core/market-pack-dev.test.ts
@@ -1,5 +1,5 @@
 import { EventEmitter } from "node:events";
-import { mkdtemp, mkdir, readFile, realpath, rm, symlink, writeFile } from "node:fs/promises";
+import { copyFile, lstat, mkdtemp, mkdir, readFile, realpath, rename, rm, symlink, unlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -40,6 +40,18 @@ async function createPackRoot(root: string, relative: string, name = "fixture") 
 	await mkdir(target, { recursive: true });
 	await writeFile(path.join(target, "pack.yaml"), `schema: 2\nname: ${name}\n`);
 	return target;
+}
+
+async function createBuiltOutputs(root: string, declared = declaration()) {
+	const author = await createPackRoot(root, declared.authorRoot, declared.pack);
+	await mkdir(path.join(author, "lib", "nested"), { recursive: true });
+	await writeFile(path.join(author, "lib", "nested", "panel.js"), "panel-current");
+	await writeFile(path.join(author, "lib", "route.mjs"), "route-current");
+	return author;
+}
+
+async function createDirectoryLink(target: string, linkPath: string) {
+	await symlink(target, linkPath, process.platform === "win32" ? "junction" : "dir");
 }
 
 afterEach(async () => {
@@ -103,7 +115,9 @@ describe("market pack serving target resolution", () => {
 		await createPackRoot(root, "dist/other-discovery/fixture");
 		await createPackRoot(root, "market-packs/stale/lib/fixture");
 
-		expect(await servingTargets(declared, [], { projectRoot: root })).toEqual([await realpath(expected)]);
+		const targets = await servingTargets(declared, [], { projectRoot: root });
+		expect(targets.map((target: { path: string }) => target.path)).toEqual([await realpath(expected)]);
+		expect(targets[0]?.identity).toMatch(/^.+:.+$/);
 	});
 
 	it("fails deterministically when the default is missing or has the wrong manifest", async () => {
@@ -138,10 +152,11 @@ describe("market pack serving target resolution", () => {
 		await createPackRoot(root, declared.authorRoot);
 		const alpha = await createPackRoot(root, "served/alpha");
 		const zulu = await createPackRoot(root, "served/zulu");
-		expect(await servingTargets(declared, ["served/zulu", "served/alpha", "served/alpha"], {
+		const targets = await servingTargets(declared, ["served/zulu", "served/alpha", "served/alpha"], {
 			projectRoot: root,
 			caseInsensitive: true,
-		})).toEqual([await realpath(alpha), await realpath(zulu)]);
+		});
+		expect(targets.map((target: { path: string }) => target.path)).toEqual([await realpath(alpha), await realpath(zulu)]);
 	});
 
 	it("rejects a symlink alias of the authored root", async () => {
@@ -194,17 +209,102 @@ describe("selected pack build and mirror", () => {
 	it("mirrors declared nested output paths without flattening or discovery", async () => {
 		const root = await fixtureRoot();
 		const declared = declaration();
-		const author = path.join(root, declared.authorRoot);
+		const author = await createBuiltOutputs(root, declared);
 		const target = await createPackRoot(root, "served/fixture");
-		await mkdir(path.join(author, "lib", "nested"), { recursive: true });
-		await writeFile(path.join(author, "lib", "nested", "panel.js"), "panel-current");
-		await writeFile(path.join(author, "lib", "route.mjs"), "route-current");
+		await mkdir(path.join(target, "lib", "nested"), { recursive: true });
+		await writeFile(path.join(target, "lib", "nested", "panel.js"), "panel-old");
+		await writeFile(path.join(target, "lib", "route.mjs"), "route-old");
 		await writeFile(path.join(author, "lib", "stale.js"), "must-not-mirror");
 
-		await mirrorDeclaredOutputs(declared, [target], { projectRoot: root });
+		const targets = await servingTargets(declared, ["served/fixture"], { projectRoot: root });
+		await mirrorDeclaredOutputs(declared, targets, { projectRoot: root });
 		expect(await readFile(path.join(target, "lib", "nested", "panel.js"), "utf8")).toBe("panel-current");
 		expect(await readFile(path.join(target, "lib", "route.mjs"), "utf8")).toBe("route-current");
 		await expect(readFile(path.join(target, "lib", "stale.js"))).rejects.toMatchObject({ code: "ENOENT" });
+	});
+
+	it("rejects a declared output parent symlink or junction without writing outside the target", async () => {
+		const root = await fixtureRoot();
+		const declared = declaration();
+		await createBuiltOutputs(root, declared);
+		await createPackRoot(root, "served/fixture");
+		const outside = path.join(root, "outside-parent");
+		await mkdir(outside);
+		await createDirectoryLink(outside, path.join(root, "served/fixture/lib"));
+		const targets = await servingTargets(declared, ["served/fixture"], { projectRoot: root });
+
+		await expect(mirrorDeclaredOutputs(declared, targets, { projectRoot: root })).rejects.toThrow(
+			"changed or is unsafe",
+		);
+		await expect(readFile(path.join(outside, "nested", "panel.js"))).rejects.toMatchObject({ code: "ENOENT" });
+	});
+
+	it("rejects a final output symlink and leaves its external sentinel unchanged", async () => {
+		const root = await fixtureRoot();
+		const declared = declaration();
+		await createBuiltOutputs(root, declared);
+		const target = await createPackRoot(root, "served/fixture");
+		const parent = path.join(target, "lib", "nested");
+		await mkdir(parent, { recursive: true });
+		const sentinel = path.join(root, "outside-sentinel.js");
+		const destination = path.join(parent, "panel.js");
+		await writeFile(sentinel, "sentinel-original");
+		let fileLinkAvailable = true;
+		try {
+			await symlink(sentinel, destination, "file");
+		} catch (error) {
+			if (!["EPERM", "EACCES", "ENOTSUP"].includes((error as NodeJS.ErrnoException).code ?? "")) throw error;
+			fileLinkAvailable = false;
+			await writeFile(destination, "existing-output");
+		}
+		const targets = await servingTargets(declared, ["served/fixture"], { projectRoot: root });
+		const realFs = { copyFile, lstat, mkdir, realpath, rename, unlink };
+		const fs = fileLinkAvailable ? realFs : {
+			...realFs,
+			async lstat(filePath: string) {
+				const stats = await lstat(filePath);
+				if (filePath !== destination) return stats;
+				return { ...stats, isFile: () => true, isDirectory: () => false, isSymbolicLink: () => true };
+			},
+		};
+
+		await expect(mirrorDeclaredOutputs(declared, targets, { projectRoot: root, fs })).rejects.toThrow(
+			"not a stable regular file",
+		);
+		expect(await readFile(sentinel, "utf8")).toBe("sentinel-original");
+	});
+
+	it("rejects a serving root identity replaced after validation without writing into the replacement", async () => {
+		const root = await fixtureRoot();
+		const declared = declaration();
+		await createBuiltOutputs(root, declared);
+		const target = await createPackRoot(root, "served/fixture");
+		const targets = await servingTargets(declared, ["served/fixture"], { projectRoot: root });
+		const displaced = path.join(root, "served/fixture-displaced");
+		await rename(target, displaced);
+		await mkdir(target);
+
+		await expect(mirrorDeclaredOutputs(declared, targets, { projectRoot: root })).rejects.toMatchObject({ code: "ESTALE" });
+		await expect(readFile(path.join(target, "lib", "nested", "panel.js"))).rejects.toMatchObject({ code: "ENOENT" });
+	});
+
+	it("rejects an output parent replaced after validation without mutating an outside sentinel", async () => {
+		const root = await fixtureRoot();
+		const declared = declaration();
+		await createBuiltOutputs(root, declared);
+		const target = await createPackRoot(root, "served/fixture");
+		const parent = path.join(target, "lib");
+		await mkdir(parent);
+		const targets = await servingTargets(declared, ["served/fixture"], { projectRoot: root });
+		await rename(parent, path.join(target, "lib-displaced"));
+		const outside = path.join(root, "outside-parent-replacement");
+		await mkdir(outside);
+		await writeFile(path.join(outside, "sentinel"), "unchanged");
+		await createDirectoryLink(outside, parent);
+
+		await expect(mirrorDeclaredOutputs(declared, targets, { projectRoot: root })).rejects.toMatchObject({ code: "ESTALE" });
+		expect(await readFile(path.join(outside, "sentinel"), "utf8")).toBe("unchanged");
+		await expect(readFile(path.join(outside, "nested", "panel.js"))).rejects.toMatchObject({ code: "ENOENT" });
 	});
 });
 
@@ -269,6 +369,39 @@ describe("serialized pack rebuilds", () => {
 		await rebuilder.flush();
 		expect(mirror).toHaveBeenCalledOnce();
 		expect(notify).toHaveBeenCalledWith({ pack: "fixture", reloadToken: 2 });
+	});
+
+	it("does not notify for an unsafe mirror and recovers after the target is repaired", async () => {
+		const root = await fixtureRoot();
+		const declared = declaration();
+		await createBuiltOutputs(root, declared);
+		const target = await createPackRoot(root, "served/fixture");
+		const outside = path.join(root, "outside-rebuilder");
+		await mkdir(outside);
+		const unsafeParent = path.join(target, "lib");
+		await createDirectoryLink(outside, unsafeParent);
+		const targets = await servingTargets(declared, ["served/fixture"], { projectRoot: root });
+		const notify = vi.fn(async () => {});
+		const rebuilder = createSerializedRebuilder({
+			pack: "fixture",
+			build: async () => {},
+			mirror: () => mirrorDeclaredOutputs(declared, targets, { projectRoot: root }),
+			notify,
+			onError() {},
+		});
+
+		rebuilder.schedule(true);
+		await rebuilder.flush();
+		expect(notify).not.toHaveBeenCalled();
+		await expect(readFile(path.join(outside, "nested", "panel.js"))).rejects.toMatchObject({ code: "ENOENT" });
+
+		await unlink(unsafeParent);
+		await mkdir(unsafeParent);
+		rebuilder.schedule(true);
+		await rebuilder.flush();
+		expect(await readFile(path.join(target, "lib", "nested", "panel.js"), "utf8")).toBe("panel-current");
+		expect(notify).toHaveBeenCalledOnce();
+		expect(notify).toHaveBeenCalledWith({ pack: "fixture", reloadToken: 1 });
 	});
 
 	it("publishes once per pack-level cycle and coalesces concurrent events into one trailing cycle", async () => {

--- a/tests2/core/market-pack-dev.test.ts
+++ b/tests2/core/market-pack-dev.test.ts
@@ -223,6 +223,64 @@ describe("selected pack build and mirror", () => {
 		await expect(readFile(path.join(target, "lib", "stale.js"))).rejects.toMatchObject({ code: "ENOENT" });
 	});
 
+	it.each(["EPERM", "EEXIST"])("replaces an existing Windows output after an eligible %s collision", async (code) => {
+		const root = await fixtureRoot();
+		const declared = { ...declaration(), entries: [{ in: "panel.ts", out: "lib/nested/panel.js" }] };
+		await createBuiltOutputs(root, declared);
+		const target = await createPackRoot(root, "served/fixture");
+		const destination = path.join(target, "lib", "nested", "panel.js");
+		await mkdir(path.dirname(destination), { recursive: true });
+		await writeFile(destination, "panel-old");
+		const targets = await servingTargets(declared, ["served/fixture"], { projectRoot: root });
+		const realFs = { copyFile, lstat, mkdir, realpath, rename, unlink };
+		let renameCalls = 0;
+		const fs = {
+			...realFs,
+			async rename(from: string, to: string) {
+				renameCalls += 1;
+				if (renameCalls === 1) throw Object.assign(new Error(`injected ${code}`), { code });
+				await rename(from, to);
+			},
+		};
+		vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+
+		await mirrorDeclaredOutputs(declared, targets, { projectRoot: root, fs });
+
+		expect(renameCalls).toBe(2);
+		expect(await readFile(destination, "utf8")).toBe("panel-current");
+	});
+
+	it.each(["EACCES", "EBUSY", "EIO"])("preserves an existing Windows output after an unrelated %s rename failure", async (code) => {
+		const root = await fixtureRoot();
+		const declared = { ...declaration(), entries: [{ in: "panel.ts", out: "lib/nested/panel.js" }] };
+		await createBuiltOutputs(root, declared);
+		const target = await createPackRoot(root, "served/fixture");
+		const destination = path.join(target, "lib", "nested", "panel.js");
+		await mkdir(path.dirname(destination), { recursive: true });
+		await writeFile(destination, "panel-old");
+		const targets = await servingTargets(declared, ["served/fixture"], { projectRoot: root });
+		const realFs = { copyFile, lstat, mkdir, realpath, rename, unlink };
+		const renameFailure = Object.assign(new Error(`injected ${code}`), { code });
+		let tempPath: string | undefined;
+		let renameCalls = 0;
+		const fs = {
+			...realFs,
+			async rename(from: string, _to: string) {
+				renameCalls += 1;
+				tempPath = from;
+				throw renameFailure;
+			},
+		};
+		vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+
+		await expect(mirrorDeclaredOutputs(declared, targets, { projectRoot: root, fs })).rejects.toBe(renameFailure);
+
+		expect(renameCalls).toBe(1);
+		expect(await readFile(destination, "utf8")).toBe("panel-old");
+		expect(tempPath).toBeDefined();
+		await expect(lstat(tempPath!)).rejects.toMatchObject({ code: "ENOENT" });
+	});
+
 	it("rejects a declared output parent symlink or junction without writing outside the target", async () => {
 		const root = await fixtureRoot();
 		const declared = declaration();

--- a/tests2/core/market-pack-dev.test.ts
+++ b/tests2/core/market-pack-dev.test.ts
@@ -1,0 +1,350 @@
+import { EventEmitter } from "node:events";
+import { mkdtemp, mkdir, readFile, rm, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+	PACKS,
+	buildSelectedPack,
+	createSerializedRebuilder,
+	mirrorDeclaredOutputs,
+	notifyVite,
+	parseArgs,
+	resolvePackBuild,
+	servingTargets,
+} from "../../scripts/build-market-packs.mjs";
+
+const roots: string[] = [];
+
+async function fixtureRoot() {
+	const root = await mkdtemp(path.join(tmpdir(), "bobbit-pack-dev-"));
+	roots.push(root);
+	return root;
+}
+
+function declaration(pack = "fixture") {
+	return {
+		pack,
+		authorRoot: `market-packs/${pack}`,
+		defaultServingRoot: `dist/server/builtin-packs/market-packs/${pack}`,
+		entries: [
+			{ in: "panel.ts", out: "lib/nested/panel.js" },
+			{ in: "route.ts", out: "lib/route.mjs", platform: "node" },
+		],
+	};
+}
+
+async function createPackRoot(root: string, relative: string, name = "fixture") {
+	const target = path.join(root, relative);
+	await mkdir(target, { recursive: true });
+	await writeFile(path.join(target, "pack.yaml"), `schema: 2\nname: ${name}\n`);
+	return target;
+}
+
+afterEach(async () => {
+	vi.restoreAllMocks();
+	await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+describe("market pack development CLI", () => {
+	it("strictly parses a watched pack, repeated targets, and an HTTP(S) Vite URL", () => {
+		expect(parseArgs([
+			"--watch",
+			"file-explorer",
+			"--target",
+			"dist/one/file-explorer",
+			"--target",
+			"dist/two/file-explorer",
+			"--vite-url",
+			"https://localhost:4173/base",
+		])).toEqual({
+			watch: true,
+			pack: "file-explorer",
+			targets: ["dist/one/file-explorer", "dist/two/file-explorer"],
+			viteUrl: "https://localhost:4173/base",
+			help: false,
+		});
+		expect(parseArgs([])).toMatchObject({ watch: false, pack: undefined, targets: [] });
+	});
+
+	it.each([
+		[[], "Missing pack id", ["--watch"]],
+		[[], "Unknown option", ["--watch", "file-explorer", "--wat"]],
+		[[], "Missing value", ["--watch", "file-explorer", "--target"]],
+		[[], "Unexpected extra", ["--watch", "file-explorer", "terminal"]],
+		[[], "safe structural id", ["--watch", "../file-explorer"]],
+		[[], "HTTP(S)", ["--watch", "file-explorer", "--vite-url", "file:///tmp/vite"]],
+		[[], "unsafe path segment", ["--watch", "file-explorer", "--target", "dist/../escape"]],
+	])("rejects malformed arguments %#", (_unused, message, argv) => {
+		expect(() => parseArgs(argv)).toThrow(message);
+	});
+
+	it("resolves only exact declarations and reports a stable sorted allowlist", () => {
+		expect(resolvePackBuild("file-explorer")).toMatchObject({
+			pack: "file-explorer",
+			authorRoot: "market-packs/file-explorer",
+			defaultServingRoot: "dist/server/builtin-packs/market-packs/file-explorer",
+		});
+		expect(() => resolvePackBuild("FILE-EXPLORER")).toThrow("Invalid pack id");
+		const declaredPacks = PACKS as Array<{ pack: string }>;
+		const expected = declaredPacks.map(({ pack }) => pack).sort().join(", ");
+		expect(() => resolvePackBuild("stale-committed-output")).toThrow(`Declared packs: ${expected}`);
+		expect(declaredPacks.some(({ pack }) => pack.includes("performance"))).toBe(false);
+	});
+});
+
+describe("market pack serving target resolution", () => {
+	it("uses only the declared default root despite unrelated pack directories", async () => {
+		const root = await fixtureRoot();
+		const declared = declaration();
+		await createPackRoot(root, declared.authorRoot);
+		const expected = await createPackRoot(root, declared.defaultServingRoot);
+		await createPackRoot(root, "dist/other-discovery/fixture");
+		await createPackRoot(root, "market-packs/stale/lib/fixture");
+
+		expect(await servingTargets(declared, [], { projectRoot: root })).toEqual([expected]);
+	});
+
+	it("fails deterministically when the default is missing or has the wrong manifest", async () => {
+		const root = await fixtureRoot();
+		const declared = declaration();
+		await createPackRoot(root, declared.authorRoot);
+		await expect(servingTargets(declared, [], { projectRoot: root })).rejects.toThrow(
+			"run npm run build:server or pass --target",
+		);
+		await createPackRoot(root, declared.defaultServingRoot, "other");
+		await expect(servingTargets(declared, [], { projectRoot: root })).rejects.toThrow(
+			'manifest name must be "fixture"',
+		);
+	});
+
+	it("rejects explicit manifest mismatches and source-root aliases before creating output directories", async () => {
+		const root = await fixtureRoot();
+		const declared = declaration();
+		await createPackRoot(root, declared.authorRoot);
+		await createPackRoot(root, "served/wrong", "other");
+		await expect(servingTargets(declared, ["served/wrong"], { projectRoot: root })).rejects.toThrow(
+			'manifest name must be "fixture"',
+		);
+		await expect(servingTargets(declared, [declared.authorRoot], { projectRoot: root })).rejects.toThrow(
+			"aliases the authored pack root",
+		);
+	});
+
+	it("canonicalizes, deduplicates, and sorts explicit targets", async () => {
+		const root = await fixtureRoot();
+		const declared = declaration();
+		await createPackRoot(root, declared.authorRoot);
+		const alpha = await createPackRoot(root, "served/alpha");
+		const zulu = await createPackRoot(root, "served/zulu");
+		expect(await servingTargets(declared, ["served/zulu", "served/alpha", "served/alpha"], {
+			projectRoot: root,
+			caseInsensitive: true,
+		})).toEqual([alpha, zulu]);
+	});
+
+	it("rejects a symlink alias of the authored root", async () => {
+		const root = await fixtureRoot();
+		const declared = declaration();
+		const author = await createPackRoot(root, declared.authorRoot);
+		await mkdir(path.join(root, "served"), { recursive: true });
+		const alias = path.join(root, "served", "alias");
+		try {
+			await symlink(author, alias, process.platform === "win32" ? "junction" : "dir");
+		} catch (error) {
+			if ((error as NodeJS.ErrnoException).code === "EPERM") return;
+			throw error;
+		}
+		await expect(servingTargets(declared, ["served/alias"], { projectRoot: root })).rejects.toThrow(
+			"aliases the authored pack root",
+		);
+	});
+});
+
+describe("selected pack build and mirror", () => {
+	it("builds only the selected declaration entries, sequentially, with production bundle invariants", async () => {
+		const root = await fixtureRoot();
+		const declared = declaration();
+		const calls: Array<Record<string, unknown>> = [];
+		let active = 0;
+		let maxActive = 0;
+		await buildSelectedPack(declared, {
+			projectRoot: root,
+			plugin: { name: "fixture", setup() {} },
+			log() {},
+			build: async (options: Record<string, unknown>) => {
+				active += 1;
+				maxActive = Math.max(maxActive, active);
+				calls.push(options);
+				await Promise.resolve();
+				active -= 1;
+			},
+		});
+		expect(maxActive).toBe(1);
+		expect(calls).toHaveLength(2);
+		expect(calls.map((call) => (call.entryPoints as string[])[0])).toEqual([
+			path.join(root, declared.authorRoot, "src", "panel.ts"),
+			path.join(root, declared.authorRoot, "src", "route.ts"),
+		]);
+		expect(calls.every((call) => call.splitting === false)).toBe(true);
+		expect(calls.map((call) => call.platform)).toEqual(["browser", "node"]);
+	});
+
+	it("mirrors declared nested output paths without flattening or discovery", async () => {
+		const root = await fixtureRoot();
+		const declared = declaration();
+		const author = path.join(root, declared.authorRoot);
+		const target = await createPackRoot(root, "served/fixture");
+		await mkdir(path.join(author, "lib", "nested"), { recursive: true });
+		await writeFile(path.join(author, "lib", "nested", "panel.js"), "panel-current");
+		await writeFile(path.join(author, "lib", "route.mjs"), "route-current");
+		await writeFile(path.join(author, "lib", "stale.js"), "must-not-mirror");
+
+		await mirrorDeclaredOutputs(declared, [target], { projectRoot: root });
+		expect(await readFile(path.join(target, "lib", "nested", "panel.js"), "utf8")).toBe("panel-current");
+		expect(await readFile(path.join(target, "lib", "route.mjs"), "utf8")).toBe("route-current");
+		await expect(readFile(path.join(target, "lib", "stale.js"))).rejects.toMatchObject({ code: "ENOENT" });
+	});
+});
+
+describe("serialized pack rebuilds", () => {
+	it("does not mirror or notify after a failed build and remains usable", async () => {
+		let shouldFail = true;
+		const mirror = vi.fn(async () => {});
+		const notify = vi.fn(async () => {});
+		const rebuilder = createSerializedRebuilder({
+			pack: "fixture",
+			build: async () => { if (shouldFail) throw new Error("compile failed"); },
+			mirror,
+			notify,
+			onError() {},
+		});
+		rebuilder.schedule(true);
+		await rebuilder.flush();
+		expect(mirror).not.toHaveBeenCalled();
+		expect(notify).not.toHaveBeenCalled();
+		shouldFail = false;
+		rebuilder.schedule(true);
+		await rebuilder.flush();
+		expect(mirror).toHaveBeenCalledOnce();
+		expect(notify).toHaveBeenCalledWith({ pack: "fixture", reloadToken: 1 });
+	});
+
+	it("publishes once per pack-level cycle and coalesces concurrent events into one trailing cycle", async () => {
+		let active = 0;
+		let maxActive = 0;
+		let releaseFirst!: () => void;
+		const firstBuild = new Promise<void>((resolve) => { releaseFirst = resolve; });
+		let builds = 0;
+		const notify = vi.fn(async (_payload: { pack: string; reloadToken: number }) => {});
+		const rebuilder = createSerializedRebuilder({
+			pack: "fixture",
+			build: async () => {
+				builds += 1;
+				active += 1;
+				maxActive = Math.max(maxActive, active);
+				if (builds === 1) await firstBuild;
+				active -= 1;
+			},
+			mirror: async () => {},
+			notify,
+			onError() {},
+		});
+		rebuilder.schedule(true);
+		await vi.waitFor(() => expect(builds).toBe(1));
+		rebuilder.schedule();
+		rebuilder.schedule();
+		rebuilder.schedule();
+		releaseFirst();
+		await rebuilder.flush();
+		expect(builds).toBe(2);
+		expect(maxActive).toBe(1);
+		expect(notify.mock.calls.map(([payload]) => payload.reloadToken)).toEqual([1, 2]);
+	});
+
+	it("does not expose a failed delivery token and retries with a newer token after a later event", async () => {
+		const delivered: number[] = [];
+		let attempt = 0;
+		const rebuilder = createSerializedRebuilder({
+			pack: "fixture",
+			build: async () => {},
+			mirror: async () => {},
+			notify: async ({ reloadToken }: { reloadToken: number }) => {
+				attempt += 1;
+				if (attempt === 1) throw new Error("Vite unavailable");
+				delivered.push(reloadToken);
+			},
+			onError() {},
+		});
+		rebuilder.schedule(true);
+		await rebuilder.flush();
+		expect(delivered).toEqual([]);
+		rebuilder.schedule(true);
+		await rebuilder.flush();
+		expect(delivered).toEqual([2]);
+	});
+
+	it("disposes during debounce or an active build and cleans watcher/signal listeners idempotently", async () => {
+		const signals = new EventEmitter();
+		const watcher = { close: vi.fn() };
+		let release!: () => void;
+		const blocked = new Promise<void>((resolve) => { release = resolve; });
+		const build = vi.fn(async () => { await blocked; });
+		const rebuilder = createSerializedRebuilder({
+			pack: "fixture",
+			build,
+			mirror: async () => {},
+			notify: async () => {},
+			debounceMs: 10_000,
+			signalSource: signals,
+			onError() {},
+		});
+		rebuilder.attachWatcher(watcher);
+		rebuilder.schedule();
+		await rebuilder.dispose();
+		expect(build).not.toHaveBeenCalled();
+		expect(watcher.close).toHaveBeenCalledOnce();
+		expect(signals.listenerCount("SIGINT")).toBe(0);
+		expect(signals.listenerCount("SIGTERM")).toBe(0);
+		await rebuilder.dispose();
+		expect(watcher.close).toHaveBeenCalledOnce();
+
+		const active = createSerializedRebuilder({
+			pack: "fixture",
+			build,
+			mirror: async () => {},
+			notify: async () => {},
+			onError() {},
+		});
+		active.schedule(true);
+		await vi.waitFor(() => expect(build).toHaveBeenCalledOnce());
+		const disposal = active.dispose();
+		release();
+		await disposal;
+		expect(active.state.closed).toBe(true);
+	});
+});
+
+describe("Vite notification", () => {
+	it("posts the exact tokenized payload and accepts only HTTP 204", async () => {
+		const fetchMock = vi.fn(async (_url: URL, _init: RequestInit) => ({ status: 204 }));
+		await notifyVite("http://127.0.0.1:5173/base", { pack: "fixture", reloadToken: 7 }, { fetch: fetchMock });
+		expect(fetchMock).toHaveBeenCalledOnce();
+		const [url, init] = fetchMock.mock.calls[0];
+		expect(String(url)).toBe("http://127.0.0.1:5173/__bobbit_dev/pack-rebuilt");
+		expect(init).toMatchObject({ method: "POST", body: '{"pack":"fixture","reloadToken":7}' });
+		await expect(notifyVite("http://127.0.0.1:5173", { pack: "fixture", reloadToken: 8 }, {
+			fetch: async () => ({ status: 200 }),
+		})).rejects.toThrow("HTTP 200");
+	});
+
+	it("bounds a stalled Vite request with a timeout", async () => {
+		const stalledFetch = (_url: URL, init: RequestInit) => new Promise((_resolve, reject) => {
+			init.signal?.addEventListener("abort", () => reject(new DOMException("aborted", "AbortError")));
+		});
+		await expect(notifyVite("http://127.0.0.1:5173", { pack: "fixture", reloadToken: 1 }, {
+			fetch: stalledFetch,
+			timeoutMs: 5,
+		})).rejects.toThrow("timed out after 5ms");
+	});
+});

--- a/tests2/core/market-pack-dev.test.ts
+++ b/tests2/core/market-pack-dev.test.ts
@@ -1,5 +1,5 @@
 import { EventEmitter } from "node:events";
-import { mkdtemp, mkdir, readFile, rm, symlink, writeFile } from "node:fs/promises";
+import { mkdtemp, mkdir, readFile, realpath, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -11,6 +11,7 @@ import {
 	notifyVite,
 	parseArgs,
 	resolvePackBuild,
+	runWatcher,
 	servingTargets,
 } from "../../scripts/build-market-packs.mjs";
 
@@ -102,7 +103,7 @@ describe("market pack serving target resolution", () => {
 		await createPackRoot(root, "dist/other-discovery/fixture");
 		await createPackRoot(root, "market-packs/stale/lib/fixture");
 
-		expect(await servingTargets(declared, [], { projectRoot: root })).toEqual([expected]);
+		expect(await servingTargets(declared, [], { projectRoot: root })).toEqual([await realpath(expected)]);
 	});
 
 	it("fails deterministically when the default is missing or has the wrong manifest", async () => {
@@ -140,7 +141,7 @@ describe("market pack serving target resolution", () => {
 		expect(await servingTargets(declared, ["served/zulu", "served/alpha", "served/alpha"], {
 			projectRoot: root,
 			caseInsensitive: true,
-		})).toEqual([alpha, zulu]);
+		})).toEqual([await realpath(alpha), await realpath(zulu)]);
 	});
 
 	it("rejects a symlink alias of the authored root", async () => {
@@ -208,8 +209,41 @@ describe("selected pack build and mirror", () => {
 });
 
 describe("serialized pack rebuilds", () => {
-	it("does not mirror or notify after a failed build and remains usable", async () => {
-		let shouldFail = true;
+	it("rejects and cleans up an initial failed cycle before reporting readiness", async () => {
+		const root = await fixtureRoot();
+		const declared = resolvePackBuild("file-explorer");
+		await createPackRoot(root, declared.authorRoot, declared.pack);
+		await mkdir(path.join(root, declared.authorRoot, "src"), { recursive: true });
+		await createPackRoot(root, declared.defaultServingRoot, declared.pack);
+		const signals = new EventEmitter();
+		const watcher = { close: vi.fn() };
+		const watch = vi.fn(() => watcher);
+		const mirror = vi.fn(async () => {});
+		const notify = vi.fn(async () => {});
+		const log = vi.fn();
+
+		await expect(runWatcher(parseArgs(["--watch", declared.pack]), {
+			projectRoot: root,
+			watch,
+			build: async () => { throw new Error("initial compile failed"); },
+			mirror,
+			notify,
+			signalSource: signals,
+			onError() {},
+			log,
+		})).rejects.toThrow("initial compile failed");
+
+		expect(watch).toHaveBeenCalledOnce();
+		expect(mirror).not.toHaveBeenCalled();
+		expect(notify).not.toHaveBeenCalled();
+		expect(log).not.toHaveBeenCalled();
+		expect(watcher.close).toHaveBeenCalledOnce();
+		expect(signals.listenerCount("SIGINT")).toBe(0);
+		expect(signals.listenerCount("SIGTERM")).toBe(0);
+	});
+
+	it("does not mirror or notify after a later failed build and remains usable", async () => {
+		let shouldFail = false;
 		const mirror = vi.fn(async () => {});
 		const notify = vi.fn(async () => {});
 		const rebuilder = createSerializedRebuilder({
@@ -221,13 +255,20 @@ describe("serialized pack rebuilds", () => {
 		});
 		rebuilder.schedule(true);
 		await rebuilder.flush();
+		mirror.mockClear();
+		notify.mockClear();
+
+		shouldFail = true;
+		rebuilder.schedule(true);
+		await rebuilder.flush();
 		expect(mirror).not.toHaveBeenCalled();
 		expect(notify).not.toHaveBeenCalled();
+
 		shouldFail = false;
 		rebuilder.schedule(true);
 		await rebuilder.flush();
 		expect(mirror).toHaveBeenCalledOnce();
-		expect(notify).toHaveBeenCalledWith({ pack: "fixture", reloadToken: 1 });
+		expect(notify).toHaveBeenCalledWith({ pack: "fixture", reloadToken: 2 });
 	});
 
 	it("publishes once per pack-level cycle and coalesces concurrent events into one trailing cycle", async () => {

--- a/tests2/core/vite-bundled-dev.test.ts
+++ b/tests2/core/vite-bundled-dev.test.ts
@@ -1,10 +1,15 @@
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { describe, expect, it } from "vitest";
-import type { UserConfig } from "vite";
+import { Readable } from "node:stream";
+import { describe, expect, it, vi } from "vitest";
+import type { Plugin, UserConfig } from "vite";
 
-import viteConfig, { configuredPublicViteHosts } from "../../vite.config.ts";
+import viteConfig, {
+	configuredPublicViteHosts,
+	isLocalVitePeer,
+	packDevHotReload,
+} from "../../vite.config.ts";
 
 async function configFor(command: "serve" | "build", mode = "development"): Promise<UserConfig> {
 	const raw = typeof viteConfig === "function"
@@ -12,6 +17,131 @@ async function configFor(command: "serve" | "build", mode = "development"): Prom
 		: viteConfig;
 	return await Promise.resolve(raw) as UserConfig;
 }
+
+interface BridgeResponse {
+	status: number;
+	body: string;
+	next: boolean;
+	send: ReturnType<typeof vi.fn>;
+	headers?: Record<string, string>;
+}
+
+async function invokePackBridge(options: {
+	method?: string;
+	url?: string;
+	body?: string;
+	remoteAddress?: string;
+	headers?: Record<string, string>;
+}): Promise<BridgeResponse> {
+	const plugin = packDevHotReload();
+	let middleware: ((req: any, res: any, next: () => void) => void) | undefined;
+	const send = vi.fn();
+	const server = {
+		middlewares: { use(handler: typeof middleware) { middleware = handler; } },
+		ws: { send },
+	};
+	const hook = plugin.configureServer;
+	if (!hook) throw new Error("pack reload plugin must configure the Vite server");
+	const configure = typeof hook === "function" ? hook : hook.handler;
+	await configure.call({} as never, server as never);
+	if (!middleware) throw new Error("pack reload plugin must install middleware");
+
+	const body = options.body ?? "";
+	const request = Readable.from(body ? [Buffer.from(body)] : []) as any;
+	request.method = options.method ?? "POST";
+	request.url = options.url ?? "/__bobbit_dev/pack-rebuilt";
+	request.headers = options.headers ?? {};
+	request.socket = { remoteAddress: options.remoteAddress ?? "127.0.0.1" };
+
+	return await new Promise<BridgeResponse>((resolve) => {
+		let status = 200;
+		let responseBody = "";
+		let responseHeaders: Record<string, string> | undefined;
+		const response = {
+			writeHead(code: number, headers?: Record<string, string>) {
+				status = code;
+				responseHeaders = headers;
+			},
+			end(chunk?: string) {
+				responseBody += chunk ?? "";
+				resolve({ status, body: responseBody, next: false, send, headers: responseHeaders });
+			},
+		};
+		middleware!(request, response, () => resolve({ status, body: responseBody, next: true, send }));
+	});
+}
+
+function pluginNamed(config: UserConfig, name: string): Plugin | undefined {
+	return (config.plugins?.flat() ?? []).find(
+		(plugin): plugin is Plugin => Boolean(plugin && "name" in plugin && plugin.name === name),
+	);
+}
+
+describe("Vite pack authoring reload bridge", () => {
+	it("is registered as a serve-only plugin", async () => {
+		const development = await configFor("serve");
+		const production = await configFor("build", "production");
+
+		expect(pluginNamed(development, "bobbit-pack-dev-hot-reload")?.apply).toBe("serve");
+		expect(pluginNamed(production, "bobbit-pack-dev-hot-reload")?.apply).toBe("serve");
+	});
+
+	it("accepts one bounded tokenized local POST and emits exactly one custom event", async () => {
+		const result = await invokePackBridge({
+			body: JSON.stringify({ pack: "file-explorer", reloadToken: 7 }),
+		});
+
+		expect(result.status).toBe(204);
+		expect(result.body).toBe("");
+		expect(result.send).toHaveBeenCalledTimes(1);
+		expect(result.send).toHaveBeenCalledWith({
+			type: "custom",
+			event: "bobbit:pack-rebuilt",
+			data: { pack: "file-explorer", reloadToken: 7 },
+		});
+	});
+
+	it("passes unrelated paths through without mutating the HMR channel", async () => {
+		const result = await invokePackBridge({
+			url: "/__bobbit_dev/not-pack-rebuilt",
+			body: JSON.stringify({ pack: "file-explorer", reloadToken: 1 }),
+		});
+
+		expect(result.next).toBe(true);
+		expect(result.send).not.toHaveBeenCalled();
+	});
+
+	it("accepts loopback and assigned-interface peers only", async () => {
+		const interfaces = {
+			ethernet: [{ address: "192.0.2.20", netmask: "255.255.255.0", family: "IPv4" as const, mac: "", internal: false, cidr: "192.0.2.20/24" }],
+		};
+		expect(isLocalVitePeer("::ffff:127.0.0.1", interfaces)).toBe(true);
+		expect(isLocalVitePeer("192.0.2.20", interfaces)).toBe(true);
+		expect(isLocalVitePeer("192.0.2.21", interfaces)).toBe(false);
+
+		const result = await invokePackBridge({
+			remoteAddress: "203.0.113.50",
+			body: JSON.stringify({ pack: "file-explorer", reloadToken: 1 }),
+		});
+		expect(result.status).toBe(403);
+		expect(result.send).not.toHaveBeenCalled();
+	});
+
+	it.each([
+		["wrong method", { method: "GET", body: "" }, 405],
+		["malformed JSON", { body: "{" }, 400],
+		["traversal pack", { body: JSON.stringify({ pack: "../file-explorer", reloadToken: 1 }) }, 400],
+		["zero token", { body: JSON.stringify({ pack: "file-explorer", reloadToken: 0 }) }, 400],
+		["fractional token", { body: JSON.stringify({ pack: "file-explorer", reloadToken: 1.5 }) }, 400],
+		["extra fields", { body: JSON.stringify({ pack: "file-explorer", reloadToken: 1, extra: true }) }, 400],
+		["oversize body", { body: JSON.stringify({ pack: `file-${"x".repeat(8192)}`, reloadToken: 1 }) }, 413],
+	] as const)("rejects %s without mutating the HMR channel", async (_label, options, status) => {
+		const result = await invokePackBridge(options);
+		expect(result.status).toBe(status);
+		expect(result.next).toBe(false);
+		expect(result.send).not.toHaveBeenCalled();
+	});
+});
 
 describe("Vite bundled development mode", () => {
 	it("bundles the browser graph during serve to avoid the native-ESM request waterfall", async () => {

--- a/tests2/core/vite-bundled-dev.test.ts
+++ b/tests2/core/vite-bundled-dev.test.ts
@@ -26,6 +26,14 @@ interface BridgeResponse {
 	headers?: Record<string, string>;
 }
 
+const PACK_RELOAD_HEADERS = { "x-bobbit-pack-reload": "1" };
+
+function expectNoCorsAllowHeaders(response: BridgeResponse): void {
+	expect(Object.keys(response.headers ?? {})).not.toEqual(
+		expect.arrayContaining([expect.stringMatching(/^access-control-allow-/i)]),
+	);
+}
+
 async function invokePackBridge(options: {
 	method?: string;
 	url?: string;
@@ -50,7 +58,7 @@ async function invokePackBridge(options: {
 	const request = Readable.from(body ? [Buffer.from(body)] : []) as any;
 	request.method = options.method ?? "POST";
 	request.url = options.url ?? "/__bobbit_dev/pack-rebuilt";
-	request.headers = options.headers ?? {};
+	request.headers = options.headers ?? PACK_RELOAD_HEADERS;
 	request.socket = { remoteAddress: options.remoteAddress ?? "127.0.0.1" };
 
 	return await new Promise<BridgeResponse>((resolve) => {
@@ -93,12 +101,47 @@ describe("Vite pack authoring reload bridge", () => {
 
 		expect(result.status).toBe(204);
 		expect(result.body).toBe("");
+		expectNoCorsAllowHeaders(result);
 		expect(result.send).toHaveBeenCalledTimes(1);
 		expect(result.send).toHaveBeenCalledWith({
 			type: "custom",
 			event: "bobbit:pack-rebuilt",
 			data: { pack: "file-explorer", reloadToken: 7 },
 		});
+	});
+
+	it("rejects an otherwise-valid loopback POST without the bridge header before publication", async () => {
+		const result = await invokePackBridge({
+			body: JSON.stringify({ pack: "file-explorer", reloadToken: 7 }),
+			headers: {},
+		});
+
+		expect(result.status).toBe(403);
+		expect(result.body).toBe("Forbidden");
+		expect(result.send).not.toHaveBeenCalled();
+		expectNoCorsAllowHeaders(result);
+	});
+
+	it("rejects a browser-simple text/plain write without authorizing a CORS preflight", async () => {
+		const result = await invokePackBridge({
+			body: JSON.stringify({ pack: "file-explorer", reloadToken: 7 }),
+			headers: { "content-type": "text/plain" },
+		});
+
+		expect(result.status).toBe(403);
+		expect(result.send).not.toHaveBeenCalled();
+		expectNoCorsAllowHeaders(result);
+	});
+
+	it("rejects an incorrect bridge header value", async () => {
+		const result = await invokePackBridge({
+			body: JSON.stringify({ pack: "file-explorer", reloadToken: 7 }),
+			headers: { "x-bobbit-pack-reload": "true" },
+		});
+
+		expect(result.status).toBe(403);
+		expect(result.send).not.toHaveBeenCalled();
+		expectNoCorsAllowHeaders(result);
 	});
 
 	it("passes unrelated paths through without mutating the HMR channel", async () => {

--- a/tests2/dom/pack-panels-reconcile.test.ts
+++ b/tests2/dom/pack-panels-reconcile.test.ts
@@ -12,15 +12,8 @@ __syncBeforeAll(() => __syncCE());
 //
 // Module-level reconcile dedupe state persists across tests in a fork (the
 // legacy suite got a fresh page per test), so each test uses UNIQUE project ids.
-//
-// PUNTED (not ported here): the legacy "pack update invalidates the cached panel
-// module — a forced re-register re-imports fresh bytes" test. Its assertions turn
-// on `loadedPanels` caching, which only populates after a SUCCESSFUL dynamic
-// `import()` of the panel module from a Blob URL. happy-dom + vite-node cannot
-// resolve/execute a `blob:` (or `data:`) ESM URL at runtime (only a real browser
-// module loader can), so the module never caches and the fetch-count deltas the
-// test observes cannot be reproduced headlessly. That behaviour must stay a
-// browser E2E.
+// The shared module importer uses source-derived data URLs under Vitest, which
+// lets this suite exercise successful module evaluation and generation fencing.
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 // pack-panels ⇄ host-api ⇄ ToolGroup form a module-init cycle (setPanelHostFactory
@@ -28,6 +21,9 @@ import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vite
 // session-manager owns the canonical import order; importing it FIRST in beforeAll
 // breaks the TDZ, then the real functions are bound from the settled modules.
 let reconcilePackPanelsForProject: typeof import("../../src/app/pack-panels.js").reconcilePackPanelsForProject;
+let registerPackPanels: typeof import("../../src/app/pack-panels.js").registerPackPanels;
+let invalidatePackPanelModules: typeof import("../../src/app/pack-panels.js").invalidatePackPanelModules;
+let renderPackPanelContent: typeof import("../../src/app/pack-panels.js").renderPackPanelContent;
 let openPackPanel: typeof import("../../src/app/pack-panels.js").openPackPanel;
 let setSessionSwitcher: typeof import("../../src/app/pack-panels.js").setSessionSwitcher;
 let state: typeof import("../../src/app/state.js").state;
@@ -35,13 +31,16 @@ let panelTabsForSession: typeof import("../../src/app/panel-workspace.js").panel
 let activePanelTabIdForSession: typeof import("../../src/app/panel-workspace.js").activePanelTabIdForSession;
 let HOST_CONTRACT_VERSION: number;
 
-type PackWire = { packId: string; packName: string; panels: Array<{ id: string; title?: string }>; entrypoints: unknown[]; routeNames: string[] };
+type PackWire = { packId: string; packName: string; panels: Array<{ id: string; title?: string; instanceMode?: "singleton" | "parameterized"; instanceParam?: string }>; entrypoints: unknown[]; routeNames: string[] };
 
 let fetchCalls: string[];
 let contributions: PackWire[];
+let panelModuleSource: string;
+let panelRequest: ((url: string) => Response | Promise<Response>) | undefined;
 const contribDelayByProject = new Map<string, number>();
 const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
-const PANEL_MODULE = "export default function(){ return { render(){ return ''; } }; }";
+const panelModule = (label: string) => `export default function(){ return { render(params){ return ${JSON.stringify(label)} + ":" + String(params?.artifactId ?? ""); } }; }`;
+const PANEL_MODULE = panelModule("default");
 
 const DEMO: PackWire = { packId: "demo_pack", packName: "demo_pack", panels: [{ id: "demo.panel", title: "Demo" }], entrypoints: [], routeNames: [] };
 
@@ -49,7 +48,7 @@ beforeAll(async () => {
 	(window as any).happyDOM?.setURL?.("file:///test.html");
 	localStorage.setItem("gateway.url", "http://localhost");
 	await import("../../src/app/session-manager.js");
-	({ reconcilePackPanelsForProject, openPackPanel, setSessionSwitcher } = await import("../../src/app/pack-panels.js"));
+	({ reconcilePackPanelsForProject, registerPackPanels, invalidatePackPanelModules, renderPackPanelContent, openPackPanel, setSessionSwitcher } = await import("../../src/app/pack-panels.js"));
 	({ state } = await import("../../src/app/state.js"));
 	({ panelTabsForSession, activePanelTabIdForSession } = await import("../../src/app/panel-workspace.js"));
 	({ HOST_CONTRACT_VERSION } = await import("../../src/shared/extension-host/host-api.js"));
@@ -59,6 +58,8 @@ beforeAll(async () => {
 beforeEach(() => {
 	fetchCalls = [];
 	contributions = [structuredClone(DEMO)];
+	panelModuleSource = PANEL_MODULE;
+	panelRequest = undefined;
 	contribDelayByProject.clear();
 	vi.stubGlobal("fetch", async (input: any): Promise<Response> => {
 		const url = typeof input === "string" ? input : (input && input.url) || String(input);
@@ -70,7 +71,8 @@ beforeEach(() => {
 			return new Response(JSON.stringify({ version: 1, tabs: [], activeTabId: "", sizeMode: "split" }), { status: 200, headers: { "Content-Type": "application/json" } });
 		}
 		if (String(url).includes("/panels/")) {
-			return new Response(PANEL_MODULE, { status: 200, headers: { "Content-Type": "text/javascript" } });
+			if (panelRequest) return panelRequest(String(url));
+			return new Response(panelModuleSource, { status: 200, headers: { "Content-Type": "text/javascript" } });
 		}
 		if (String(url).includes("/api/ext/contributions")) {
 			const m = /[?&]projectId=([^&]*)/.exec(String(url));
@@ -104,6 +106,8 @@ const openInSession = (panelId: string, sessionId: string, packId?: string) => {
 const tabIdsForSession = (sid: string | undefined): string[] => panelTabsForSession(state, sid).map((t: any) => t?.id);
 const activeTabIdForSession = (sid: string | undefined): string => activePanelTabIdForSession(state, sid);
 const flush = async () => { await new Promise((r) => setTimeout(r, 30)); };
+const panelRequestUrls = () => calls().filter((url) => url.includes("/panels/"));
+const renderedPanel = (packId: string, panelId: string, params?: Record<string, unknown>) => renderPackPanelContent(packId, panelId, params);
 
 describe("reconcilePackPanelsForProject (pack schema V1 §8.1)", () => {
 	it("re-drives registration scoped to the active project; dedupes unchanged; swaps the loader on project change", async () => {
@@ -236,5 +240,131 @@ describe("reconcilePackPanelsForProject (pack schema V1 §8.1)", () => {
 		expect(ids).toContain("pack:demo_pack:demo.panel:artifact-a");
 		expect(ids).toContain("pack:demo_pack:demo.panel:artifact-b");
 		expect(ids).toContain("pack:demo_pack:demo.panel:explicit-key");
+	});
+
+	it("hot-invalidates fresh module bytes by token without changing tab identity, params, order, or selection", async () => {
+		contributions = [{
+			packId: "hot_identity",
+			packName: "hot_identity",
+			panels: [{ id: "viewer", title: "Hot viewer", instanceMode: "parameterized", instanceParam: "artifactId" }],
+			entrypoints: [],
+			routeNames: [],
+		}];
+		panelModuleSource = panelModule("v1");
+		await reconcile("P9-hot-identity");
+		(state as any).selectedSessionId = "hot-session";
+		openPackPanel({ panelId: "viewer", params: { artifactId: "artifact-a", stable: true } }, "hot_identity");
+		openPackPanel({ panelId: "viewer", params: { artifactId: "artifact-b", stable: true } }, "hot_identity");
+		await vi.waitFor(() => expect(renderedPanel("hot_identity", "viewer", { artifactId: "artifact-a" })).toBe("v1:artifact-a"));
+
+		const workspaceBefore = structuredClone({
+			selectedSessionId: (state as any).selectedSessionId,
+			panelTabsBySession: state.panelTabsBySession,
+			panelWorkspaceActiveBySession: state.panelWorkspaceActiveBySession,
+		});
+
+		clearCalls();
+		panelModuleSource = panelModule("v2");
+		expect(invalidatePackPanelModules("hot_identity", 101)).toBe(1);
+		expect({
+			selectedSessionId: (state as any).selectedSessionId,
+			panelTabsBySession: state.panelTabsBySession,
+			panelWorkspaceActiveBySession: state.panelWorkspaceActiveBySession,
+		}).toEqual(workspaceBefore);
+		await vi.waitFor(() => expect(renderedPanel("hot_identity", "viewer", { artifactId: "artifact-a" })).toBe("v2:artifact-a"));
+		expect(panelRequestUrls()).toEqual([
+			"http://localhost/api/ext/packs/hot_identity/panels/viewer?projectId=P9-hot-identity&devReload=101",
+		]);
+		expect({
+			selectedSessionId: (state as any).selectedSessionId,
+			panelTabsBySession: state.panelTabsBySession,
+			panelWorkspaceActiveBySession: state.panelWorkspaceActiveBySession,
+		}).toEqual(workspaceBefore);
+
+		clearCalls();
+		panelModuleSource = panelModule("v3");
+		expect(invalidatePackPanelModules("hot_identity", 102)).toBe(1);
+		await vi.waitFor(() => expect(renderedPanel("hot_identity", "viewer", { artifactId: "artifact-b" })).toBe("v3:artifact-b"));
+		expect(panelRequestUrls()).toEqual([
+			"http://localhost/api/ext/packs/hot_identity/panels/viewer?projectId=P9-hot-identity&devReload=102",
+		]);
+		expect({
+			selectedSessionId: (state as any).selectedSessionId,
+			panelTabsBySession: state.panelTabsBySession,
+			panelWorkspaceActiveBySession: state.panelWorkspaceActiveBySession,
+		}).toEqual(workspaceBefore);
+	});
+
+	it("invalidating one pack leaves another pack's evaluated panel cached", async () => {
+		registerPackPanels([
+			{ packId: "hot_pack_a", panelId: "viewer" },
+			{ packId: "hot_pack_b", panelId: "viewer" },
+		], "P10-pack-isolation");
+		let sourceA = panelModule("a-v1");
+		let sourceB = panelModule("b-v1");
+		panelRequest = (url) => new Response(url.includes("/hot_pack_a/") ? sourceA : sourceB, {
+			status: 200,
+			headers: { "Content-Type": "text/javascript" },
+		});
+		await vi.waitFor(() => expect(renderedPanel("hot_pack_a", "viewer")).toBe("a-v1:"));
+		await vi.waitFor(() => expect(renderedPanel("hot_pack_b", "viewer")).toBe("b-v1:"));
+
+		clearCalls();
+		sourceA = panelModule("a-v2");
+		sourceB = panelModule("b-v2");
+		expect(invalidatePackPanelModules("hot_pack_a", 201)).toBe(1);
+		expect(renderedPanel("hot_pack_b", "viewer")).toBe("b-v1:");
+		await vi.waitFor(() => expect(renderedPanel("hot_pack_a", "viewer")).toBe("a-v2:"));
+		expect(panelRequestUrls()).toEqual([
+			"http://localhost/api/ext/packs/hot_pack_a/panels/viewer?projectId=P10-pack-isolation&devReload=201",
+		]);
+		expect(renderedPanel("hot_pack_b", "viewer")).toBe("b-v1:");
+	});
+
+	it("a stale in-flight module cannot resurrect after tokenized invalidation", async () => {
+		registerPackPanels([{ packId: "hot_stale", panelId: "viewer" }], "P11-stale");
+		let resolveStale!: (response: Response) => void;
+		let requestCount = 0;
+		panelRequest = () => {
+			requestCount += 1;
+			if (requestCount === 1) return new Promise<Response>((resolve) => { resolveStale = resolve; });
+			return new Response(panelModule("new"), { status: 200, headers: { "Content-Type": "text/javascript" } });
+		};
+
+		renderedPanel("hot_stale", "viewer");
+		await vi.waitFor(() => expect(requestCount).toBe(1));
+		expect(invalidatePackPanelModules("hot_stale", 301)).toBe(1);
+		await vi.waitFor(() => expect(renderedPanel("hot_stale", "viewer")).toBe("new:"));
+		resolveStale(new Response(panelModule("stale"), { status: 200, headers: { "Content-Type": "text/javascript" } }));
+		await flush();
+
+		expect(renderedPanel("hot_stale", "viewer")).toBe("new:");
+		expect(panelRequestUrls()).toEqual([
+			"http://localhost/api/ext/packs/hot_stale/panels/viewer?projectId=P11-stale",
+			"http://localhost/api/ext/packs/hot_stale/panels/viewer?projectId=P11-stale&devReload=301",
+		]);
+	});
+
+	it("a later rebuild event recovers a panel after a failed tokenized load", async () => {
+		registerPackPanels([{ packId: "hot_recovery", panelId: "viewer" }], "P12-recovery");
+		panelModuleSource = panelModule("before");
+		await vi.waitFor(() => expect(renderedPanel("hot_recovery", "viewer")).toBe("before:"));
+		clearCalls();
+		const error = vi.spyOn(console, "error").mockImplementation(() => {});
+		panelRequest = (url) => {
+			const token = new URL(url).searchParams.get("devReload");
+			if (token === "401") return new Response("failed", { status: 500 });
+			return new Response(panelModule("recovered"), { status: 200, headers: { "Content-Type": "text/javascript" } });
+		};
+
+		expect(invalidatePackPanelModules("hot_recovery", 401)).toBe(1);
+		renderedPanel("hot_recovery", "viewer");
+		await vi.waitFor(() => expect(panelRequestUrls().some((url) => new URL(url).searchParams.get("devReload") === "401")).toBe(true));
+		await flush();
+		expect(invalidatePackPanelModules("hot_recovery", 402)).toBe(1);
+		await vi.waitFor(() => expect(renderedPanel("hot_recovery", "viewer")).toBe("recovered:"));
+
+		expect(panelRequestUrls().map((url) => new URL(url).searchParams.get("devReload"))).toEqual(["401", "402"]);
+		error.mockRestore();
 	});
 });

--- a/tests2/dom/pack-renderers-reconcile.test.ts
+++ b/tests2/dom/pack-renderers-reconcile.test.ts
@@ -12,24 +12,50 @@ __syncBeforeAll(() => __syncCE());
 // Module-level reconcile dedupe state persists across tests in a fork (the
 // legacy suite got a fresh page per test), so each test uses UNIQUE project ids.
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { packHasLocalDataForTool, registerPackRenderers, reconcilePackRenderersForProject } from "../../src/app/pack-renderers.js";
-import { getToolRenderer } from "../../src/ui/tools/renderer-registry.js";
+import {
+	invalidatePackRendererModules,
+	packHasLocalDataForTool,
+	packIdForTool,
+	registerPackRenderers,
+	reconcilePackRenderersForProject,
+} from "../../src/app/pack-renderers.js";
+import { getToolRenderer, TOOL_RENDERER_LOADED_EVENT } from "../../src/ui/tools/renderer-registry.js";
 
 let fetchCalls: string[];
 let toolsResponse: Array<{ name: string; rendererKind?: string }>;
+let rendererResponder: ((url: string) => Response | Promise<Response>) | undefined;
+const rendererVersions = new Map<string, string>();
 const toolsDelayByProject = new Map<string, number>();
 const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
-const RENDERER_MODULE = "export default function(){ return { render(){ return { content: '', isCustom: false }; } }; }";
+const rendererModule = (version: string) => `export default function(){ return { version: ${JSON.stringify(version)}, render(){ return { content: '', isCustom: false }; } }; }`;
+
+interface Deferred<T> {
+	promise: Promise<T>;
+	resolve: (value: T) => void;
+}
+function defer<T>(): Deferred<T> {
+	let resolve!: (value: T) => void;
+	const promise = new Promise<T>((res) => { resolve = res; });
+	return { promise, resolve };
+}
 
 beforeEach(() => {
 	fetchCalls = [];
 	toolsResponse = [{ name: "demo_pack_tool", rendererKind: "pack" }];
+	rendererResponder = undefined;
+	rendererVersions.clear();
 	toolsDelayByProject.clear();
 	vi.stubGlobal("fetch", async (input: any): Promise<Response> => {
-		const url = typeof input === "string" ? input : (input && input.url) || String(input);
-		fetchCalls.push(String(url));
-		if (String(url).includes("/renderer")) {
-			return new Response(RENDERER_MODULE, { status: 200, headers: { "Content-Type": "text/javascript" } });
+		const url = String(typeof input === "string" ? input : (input && input.url) || input);
+		fetchCalls.push(url);
+		if (url.includes("/renderer")) {
+			if (rendererResponder) return rendererResponder(url);
+			const match = /\/api\/tools\/([^/?]+)\/renderer/.exec(url);
+			const toolName = match ? decodeURIComponent(match[1]) : "";
+			return new Response(rendererModule(rendererVersions.get(toolName) ?? "default"), {
+				status: 200,
+				headers: { "Content-Type": "text/javascript" },
+			});
 		}
 		const m = /[?&]projectId=([^&]*)/.exec(String(url));
 		const pid = m ? decodeURIComponent(m[1]) : "";
@@ -48,7 +74,16 @@ const clearCalls = () => { fetchCalls.length = 0; };
 const calls = (): string[] => fetchCalls.slice();
 const reconcile = (pid?: string) => reconcilePackRenderersForProject(pid);
 const triggerLoad = (name: string) => { getToolRenderer(name); };
+const loadedVersion = (name: string): string | undefined => (getToolRenderer(name) as { version?: string } | undefined)?.version;
 const flush = async () => { await new Promise((r) => setTimeout(r, 30)); };
+const waitForRendererLoaded = (toolName: string): Promise<void> => new Promise((resolve) => {
+	const listener = (event: Event) => {
+		if ((event as CustomEvent).detail?.toolName !== toolName) return;
+		document.removeEventListener(TOOL_RENDERER_LOADED_EVENT, listener);
+		resolve();
+	};
+	document.addEventListener(TOOL_RENDERER_LOADED_EVENT, listener);
+});
 
 describe("reconcilePackRenderersForProject (extension-host §4a/§4c)", () => {
 	it("projects local-data capability only for the current declared winning pack renderer", () => {
@@ -109,6 +144,101 @@ describe("reconcilePackRenderersForProject (extension-host §4a/§4c)", () => {
 		clearCalls();
 		await reconcile("C2");
 		expect(calls().some((u) => /\/api\/tools\?projectId=C2$/.test(u))).toBe(true);
+	});
+
+	it("reloads only the named pack with tokenized fresh module requests and preserves project scope", async () => {
+		const toolA = "hot_renderer_a";
+		const toolB = "hot_renderer_b";
+		const projectId = "project with & data";
+		rendererVersions.set(toolA, "a-v1");
+		rendererVersions.set(toolB, "b-v1");
+		registerPackRenderers([
+			{ name: toolA, rendererKind: "pack", packId: "pack-a" },
+			{ name: toolB, rendererKind: "pack", packId: "pack-b" },
+		], projectId);
+
+		const initialA = waitForRendererLoaded(toolA);
+		triggerLoad(toolA);
+		await initialA;
+		const initialB = waitForRendererLoaded(toolB);
+		triggerLoad(toolB);
+		await initialB;
+		expect(loadedVersion(toolA)).toBe("a-v1");
+		expect(loadedVersion(toolB)).toBe("b-v1");
+		expect(packIdForTool(toolA)).toBe("pack-a");
+		expect(packIdForTool(toolB)).toBe("pack-b");
+
+		clearCalls();
+		const repaintEvents: string[] = [];
+		const onRepaint = (event: Event) => repaintEvents.push((event as CustomEvent).detail?.toolName);
+		document.addEventListener(TOOL_RENDERER_LOADED_EVENT, onRepaint);
+		try {
+			rendererVersions.set(toolA, "a-v2");
+			expect(invalidatePackRendererModules("pack-a", 41)).toEqual([toolA]);
+			const loadedA2 = waitForRendererLoaded(toolA);
+			triggerLoad(toolA);
+			await loadedA2;
+			expect(loadedVersion(toolA)).toBe("a-v2");
+			expect(loadedVersion(toolB)).toBe("b-v1");
+
+			rendererVersions.set(toolA, "a-v3");
+			expect(invalidatePackRendererModules("pack-a", 42)).toEqual([toolA]);
+			const loadedA3 = waitForRendererLoaded(toolA);
+			triggerLoad(toolA);
+			await loadedA3;
+			expect(loadedVersion(toolA)).toBe("a-v3");
+		} finally {
+			document.removeEventListener(TOOL_RENDERER_LOADED_EVENT, onRepaint);
+		}
+
+		const rendererCalls = calls().filter((url) => url.includes("/renderer"));
+		expect(rendererCalls).toHaveLength(2);
+		expect(rendererCalls.map((url) => {
+			const parsed = new URL(url);
+			return {
+				path: parsed.pathname,
+				projectId: parsed.searchParams.get("projectId"),
+				devReload: parsed.searchParams.get("devReload"),
+			};
+		})).toEqual([
+			{ path: `/api/tools/${toolA}/renderer`, projectId, devReload: "41" },
+			{ path: `/api/tools/${toolA}/renderer`, projectId, devReload: "42" },
+		]);
+		expect(repaintEvents).toEqual([toolA, toolA]);
+		expect(packIdForTool(toolA)).toBe("pack-a");
+		expect(packIdForTool(toolB)).toBe("pack-b");
+	});
+
+	it("drops a stale in-flight renderer after hot invalidation", async () => {
+		const toolName = "hot_renderer_stale";
+		const oldResponse = defer<Response>();
+		rendererResponder = (url) => {
+			const token = new URL(url).searchParams.get("devReload");
+			if (token === null) return oldResponse.promise;
+			return new Response(rendererModule("fresh"), { status: 200 });
+		};
+		registerPackRenderers([
+			{ name: toolName, rendererKind: "pack", packId: "stale-pack" },
+		], "stale-project");
+
+		const loadedEvents: string[] = [];
+		const onLoad = (event: Event) => loadedEvents.push((event as CustomEvent).detail?.toolName);
+		document.addEventListener(TOOL_RENDERER_LOADED_EVENT, onLoad);
+		try {
+			triggerLoad(toolName);
+			expect(invalidatePackRendererModules("stale-pack", 7)).toEqual([toolName]);
+			const freshLoaded = waitForRendererLoaded(toolName);
+			triggerLoad(toolName);
+			await freshLoaded;
+			expect(loadedVersion(toolName)).toBe("fresh");
+
+			oldResponse.resolve(new Response(rendererModule("stale"), { status: 200 }));
+			await flush();
+			expect(loadedVersion(toolName)).toBe("fresh");
+			expect(loadedEvents).toEqual([toolName]);
+		} finally {
+			document.removeEventListener(TOOL_RENDERER_LOADED_EVENT, onLoad);
+		}
 	});
 });
 

--- a/tests2/tests-map.json
+++ b/tests2/tests-map.json
@@ -21,6 +21,15 @@
   },
   "v2Native": [
     {
+      "path": "tests2/core/market-pack-dev.test.ts",
+      "reason": "Focused core coverage for strict generic pack-watch parsing and resolution, deterministic declared-output mirroring, serialized rebuild publication and failure recovery, bounded Vite notification, and cleanup.",
+      "execution": {
+        "runner": "vitest",
+        "tier": "unit",
+        "project": "core"
+      }
+    },
+    {
       "path": "tests2/core/session-transcript-roots.test.ts",
       "reason": "Focused security coverage for deterministic owner roots, exact session/control mounts, mount attestation, and owner-aware transcript publication and translation.",
       "execution": {

--- a/tests2/tests-map.json
+++ b/tests2/tests-map.json
@@ -2,13 +2,13 @@
   "$schema": "./tests-map.schema (informal): { generatedBy, censusTotal, buckets, methods, v2Native[{path,reason,execution}], journeys, entries[{file,bucket,method,replacement,rationale,migrated?,v2Path?,execution?}] }",
   "generatedBy": "scripts/testing-v2/gen-inventory.mjs, preserving reconciled v2Path/v2Native ownership",
   "note": "Re-run `node scripts/testing-v2/gen-inventory.mjs` after census changes. Classification overrides live in this generator; execution ownership is derived by test-map-execution.mjs.",
-  "censusTotal": 1146,
+  "censusTotal": 1143,
   "buckets": {
     "daily": 68,
-    "v2-browser": 217,
-    "v2-core": 513,
+    "v2-browser": 216,
+    "v2-core": 512,
     "v2-dom": 144,
-    "v2-integration": 204
+    "v2-integration": 203
   },
   "methods": {
     "adapter": 276,
@@ -20,6 +20,15 @@
     "vitest-e2e": 2
   },
   "v2Native": [
+    {
+      "path": "tests2/browser/journeys/pack-hot-reload.journey.spec.ts",
+      "reason": "Real source-Vite browser journey proving nested marketplace renderer and parameterized-panel bytes repaint through the development bridge without page or workspace identity loss, survive ordinary reload, and clean all fixture state.",
+      "execution": {
+        "runner": "playwright",
+        "tier": "browser",
+        "project": "browser"
+      }
+    },
     {
       "path": "tests2/core/market-pack-dev.test.ts",
       "reason": "Focused core coverage for strict generic pack-watch parsing and resolution, deterministic declared-output mirroring, serialized rebuild publication and failure recovery, bounded Vite notification, and cleanup.",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -314,6 +314,7 @@ function tailwindcssWithBundledDevGuard(): Plugin[] {
 
 const PACK_DEV_REBUILT_PATH = "/__bobbit_dev/pack-rebuilt";
 const PACK_DEV_REBUILT_MAX_BODY = 8 * 1024;
+const PACK_DEV_RELOAD_HEADER = "x-bobbit-pack-reload";
 const SAFE_PACK_ID = /^[a-z0-9][a-z0-9-]*$/;
 
 type NetworkInterfaces = ReturnType<typeof os.networkInterfaces>;
@@ -386,6 +387,14 @@ export function packDevHotReload(): Plugin {
 					return;
 				}
 				if (!isLocalVitePeer(req.socket.remoteAddress)) {
+					res.writeHead(403, { "Content-Type": "text/plain; charset=utf-8" });
+					res.end("Forbidden");
+					return;
+				}
+				// A required non-simple header prevents a hostile browser origin from
+				// issuing an opaque loopback write. This route deliberately emits no
+				// CORS allow headers, so browsers cannot preflight the header.
+				if (req.headers[PACK_DEV_RELOAD_HEADER] !== "1") {
 					res.writeHead(403, { "Content-Type": "text/plain; charset=utf-8" });
 					res.end("Forbidden");
 					return;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,6 +3,7 @@ import crypto from "node:crypto";
 import fs from "node:fs";
 import http from "node:http";
 import https from "node:https";
+import net from "node:net";
 import os from "node:os";
 import path from "node:path";
 import { defineConfig, type Plugin } from "vite";
@@ -311,6 +312,145 @@ function tailwindcssWithBundledDevGuard(): Plugin[] {
 	return plugins;
 }
 
+const PACK_DEV_REBUILT_PATH = "/__bobbit_dev/pack-rebuilt";
+const PACK_DEV_REBUILT_MAX_BODY = 8 * 1024;
+const SAFE_PACK_ID = /^[a-z0-9][a-z0-9-]*$/;
+
+type NetworkInterfaces = ReturnType<typeof os.networkInterfaces>;
+
+function normalizedPeerAddress(address: string): string {
+	const withoutScope = address.trim().toLowerCase().replace(/%.+$/, "");
+	const mapped = /^::ffff:(\d+\.\d+\.\d+\.\d+)$/.exec(withoutScope);
+	return mapped?.[1] ?? withoutScope;
+}
+
+function sameIpAddress(left: string, right: string): boolean {
+	const family = net.isIP(left);
+	if (family === 0 || net.isIP(right) !== family) return false;
+	const type = family === 4 ? "ipv4" : "ipv6";
+	try {
+		const addresses = new net.BlockList();
+		addresses.addAddress(left, type);
+		return addresses.check(right, type);
+	} catch {
+		return false;
+	}
+}
+
+/** True only for a loopback peer or an address assigned to this machine. */
+export function isLocalVitePeer(remoteAddress: string | undefined, interfaces: NetworkInterfaces = os.networkInterfaces()): boolean {
+	if (!remoteAddress) return false;
+	const peer = normalizedPeerAddress(remoteAddress);
+	if ((net.isIP(peer) === 4 && peer.startsWith("127.")) || sameIpAddress(peer, "::1")) return true;
+	if (net.isIP(peer) === 0) return false;
+
+	for (const addresses of Object.values(interfaces)) {
+		for (const address of addresses ?? []) {
+			if (sameIpAddress(peer, normalizedPeerAddress(address.address))) return true;
+		}
+	}
+	return false;
+}
+
+function validPackReloadPayload(value: unknown): value is { pack: string; reloadToken: number } {
+	if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+	const record = value as Record<string, unknown>;
+	return Object.keys(record).length === 2
+		&& typeof record.pack === "string"
+		&& SAFE_PACK_ID.test(record.pack)
+		&& typeof record.reloadToken === "number"
+		&& Number.isSafeInteger(record.reloadToken)
+		&& record.reloadToken > 0;
+}
+
+/**
+ * Development-only bridge from the authored-pack watcher to Vite's existing
+ * HMR channel. The gateway and production build expose no corresponding API.
+ */
+export function packDevHotReload(): Plugin {
+	return {
+		name: "bobbit-pack-dev-hot-reload",
+		apply: "serve",
+		configureServer(server) {
+			server.middlewares.use((req, res, next) => {
+				let pathname: string;
+				try {
+					pathname = new URL(req.url || "/", "http://vite.invalid").pathname;
+				} catch {
+					return next();
+				}
+				if (pathname !== PACK_DEV_REBUILT_PATH) return next();
+				if (req.method !== "POST") {
+					res.writeHead(405, { Allow: "POST", "Content-Type": "text/plain; charset=utf-8" });
+					res.end("Method Not Allowed");
+					return;
+				}
+				if (!isLocalVitePeer(req.socket.remoteAddress)) {
+					res.writeHead(403, { "Content-Type": "text/plain; charset=utf-8" });
+					res.end("Forbidden");
+					return;
+				}
+
+				const declaredLength = req.headers["content-length"];
+				if (declaredLength !== undefined) {
+					const rawLength = Array.isArray(declaredLength) ? declaredLength[0] : declaredLength;
+					const isNumericLength = typeof rawLength === "string" && /^\d+$/.test(rawLength);
+					if (!isNumericLength || Number(rawLength) > PACK_DEV_REBUILT_MAX_BODY) {
+						res.writeHead(isNumericLength ? 413 : 400, { "Content-Type": "text/plain; charset=utf-8" });
+						res.end(isNumericLength ? "Payload Too Large" : "Bad Request");
+						req.resume();
+						return;
+					}
+				}
+
+				let size = 0;
+				let complete = false;
+				const chunks: Buffer[] = [];
+				const reject = (status: number, message: string) => {
+					if (complete) return;
+					complete = true;
+					res.writeHead(status, { "Content-Type": "text/plain; charset=utf-8" });
+					res.end(message);
+				};
+				req.on("data", (chunk: Buffer | string) => {
+					if (complete) return;
+					const bytes = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+					size += bytes.byteLength;
+					if (size > PACK_DEV_REBUILT_MAX_BODY) {
+						reject(413, "Payload Too Large");
+						return;
+					}
+					chunks.push(bytes);
+				});
+				req.on("error", () => reject(400, "Bad Request"));
+				req.on("aborted", () => reject(400, "Bad Request"));
+				req.on("end", () => {
+					if (complete) return;
+					let payload: unknown;
+					try {
+						payload = JSON.parse(Buffer.concat(chunks).toString("utf8"));
+					} catch {
+						reject(400, "Bad Request");
+						return;
+					}
+					if (!validPackReloadPayload(payload)) {
+						reject(400, "Bad Request");
+						return;
+					}
+					complete = true;
+					server.ws.send({
+						type: "custom",
+						event: "bobbit:pack-rebuilt",
+						data: payload,
+					});
+					res.writeHead(204);
+					res.end();
+				});
+			});
+		},
+	};
+}
+
 /**
  * Defense-in-depth: Reject requests from non-localhost IPs when Vite is
  * bound to localhost, and block Docker bridge subnet IPs in all modes.
@@ -616,6 +756,7 @@ export default defineConfig(({ command, mode }) => ({
 		tailwindcssWithBundledDevGuard(),
 		blockDangerousGlobs(),
 		localhostGuard(),
+		packDevHotReload(),
 		bobbitSwVersion(),
 		dynamicGatewayProxy(),
 	],


### PR DESCRIPTION
## Summary
- add a generic selected-pack `dev:pack` watcher with explicit declarations, deterministic mirrors, serialized rebuilds, and recoverable Vite notifications
- hot-invalidate pack renderer and panel modules while preserving tabs, selection, and panel instance identity
- add focused core/DOM coverage, a real browser hot-reload journey, and authoring documentation

## Testing
- full implementation workflow: build, type check, unit, browser, E2E, code review, security review, and QA passed
- retry-free browser journey for real renderer/panel bytes passed

## Scope
- production build/runtime behavior is unchanged
- no performance pack files were added or modified

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)