### PR TITLE
Migrate proposal test fixtures

### DIFF
--- a/docs/testing-strategy.md
+++ b/docs/testing-strategy.md
@@ -85,6 +85,8 @@ Valid semantics are `unit-core`, `unit-isolated`, `dom`, `gateway-integration`, 
 
 Move tests in small, rename-oriented PRs based on then-current `main`. Each cohort must preserve runner selection and coverage, and must not include product fixes or broad documentation cleanup.
 
+**Current shared-support migration status.** The proposal fixture cohort now lives at `tests/support/fixtures/unit/proposals/{goal-route-fixture,project-fixture}.ts`. Remaining support/harness cohorts are unit helpers, fixtures, and the general unit harness; browser helpers and assets; integration helpers and harnesses; E2E support; and manual support. Migrate each remaining cohort in a separate bounded PR.
+
 1. **Shared support and harnesses** — move non-runnable helpers, fixtures, data, and harnesses into `tests/support/` or lane-local `_helpers/` directories.
 2. **Bounded unit-core cohorts** — migrate small, reviewable groups into `tests/unit/core/`, preserving behavior before starting the next group.
 3. **DOM and gateway integration** — migrate the happy-dom and in-process gateway cohorts into `tests/dom/` and `tests/integration/gateway/`.

--- a/tests/support/fixtures/unit/proposals/goal-route-fixture.ts
+++ b/tests/support/fixtures/unit/proposals/goal-route-fixture.ts
@@ -1,6 +1,6 @@
-import type { PersistedGoal } from "../../src/server/agent/goal-store.js";
-import type { Workflow } from "../../src/server/agent/workflow-store.js";
-import { prepareGoalProposalSeed, validateGoalProposalWorkflow } from "../../src/server/proposals/goal-proposal-seed.js";
+import type { PersistedGoal } from "../../../../../src/server/agent/goal-store.js";
+import type { Workflow } from "../../../../../src/server/agent/workflow-store.js";
+import { prepareGoalProposalSeed, validateGoalProposalWorkflow } from "../../../../../src/server/proposals/goal-proposal-seed.js";
 
 export const VALIDATION_PROJECT_WORKFLOWS: readonly Workflow[] = [
 	{

--- a/tests/support/fixtures/unit/proposals/project-fixture.ts
+++ b/tests/support/fixtures/unit/proposals/project-fixture.ts
@@ -5,8 +5,8 @@ import {
 	deleteProposalFile,
 	parseProposalFile,
 	type ProposalType,
-} from "../../src/server/proposals/proposal-files.js";
-import type { TestComponent, TestWorkflowsBlock } from "../../tests/e2e/seed-workflows.js";
+} from "../../../../../src/server/proposals/proposal-files.js";
+import type { TestComponent, TestWorkflowsBlock } from "../../../../e2e/seed-workflows.js";
 
 interface ProposalProjectFixture {
 	id: string;

--- a/tests2/integration/cross-project-proposals.test.ts
+++ b/tests2/integration/cross-project-proposals.test.ts
@@ -43,7 +43,7 @@ import {
 	releaseSharedProposalSession,
 	sharedProposalSession,
 	withProposalSessionSnapshot,
-} from "./_proposal-project-fixture.js";
+} from "../../tests/support/fixtures/unit/proposals/project-fixture.js";
 
 const HEADQUARTERS_PROJECT_ID = "headquarters";
 const SYSTEM_PROJECT_ID = "system";

--- a/tests2/integration/proposal-goal-workflow-validation.test.ts
+++ b/tests2/integration/proposal-goal-workflow-validation.test.ts
@@ -10,7 +10,7 @@ import { beforeEach, expect, test } from "vitest";
 import {
 	GoalProposalRouteFixture,
 	VALIDATION_PROJECT_WORKFLOWS,
-} from "./_proposal-goal-route-fixture.js";
+} from "../../tests/support/fixtures/unit/proposals/goal-route-fixture.js";
 
 const INLINE_WORKFLOW = {
 	id: "bespoke-seed-inline-e2e",


### PR DESCRIPTION
## Summary

- move the shared gateway-integration proposal fixtures into `tests/support/fixtures/unit/proposals/`
- update their consumer and internal imports without changing runnable test ownership
- document the completed cohort and defer remaining support migrations

## Verification

- `npm run test:layout`
- `npm run check`
- focused proposal consumers: 2 files, 37 tests
- unchanged unit, browser, E2E, and manual discovery counts
- full workflow build, unit, browser, E2E, conformance, integrated review, and security verification

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)