### PR TITLE
Migrate archived maintenance tests

### DIFF
--- a/tests/integration/gateway/maintenance/maintenance-api-archived-cleanup.gateway.test.ts
+++ b/tests/integration/gateway/maintenance/maintenance-api-archived-cleanup.gateway.test.ts
@@ -1,6 +1,6 @@
 import { afterAll, afterEach, beforeAll, describe, it } from "vitest";
-import * as maintenance from "./maintenance-api-support.js";
-import type { MaintenanceGitSnapshot } from "./maintenance-git-model.js";
+import * as maintenance from "../../../../tests2/integration/helpers/maintenance-api-support.js";
+import type { MaintenanceGitSnapshot } from "../../../../tests2/integration/helpers/maintenance-git-model.js";
 
 const {
 	test, expect, apiFetch, expectArchivedCleanupShape,

--- a/tests/integration/gateway/maintenance/maintenance-api-archived-guards.gateway.test.ts
+++ b/tests/integration/gateway/maintenance/maintenance-api-archived-guards.gateway.test.ts
@@ -1,6 +1,6 @@
 import { afterAll, afterEach, beforeAll, describe, it } from "vitest";
-import * as maintenance from "./maintenance-api-support.js";
-import type { MaintenanceGitSnapshot } from "./maintenance-git-model.js";
+import * as maintenance from "../../../../tests2/integration/helpers/maintenance-api-support.js";
+import type { MaintenanceGitSnapshot } from "../../../../tests2/integration/helpers/maintenance-git-model.js";
 
 const {
 	expect, apiFetch, expectArchivedCleanupShape,

--- a/tests/integration/gateway/maintenance/maintenance-api-archived-scan.gateway.test.ts
+++ b/tests/integration/gateway/maintenance/maintenance-api-archived-scan.gateway.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from "vitest";
-import * as maintenance from "./maintenance-api-support.js";
-import type { MaintenanceGitSnapshot } from "./maintenance-git-model.js";
+import * as maintenance from "../../../../tests2/integration/helpers/maintenance-api-support.js";
+import type { MaintenanceGitSnapshot } from "../../../../tests2/integration/helpers/maintenance-git-model.js";
 
 const {
 	test, expect, apiFetch, expectArchivedScanShape, expectArchivedCleanupShape,

--- a/tests/integration/gateway/maintenance/maintenance-api-archived-selectors.gateway.test.ts
+++ b/tests/integration/gateway/maintenance/maintenance-api-archived-selectors.gateway.test.ts
@@ -2,10 +2,10 @@ import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { WorktreeInventoryService } from "../../../src/server/agent/worktree-inventory.js";
-import type { PersistedSession } from "../../../src/server/agent/session-store.js";
-import type { CommandRunner } from "../../../src/server/gateway-deps.js";
-import { MaintenanceGitModel } from "./maintenance-git-model.js";
+import { WorktreeInventoryService } from "../../../../src/server/agent/worktree-inventory.js";
+import type { PersistedSession } from "../../../../src/server/agent/session-store.js";
+import type { CommandRunner } from "../../../../src/server/gateway-deps.js";
+import { MaintenanceGitModel } from "../../../../tests2/integration/helpers/maintenance-git-model.js";
 
 const projectId = "archived-selectors-project";
 const clockNow = 1_750_000_000_000;


### PR DESCRIPTION
## Summary
- move four archived maintenance API suites into the canonical gateway integration hierarchy
- preserve assertions and existing maintenance support imports
- keep discovery counts stable while shifting four suites from transitional to canonical ownership

## Validation
- `npm run test:layout`
- `npm run check`
- four-suite `v2-integration` run: 13 tests passed
- phase-invariant and focused discovery/layout checks
- workflow build, unit, browser, E2E, conformance, integrated, and security verification

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)