### PR TITLE
Make side panel divider resizable

### DIFF
--- a/src/app/app.css
+++ b/src/app/app.css
@@ -1188,6 +1188,45 @@ details.wf-proposal-workflow .wf-proposal-gates {
 	.side-panel-resize-handle:focus-visible::after {
 		background: color-mix(in oklch, var(--primary) 55%, transparent);
 	}
+	/* Once the pointer passes a terminal threshold, preview the action that
+	   releasing will take instead of leaving the clamped divider ambiguous. */
+	.side-panel-split-layout[data-resize-intent]::after {
+		position: absolute;
+		left: 50%;
+		top: 50%;
+		z-index: 30;
+		transform: translate(-50%, -50%);
+		padding: 6px 10px;
+		border: 1px solid var(--border);
+		border-radius: 6px;
+		background: var(--card);
+		color: var(--foreground);
+		box-shadow: 0 4px 14px color-mix(in oklch, var(--foreground) 16%, transparent);
+		font-size: 12px;
+		font-weight: 600;
+		white-space: nowrap;
+		pointer-events: none;
+	}
+	.side-panel-split-layout[data-resize-intent="collapse"]::after {
+		content: "Release to collapse panel";
+		border-color: color-mix(in oklch, var(--warning) 55%, var(--border));
+	}
+	.side-panel-split-layout[data-resize-intent="fullscreen"]::after {
+		content: "Release to expand panel";
+		border-color: color-mix(in oklch, var(--info) 55%, var(--border));
+	}
+	.side-panel-split-layout[data-resize-intent="collapse"] > .side-panel-workspace {
+		box-shadow: inset 0 0 0 2px color-mix(in oklch, var(--warning) 45%, transparent);
+	}
+	.side-panel-split-layout[data-resize-intent="fullscreen"] > .side-panel-workspace {
+		box-shadow: inset 0 0 0 2px color-mix(in oklch, var(--info) 45%, transparent);
+	}
+	.side-panel-split-layout[data-resize-intent="collapse"] > .side-panel-resize-handle::after {
+		background: var(--warning);
+	}
+	.side-panel-split-layout[data-resize-intent="fullscreen"] > .side-panel-resize-handle::after {
+		background: var(--info);
+	}
 	/* When a proposal/preview panel is nested inside the shared side-panel
 	   workspace, the inner panel must fill its parent — the outer panel already
 	   supplies the user-selected width and the left border. */

--- a/src/app/app.css
+++ b/src/app/app.css
@@ -1188,44 +1188,42 @@ details.wf-proposal-workflow .wf-proposal-gates {
 	.side-panel-resize-handle:focus-visible::after {
 		background: color-mix(in oklch, var(--primary) 55%, transparent);
 	}
-	/* Once the pointer passes a terminal threshold, preview the action that
-	   releasing will take instead of leaving the clamped divider ambiguous. */
+	/* Once the pointer passes a terminal threshold, fade the pane that will
+	   disappear and pulse the outer edge toward which the divider was dragged. */
+	.side-panel-split-layout > .side-panel-chat-pane,
+	.side-panel-split-layout > .side-panel-workspace {
+		transition: opacity 140ms ease;
+	}
+	.side-panel-split-layout[data-resize-intent="collapse"] > .side-panel-workspace,
+	.side-panel-split-layout[data-resize-intent="fullscreen"] > .side-panel-chat-pane {
+		opacity: 0.22;
+	}
 	.side-panel-split-layout[data-resize-intent]::after {
+		content: "";
 		position: absolute;
-		left: 50%;
-		top: 50%;
+		top: 0;
+		bottom: 0;
 		z-index: 30;
-		transform: translate(-50%, -50%);
-		padding: 6px 10px;
-		border: 1px solid var(--border);
-		border-radius: 6px;
-		background: var(--card);
-		color: var(--foreground);
-		box-shadow: 0 4px 14px color-mix(in oklch, var(--foreground) 16%, transparent);
-		font-size: 12px;
-		font-weight: 600;
-		white-space: nowrap;
+		width: 12px;
 		pointer-events: none;
+		animation: side-panel-terminal-edge-pulse 900ms ease-in-out infinite;
 	}
 	.side-panel-split-layout[data-resize-intent="collapse"]::after {
-		content: "Release to collapse panel";
-		border-color: color-mix(in oklch, var(--warning) 55%, var(--border));
+		right: 0;
+		transform-origin: right center;
+		background: linear-gradient(to left, color-mix(in oklch, var(--primary) 65%, transparent), transparent);
 	}
 	.side-panel-split-layout[data-resize-intent="fullscreen"]::after {
-		content: "Release to expand panel";
-		border-color: color-mix(in oklch, var(--info) 55%, var(--border));
+		left: 0;
+		transform-origin: left center;
+		background: linear-gradient(to right, color-mix(in oklch, var(--primary) 65%, transparent), transparent);
 	}
-	.side-panel-split-layout[data-resize-intent="collapse"] > .side-panel-workspace {
-		box-shadow: inset 0 0 0 2px color-mix(in oklch, var(--warning) 45%, transparent);
+	.side-panel-split-layout[data-resize-intent] > .side-panel-resize-handle::after {
+		background: var(--primary);
 	}
-	.side-panel-split-layout[data-resize-intent="fullscreen"] > .side-panel-workspace {
-		box-shadow: inset 0 0 0 2px color-mix(in oklch, var(--info) 45%, transparent);
-	}
-	.side-panel-split-layout[data-resize-intent="collapse"] > .side-panel-resize-handle::after {
-		background: var(--warning);
-	}
-	.side-panel-split-layout[data-resize-intent="fullscreen"] > .side-panel-resize-handle::after {
-		background: var(--info);
+	@keyframes side-panel-terminal-edge-pulse {
+		0%, 100% { opacity: 0.3; transform: scaleX(0.65); }
+		50% { opacity: 0.8; transform: scaleX(1); }
 	}
 	/* When a proposal/preview panel is nested inside the shared side-panel
 	   workspace, the inner panel must fill its parent — the outer panel already
@@ -1235,6 +1233,13 @@ details.wf-proposal-workflow .wf-proposal-gates {
 		flex: 1 1 auto;
 		max-width: 100%;
 		border-left: none;
+	}
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.side-panel-split-layout[data-resize-intent]::after {
+		animation: none;
+		opacity: 0.55;
 	}
 }
 

--- a/src/app/app.css
+++ b/src/app/app.css
@@ -1140,26 +1140,57 @@ details.wf-proposal-workflow .wf-proposal-gates {
  * GOAL ASSISTANT — split-screen preview panel & mobile tabs
  * ============================================================================ */
 
-/* Chat and preview panels each take 50% on desktop. Scope this to the
- * top-level split row only: proposal renderers can nest their own
- * .goal-preview-panel inside the right workspace, and those must fill the
- * workspace rather than inheriting a second 50% constraint. */
+/* The desktop split defaults to 50/50. The right workspace basis is a
+ * persisted user preference updated by its shared divider. Scope sizing to the
+ * top-level split row: proposal renderers can nest their own
+ * .goal-preview-panel, and those must fill the workspace. */
 @media (min-width: 768px) {
 	.side-panel-split-layout > .side-panel-chat-pane,
 	.goal-split-layout > .goal-chat-panel {
-		flex: 0 0 50%;
-		max-width: 50%;
+		flex: 1 1 auto;
+		max-width: calc(100% - var(--side-panel-width, 50%));
 		overflow: hidden;
 	}
 	.side-panel-split-layout > .side-panel-workspace,
 	.goal-split-layout > .goal-preview-panel {
-		flex: 0 0 50%;
-		max-width: 50%;
+		flex: 0 0 var(--side-panel-width, 50%);
+		max-width: var(--side-panel-width, 50%);
 		overflow: hidden;
+	}
+	.side-panel-split-layout > .side-panel-workspace {
+		position: relative;
+	}
+	/* A wide transparent target makes the one-pixel boundary easy to grab
+	   without taking layout space away from either pane. */
+	.side-panel-resize-handle {
+		position: absolute;
+		top: 0;
+		bottom: 0;
+		left: -4px;
+		width: 8px;
+		z-index: 20;
+		cursor: col-resize;
+		touch-action: none;
+		outline: none;
+	}
+	.side-panel-resize-handle::after {
+		content: "";
+		position: absolute;
+		top: 0;
+		bottom: 0;
+		left: 3px;
+		width: 2px;
+		background: transparent;
+		transition: background 120ms ease;
+	}
+	.side-panel-resize-handle:hover::after,
+	.side-panel-resize-handle:active::after,
+	.side-panel-resize-handle:focus-visible::after {
+		background: color-mix(in oklch, var(--primary) 55%, transparent);
 	}
 	/* When a proposal/preview panel is nested inside the shared side-panel
 	   workspace, the inner panel must fill its parent — the outer panel already
-	   supplies the 50% width and the left border. */
+	   supplies the user-selected width and the left border. */
 	.side-panel-workspace .goal-preview-panel,
 	.goal-preview-panel .goal-preview-panel {
 		flex: 1 1 auto;

--- a/src/app/app.css
+++ b/src/app/app.css
@@ -1157,16 +1157,16 @@ details.wf-proposal-workflow .wf-proposal-gates {
 		max-width: var(--side-panel-width, 50%);
 		overflow: hidden;
 	}
-	.side-panel-split-layout > .side-panel-workspace {
+	.side-panel-split-layout {
 		position: relative;
 	}
-	/* A wide transparent target makes the one-pixel boundary easy to grab
-	   without taking layout space away from either pane. */
+	/* Keep the wide transparent target in the split-layout parent so the
+	   workspace's overflow clipping cannot cut its chat-side half off. */
 	.side-panel-resize-handle {
 		position: absolute;
 		top: 0;
 		bottom: 0;
-		left: -4px;
+		left: calc(100% - var(--side-panel-width, 50%) - 4px);
 		width: 8px;
 		z-index: 20;
 		cursor: col-resize;

--- a/src/app/render.ts
+++ b/src/app/render.ts
@@ -1163,7 +1163,13 @@ export function workspaceSessionId(): string {
 }
 
 type SidePanelSizeMode = "collapsed" | "split" | "fullscreen";
-const SIDE_PANEL_COLLAPSE_THRESHOLD = 10;
+type SidePanelDragIntent = "collapse" | "fullscreen" | null;
+
+function sidePanelDragIntent(rawPercent: number): SidePanelDragIntent {
+	if (rawPercent < SIDE_PANEL_WIDTH_MIN) return "collapse";
+	if (rawPercent > SIDE_PANEL_WIDTH_MAX) return "fullscreen";
+	return null;
+}
 
 function renderSidePanelResizeHandle() {
 	return html`
@@ -1213,6 +1219,8 @@ function onSidePanelResizePointerDown(event: PointerEvent): void {
 		window.removeEventListener("pointerup", onUp);
 		window.removeEventListener("pointercancel", onCancel);
 		window.removeEventListener("blur", onBlur);
+		delete layout.dataset.resizeIntent;
+		handle.removeAttribute("aria-valuetext");
 		if (pointerId !== undefined) {
 			try { handle.releasePointerCapture(pointerId); } catch {}
 		}
@@ -1223,14 +1231,23 @@ function onSidePanelResizePointerDown(event: PointerEvent): void {
 		const nextWidth = startPanelWidth - (moveEvent.clientX - startX);
 		lastRawPercent = (nextWidth / layoutWidth) * 100;
 		updateSidePanelDividerValue(handle, lastRawPercent);
+		const intent = sidePanelDragIntent(lastRawPercent);
+		if (intent) {
+			layout.dataset.resizeIntent = intent;
+			handle.setAttribute("aria-valuetext", intent === "collapse" ? "Release to collapse panel" : "Release to expand panel fullscreen");
+		} else {
+			delete layout.dataset.resizeIntent;
+			handle.removeAttribute("aria-valuetext");
+		}
 	};
 	const onUp = (upEvent: PointerEvent) => {
-		const shouldCollapse = lastRawPercent <= SIDE_PANEL_COLLAPSE_THRESHOLD;
+		const intent = sidePanelDragIntent(lastRawPercent);
 		cleanup(upEvent.pointerId);
-		if (shouldCollapse) {
-			// A collapse gesture should not overwrite the width restored on reopen.
+		if (intent) {
+			// A terminal drag gesture should not overwrite the split width restored
+			// when the user returns from collapsed or fullscreen mode.
 			setSidePanelWidthPercent(startPercent);
-			void setSidePanelSizeMode("collapsed", workspaceSessionId());
+			void setSidePanelSizeMode(intent === "collapse" ? "collapsed" : "fullscreen", workspaceSessionId());
 		}
 	};
 	const onCancel = (cancelEvent: PointerEvent) => cleanup(cancelEvent.pointerId);

--- a/src/app/render.ts
+++ b/src/app/render.ts
@@ -1199,6 +1199,7 @@ function updateSidePanelDividerValue(handle: HTMLElement, percent: number): void
 }
 
 function onSidePanelResizePointerDown(event: PointerEvent): void {
+	if (!event.isPrimary || event.button !== 0) return;
 	event.preventDefault();
 	if (activeSidePanelResizeCancelIfInvalid) return;
 	const handle = event.currentTarget as HTMLElement;

--- a/src/app/render.ts
+++ b/src/app/render.ts
@@ -17,6 +17,10 @@ import {
 	activeSessionId,
 	getSidebarData,
 	setRenderSuppressed,
+	setSidePanelWidthPercent,
+	SIDE_PANEL_WIDTH_DEFAULT,
+	SIDE_PANEL_WIDTH_MIN,
+	SIDE_PANEL_WIDTH_MAX,
 	type GatewaySession,
 	type Project,
 } from "./state.js";
@@ -1159,6 +1163,62 @@ export function workspaceSessionId(): string {
 }
 
 type SidePanelSizeMode = "collapsed" | "split" | "fullscreen";
+
+function updateSidePanelDividerValue(handle: HTMLElement, percent: number): void {
+	setSidePanelWidthPercent(percent);
+	handle.setAttribute("aria-valuenow", String(state.sidePanelWidthPercent));
+}
+
+function onSidePanelResizePointerDown(event: PointerEvent): void {
+	event.preventDefault();
+	const handle = event.currentTarget as HTMLElement;
+	const layout = handle.closest<HTMLElement>(".side-panel-split-layout");
+	const panel = handle.closest<HTMLElement>(".side-panel-workspace");
+	if (!layout || !panel) return;
+
+	const layoutWidth = layout.getBoundingClientRect().width;
+	if (layoutWidth <= 0) return;
+	const startX = event.clientX;
+	const startPanelWidth = panel.getBoundingClientRect().width;
+	const previousCursor = document.body.style.cursor;
+	const previousUserSelect = document.body.style.userSelect;
+	try { handle.setPointerCapture(event.pointerId); } catch {}
+	document.body.style.cursor = "col-resize";
+	document.body.style.userSelect = "none";
+
+	const onMove = (moveEvent: PointerEvent) => {
+		const nextWidth = startPanelWidth - (moveEvent.clientX - startX);
+		updateSidePanelDividerValue(handle, (nextWidth / layoutWidth) * 100);
+	};
+	const onEnd = (endEvent: PointerEvent) => {
+		handle.removeEventListener("pointermove", onMove);
+		handle.removeEventListener("pointerup", onEnd);
+		handle.removeEventListener("pointercancel", onEnd);
+		try { handle.releasePointerCapture(endEvent.pointerId); } catch {}
+		document.body.style.cursor = previousCursor;
+		document.body.style.userSelect = previousUserSelect;
+	};
+	handle.addEventListener("pointermove", onMove);
+	handle.addEventListener("pointerup", onEnd);
+	handle.addEventListener("pointercancel", onEnd);
+}
+
+function onSidePanelResizeDoubleClick(event: MouseEvent): void {
+	event.preventDefault();
+	updateSidePanelDividerValue(event.currentTarget as HTMLElement, SIDE_PANEL_WIDTH_DEFAULT);
+}
+
+function onSidePanelResizeKeyDown(event: KeyboardEvent): void {
+	let next: number | undefined;
+	const step = event.shiftKey ? 10 : 2;
+	if (event.key === "ArrowLeft") next = state.sidePanelWidthPercent + step;
+	if (event.key === "ArrowRight") next = state.sidePanelWidthPercent - step;
+	if (event.key === "Home") next = SIDE_PANEL_WIDTH_MAX;
+	if (event.key === "End") next = SIDE_PANEL_WIDTH_MIN;
+	if (next === undefined) return;
+	event.preventDefault();
+	updateSidePanelDividerValue(event.currentTarget as HTMLElement, next);
+}
 
 function sidePanelSizeModeBySession(): Record<string, SidePanelSizeMode> {
 	const holder = state as any;

--- a/src/app/render.ts
+++ b/src/app/render.ts
@@ -1165,6 +1165,8 @@ export function workspaceSessionId(): string {
 type SidePanelSizeMode = "collapsed" | "split" | "fullscreen";
 type SidePanelDragIntent = "collapse" | "fullscreen" | null;
 
+let activeSidePanelResizeCancelIfInvalid: (() => void) | null = null;
+
 function sidePanelDragIntent(rawPercent: number): SidePanelDragIntent {
 	if (rawPercent < SIDE_PANEL_WIDTH_MIN) return "collapse";
 	if (rawPercent > SIDE_PANEL_WIDTH_MAX) return "fullscreen";
@@ -1181,6 +1183,7 @@ function renderSidePanelResizeHandle() {
 			aria-valuemin=${SIDE_PANEL_WIDTH_MIN}
 			aria-valuemax=${SIDE_PANEL_WIDTH_MAX}
 			aria-valuenow=${state.sidePanelWidthPercent}
+			aria-controls="side-panel-workspace"
 			tabindex="0"
 			title="Drag to resize (drag fully right to collapse; double-click to reset)"
 			@pointerdown=${onSidePanelResizePointerDown}
@@ -1197,6 +1200,7 @@ function updateSidePanelDividerValue(handle: HTMLElement, percent: number): void
 
 function onSidePanelResizePointerDown(event: PointerEvent): void {
 	event.preventDefault();
+	if (activeSidePanelResizeCancelIfInvalid) return;
 	const handle = event.currentTarget as HTMLElement;
 	const layout = handle.closest<HTMLElement>(".side-panel-split-layout");
 	const panel = layout?.querySelector<HTMLElement>(":scope > .side-panel-workspace");
@@ -1204,32 +1208,50 @@ function onSidePanelResizePointerDown(event: PointerEvent): void {
 
 	const layoutWidth = layout.getBoundingClientRect().width;
 	if (layoutWidth <= 0) return;
+	const pointerId = event.pointerId;
+	const dragSessionId = workspaceSessionId();
 	const startX = event.clientX;
 	const startPanelWidth = panel.getBoundingClientRect().width;
 	const startPercent = (startPanelWidth / layoutWidth) * 100;
 	let lastRawPercent = startPercent;
+	let cleaned = false;
+	let observer: MutationObserver | null = null;
+	let cancelIfInvalid: (() => void) | null = null;
 	const previousCursor = document.body.style.cursor;
 	const previousUserSelect = document.body.style.userSelect;
-	try { handle.setPointerCapture(event.pointerId); } catch {}
+	try { handle.setPointerCapture(pointerId); } catch {}
 	document.body.style.cursor = "col-resize";
 	document.body.style.userSelect = "none";
 
-	const cleanup = (pointerId?: number) => {
+	const rawPercentAt = (clientX: number) => {
+		const nextWidth = startPanelWidth - (clientX - startX);
+		return (nextWidth / layoutWidth) * 100;
+	};
+	const cleanup = (restoreTerminalWidth: boolean) => {
+		if (cleaned) return;
+		cleaned = true;
+		if (cancelIfInvalid && activeSidePanelResizeCancelIfInvalid === cancelIfInvalid) {
+			activeSidePanelResizeCancelIfInvalid = null;
+		}
+		observer?.disconnect();
 		window.removeEventListener("pointermove", onMove);
 		window.removeEventListener("pointerup", onUp);
 		window.removeEventListener("pointercancel", onCancel);
 		window.removeEventListener("blur", onBlur);
+		handle.removeEventListener("lostpointercapture", onLostPointerCapture);
 		delete layout.dataset.resizeIntent;
 		handle.removeAttribute("aria-valuetext");
-		if (pointerId !== undefined) {
-			try { handle.releasePointerCapture(pointerId); } catch {}
+		if (restoreTerminalWidth && sidePanelDragIntent(lastRawPercent)) {
+			setSidePanelWidthPercent(startPercent);
 		}
+		try { handle.releasePointerCapture(pointerId); } catch {}
 		document.body.style.cursor = previousCursor;
 		document.body.style.userSelect = previousUserSelect;
 	};
+	const cancel = () => cleanup(true);
 	const onMove = (moveEvent: PointerEvent) => {
-		const nextWidth = startPanelWidth - (moveEvent.clientX - startX);
-		lastRawPercent = (nextWidth / layoutWidth) * 100;
+		if (moveEvent.pointerId !== pointerId) return;
+		lastRawPercent = rawPercentAt(moveEvent.clientX);
 		updateSidePanelDividerValue(handle, lastRawPercent);
 		const intent = sidePanelDragIntent(lastRawPercent);
 		if (intent) {
@@ -1241,21 +1263,47 @@ function onSidePanelResizePointerDown(event: PointerEvent): void {
 		}
 	};
 	const onUp = (upEvent: PointerEvent) => {
+		if (upEvent.pointerId !== pointerId) return;
+		lastRawPercent = rawPercentAt(upEvent.clientX);
 		const intent = sidePanelDragIntent(lastRawPercent);
-		cleanup(upEvent.pointerId);
 		if (intent) {
 			// A terminal drag gesture should not overwrite the split width restored
 			// when the user returns from collapsed or fullscreen mode.
 			setSidePanelWidthPercent(startPercent);
-			void setSidePanelSizeMode(intent === "collapse" ? "collapsed" : "fullscreen", workspaceSessionId());
+		} else {
+			updateSidePanelDividerValue(handle, lastRawPercent);
+		}
+		cleanup(false);
+		if (intent) {
+			void setSidePanelSizeMode(intent === "collapse" ? "collapsed" : "fullscreen", dragSessionId);
 		}
 	};
-	const onCancel = (cancelEvent: PointerEvent) => cleanup(cancelEvent.pointerId);
-	const onBlur = () => cleanup();
+	const onCancel = (cancelEvent: PointerEvent) => {
+		if (cancelEvent.pointerId !== pointerId) return;
+		cancel();
+	};
+	const onLostPointerCapture = (lostEvent: PointerEvent) => {
+		if (lostEvent.pointerId !== pointerId) return;
+		cancel();
+	};
+	const onBlur = () => cancel();
+	const isCurrentDivider = () => handle.isConnected
+		&& layout.isConnected
+		&& isDesktop()
+		&& workspaceSessionId() === dragSessionId
+		&& getSidePanelSizeMode(dragSessionId) === "split"
+		&& layout.querySelector(":scope > .side-panel-resize-handle") === handle;
+	cancelIfInvalid = () => {
+		if (!isCurrentDivider()) cancel();
+	};
+	activeSidePanelResizeCancelIfInvalid = cancelIfInvalid;
+	observer = new MutationObserver(cancelIfInvalid);
+	observer.observe(document.body, { childList: true, subtree: true });
 	window.addEventListener("pointermove", onMove);
 	window.addEventListener("pointerup", onUp);
 	window.addEventListener("pointercancel", onCancel);
 	window.addEventListener("blur", onBlur);
+	handle.addEventListener("lostpointercapture", onLostPointerCapture);
 }
 
 function onSidePanelResizeDoubleClick(event: MouseEvent): void {
@@ -1268,8 +1316,8 @@ function onSidePanelResizeKeyDown(event: KeyboardEvent): void {
 	const step = event.shiftKey ? 10 : 2;
 	if (event.key === "ArrowLeft") next = state.sidePanelWidthPercent + step;
 	if (event.key === "ArrowRight") next = state.sidePanelWidthPercent - step;
-	if (event.key === "Home") next = SIDE_PANEL_WIDTH_MAX;
-	if (event.key === "End") next = SIDE_PANEL_WIDTH_MIN;
+	if (event.key === "Home") next = SIDE_PANEL_WIDTH_MIN;
+	if (event.key === "End") next = SIDE_PANEL_WIDTH_MAX;
 	if (next === undefined) return;
 	event.preventDefault();
 	updateSidePanelDividerValue(event.currentTarget as HTMLElement, next);
@@ -2511,6 +2559,7 @@ function renderArchivedBanner() {
 export function doRenderApp(): void {
 	const app = document.getElementById("app");
 	if (!app) return;
+	activeSidePanelResizeCancelIfInvalid?.();
 	installSidebarStatusMotionClickGuard();
 	const sidebarStatusMotion = captureSidebarStatusMotion(app);
 
@@ -3624,6 +3673,7 @@ export function doRenderApp(): void {
 
 		return html`
 			<div
+				id="side-panel-workspace"
 				class="side-panel-workspace goal-preview-panel flex-1 flex flex-col ${mode === "split" ? "border-l border-border" : ""} min-h-0"
 				data-panel-workspace="content"
 				data-side-panel-mode=${mode}

--- a/src/app/render.ts
+++ b/src/app/render.ts
@@ -1163,6 +1163,26 @@ export function workspaceSessionId(): string {
 }
 
 type SidePanelSizeMode = "collapsed" | "split" | "fullscreen";
+const SIDE_PANEL_COLLAPSE_THRESHOLD = 10;
+
+function renderSidePanelResizeHandle() {
+	return html`
+		<div
+			class="side-panel-resize-handle"
+			role="separator"
+			aria-label="Resize side panel"
+			aria-orientation="vertical"
+			aria-valuemin=${SIDE_PANEL_WIDTH_MIN}
+			aria-valuemax=${SIDE_PANEL_WIDTH_MAX}
+			aria-valuenow=${state.sidePanelWidthPercent}
+			tabindex="0"
+			title="Drag to resize (drag fully right to collapse; double-click to reset)"
+			@pointerdown=${onSidePanelResizePointerDown}
+			@dblclick=${onSidePanelResizeDoubleClick}
+			@keydown=${onSidePanelResizeKeyDown}
+		></div>
+	`;
+}
 
 function updateSidePanelDividerValue(handle: HTMLElement, percent: number): void {
 	setSidePanelWidthPercent(percent);
@@ -1173,34 +1193,52 @@ function onSidePanelResizePointerDown(event: PointerEvent): void {
 	event.preventDefault();
 	const handle = event.currentTarget as HTMLElement;
 	const layout = handle.closest<HTMLElement>(".side-panel-split-layout");
-	const panel = handle.closest<HTMLElement>(".side-panel-workspace");
+	const panel = layout?.querySelector<HTMLElement>(":scope > .side-panel-workspace");
 	if (!layout || !panel) return;
 
 	const layoutWidth = layout.getBoundingClientRect().width;
 	if (layoutWidth <= 0) return;
 	const startX = event.clientX;
 	const startPanelWidth = panel.getBoundingClientRect().width;
+	const startPercent = (startPanelWidth / layoutWidth) * 100;
+	let lastRawPercent = startPercent;
 	const previousCursor = document.body.style.cursor;
 	const previousUserSelect = document.body.style.userSelect;
 	try { handle.setPointerCapture(event.pointerId); } catch {}
 	document.body.style.cursor = "col-resize";
 	document.body.style.userSelect = "none";
 
-	const onMove = (moveEvent: PointerEvent) => {
-		const nextWidth = startPanelWidth - (moveEvent.clientX - startX);
-		updateSidePanelDividerValue(handle, (nextWidth / layoutWidth) * 100);
-	};
-	const onEnd = (endEvent: PointerEvent) => {
-		handle.removeEventListener("pointermove", onMove);
-		handle.removeEventListener("pointerup", onEnd);
-		handle.removeEventListener("pointercancel", onEnd);
-		try { handle.releasePointerCapture(endEvent.pointerId); } catch {}
+	const cleanup = (pointerId?: number) => {
+		window.removeEventListener("pointermove", onMove);
+		window.removeEventListener("pointerup", onUp);
+		window.removeEventListener("pointercancel", onCancel);
+		window.removeEventListener("blur", onBlur);
+		if (pointerId !== undefined) {
+			try { handle.releasePointerCapture(pointerId); } catch {}
+		}
 		document.body.style.cursor = previousCursor;
 		document.body.style.userSelect = previousUserSelect;
 	};
-	handle.addEventListener("pointermove", onMove);
-	handle.addEventListener("pointerup", onEnd);
-	handle.addEventListener("pointercancel", onEnd);
+	const onMove = (moveEvent: PointerEvent) => {
+		const nextWidth = startPanelWidth - (moveEvent.clientX - startX);
+		lastRawPercent = (nextWidth / layoutWidth) * 100;
+		updateSidePanelDividerValue(handle, lastRawPercent);
+	};
+	const onUp = (upEvent: PointerEvent) => {
+		const shouldCollapse = lastRawPercent <= SIDE_PANEL_COLLAPSE_THRESHOLD;
+		cleanup(upEvent.pointerId);
+		if (shouldCollapse) {
+			// A collapse gesture should not overwrite the width restored on reopen.
+			setSidePanelWidthPercent(startPercent);
+			void setSidePanelSizeMode("collapsed", workspaceSessionId());
+		}
+	};
+	const onCancel = (cancelEvent: PointerEvent) => cleanup(cancelEvent.pointerId);
+	const onBlur = () => cleanup();
+	window.addEventListener("pointermove", onMove);
+	window.addEventListener("pointerup", onUp);
+	window.addEventListener("pointercancel", onCancel);
+	window.addEventListener("blur", onBlur);
 }
 
 function onSidePanelResizeDoubleClick(event: MouseEvent): void {
@@ -3762,6 +3800,7 @@ export function doRenderApp(): void {
 							?inert=${fullscreen}
 							aria-hidden=${fullscreen ? "true" : nothing}
 						>${chatContent}</div>
+						${workspaceOccupiesSplitLayout ? renderSidePanelResizeHandle() : ""}
 						${workspaceCollapsed ? sidePanelRestoreButton() : ""}
 						${renderSidePanelWorkspace(mode, { hidden: workspaceHidden, retainedSlots, showPackHost })}
 					</div>

--- a/src/app/state.ts
+++ b/src/app/state.ts
@@ -370,6 +370,34 @@ export function applySidebarWidthVar(w: number): void {
 applySidebarWidthVar(loadSidebarWidth());
 
 // ============================================================================
+// SIDE PANEL WIDTH (user-resizable desktop split)
+// ============================================================================
+
+export const SIDE_PANEL_WIDTH_KEY = "bobbit-side-panel-width-percent";
+export const SIDE_PANEL_WIDTH_DEFAULT = 50;
+export const SIDE_PANEL_WIDTH_MIN = 25;
+export const SIDE_PANEL_WIDTH_MAX = 75;
+
+export function clampSidePanelWidthPercent(percent: number): number {
+	if (!Number.isFinite(percent)) return SIDE_PANEL_WIDTH_DEFAULT;
+	return Math.max(SIDE_PANEL_WIDTH_MIN, Math.min(SIDE_PANEL_WIDTH_MAX, Math.round(percent * 10) / 10));
+}
+
+function loadSidePanelWidthPercent(): number {
+	const raw = safeGetItem(SIDE_PANEL_WIDTH_KEY);
+	if (!raw) return SIDE_PANEL_WIDTH_DEFAULT;
+	return clampSidePanelWidthPercent(Number.parseFloat(raw));
+}
+
+export function applySidePanelWidthVar(percent: number): void {
+	if (typeof document === "undefined") return;
+	document.documentElement.style.setProperty("--side-panel-width", `${percent}%`);
+}
+
+// Apply before the workspace is painted to avoid a 50% → persisted-width jump.
+applySidePanelWidthVar(loadSidePanelWidthPercent());
+
+// ============================================================================
 // SIDEBAR FONT SCALE — helpers live in `./sidebar-font-scale.ts` (no DOM
 // dependencies, so the Node unit test can import them directly). Re-exported
 // here so existing call sites can keep importing from `./state.js`.
@@ -532,6 +560,8 @@ export const state = {
 	sidebarCollapsed: safeGetItem("bobbit-sidebar-collapsed") === "true",
 	/** User-resizable sidebar width in px (expanded state). Clamped 180–480. */
 	sidebarWidth: loadSidebarWidth(),
+	/** Right-side workspace width as a percentage of the desktop split layout. */
+	sidePanelWidthPercent: loadSidePanelWidthPercent(),
 
 	/** Active session browsing view. Unknown persisted values safely resolve to By Project. */
 	sidebarSessionView: loadSidebarSessionView(),
@@ -1024,6 +1054,13 @@ export function setSidebarWidth(w: number, persist = true): void {
 	state.sidebarWidth = clamped;
 	applySidebarWidthVar(clamped);
 	if (persist) safeSetItem(SIDEBAR_WIDTH_KEY, String(clamped));
+}
+
+export function setSidePanelWidthPercent(percent: number, persist = true): void {
+	const clamped = clampSidePanelWidthPercent(percent);
+	state.sidePanelWidthPercent = clamped;
+	applySidePanelWidthVar(clamped);
+	if (persist) safeSetItem(SIDE_PANEL_WIDTH_KEY, String(clamped));
 }
 
 export const SIDEBAR_BREAKPOINT = 768;

--- a/tests/ui-fixtures/side-panel-pane-retention-entry.ts
+++ b/tests/ui-fixtures/side-panel-pane-retention-entry.ts
@@ -180,15 +180,15 @@ function addFixtureStyle(): void {
 	if (document.getElementById("pane-retention-fixture-style")) return;
 	const style = document.createElement("style");
 	style.id = "pane-retention-fixture-style";
-	// Minimal Tailwind-equivalents plus the REAL app.css split-row rules the
-	// geometry assertions depend on (app.css:1147-1159). `[hidden]` is deliberately
+	// Minimal Tailwind-equivalents plus the REAL app.css split-row and divider
+	// rules the geometry assertions depend on (app.css:1147-1190). `[hidden]` is deliberately
 	// NOT `!important`: Tailwind's preflight rule loses to a `display:flex`
 	// utility class exactly as it does in production, so the fixture still
 	// exercises the "hidden alone does not hide a flex box" trap (design §3.3).
 	style.textContent = `
 		:root { --border:#d0d0d0; --background:#fff; --foreground:#111; --muted-foreground:#666; --primary:#2563eb; --secondary:#f4f4f5; --mobile-header-height:60px; }
 		*, *::before, *::after { box-sizing: border-box; }
-		body { margin: 0; font-family: system-ui, sans-serif; }
+		body { margin: 0; font-family: system-ui, sans-serif; background: var(--background); color: var(--foreground); }
 		.app-shell { height: 100vh; }
 		[hidden] { display: none; }
 		.hidden { display: none; }
@@ -215,12 +215,46 @@ function addFixtureStyle(): void {
 		.py-2 { padding-top: 0.5rem; padding-bottom: 0.5rem; }
 		.goal-tab-bar { background: var(--background); overflow-x: auto; }
 		.goal-tab-pill { display: inline-flex; align-items: center; gap: 0.25rem; border: 1px solid var(--border); border-radius: 999px; padding: 0.25rem 0.5rem; white-space: nowrap; }
-		.goal-tab-pill--active { background: var(--primary); color: #fff; }
+		.goal-tab-pill--active { background: var(--primary); color: var(--background); }
 		@media (min-width: 768px) {
 			.side-panel-split-layout > .side-panel-chat-pane,
-			.goal-split-layout > .goal-chat-panel { flex: 0 0 50%; max-width: 50%; overflow: hidden; }
+			.goal-split-layout > .goal-chat-panel {
+				flex: 1 1 auto;
+				max-width: calc(100% - var(--side-panel-width, 50%));
+				overflow: hidden;
+			}
 			.side-panel-split-layout > .side-panel-workspace,
-			.goal-split-layout > .goal-preview-panel { flex: 0 0 50%; max-width: 50%; overflow: hidden; }
+			.goal-split-layout > .goal-preview-panel {
+				flex: 0 0 var(--side-panel-width, 50%);
+				max-width: var(--side-panel-width, 50%);
+				overflow: hidden;
+			}
+			.side-panel-split-layout { position: relative; }
+			.side-panel-resize-handle {
+				position: absolute;
+				top: 0;
+				bottom: 0;
+				left: calc(100% - var(--side-panel-width, 50%) - 4px);
+				width: 8px;
+				z-index: 20;
+				cursor: col-resize;
+				touch-action: none;
+				outline: none;
+			}
+			.side-panel-resize-handle::after {
+				content: "";
+				position: absolute;
+				top: 0;
+				bottom: 0;
+				left: 3px;
+				width: 2px;
+				background: transparent;
+			}
+			.side-panel-resize-handle:hover::after,
+			.side-panel-resize-handle:active::after,
+			.side-panel-resize-handle:focus-visible::after {
+				background: color-mix(in oklch, var(--primary) 55%, transparent);
+			}
 		}
 		.side-panel-slider { width: 100%; }
 	`;

--- a/tests2/browser/fixtures/side-panel-pane-retention.spec.ts
+++ b/tests2/browser/fixtures/side-panel-pane-retention.spec.ts
@@ -25,7 +25,7 @@
  * liveness test. The claim is that the framed document is DETACHED, not merely hidden,
  * which needs a held element reference in a live document.
  */
-import { test, expect } from "@playwright/test";
+import { test, expect, type Page } from "@playwright/test";
 import {
 	RETENTION_LIMIT,
 	beaconCount,
@@ -52,6 +52,35 @@ import {
 
 registerRetentionBundleBuild();
 
+async function dragRetentionDivider(page: Page, rawPercent: number, pointerId: number): Promise<void> {
+	await page.getByRole("separator", { name: "Resize side panel" }).evaluate((element, input) => {
+		const handle = element as HTMLElement;
+		const layout = handle.closest<HTMLElement>(".side-panel-split-layout");
+		const panel = layout?.querySelector<HTMLElement>(":scope > .side-panel-workspace");
+		if (!layout || !panel) throw new Error("retention divider has no split geometry");
+		const layoutBox = layout.getBoundingClientRect();
+		const handleBox = handle.getBoundingClientRect();
+		const startX = handleBox.x + handleBox.width / 2;
+		const startY = handleBox.y + Math.max(handleBox.height / 2, 1);
+		const startPercent = panel.getBoundingClientRect().width / layoutBox.width * 100;
+		const clientX = startX + (startPercent - input.rawPercent) * layoutBox.width / 100;
+		const event = (type: "pointerdown" | "pointermove" | "pointerup", x: number, buttons: number) => new PointerEvent(type, {
+			pointerId: input.pointerId,
+			pointerType: "touch",
+			isPrimary: true,
+			clientX: x,
+			clientY: startY,
+			button: type === "pointerdown" || type === "pointerup" ? 0 : -1,
+			buttons,
+			bubbles: true,
+		});
+		handle.dispatchEvent(event("pointerdown", startX, 1));
+		window.dispatchEvent(event("pointermove", clientX, 1));
+		window.dispatchEvent(event("pointerup", clientX, 0));
+	}, { rawPercent, pointerId });
+	await settleRender(page);
+}
+
 test.describe("side-panel pane retention (desktop)", () => {
 	test("a retained pane's framed document loads exactly once across collapse, tab switch, session round-trip and the mode ladder — and cold-mounts after the tab is closed", async ({ page }) => {
 		const requests = await loadFixture(page);
@@ -62,8 +91,13 @@ test.describe("side-panel pane retention (desktop)", () => {
 		await expectFrameLoads(page, "a1", 1, "the pane's framed document should load once on first mount");
 		const probe = await stampFrameProbe(page, "a1");
 
-		// 1. Collapse → expand. The workspace is hidden, never removed.
-		await page.getByTestId("side-panel-collapse").first().click();
+		// 1. Real pointer resize, then pointer-driven collapse → expand. Neither may
+		// detach or re-navigate the retained pack iframe.
+		await dragRetentionDivider(page, 63, 801);
+		await expect(page.getByRole("separator", { name: "Resize side panel" })).toHaveAttribute("aria-valuenow", "63");
+		expect(await frameLoadCount(page, "a1"), "an interior pointer resize must not reload the framed document").toBe(1);
+		expect((await readFrameProbe(page, "a1")).property, "interior resize keeps the same iframe element").toBe(probe);
+		await dragRetentionDivider(page, 24, 802);
 		await expect(page.getByTestId("side-panel-restore")).toBeVisible({ timeout: 5_000 });
 		expect(await inertnessOf(page, '[data-panel-workspace="content"]'), "a collapsed workspace stays mounted but inert")
 			.toMatchObject({ display: "none", hidden: true, inert: true, ariaHidden: "true" });
@@ -89,8 +123,8 @@ test.describe("side-panel pane retention (desktop)", () => {
 		await selectSession(page, sessionA);
 		await expect(frameLocator(page, "a1")).toBeVisible({ timeout: 5_000 });
 
-		// 4. Split → fullscreen → split.
-		await page.getByTestId("side-panel-fullscreen").first().click();
+		// 4. Pointer-driven split → fullscreen → split.
+		await dragRetentionDivider(page, 76, 803);
 		await expect.poll(async () => page.locator('[data-panel-workspace="content"]').first().getAttribute("data-side-panel-mode"), { timeout: 5_000 })
 			.toBe("fullscreen");
 		await expect(page.getByTestId("side-panel-restore"), "fullscreen shows no restore button").toHaveCount(0);

--- a/tests2/browser/fixtures/side-panel-pane-retention.spec.ts
+++ b/tests2/browser/fixtures/side-panel-pane-retention.spec.ts
@@ -52,32 +52,20 @@ import {
 
 registerRetentionBundleBuild();
 
-async function dragRetentionDivider(page: Page, rawPercent: number, pointerId: number): Promise<void> {
-	await page.getByRole("separator", { name: "Resize side panel" }).evaluate((element, input) => {
-		const handle = element as HTMLElement;
-		const layout = handle.closest<HTMLElement>(".side-panel-split-layout");
-		const panel = layout?.querySelector<HTMLElement>(":scope > .side-panel-workspace");
-		if (!layout || !panel) throw new Error("retention divider has no split geometry");
-		const layoutBox = layout.getBoundingClientRect();
-		const handleBox = handle.getBoundingClientRect();
-		const startX = handleBox.x + handleBox.width / 2;
-		const startY = handleBox.y + Math.max(handleBox.height / 2, 1);
-		const startPercent = panel.getBoundingClientRect().width / layoutBox.width * 100;
-		const clientX = startX + (startPercent - input.rawPercent) * layoutBox.width / 100;
-		const event = (type: "pointerdown" | "pointermove" | "pointerup", x: number, buttons: number) => new PointerEvent(type, {
-			pointerId: input.pointerId,
-			pointerType: "touch",
-			isPrimary: true,
-			clientX: x,
-			clientY: startY,
-			button: type === "pointerdown" || type === "pointerup" ? 0 : -1,
-			buttons,
-			bubbles: true,
-		});
-		handle.dispatchEvent(event("pointerdown", startX, 1));
-		window.dispatchEvent(event("pointermove", clientX, 1));
-		window.dispatchEvent(event("pointerup", clientX, 0));
-	}, { rawPercent, pointerId });
+async function dragRetentionDivider(page: Page, rawPercent: number): Promise<void> {
+	const handle = page.getByRole("separator", { name: "Resize side panel" });
+	const [handleBox, layoutBox] = await Promise.all([
+		handle.boundingBox(),
+		page.locator(".side-panel-split-layout").boundingBox(),
+	]);
+	if (!handleBox || !layoutBox) throw new Error("retention divider has no visible split geometry");
+	const startX = handleBox.x + handleBox.width / 2;
+	const startY = handleBox.y + handleBox.height / 2;
+	const targetX = layoutBox.x + layoutBox.width * (1 - rawPercent / 100);
+	await page.mouse.move(startX, startY);
+	await page.mouse.down();
+	await page.mouse.move(targetX, startY, { steps: 6 });
+	await page.mouse.up();
 	await settleRender(page);
 }
 
@@ -93,11 +81,22 @@ test.describe("side-panel pane retention (desktop)", () => {
 
 		// 1. Real pointer resize, then pointer-driven collapse → expand. Neither may
 		// detach or re-navigate the retained pack iframe.
-		await dragRetentionDivider(page, 63, 801);
-		await expect(page.getByRole("separator", { name: "Resize side panel" })).toHaveAttribute("aria-valuenow", "63");
+		const divider = page.getByRole("separator", { name: "Resize side panel" });
+		await expect(divider, "the retained-pane fixture exposes the production-sized divider hit target").toBeVisible();
+		const dividerBox = await divider.boundingBox();
+		expect(dividerBox?.width, "the visible divider keeps its 8px pointer target").toBeCloseTo(8, 0);
+		await dragRetentionDivider(page, 63);
+		await expect(divider).toHaveAttribute("aria-valuenow", "63");
+		const resizedGeometry = await page.locator(".side-panel-split-layout").evaluate((layout) => {
+			const row = layout.getBoundingClientRect();
+			const panel = layout.querySelector<HTMLElement>(":scope > .side-panel-workspace")!.getBoundingClientRect();
+			return { panelPercent: panel.width / row.width * 100, handleColor: getComputedStyle(layout.querySelector(".side-panel-resize-handle")!, "::after").backgroundColor };
+		});
+		expect(resizedGeometry.panelPercent, "the real drag must change retained-pane geometry to the requested split").toBeCloseTo(63, 0);
+		expect(resizedGeometry.handleColor, "the hovered divider exposes its theme-token line").not.toBe("rgba(0, 0, 0, 0)");
 		expect(await frameLoadCount(page, "a1"), "an interior pointer resize must not reload the framed document").toBe(1);
 		expect((await readFrameProbe(page, "a1")).property, "interior resize keeps the same iframe element").toBe(probe);
-		await dragRetentionDivider(page, 24, 802);
+		await dragRetentionDivider(page, 24);
 		await expect(page.getByTestId("side-panel-restore")).toBeVisible({ timeout: 5_000 });
 		expect(await inertnessOf(page, '[data-panel-workspace="content"]'), "a collapsed workspace stays mounted but inert")
 			.toMatchObject({ display: "none", hidden: true, inert: true, ariaHidden: "true" });
@@ -124,7 +123,7 @@ test.describe("side-panel pane retention (desktop)", () => {
 		await expect(frameLocator(page, "a1")).toBeVisible({ timeout: 5_000 });
 
 		// 4. Pointer-driven split → fullscreen → split.
-		await dragRetentionDivider(page, 76, 803);
+		await dragRetentionDivider(page, 76);
 		await expect.poll(async () => page.locator('[data-panel-workspace="content"]').first().getAttribute("data-side-panel-mode"), { timeout: 5_000 })
 			.toBe("fullscreen");
 		await expect(page.getByTestId("side-panel-restore"), "fullscreen shows no restore button").toHaveCount(0);

--- a/tests2/browser/fixtures/side-panel-tabs.spec.ts
+++ b/tests2/browser/fixtures/side-panel-tabs.spec.ts
@@ -265,6 +265,39 @@ async function expectSplitPercent(page: Page, percent: number): Promise<void> {
 	}, { message: `workspace should occupy ${percent}% of the split` }).toBeCloseTo(percent, 0);
 }
 
+async function terminalCueStyle(page: Page): Promise<{
+	content: string;
+	left: string;
+	right: string;
+	background: string;
+	expectedMixedPrimary: string;
+	animation: string;
+}> {
+	return page.locator(".side-panel-split-layout").evaluate((layout) => {
+		// Resolve the same expression as the outer-edge gradient in this document.
+		// Comparing computed values avoids pinning Chromium's oklch/oklab/rgb
+		// serialization while still proving the cue follows the live theme token.
+		const probe = document.createElement("span");
+		probe.style.backgroundColor = "color-mix(in oklch, var(--primary) 65%, transparent)";
+		layout.appendChild(probe);
+		const expectedMixedPrimary = getComputedStyle(probe).backgroundColor;
+		probe.remove();
+		const cue = getComputedStyle(layout, "::after");
+		return {
+			content: cue.content,
+			left: cue.left,
+			right: cue.right,
+			background: cue.backgroundImage,
+			expectedMixedPrimary,
+			animation: cue.animationName,
+		};
+	});
+}
+
+function compactCss(value: string): string {
+	return value.replace(/\s+/g, "");
+}
+
 test.describe("Side-panel tab contract", () => {
 	test("Chat is never a persisted tab and an empty non-staff side pane stays hidden @smoke", async ({ page }) => {
 		await page.setViewportSize({ width: 1280, height: 800 });
@@ -383,16 +416,16 @@ test.describe("Side-panel tab contract", () => {
 		await beginDividerDrag(page, 24);
 		await expect(splitLayout).toHaveAttribute("data-resize-intent", "collapse");
 		await expect.poll(() => page.locator(".side-panel-workspace").evaluate((panel) => Number(getComputedStyle(panel).opacity))).toBeLessThan(0.4);
-		const collapseCue = await splitLayout.evaluate((layout) => {
-			const cue = getComputedStyle(layout, "::after");
-			return { content: cue.content, left: cue.left, right: cue.right, background: cue.backgroundImage, animation: cue.animationName };
-		});
-		expect(collapseCue).toMatchObject({ content: '\"\"', right: "0px" });
-		await expect.poll(() => splitLayout.evaluate((layout) => getComputedStyle(layout.querySelector(".side-panel-resize-handle")!, "::after").backgroundColor),
-			{ message: "the collapse divider cue resolves the current --primary after its transition" }).toBe("rgb(12, 34, 56)");
+		const collapseCue = await terminalCueStyle(page);
+		expect(collapseCue.content, "the collapse cue is an empty edge treatment, not a text overlay").toBe('\"\"');
+		expect(collapseCue.right, "the collapse cue pulses on the workspace outer edge").toBe("0px");
 		expect(collapseCue.left).not.toBe("0px");
 		expect(collapseCue.background).toContain("linear-gradient");
+		expect(compactCss(collapseCue.background), "the collapse edge gradient must contain the resolved mixed sentinel --primary")
+			.toContain(compactCss(collapseCue.expectedMixedPrimary));
 		expect(collapseCue.animation).toContain("side-panel-terminal-edge-pulse");
+		await expect.poll(() => splitLayout.evaluate((layout) => getComputedStyle(layout.querySelector(".side-panel-resize-handle")!, "::after").backgroundColor),
+			{ message: "the collapse divider cue resolves the current --primary after its transition" }).toBe("rgb(12, 34, 56)");
 		await moveDividerDrag(page, 25);
 		await expect(splitLayout, "retreating to the inclusive bound clears the terminal cue").not.toHaveAttribute("data-resize-intent");
 		await expect.poll(() => page.locator(".side-panel-workspace").evaluate((panel) => Number(getComputedStyle(panel).opacity))).toBeGreaterThan(0.9);
@@ -417,16 +450,16 @@ test.describe("Side-panel tab contract", () => {
 		await beginDividerDrag(page, 76, 703);
 		await expect(splitLayout).toHaveAttribute("data-resize-intent", "fullscreen");
 		await expect.poll(() => page.locator(".side-panel-chat-pane").evaluate((chat) => Number(getComputedStyle(chat).opacity))).toBeLessThan(0.4);
-		const fullscreenCue = await splitLayout.evaluate((layout) => {
-			const cue = getComputedStyle(layout, "::after");
-			return { content: cue.content, left: cue.left, right: cue.right, background: cue.backgroundImage, animation: cue.animationName };
-		});
-		expect(fullscreenCue).toMatchObject({ content: '\"\"', left: "0px" });
-		await expect.poll(() => splitLayout.evaluate((layout) => getComputedStyle(layout.querySelector(".side-panel-resize-handle")!, "::after").backgroundColor),
-			{ message: "the fullscreen divider cue resolves the current --primary after its transition" }).toBe("rgb(12, 34, 56)");
+		const fullscreenCue = await terminalCueStyle(page);
+		expect(fullscreenCue.content, "the fullscreen cue is an empty edge treatment, not a text overlay").toBe('\"\"');
+		expect(fullscreenCue.left, "the fullscreen cue pulses on the chat outer edge").toBe("0px");
 		expect(fullscreenCue.right).not.toBe("0px");
 		expect(fullscreenCue.background).toContain("linear-gradient");
+		expect(compactCss(fullscreenCue.background), "the fullscreen edge gradient must contain the resolved mixed sentinel --primary")
+			.toContain(compactCss(fullscreenCue.expectedMixedPrimary));
 		expect(fullscreenCue.animation).toContain("side-panel-terminal-edge-pulse");
+		await expect.poll(() => splitLayout.evaluate((layout) => getComputedStyle(layout.querySelector(".side-panel-resize-handle")!, "::after").backgroundColor),
+			{ message: "the fullscreen divider cue resolves the current --primary after its transition" }).toBe("rgb(12, 34, 56)");
 		await moveDividerDrag(page, 75, 703);
 		await expect(splitLayout, "retreating to the inclusive bound clears the fullscreen cue").not.toHaveAttribute("data-resize-intent");
 		await expect.poll(() => page.locator(".side-panel-chat-pane").evaluate((chat) => Number(getComputedStyle(chat).opacity))).toBeGreaterThan(0.9);

--- a/tests2/browser/fixtures/side-panel-tabs.spec.ts
+++ b/tests2/browser/fixtures/side-panel-tabs.spec.ts
@@ -508,7 +508,7 @@ test.describe("Side-panel tab contract", () => {
 		await expectSplitPercent(page, 75);
 	});
 
-	test("desktop divider ignores unrelated pointers until the initiating pointer completes", async ({ page }) => {
+	test("desktop divider ignores secondary activations and unrelated pointers until the initiating pointer completes", async ({ page }) => {
 		await page.setViewportSize({ width: 1280, height: 800 });
 		await openApp(page);
 		await page.evaluate(() => localStorage.removeItem("bobbit-side-panel-width-percent"));
@@ -518,6 +518,82 @@ test.describe("Side-panel tab contract", () => {
 
 		const handle = page.getByRole("separator", { name: "Resize side panel" });
 		await expect(handle).toHaveAttribute("aria-valuenow", "50");
+		await expect.poll(async () => (await workspace(sessionId)).sizeMode).toBe("split");
+
+		const rejectedActivations = await handle.evaluate((element) => {
+			const handle = element as HTMLElement;
+			const layout = handle.closest<HTMLElement>(".side-panel-split-layout");
+			if (!layout) throw new Error("side-panel resize handle has no split layout");
+			const handleBox = handle.getBoundingClientRect();
+			const layoutBox = layout.getBoundingClientRect();
+			const startX = handleBox.x + handleBox.width / 2;
+			const startY = handleBox.y + handleBox.height / 2;
+			const snapshot = () => ({
+				value: handle.getAttribute("aria-valuenow"),
+				persisted: localStorage.getItem("bobbit-side-panel-width-percent"),
+				intent: layout.dataset.resizeIntent ?? null,
+				cursor: document.body.style.cursor,
+				userSelect: document.body.style.userSelect,
+			});
+			const dispatchRejectedActivation = (pointerId: number, pointerType: string, isPrimary: boolean, button: number, buttons: number) => {
+				handle.dispatchEvent(new PointerEvent("pointerdown", {
+					pointerId,
+					pointerType,
+					isPrimary,
+					clientX: startX,
+					clientY: startY,
+					button,
+					buttons,
+					bubbles: true,
+				}));
+				const afterDown = snapshot();
+				window.dispatchEvent(new PointerEvent("pointermove", {
+					pointerId,
+					pointerType,
+					isPrimary,
+					clientX: layoutBox.left + 1,
+					clientY: startY,
+					button: -1,
+					buttons,
+					bubbles: true,
+				}));
+				const afterMove = snapshot();
+				window.dispatchEvent(new PointerEvent("pointerup", {
+					pointerId,
+					pointerType,
+					isPrimary,
+					clientX: layoutBox.left + 1,
+					clientY: startY,
+					button,
+					buttons: 0,
+					bubbles: true,
+				}));
+				return { afterDown, afterMove, afterUp: snapshot() };
+			};
+			return {
+				rightButton: dispatchRejectedActivation(31, "mouse", true, 2, 2),
+				middleButton: dispatchRejectedActivation(32, "mouse", true, 1, 4),
+				nonPrimary: dispatchRejectedActivation(33, "touch", false, 0, 1),
+			};
+		});
+		const unchangedActivation = {
+			value: "50",
+			persisted: null,
+			intent: null,
+			cursor: "",
+			userSelect: "",
+		};
+		for (const activation of Object.values(rejectedActivations)) {
+			expect(activation).toEqual({
+				afterDown: unchangedActivation,
+				afterMove: unchangedActivation,
+				afterUp: unchangedActivation,
+			});
+		}
+		await expectSplitPercent(page, 50);
+		expect(await page.evaluate(() => localStorage.getItem("bobbit-side-panel-width-percent"))).toBeNull();
+		await expect.poll(async () => (await workspace(sessionId)).sizeMode).toBe("split");
+
 		const result = await handle.evaluate((element) => {
 			const handle = element as HTMLElement;
 			const layout = handle.closest<HTMLElement>(".side-panel-split-layout");

--- a/tests2/browser/fixtures/side-panel-tabs.spec.ts
+++ b/tests2/browser/fixtures/side-panel-tabs.spec.ts
@@ -280,8 +280,17 @@ test.describe("Side-panel tab contract", () => {
 		await page.mouse.move(collapseStartX, collapseY);
 		await page.mouse.down();
 		await page.mouse.move(layoutBox.x + layoutBox.width - 1, collapseY, { steps: 8 });
-		await expect(page.locator(".side-panel-split-layout")).toHaveAttribute("data-resize-intent", "collapse");
-		expect(await page.locator(".side-panel-split-layout").evaluate((layout) => getComputedStyle(layout, "::after").content)).toContain("Release to collapse panel");
+		const splitLayout = page.locator(".side-panel-split-layout");
+		await expect(splitLayout).toHaveAttribute("data-resize-intent", "collapse");
+		await expect.poll(() => page.locator(".side-panel-workspace").evaluate((panel) => Number(getComputedStyle(panel).opacity))).toBeLessThan(0.4);
+		const collapseCue = await splitLayout.evaluate((layout) => {
+			const cue = getComputedStyle(layout, "::after");
+			return { content: cue.content, right: cue.right, background: cue.backgroundImage, animation: cue.animationName };
+		});
+		expect(collapseCue.content).not.toContain("Release");
+		expect(collapseCue.right).toBe("0px");
+		expect(collapseCue.background).toContain("linear-gradient");
+		expect(collapseCue.animation).toContain("side-panel-terminal-edge-pulse");
 		await page.mouse.up();
 
 		const restore = page.getByTestId("side-panel-restore");
@@ -302,8 +311,16 @@ test.describe("Side-panel tab contract", () => {
 		await page.mouse.move(expandStartX, expandY);
 		await page.mouse.down();
 		await page.mouse.move(restoredLayoutBox.x + 1, expandY, { steps: 8 });
-		await expect(page.locator(".side-panel-split-layout")).toHaveAttribute("data-resize-intent", "fullscreen");
-		expect(await page.locator(".side-panel-split-layout").evaluate((layout) => getComputedStyle(layout, "::after").content)).toContain("Release to expand panel");
+		await expect(splitLayout).toHaveAttribute("data-resize-intent", "fullscreen");
+		await expect.poll(() => page.locator(".side-panel-chat-pane").evaluate((chat) => Number(getComputedStyle(chat).opacity))).toBeLessThan(0.4);
+		const fullscreenCue = await splitLayout.evaluate((layout) => {
+			const cue = getComputedStyle(layout, "::after");
+			return { content: cue.content, left: cue.left, background: cue.backgroundImage, animation: cue.animationName };
+		});
+		expect(fullscreenCue.content).not.toContain("Release");
+		expect(fullscreenCue.left).toBe("0px");
+		expect(fullscreenCue.background).toContain("linear-gradient");
+		expect(fullscreenCue.animation).toContain("side-panel-terminal-edge-pulse");
 		await page.mouse.up();
 
 		await expect(page.locator('[data-side-panel-mode="fullscreen"]'), "dragging the divider fully left should expand the side panel").toBeVisible();

--- a/tests2/browser/fixtures/side-panel-tabs.spec.ts
+++ b/tests2/browser/fixtures/side-panel-tabs.spec.ts
@@ -264,6 +264,14 @@ test.describe("Side-panel tab contract", () => {
 
 		await handle.dblclick();
 		await expect(handle).toHaveAttribute("aria-valuenow", "50");
+		await expect(handle).toHaveAttribute("aria-controls", "side-panel-workspace");
+		await expect(page.locator("#side-panel-workspace")).toHaveCount(1);
+		await handle.press("Home");
+		await expect(handle).toHaveAttribute("aria-valuenow", "25");
+		await handle.press("End");
+		await expect(handle).toHaveAttribute("aria-valuenow", "75");
+		await handle.dblclick();
+		await expect(handle).toHaveAttribute("aria-valuenow", "50");
 		const reset = await widths();
 		expect(Math.abs(reset.panel - reset.chat), "double-click should restore the even split").toBeLessThan(3);
 
@@ -330,6 +338,130 @@ test.describe("Side-panel tab contract", () => {
 		await expect(handle).toBeVisible();
 		const splitAfterFullscreen = await widths();
 		expect(Math.abs(splitAfterFullscreen.panel - splitAfterFullscreen.chat), "returning from drag-fullscreen should preserve the prior split width").toBeLessThan(3);
+	});
+
+	test("desktop divider ignores unrelated pointers until the initiating pointer completes", async ({ page }) => {
+		await page.setViewportSize({ width: 1280, height: 800 });
+		await openApp(page);
+		await page.evaluate(() => localStorage.removeItem("bobbit-side-panel-width-percent"));
+		await page.reload({ waitUntil: "domcontentloaded" });
+		const sessionId = await createRegularSessionViaApi(page);
+		await mountPreviewHtml(page, sessionId, "pointer-owner.html", "Pointer owner preview");
+
+		const handle = page.getByRole("separator", { name: "Resize side panel" });
+		await expect(handle).toHaveAttribute("aria-valuenow", "50");
+		const result = await handle.evaluate((element) => {
+			const handle = element as HTMLElement;
+			const layout = handle.closest<HTMLElement>(".side-panel-split-layout");
+			if (!layout) throw new Error("side-panel resize handle has no split layout");
+			const handleBox = handle.getBoundingClientRect();
+			const layoutBox = layout.getBoundingClientRect();
+			const startX = handleBox.x + handleBox.width / 2;
+			const startY = handleBox.y + handleBox.height / 2;
+			const dispatch = (target: EventTarget, type: string, pointerId: number, clientX: number, buttons: number) => {
+				target.dispatchEvent(new PointerEvent(type, {
+					pointerId,
+					pointerType: "touch",
+					isPrimary: pointerId === 41,
+					clientX,
+					clientY: startY,
+					button: type === "pointerdown" || type === "pointerup" ? 0 : -1,
+					buttons,
+					bubbles: true,
+				}));
+			};
+
+			dispatch(handle, "pointerdown", 41, startX, 1);
+			dispatch(window, "pointermove", 99, layoutBox.right - 1, 1);
+			const afterForeignMove = {
+				value: handle.getAttribute("aria-valuenow"),
+				persisted: localStorage.getItem("bobbit-side-panel-width-percent"),
+				intent: layout.dataset.resizeIntent ?? null,
+			};
+			dispatch(window, "pointerup", 99, layoutBox.right - 1, 0);
+			dispatch(window, "pointercancel", 100, layoutBox.right - 1, 0);
+			const afterForeignEnd = {
+				cursor: document.body.style.cursor,
+				userSelect: document.body.style.userSelect,
+			};
+			dispatch(window, "pointermove", 41, startX - 80, 1);
+			const afterOwnerMove = {
+				value: Number(handle.getAttribute("aria-valuenow")),
+				persisted: Number(localStorage.getItem("bobbit-side-panel-width-percent")),
+			};
+			dispatch(window, "pointerup", 41, startX - 80, 0);
+			return {
+				afterForeignMove,
+				afterForeignEnd,
+				afterOwnerMove,
+				afterOwnerEnd: {
+					cursor: document.body.style.cursor,
+					userSelect: document.body.style.userSelect,
+				},
+			};
+		});
+
+		expect(result.afterForeignMove).toEqual({ value: "50", persisted: null, intent: null });
+		expect(result.afterForeignEnd).toEqual({ cursor: "col-resize", userSelect: "none" });
+		expect(result.afterOwnerMove.value).toBeGreaterThan(50);
+		expect(result.afterOwnerMove.persisted).toBeGreaterThan(50);
+		expect(result.afterOwnerEnd).toEqual({ cursor: "", userSelect: "" });
+		await expect.poll(async () => (await workspace(sessionId)).sizeMode, { timeout: 10_000 }).toBe("split");
+
+		const preferredSplit = result.afterOwnerMove.persisted;
+		const otherSessionId = await createRegularSessionViaApi(page);
+		await mountPreviewHtml(page, otherSessionId, "pointer-owner-other.html", "Other pointer owner preview");
+		await navigateToSession(page, sessionId);
+		await expect(handle).toBeVisible();
+		await handle.evaluate((element) => {
+			const handle = element as HTMLElement;
+			const layout = handle.closest<HTMLElement>(".side-panel-split-layout");
+			if (!layout) throw new Error("side-panel resize handle has no split layout");
+			const handleBox = handle.getBoundingClientRect();
+			const layoutBox = layout.getBoundingClientRect();
+			const startX = handleBox.x + handleBox.width / 2;
+			const startY = handleBox.y + handleBox.height / 2;
+			handle.dispatchEvent(new PointerEvent("pointerdown", {
+				pointerId: 51,
+				pointerType: "touch",
+				isPrimary: true,
+				clientX: startX,
+				clientY: startY,
+				button: 0,
+				buttons: 1,
+				bubbles: true,
+			}));
+			window.dispatchEvent(new PointerEvent("pointermove", {
+				pointerId: 51,
+				pointerType: "touch",
+				isPrimary: true,
+				clientX: layoutBox.right - 1,
+				clientY: startY,
+				button: -1,
+				buttons: 1,
+			}));
+		});
+		await expect(page.locator(".side-panel-split-layout")).toHaveAttribute("data-resize-intent", "collapse");
+		expect(await page.evaluate(() => Number(localStorage.getItem("bobbit-side-panel-width-percent")))).toBe(25);
+
+		await navigateToSession(page, otherSessionId);
+		await expect.poll(() => page.evaluate(() => ({
+			cursor: document.body.style.cursor,
+			userSelect: document.body.style.userSelect,
+		}))).toEqual({ cursor: "", userSelect: "" });
+		const restoredPreference = await page.evaluate(() => Number(localStorage.getItem("bobbit-side-panel-width-percent")));
+		expect(restoredPreference).toBeCloseTo(preferredSplit, 3);
+		await page.evaluate(() => window.dispatchEvent(new PointerEvent("pointerup", {
+			pointerId: 51,
+			pointerType: "touch",
+			isPrimary: true,
+			clientX: window.innerWidth - 1,
+			clientY: window.innerHeight / 2,
+			button: 0,
+			buttons: 0,
+		})));
+		await expect.poll(async () => (await workspace(sessionId)).sizeMode, { timeout: 10_000 }).toBe("split");
+		await expect.poll(async () => (await workspace(otherSessionId)).sizeMode, { timeout: 10_000 }).toBe("split");
 	});
 
 	test("sequential preview files keep stable artifact routes across tabs and reload", async ({ page }) => {

--- a/tests2/browser/fixtures/side-panel-tabs.spec.ts
+++ b/tests2/browser/fixtures/side-panel-tabs.spec.ts
@@ -177,6 +177,94 @@ async function workspace(sessionId: string): Promise<any> {
 	return JSON.parse(text);
 }
 
+type SplitGeometry = { row: number; chat: number; panel: number };
+
+async function splitGeometry(page: Page): Promise<SplitGeometry> {
+	return page.locator(".side-panel-split-layout").evaluate((layout) => ({
+		row: layout.getBoundingClientRect().width,
+		chat: layout.querySelector<HTMLElement>(".side-panel-chat-pane")?.getBoundingClientRect().width ?? 0,
+		panel: layout.querySelector<HTMLElement>(".side-panel-workspace")?.getBoundingClientRect().width ?? 0,
+	}));
+}
+
+async function beginDividerDrag(page: Page, rawPercent?: number, pointerId = 701): Promise<void> {
+	await page.getByRole("separator", { name: "Resize side panel" }).evaluate((element, input) => {
+		const handle = element as HTMLElement;
+		const layout = handle.closest<HTMLElement>(".side-panel-split-layout");
+		const panel = layout?.querySelector<HTMLElement>(":scope > .side-panel-workspace");
+		if (!layout || !panel) throw new Error("side-panel resize handle has no split geometry");
+		const handleBox = handle.getBoundingClientRect();
+		const layoutBox = layout.getBoundingClientRect();
+		const drag = {
+			layout,
+			pointerId: input.pointerId,
+			startX: handleBox.x + handleBox.width / 2,
+			startY: handleBox.y + Math.max(handleBox.height / 2, 1),
+			startPercent: panel.getBoundingClientRect().width / layoutBox.width * 100,
+			layoutWidth: layoutBox.width,
+		};
+		(window as any).__sidePanelSpecDrag = drag;
+		const dispatch = (target: EventTarget, type: string, raw: number, buttons: number) => {
+			const clientX = drag.startX + (drag.startPercent - raw) * drag.layoutWidth / 100;
+			target.dispatchEvent(new PointerEvent(type, {
+				pointerId: drag.pointerId,
+				pointerType: "touch",
+				isPrimary: true,
+				clientX,
+				clientY: drag.startY,
+				button: type === "pointerdown" || type === "pointerup" ? 0 : -1,
+				buttons,
+				bubbles: true,
+			}));
+		};
+		dispatch(handle, "pointerdown", drag.startPercent, 1);
+		if (input.rawPercent !== undefined) dispatch(window, "pointermove", input.rawPercent, 1);
+	}, { rawPercent, pointerId });
+}
+
+async function moveDividerDrag(page: Page, rawPercent: number, pointerId = 701): Promise<void> {
+	await page.evaluate(({ rawPercent, pointerId }) => {
+		const drag = (window as any).__sidePanelSpecDrag;
+		if (!drag || drag.pointerId !== pointerId) throw new Error("no matching side-panel spec drag");
+		const clientX = drag.startX + (drag.startPercent - rawPercent) * drag.layoutWidth / 100;
+		window.dispatchEvent(new PointerEvent("pointermove", {
+			pointerId,
+			pointerType: "touch",
+			isPrimary: true,
+			clientX,
+			clientY: drag.startY,
+			button: -1,
+			buttons: 1,
+			bubbles: true,
+		}));
+	}, { rawPercent, pointerId });
+}
+
+async function endDividerDrag(page: Page, rawPercent: number, pointerId = 701): Promise<void> {
+	await page.evaluate(({ rawPercent, pointerId }) => {
+		const drag = (window as any).__sidePanelSpecDrag;
+		if (!drag || drag.pointerId !== pointerId) throw new Error("no matching side-panel spec drag");
+		const clientX = drag.startX + (drag.startPercent - rawPercent) * drag.layoutWidth / 100;
+		window.dispatchEvent(new PointerEvent("pointerup", {
+			pointerId,
+			pointerType: "touch",
+			isPrimary: true,
+			clientX,
+			clientY: drag.startY,
+			button: 0,
+			buttons: 0,
+			bubbles: true,
+		}));
+	}, { rawPercent, pointerId });
+}
+
+async function expectSplitPercent(page: Page, percent: number): Promise<void> {
+	await expect.poll(async () => {
+		const geometry = await splitGeometry(page);
+		return geometry.panel / geometry.row * 100;
+	}, { message: `workspace should occupy ${percent}% of the split` }).toBeCloseTo(percent, 0);
+}
+
 test.describe("Side-panel tab contract", () => {
 	test("Chat is never a persisted tab and an empty non-staff side pane stays hidden @smoke", async ({ page }) => {
 		await page.setViewportSize({ width: 1280, height: 800 });
@@ -224,7 +312,7 @@ test.describe("Side-panel tab contract", () => {
 		await expectNoPersistedChatTab(page, sessionId);
 	});
 
-	test("desktop divider resizes every side-panel workspace and persists the split", async ({ page }) => {
+	test("desktop resizing persists, follows the separator APG contract, and restores a non-default split through terminal modes", async ({ page }) => {
 		await page.setViewportSize({ width: 1280, height: 800 });
 		await openApp(page);
 		await page.evaluate(() => localStorage.removeItem("bobbit-side-panel-width-percent"));
@@ -233,111 +321,158 @@ test.describe("Side-panel tab contract", () => {
 		await mountPreviewHtml(page, sessionId, "resizable.html", "Resizable preview");
 
 		const handle = page.getByRole("separator", { name: "Resize side panel" });
+		const splitLayout = page.locator(".side-panel-split-layout");
 		await expect(handle).toBeVisible();
+		await expect(handle).toHaveAttribute("aria-valuemin", "25");
+		await expect(handle).toHaveAttribute("aria-valuemax", "75");
 		await expect(handle).toHaveAttribute("aria-valuenow", "50");
-		const widths = async () => page.locator(".side-panel-split-layout").evaluate((layout) => ({
-			chat: layout.querySelector<HTMLElement>(".side-panel-chat-pane")?.getBoundingClientRect().width ?? 0,
-			panel: layout.querySelector<HTMLElement>(".side-panel-workspace")?.getBoundingClientRect().width ?? 0,
-		}));
-		const initial = await widths();
+		await expect(handle).toHaveAttribute("aria-controls", "side-panel-workspace");
+		await expect(page.locator("#side-panel-workspace")).toHaveCount(1);
+		expect(await page.evaluate(() => localStorage.getItem("bobbit-side-panel-width-percent")), "the even default must not manufacture a stored preference").toBeNull();
+		const initial = await splitGeometry(page);
+		expect(initial.panel, "the default workspace is half the row").toBeCloseTo(initial.row / 2, 0);
+		expect(initial.chat, "the default chat pane is half the row").toBeCloseTo(initial.row / 2, 0);
 
-		const box = await handle.boundingBox();
-		if (!box) throw new Error("side-panel resize handle has no bounding box");
-		const startX = box.x + box.width / 2;
-		const startY = box.y + box.height / 2;
-		await page.mouse.move(startX, startY);
-		await page.mouse.down();
-		await page.mouse.move(startX - 120, startY, { steps: 6 });
-		await page.mouse.up();
-
-		const resized = await widths();
-		expect(resized.panel - initial.panel, "dragging the divider left should widen the shared right workspace").toBeGreaterThan(100);
-		expect(initial.chat - resized.chat, "the chat should give the same space to the right workspace").toBeGreaterThan(100);
-		const persistedPercent = await page.evaluate(() => Number(localStorage.getItem("bobbit-side-panel-width-percent")));
-		expect(persistedPercent).toBeGreaterThan(50);
+		await beginDividerDrag(page, 63);
+		await endDividerDrag(page, 63);
+		await expect(handle).toHaveAttribute("aria-valuenow", "63");
+		await expectSplitPercent(page, 63);
+		expect(await page.evaluate(() => localStorage.getItem("bobbit-side-panel-width-percent"))).toBe("63");
+		await expect.poll(async () => (await workspace(sessionId)).sizeMode).toBe("split");
 
 		await page.reload({ waitUntil: "domcontentloaded" });
 		await navigateToSession(page, sessionId);
 		await expectPreviewContains(page, "Resizable preview", "resizable preview after reload");
-		const reloaded = await widths();
-		expect(Math.abs(reloaded.panel - resized.panel), "the selected split should survive reload").toBeLessThan(3);
+		await expect(handle).toHaveAttribute("aria-valuenow", "63");
+		await expectSplitPercent(page, 63);
 
+		await handle.focus();
+		expect(await handle.evaluate((element) => document.activeElement === element), "the separator remains keyboard-focusable").toBe(true);
+		expect(await handle.evaluate((element) => getComputedStyle(element, "::after").backgroundColor), "focus-visible must expose the divider accent").not.toBe("rgba(0, 0, 0, 0)");
 		await handle.dblclick();
 		await expect(handle).toHaveAttribute("aria-valuenow", "50");
-		await expect(handle).toHaveAttribute("aria-controls", "side-panel-workspace");
-		await expect(page.locator("#side-panel-workspace")).toHaveCount(1);
+		await handle.press("ArrowLeft");
+		await expect(handle).toHaveAttribute("aria-valuenow", "52");
+		await handle.press("Shift+ArrowLeft");
+		await expect(handle).toHaveAttribute("aria-valuenow", "62");
+		await handle.press("ArrowRight");
+		await expect(handle).toHaveAttribute("aria-valuenow", "60");
+		await handle.press("Shift+ArrowRight");
+		await expect(handle).toHaveAttribute("aria-valuenow", "50");
 		await handle.press("Home");
 		await expect(handle).toHaveAttribute("aria-valuenow", "25");
+		await handle.press("ArrowRight");
+		await expect(handle, "keyboard changes clamp at the APG minimum").toHaveAttribute("aria-valuenow", "25");
 		await handle.press("End");
 		await expect(handle).toHaveAttribute("aria-valuenow", "75");
+		await handle.press("ArrowLeft");
+		await expect(handle, "keyboard changes clamp at the APG maximum").toHaveAttribute("aria-valuenow", "75");
 		await handle.dblclick();
-		await expect(handle).toHaveAttribute("aria-valuenow", "50");
-		const reset = await widths();
-		expect(Math.abs(reset.panel - reset.chat), "double-click should restore the even split").toBeLessThan(3);
+		await expectSplitPercent(page, 50);
 
-		const [resetHandleBox, panelBox, layoutBox] = await Promise.all([
-			handle.boundingBox(),
-			page.locator(".side-panel-workspace").boundingBox(),
-			page.locator(".side-panel-split-layout").boundingBox(),
-		]);
-		expect(resetHandleBox && panelBox ? resetHandleBox.x < panelBox.x && resetHandleBox.x + resetHandleBox.width > panelBox.x : false,
-			"the divider hit target should extend into both panes instead of being clipped by the workspace").toBe(true);
-		if (!resetHandleBox || !layoutBox) throw new Error("split layout has no resize geometry");
-		const collapseStartX = resetHandleBox.x + resetHandleBox.width / 2;
-		const collapseY = resetHandleBox.y + resetHandleBox.height / 2;
-		await page.mouse.move(collapseStartX, collapseY);
-		await page.mouse.down();
-		await page.mouse.move(layoutBox.x + layoutBox.width - 1, collapseY, { steps: 8 });
-		const splitLayout = page.locator(".side-panel-split-layout");
+		const [handleBox, panelBox] = await Promise.all([handle.boundingBox(), page.locator(".side-panel-workspace").boundingBox()]);
+		expect(handleBox && panelBox ? handleBox.x < panelBox.x && handleBox.x + handleBox.width > panelBox.x : false,
+			"the divider hit target extends into both panes and is not clipped").toBe(true);
+
+		// Set the split restored after both terminal modes and override the live theme
+		// accent so the cue assertions cannot pass on a hard-coded legacy colour.
+		await beginDividerDrag(page, 63);
+		await endDividerDrag(page, 63);
+		await page.evaluate(() => document.documentElement.style.setProperty("--primary", "rgb(12, 34, 56)"));
+
+		await beginDividerDrag(page, 24);
 		await expect(splitLayout).toHaveAttribute("data-resize-intent", "collapse");
 		await expect.poll(() => page.locator(".side-panel-workspace").evaluate((panel) => Number(getComputedStyle(panel).opacity))).toBeLessThan(0.4);
 		const collapseCue = await splitLayout.evaluate((layout) => {
 			const cue = getComputedStyle(layout, "::after");
-			return { content: cue.content, right: cue.right, background: cue.backgroundImage, animation: cue.animationName };
+			return { content: cue.content, left: cue.left, right: cue.right, background: cue.backgroundImage, animation: cue.animationName };
 		});
-		expect(collapseCue.content).not.toContain("Release");
-		expect(collapseCue.right).toBe("0px");
+		expect(collapseCue).toMatchObject({ content: '\"\"', right: "0px" });
+		await expect.poll(() => splitLayout.evaluate((layout) => getComputedStyle(layout.querySelector(".side-panel-resize-handle")!, "::after").backgroundColor),
+			{ message: "the collapse divider cue resolves the current --primary after its transition" }).toBe("rgb(12, 34, 56)");
+		expect(collapseCue.left).not.toBe("0px");
 		expect(collapseCue.background).toContain("linear-gradient");
 		expect(collapseCue.animation).toContain("side-panel-terminal-edge-pulse");
-		await page.mouse.up();
+		await moveDividerDrag(page, 25);
+		await expect(splitLayout, "retreating to the inclusive bound clears the terminal cue").not.toHaveAttribute("data-resize-intent");
+		await expect.poll(() => page.locator(".side-panel-workspace").evaluate((panel) => Number(getComputedStyle(panel).opacity))).toBeGreaterThan(0.9);
+		await endDividerDrag(page, 25);
+		await expect.poll(async () => (await workspace(sessionId)).sizeMode).toBe("split");
+		await beginDividerDrag(page, 63, 706);
+		await endDividerDrag(page, 63, 706);
 
-		const restore = page.getByTestId("side-panel-restore");
-		await expect(restore, "dragging the divider fully right should collapse the side panel").toBeVisible();
-		await expect.poll(async () => (await workspace(sessionId)).sizeMode, { timeout: 10_000 }).toBe("collapsed");
-		await restore.click();
-		await expect(handle).toBeVisible();
-		const restored = await widths();
-		expect(Math.abs(restored.panel - restored.chat), "restoring a drag-collapsed panel should preserve its prior width").toBeLessThan(3);
+		await beginDividerDrag(page, undefined, 702);
+		await endDividerDrag(page, 24, 702);
+		await expect(page.getByTestId("side-panel-restore"), "pointerup itself crossing 25 must collapse").toBeVisible();
+		await expect.poll(async () => (await workspace(sessionId)).sizeMode).toBe("collapsed");
+		expect(await page.evaluate(() => localStorage.getItem("bobbit-side-panel-width-percent"))).toBe("63");
+		await page.reload({ waitUntil: "domcontentloaded" });
+		await navigateToSession(page, sessionId);
+		await expect(page.getByTestId("side-panel-restore"), "collapsed mode survives reload").toBeVisible();
+		await page.getByTestId("side-panel-restore").click();
+		await expect(handle).toHaveAttribute("aria-valuenow", "63");
+		await expectSplitPercent(page, 63);
 
-		const [expandHandleBox, restoredLayoutBox] = await Promise.all([
-			handle.boundingBox(),
-			page.locator(".side-panel-split-layout").boundingBox(),
-		]);
-		if (!expandHandleBox || !restoredLayoutBox) throw new Error("restored split layout has no resize geometry");
-		const expandStartX = expandHandleBox.x + expandHandleBox.width / 2;
-		const expandY = expandHandleBox.y + expandHandleBox.height / 2;
-		await page.mouse.move(expandStartX, expandY);
-		await page.mouse.down();
-		await page.mouse.move(restoredLayoutBox.x + 1, expandY, { steps: 8 });
+		await page.evaluate(() => document.documentElement.style.setProperty("--primary", "rgb(12, 34, 56)"));
+		await beginDividerDrag(page, 76, 703);
 		await expect(splitLayout).toHaveAttribute("data-resize-intent", "fullscreen");
 		await expect.poll(() => page.locator(".side-panel-chat-pane").evaluate((chat) => Number(getComputedStyle(chat).opacity))).toBeLessThan(0.4);
 		const fullscreenCue = await splitLayout.evaluate((layout) => {
 			const cue = getComputedStyle(layout, "::after");
-			return { content: cue.content, left: cue.left, background: cue.backgroundImage, animation: cue.animationName };
+			return { content: cue.content, left: cue.left, right: cue.right, background: cue.backgroundImage, animation: cue.animationName };
 		});
-		expect(fullscreenCue.content).not.toContain("Release");
-		expect(fullscreenCue.left).toBe("0px");
+		expect(fullscreenCue).toMatchObject({ content: '\"\"', left: "0px" });
+		await expect.poll(() => splitLayout.evaluate((layout) => getComputedStyle(layout.querySelector(".side-panel-resize-handle")!, "::after").backgroundColor),
+			{ message: "the fullscreen divider cue resolves the current --primary after its transition" }).toBe("rgb(12, 34, 56)");
+		expect(fullscreenCue.right).not.toBe("0px");
 		expect(fullscreenCue.background).toContain("linear-gradient");
 		expect(fullscreenCue.animation).toContain("side-panel-terminal-edge-pulse");
-		await page.mouse.up();
+		await moveDividerDrag(page, 75, 703);
+		await expect(splitLayout, "retreating to the inclusive bound clears the fullscreen cue").not.toHaveAttribute("data-resize-intent");
+		await expect.poll(() => page.locator(".side-panel-chat-pane").evaluate((chat) => Number(getComputedStyle(chat).opacity))).toBeGreaterThan(0.9);
+		await endDividerDrag(page, 75, 703);
+		await expect.poll(async () => (await workspace(sessionId)).sizeMode).toBe("split");
 
-		await expect(page.locator('[data-side-panel-mode="fullscreen"]'), "dragging the divider fully left should expand the side panel").toBeVisible();
-		await expect(handle).toHaveCount(0);
-		await expect.poll(async () => (await workspace(sessionId)).sizeMode, { timeout: 10_000 }).toBe("fullscreen");
+		await beginDividerDrag(page, 63, 704);
+		await endDividerDrag(page, 63, 704);
+		await beginDividerDrag(page, undefined, 705);
+		await endDividerDrag(page, 76, 705);
+		await expect(page.locator('[data-side-panel-mode="fullscreen"]'), "pointerup itself crossing 75 must enter fullscreen").toBeVisible();
+		await expect.poll(async () => (await workspace(sessionId)).sizeMode).toBe("fullscreen");
+		expect(await page.evaluate(() => localStorage.getItem("bobbit-side-panel-width-percent"))).toBe("63");
+		await page.reload({ waitUntil: "domcontentloaded" });
+		await expect.poll(() => page.evaluate(() => (window as any).bobbitState?.selectedSessionId ?? ""), { timeout: 20_000 }).toBe(sessionId);
+		await expect(page.locator('[data-side-panel-mode="fullscreen"]'), "fullscreen mode survives reload").toBeVisible({ timeout: 20_000 });
 		await page.getByTestId("side-panel-collapse").click();
-		await expect(handle).toBeVisible();
-		const splitAfterFullscreen = await widths();
-		expect(Math.abs(splitAfterFullscreen.panel - splitAfterFullscreen.chat), "returning from drag-fullscreen should preserve the prior split width").toBeLessThan(3);
+		await expect(handle).toHaveAttribute("aria-valuenow", "63");
+		await expectSplitPercent(page, 63);
+
+		// Mobile keeps its full-width slider/navigation and never consumes or mutates
+		// the desktop-only preference.
+		await handle.press("End");
+		await expect(handle).toHaveAttribute("aria-valuenow", "75");
+		await page.setViewportSize({ width: 390, height: 780 });
+		await expect(handle).toHaveCount(0);
+		const mobileBar = page.locator(".goal-tab-bar--mobile");
+		await expect(mobileBar.locator('[data-panel-tab-kind="chat"]')).toBeVisible();
+		const previewTab = mobileBar.locator(`[data-panel-tab-id="${previewId("resizable.html")}"]`);
+		await expect(previewTab).toBeVisible();
+		const mobileGeometry = await page.locator(".side-panel-slider").evaluate((slider) => {
+			const sliderBox = slider.getBoundingClientRect();
+			const visiblePane = [...slider.querySelectorAll<HTMLElement>("[data-mobile-pane-key]")]
+				.find((pane) => pane.getBoundingClientRect().width > 0 && getComputedStyle(pane).visibility !== "hidden");
+			return { slider: sliderBox.width, pane: visiblePane?.getBoundingClientRect().width ?? 0 };
+		});
+		expect(mobileGeometry.slider, "the mobile slider fills the viewport-width main surface").toBeGreaterThan(350);
+		expect(mobileGeometry.pane, "each mobile navigation pane remains full slider width").toBeCloseTo(mobileGeometry.slider, 0);
+		await mobileBar.locator('[data-panel-tab-kind="chat"]').click();
+		await expect(page.locator("textarea").first()).toBeVisible();
+		await previewTab.click();
+		await expectPreviewContains(page, "Resizable preview", "mobile navigation still reaches the panel");
+		expect(await page.evaluate(() => localStorage.getItem("bobbit-side-panel-width-percent"))).toBe("75");
+		await page.setViewportSize({ width: 1280, height: 800 });
+		await expect(handle).toHaveAttribute("aria-valuenow", "75");
+		await expectSplitPercent(page, 75);
 	});
 
 	test("desktop divider ignores unrelated pointers until the initiating pointer completes", async ({ page }) => {
@@ -421,6 +556,7 @@ test.describe("Side-panel tab contract", () => {
 			const layoutBox = layout.getBoundingClientRect();
 			const startX = handleBox.x + handleBox.width / 2;
 			const startY = handleBox.y + handleBox.height / 2;
+			(window as any).__removedResizeLayout = layout;
 			handle.dispatchEvent(new PointerEvent("pointerdown", {
 				pointerId: 51,
 				pointerType: "touch",
@@ -451,6 +587,7 @@ test.describe("Side-panel tab contract", () => {
 		}))).toEqual({ cursor: "", userSelect: "" });
 		const restoredPreference = await page.evaluate(() => Number(localStorage.getItem("bobbit-side-panel-width-percent")));
 		expect(restoredPreference).toBeCloseTo(preferredSplit, 3);
+		expect(await page.evaluate(() => (window as any).__removedResizeLayout?.dataset.resizeIntent ?? null), "navigation cleanup clears intent on the removed layout").toBeNull();
 		await page.evaluate(() => window.dispatchEvent(new PointerEvent("pointerup", {
 			pointerId: 51,
 			pointerType: "touch",
@@ -462,6 +599,44 @@ test.describe("Side-panel tab contract", () => {
 		})));
 		await expect.poll(async () => (await workspace(sessionId)).sizeMode, { timeout: 10_000 }).toBe("split");
 		await expect.poll(async () => (await workspace(otherSessionId)).sizeMode, { timeout: 10_000 }).toBe("split");
+
+		// A mode change that removes the divider must cancel before a stale owner-up
+		// can reinterpret the drag as a second mode change.
+		await beginDividerDrag(page, 24, 61);
+		await expect(page.locator(".side-panel-split-layout")).toHaveAttribute("data-resize-intent", "collapse");
+		await page.getByTestId("side-panel-fullscreen").click();
+		await expect(handle).toHaveCount(0);
+		await expect.poll(() => page.evaluate(() => ({ cursor: document.body.style.cursor, userSelect: document.body.style.userSelect })))
+			.toEqual({ cursor: "", userSelect: "" });
+		expect(await page.evaluate(() => Number(localStorage.getItem("bobbit-side-panel-width-percent")))).toBeCloseTo(preferredSplit, 3);
+		expect(await page.evaluate(() => (window as any).__sidePanelSpecDrag.layout.dataset.resizeIntent ?? null), "mode cleanup clears intent on the removed layout").toBeNull();
+		await endDividerDrag(page, 24, 61);
+		await expect.poll(async () => (await workspace(otherSessionId)).sizeMode).toBe("fullscreen");
+		expect(await page.evaluate(() => Number(localStorage.getItem("bobbit-side-panel-width-percent")))).toBeCloseTo(preferredSplit, 3);
+		await page.getByTestId("side-panel-collapse").click();
+		await expect(handle).toBeVisible();
+
+		// Crossing to mobile removes the desktop divider without changing mobile
+		// navigation or allowing the stale desktop pointer to commit.
+		await beginDividerDrag(page, 24, 62);
+		await expect(page.locator(".side-panel-split-layout")).toHaveAttribute("data-resize-intent", "collapse");
+		await page.setViewportSize({ width: 390, height: 780 });
+		await expect(handle).toHaveCount(0);
+		await expect.poll(() => page.evaluate(() => ({ cursor: document.body.style.cursor, userSelect: document.body.style.userSelect })))
+			.toEqual({ cursor: "", userSelect: "" });
+		expect(await page.evaluate(() => Number(localStorage.getItem("bobbit-side-panel-width-percent")))).toBeCloseTo(preferredSplit, 3);
+		expect(await page.evaluate(() => (window as any).__sidePanelSpecDrag.layout.dataset.resizeIntent ?? null), "mobile cleanup clears intent on the removed layout").toBeNull();
+		await endDividerDrag(page, 24, 62);
+		await expect.poll(async () => (await workspace(sessionId)).sizeMode).toBe("split");
+		await expect.poll(async () => (await workspace(otherSessionId)).sizeMode).toBe("split");
+		expect(await page.evaluate(() => Number(localStorage.getItem("bobbit-side-panel-width-percent")))).toBeCloseTo(preferredSplit, 3);
+
+		await page.setViewportSize({ width: 1280, height: 800 });
+		await expect(handle).toBeVisible();
+		await beginDividerDrag(page, 57, 63);
+		await endDividerDrag(page, 57, 63);
+		await expect(handle, "a fresh drag must work after every cleanup path").toHaveAttribute("aria-valuenow", "57");
+		await expectSplitPercent(page, 57);
 	});
 
 	test("sequential preview files keep stable artifact routes across tabs and reload", async ({ page }) => {

--- a/tests2/browser/fixtures/side-panel-tabs.spec.ts
+++ b/tests2/browser/fixtures/side-panel-tabs.spec.ts
@@ -266,6 +266,29 @@ test.describe("Side-panel tab contract", () => {
 		await expect(handle).toHaveAttribute("aria-valuenow", "50");
 		const reset = await widths();
 		expect(Math.abs(reset.panel - reset.chat), "double-click should restore the even split").toBeLessThan(3);
+
+		const [resetHandleBox, panelBox, layoutBox] = await Promise.all([
+			handle.boundingBox(),
+			page.locator(".side-panel-workspace").boundingBox(),
+			page.locator(".side-panel-split-layout").boundingBox(),
+		]);
+		expect(resetHandleBox && panelBox ? resetHandleBox.x < panelBox.x && resetHandleBox.x + resetHandleBox.width > panelBox.x : false,
+			"the divider hit target should extend into both panes instead of being clipped by the workspace").toBe(true);
+		if (!resetHandleBox || !layoutBox) throw new Error("split layout has no resize geometry");
+		const collapseStartX = resetHandleBox.x + resetHandleBox.width / 2;
+		const collapseY = resetHandleBox.y + resetHandleBox.height / 2;
+		await page.mouse.move(collapseStartX, collapseY);
+		await page.mouse.down();
+		await page.mouse.move(layoutBox.x + layoutBox.width - 1, collapseY, { steps: 8 });
+		await page.mouse.up();
+
+		const restore = page.getByTestId("side-panel-restore");
+		await expect(restore, "dragging the divider fully right should collapse the side panel").toBeVisible();
+		await expect.poll(async () => (await workspace(sessionId)).sizeMode, { timeout: 10_000 }).toBe("collapsed");
+		await restore.click();
+		await expect(handle).toBeVisible();
+		const restored = await widths();
+		expect(Math.abs(restored.panel - restored.chat), "restoring a drag-collapsed panel should preserve its prior width").toBeLessThan(3);
 	});
 
 	test("sequential preview files keep stable artifact routes across tabs and reload", async ({ page }) => {

--- a/tests2/browser/fixtures/side-panel-tabs.spec.ts
+++ b/tests2/browser/fixtures/side-panel-tabs.spec.ts
@@ -224,6 +224,50 @@ test.describe("Side-panel tab contract", () => {
 		await expectNoPersistedChatTab(page, sessionId);
 	});
 
+	test("desktop divider resizes every side-panel workspace and persists the split", async ({ page }) => {
+		await page.setViewportSize({ width: 1280, height: 800 });
+		await openApp(page);
+		await page.evaluate(() => localStorage.removeItem("bobbit-side-panel-width-percent"));
+		await page.reload({ waitUntil: "domcontentloaded" });
+		const sessionId = await createRegularSessionViaApi(page);
+		await mountPreviewHtml(page, sessionId, "resizable.html", "Resizable preview");
+
+		const handle = page.getByRole("separator", { name: "Resize side panel" });
+		await expect(handle).toBeVisible();
+		await expect(handle).toHaveAttribute("aria-valuenow", "50");
+		const widths = async () => page.locator(".side-panel-split-layout").evaluate((layout) => ({
+			chat: layout.querySelector<HTMLElement>(".side-panel-chat-pane")?.getBoundingClientRect().width ?? 0,
+			panel: layout.querySelector<HTMLElement>(".side-panel-workspace")?.getBoundingClientRect().width ?? 0,
+		}));
+		const initial = await widths();
+
+		const box = await handle.boundingBox();
+		if (!box) throw new Error("side-panel resize handle has no bounding box");
+		const startX = box.x + box.width / 2;
+		const startY = box.y + box.height / 2;
+		await page.mouse.move(startX, startY);
+		await page.mouse.down();
+		await page.mouse.move(startX - 120, startY, { steps: 6 });
+		await page.mouse.up();
+
+		const resized = await widths();
+		expect(resized.panel - initial.panel, "dragging the divider left should widen the shared right workspace").toBeGreaterThan(100);
+		expect(initial.chat - resized.chat, "the chat should give the same space to the right workspace").toBeGreaterThan(100);
+		const persistedPercent = await page.evaluate(() => Number(localStorage.getItem("bobbit-side-panel-width-percent")));
+		expect(persistedPercent).toBeGreaterThan(50);
+
+		await page.reload({ waitUntil: "domcontentloaded" });
+		await navigateToSession(page, sessionId);
+		await expectPreviewContains(page, "Resizable preview", "resizable preview after reload");
+		const reloaded = await widths();
+		expect(Math.abs(reloaded.panel - resized.panel), "the selected split should survive reload").toBeLessThan(3);
+
+		await handle.dblclick();
+		await expect(handle).toHaveAttribute("aria-valuenow", "50");
+		const reset = await widths();
+		expect(Math.abs(reset.panel - reset.chat), "double-click should restore the even split").toBeLessThan(3);
+	});
+
 	test("sequential preview files keep stable artifact routes across tabs and reload", async ({ page }) => {
 		await page.setViewportSize({ width: 1280, height: 800 });
 		await openApp(page);

--- a/tests2/browser/fixtures/side-panel-tabs.spec.ts
+++ b/tests2/browser/fixtures/side-panel-tabs.spec.ts
@@ -280,6 +280,8 @@ test.describe("Side-panel tab contract", () => {
 		await page.mouse.move(collapseStartX, collapseY);
 		await page.mouse.down();
 		await page.mouse.move(layoutBox.x + layoutBox.width - 1, collapseY, { steps: 8 });
+		await expect(page.locator(".side-panel-split-layout")).toHaveAttribute("data-resize-intent", "collapse");
+		expect(await page.locator(".side-panel-split-layout").evaluate((layout) => getComputedStyle(layout, "::after").content)).toContain("Release to collapse panel");
 		await page.mouse.up();
 
 		const restore = page.getByTestId("side-panel-restore");
@@ -289,6 +291,28 @@ test.describe("Side-panel tab contract", () => {
 		await expect(handle).toBeVisible();
 		const restored = await widths();
 		expect(Math.abs(restored.panel - restored.chat), "restoring a drag-collapsed panel should preserve its prior width").toBeLessThan(3);
+
+		const [expandHandleBox, restoredLayoutBox] = await Promise.all([
+			handle.boundingBox(),
+			page.locator(".side-panel-split-layout").boundingBox(),
+		]);
+		if (!expandHandleBox || !restoredLayoutBox) throw new Error("restored split layout has no resize geometry");
+		const expandStartX = expandHandleBox.x + expandHandleBox.width / 2;
+		const expandY = expandHandleBox.y + expandHandleBox.height / 2;
+		await page.mouse.move(expandStartX, expandY);
+		await page.mouse.down();
+		await page.mouse.move(restoredLayoutBox.x + 1, expandY, { steps: 8 });
+		await expect(page.locator(".side-panel-split-layout")).toHaveAttribute("data-resize-intent", "fullscreen");
+		expect(await page.locator(".side-panel-split-layout").evaluate((layout) => getComputedStyle(layout, "::after").content)).toContain("Release to expand panel");
+		await page.mouse.up();
+
+		await expect(page.locator('[data-side-panel-mode="fullscreen"]'), "dragging the divider fully left should expand the side panel").toBeVisible();
+		await expect(handle).toHaveCount(0);
+		await expect.poll(async () => (await workspace(sessionId)).sizeMode, { timeout: 10_000 }).toBe("fullscreen");
+		await page.getByTestId("side-panel-collapse").click();
+		await expect(handle).toBeVisible();
+		const splitAfterFullscreen = await widths();
+		expect(Math.abs(splitAfterFullscreen.panel - splitAfterFullscreen.chat), "returning from drag-fullscreen should preserve the prior split width").toBeLessThan(3);
 	});
 
 	test("sequential preview files keep stable artifact routes across tabs and reload", async ({ page }) => {


### PR DESCRIPTION
## Summary
- add a persisted 25–75% desktop side-panel split with a 50/50 default
- support pointer, keyboard, reset, collapse, and fullscreen gestures while restoring the prior split
- keep retained pack iframes mounted across resizing and mode changes
- fence drag ownership and cleanup across unrelated pointers, navigation, mode changes, and mobile transitions
- show theme-aware pane fades and `--primary` edge pulses at terminal thresholds

## Testing
- `npm run check`
- `npm run test:browser -- tests2/browser/fixtures/side-panel-tabs.spec.ts tests2/browser/fixtures/side-panel-pane-retention.spec.ts`
- full implementation workflow: build, type-check, unit, browser, E2E, conformance, integrated review, and security review

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)