### PR TITLE
Migrate gate unit tests

### DIFF
--- a/tests/unit/core/gates/gate-dependency-enforcement.unit.test.ts
+++ b/tests/unit/core/gates/gate-dependency-enforcement.unit.test.ts
@@ -14,7 +14,7 @@
  */
 import { describe, it } from "vitest";
 import assert from "node:assert/strict";
-import { checkGateDependencies, type GateDef } from "../../src/server/agent/gate-dependency-check.js";
+import { checkGateDependencies, type GateDef } from "../../../../src/server/agent/gate-dependency-check.js";
 
 // ── Test workflow: design-doc → implementation → ready-to-merge ──────
 

--- a/tests/unit/core/gates/gate-diagnostics-cleanup.unit.test.ts
+++ b/tests/unit/core/gates/gate-diagnostics-cleanup.unit.test.ts
@@ -3,14 +3,14 @@
 // Bucket: v2-core | Method: codemod | Classification: needs-manual
 // Review: default/namespace `node:test` import — map hooks/vi by hand
 
-import test from "node:test";
+import { test } from "vitest";
 import assert from "node:assert/strict";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { GoalStore, type PersistedGoal } from "../../src/server/agent/goal-store.js";
-import { GoalManager } from "../../src/server/agent/goal-manager.js";
-import { gateDiagnosticsGoalDir } from "../../src/server/agent/gate-diagnostics-cleanup.js";
+import { GoalStore, type PersistedGoal } from "../../../../src/server/agent/goal-store.js";
+import { GoalManager } from "../../../../src/server/agent/goal-manager.js";
+import { gateDiagnosticsGoalDir } from "../../../../src/server/agent/gate-diagnostics-cleanup.js";
 
 function makeGoal(id: string): PersistedGoal {
 	return {

--- a/tests/unit/core/gates/gate-diagnostics.unit.test.ts
+++ b/tests/unit/core/gates/gate-diagnostics.unit.test.ts
@@ -3,13 +3,13 @@
 // Bucket: v2-core | Method: codemod | Classification: needs-manual
 // Review: default/namespace `node:test` import — map hooks/vi by hand | test-context helper (t.skip/t.todo/...) — vitest has no per-context equivalent
 
-import test from "node:test";
+import { test } from "vitest";
 import assert from "node:assert/strict";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
-import { finalizeGateStepDiagnostics, prepareGateStepDiagnosticsPaths } from "../../src/server/gate-diagnostics.ts";
+import { finalizeGateStepDiagnostics, prepareGateStepDiagnosticsPaths } from "../../../../src/server/gate-diagnostics.ts";
 
 function makeTempDir(prefix: string): string {
 	return fs.mkdtempSync(path.join(os.tmpdir(), prefix));

--- a/tests/unit/core/gates/gate-reset-intent.unit.test.ts
+++ b/tests/unit/core/gates/gate-reset-intent.unit.test.ts
@@ -1,10 +1,10 @@
 import path from "node:path";
 import { describe, expect, it } from "vitest";
-import { GoalStore, type PersistedGoal } from "../../src/server/agent/goal-store.js";
-import { GateStore } from "../../src/server/agent/gate-store.js";
-import { GateResetCoordinator } from "../../src/server/agent/gate-reset-intent.js";
-import type { Workflow } from "../../src/server/agent/workflow-store.js";
-import { createMemFs, type MemFs } from "../harness/mem-fs.js";
+import { GoalStore, type PersistedGoal } from "../../../../src/server/agent/goal-store.js";
+import { GateStore } from "../../../../src/server/agent/gate-store.js";
+import { GateResetCoordinator } from "../../../../src/server/agent/gate-reset-intent.js";
+import type { Workflow } from "../../../../src/server/agent/workflow-store.js";
+import { createMemFs, type MemFs } from "../../../../tests2/harness/mem-fs.js";
 
 const workflow: Workflow = {
 	id: "reset-wal",

--- a/tests/unit/core/gates/gate-signal-step-enumeration.unit.test.ts
+++ b/tests/unit/core/gates/gate-signal-step-enumeration.unit.test.ts
@@ -48,11 +48,11 @@ const TEST_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "gate-signal-enum-test-")
 const STATE_DIR = path.join(TEST_DIR, "state");
 fs.mkdirSync(STATE_DIR, { recursive: true });
 
-const { VerificationHarness } = await import("../../src/server/agent/verification-harness.js");
-const { GateStore } = await import("../../src/server/agent/gate-store.js");
+const { VerificationHarness } = await import("../../../../src/server/agent/verification-harness.js");
+const { GateStore } = await import("../../../../src/server/agent/gate-store.js");
 
-import type { GateSignal } from "../../src/server/agent/gate-store.js";
-import type { WorkflowGate } from "../../src/server/agent/workflow-store.js";
+import type { GateSignal } from "../../../../src/server/agent/gate-store.js";
+import type { WorkflowGate } from "../../../../src/server/agent/workflow-store.js";
 
 const GOAL_ID = "goal-enum-test";
 const GATE_ID = "implementation";

--- a/tests/unit/core/gates/gate-status-summary.unit.test.ts
+++ b/tests/unit/core/gates/gate-status-summary.unit.test.ts
@@ -4,9 +4,9 @@
 
 import assert from "node:assert/strict";
 import { describe, it } from "vitest";
-import { buildGateStatusSummary } from "../../src/server/gate-status-summary.js";
-import type { GateState } from "../../src/server/agent/gate-store.js";
-import type { ActiveVerification } from "../../src/server/agent/verification-harness.js";
+import { buildGateStatusSummary } from "../../../../src/server/gate-status-summary.js";
+import type { GateState } from "../../../../src/server/agent/gate-store.js";
+import type { ActiveVerification } from "../../../../src/server/agent/verification-harness.js";
 
 function gate(status: GateState["status"], gateId = "implementation"): GateState {
 	return {

--- a/tests/unit/core/gates/gate-store-logic.unit.test.ts
+++ b/tests/unit/core/gates/gate-store-logic.unit.test.ts
@@ -13,9 +13,9 @@
 import { describe, it, beforeEach } from "vitest";
 import assert from "node:assert/strict";
 import path from "node:path";
-import { GateStore } from "../../src/server/agent/gate-store.ts";
-import type { Workflow, WorkflowGate } from "../../src/server/agent/workflow-store.ts";
-import { createMemFs, type MemFs } from "../harness/mem-fs.js";
+import { GateStore } from "../../../../src/server/agent/gate-store.ts";
+import type { Workflow, WorkflowGate } from "../../../../src/server/agent/workflow-store.ts";
+import { createMemFs, type MemFs } from "../../../../tests2/harness/mem-fs.js";
 
 let dirSeq = 0;
 

--- a/tests/unit/core/gates/gate-store-sqlite.unit.test.ts
+++ b/tests/unit/core/gates/gate-store-sqlite.unit.test.ts
@@ -4,11 +4,11 @@ import os from "node:os";
 import path from "node:path";
 import Database from "better-sqlite3";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { GateStore, type GateSignal, type GateState } from "../../src/server/agent/gate-store.js";
-import { ProjectContext } from "../../src/server/agent/project-context.js";
-import { recoverPreMigrationData } from "../../src/server/agent/state-migration.js";
-import type { Workflow } from "../../src/server/agent/workflow-store.js";
-import { createMemFs } from "../harness/mem-fs.js";
+import { GateStore, type GateSignal, type GateState } from "../../../../src/server/agent/gate-store.js";
+import { ProjectContext } from "../../../../src/server/agent/project-context.js";
+import { recoverPreMigrationData } from "../../../../src/server/agent/state-migration.js";
+import type { Workflow } from "../../../../src/server/agent/workflow-store.js";
+import { createMemFs } from "../../../../tests2/harness/mem-fs.js";
 
 const roots: string[] = [];
 const stores: GateStore[] = [];

--- a/tests/unit/core/gates/gate-verification-snapshot.unit.test.ts
+++ b/tests/unit/core/gates/gate-verification-snapshot.unit.test.ts
@@ -8,15 +8,15 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
-import { installScopedMemoryFs } from "./helpers/scoped-memory-fs.ts";
-import { GateArtifactResolutionError, buildArtifactLookup, resolveArtifactFromLookup } from "../../src/server/gate-artifacts.ts";
-import { buildGateVerificationSnapshot, UnknownVerificationStepError } from "../../src/server/gate-verification-snapshot.ts";
+import { installScopedMemoryFs } from "../../../../tests2/core/helpers/scoped-memory-fs.ts";
+import { GateArtifactResolutionError, buildArtifactLookup, resolveArtifactFromLookup } from "../../../../src/server/gate-artifacts.ts";
+import { buildGateVerificationSnapshot, UnknownVerificationStepError } from "../../../../src/server/gate-verification-snapshot.ts";
 import {
 	VERIFICATION_WS_STEP_COMPLETE_OUTPUT_PREVIEW_BYTES,
 	VERIFICATION_WS_STEP_OUTPUT_PREVIEW_BYTES,
 	VerificationHarness,
 	sanitizeVerificationWsEvent,
-} from "../../src/server/agent/verification-harness.ts";
+} from "../../../../src/server/agent/verification-harness.ts";
 
 const tempDirs: string[] = [];
 let sharedArtifactFixtureDir: string | undefined;

--- a/tests/unit/core/gates/gate-verification-ux.unit.test.ts
+++ b/tests/unit/core/gates/gate-verification-ux.unit.test.ts
@@ -36,11 +36,11 @@ import assert from "node:assert/strict";
 // fail independently.
 
 // Issue 1 — slim gate-list projection (contract: gate-status-summary.ts).
-import * as gateStatusSummary from "../../src/server/gate-status-summary.ts";
+import * as gateStatusSummary from "../../../../src/server/gate-status-summary.ts";
 // Issue 2 — snapshot liveness (existing export; gains an additive input/field).
-import { buildGateVerificationSnapshot } from "../../src/server/gate-verification-snapshot.ts";
+import { buildGateVerificationSnapshot } from "../../../../src/server/gate-verification-snapshot.ts";
 // Issue 3 — restart-recovery classification helpers (contract: verification-logic.ts).
-import * as verificationLogic from "../../src/server/agent/verification-logic.ts";
+import * as verificationLogic from "../../../../src/server/agent/verification-logic.ts";
 
 // Type-only import is erased by tsx/esbuild at runtime; harmless if absent.
 // Kept for contract fidelity (the fix adds this exact type name).


### PR DESCRIPTION
## Summary
- move 10 gate unit suites into `tests/unit/core/gates/` with canonical `*.unit.test.ts` names
- preserve all 109 tests and update only runner/relative imports required by the moves
- retain exactly-once `v2-core` discovery with canonical +10 and transitional -10

## Validation
- `npm run test:layout`
- `npm run check`
- full unit, browser, and E2E workflow verification
- focused moved cohort: 10 files, 109 tests
- inventory and core parity checks

No `gate-*.e2e.*` file matched the bounded cohort; gate-prefixed DOM, integration, browser, and legacy E2E suites remain unmoved.

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)