### PR TITLE
Migrate DOM search tests

### DIFF
--- a/tests/dom/search/chunker.dom.test.ts
+++ b/tests/dom/search/chunker.dom.test.ts
@@ -1,5 +1,5 @@
 import { beforeAll as __syncBeforeAll } from "vitest";
-import { syncCustomElements as __syncCE } from "../_setup/custom-elements.js";
+import { syncCustomElements as __syncCE } from "../../../tests2/dom/_setup/custom-elements.js";
 __syncBeforeAll(() => __syncCE());
 // Migrated from tests/search/chunker.spec.ts (v2-dom tier).
 // Pure-logic test: imports the REAL chunkText from src/server/search/chunker.

--- a/tests/dom/search/content-policy.dom.test.ts
+++ b/tests/dom/search/content-policy.dom.test.ts
@@ -1,5 +1,5 @@
 import { beforeAll as __syncBeforeAll } from "vitest";
-import { syncCustomElements as __syncCE } from "../_setup/custom-elements.js";
+import { syncCustomElements as __syncCE } from "../../../tests2/dom/_setup/custom-elements.js";
 __syncBeforeAll(() => __syncCE());
 // Migrated from tests/search/content-policy.spec.ts (v2-dom tier).
 // Pure-logic test: imports the REAL content-policy helpers from

--- a/tests/dom/search/files-source-stub.dom.test.ts
+++ b/tests/dom/search/files-source-stub.dom.test.ts
@@ -1,5 +1,5 @@
 import { beforeAll as __syncBeforeAll } from "vitest";
-import { syncCustomElements as __syncCE } from "../_setup/custom-elements.js";
+import { syncCustomElements as __syncCE } from "../../../tests2/dom/_setup/custom-elements.js";
 __syncBeforeAll(() => __syncCE());
 /**
  * V2-readiness smoke test.

--- a/tests/dom/search/flex-store-close-teardown.dom.test.ts
+++ b/tests/dom/search/flex-store-close-teardown.dom.test.ts
@@ -1,5 +1,5 @@
 import { beforeAll as __syncBeforeAll } from "vitest";
-import { syncCustomElements as __syncCE } from "../_setup/custom-elements.js";
+import { syncCustomElements as __syncCE } from "../../../tests2/dom/_setup/custom-elements.js";
 __syncBeforeAll(() => __syncCE());
 
 import { expect, test } from "vitest";

--- a/tests/dom/search/flex-store.dom.test.ts
+++ b/tests/dom/search/flex-store.dom.test.ts
@@ -1,5 +1,5 @@
 import { beforeAll as __syncBeforeAll } from "vitest";
-import { syncCustomElements as __syncCE } from "../_setup/custom-elements.js";
+import { syncCustomElements as __syncCE } from "../../../tests2/dom/_setup/custom-elements.js";
 __syncBeforeAll(() => __syncCE());
 /**
  * Core FlexSearchStore behaviour:

--- a/tests/dom/search/index-source-contract.dom.test.ts
+++ b/tests/dom/search/index-source-contract.dom.test.ts
@@ -1,5 +1,5 @@
 import { beforeAll as __syncBeforeAll } from "vitest";
-import { syncCustomElements as __syncCE } from "../_setup/custom-elements.js";
+import { syncCustomElements as __syncCE } from "../../../tests2/dom/_setup/custom-elements.js";
 __syncBeforeAll(() => __syncCE());
 /**
  * Shared contract runner for `IndexSource` implementations.
@@ -41,7 +41,7 @@ import type { IndexSource, IndexSourceContext, Indexable } from "../../../src/se
 import type { PersistedGoal, GoalStore } from "../../../src/server/agent/goal-store.ts";
 import type { PersistedSession, SessionStore } from "../../../src/server/agent/session-store.ts";
 import type { PersistedStaff, StaffStore } from "../../../src/server/agent/staff-store.ts";
-import { installScopedMemoryFs } from "../../core/helpers/scoped-memory-fs.ts";
+import { installScopedMemoryFs } from "../../../tests2/core/helpers/scoped-memory-fs.ts";
 
 // ── In-memory fake stores ────────────────────────────────────────────
 

--- a/tests/dom/search/indexer.dom.test.ts
+++ b/tests/dom/search/indexer.dom.test.ts
@@ -1,5 +1,5 @@
 import { beforeAll as __syncBeforeAll } from "vitest";
-import { syncCustomElements as __syncCE } from "../_setup/custom-elements.js";
+import { syncCustomElements as __syncCE } from "../../../tests2/dom/_setup/custom-elements.js";
 __syncBeforeAll(() => __syncCE());
 /**
  * Unit tests for `src/server/search/indexer.ts::Indexer`.

--- a/tests/dom/search/lexical-parity.dom.test.ts
+++ b/tests/dom/search/lexical-parity.dom.test.ts
@@ -1,5 +1,5 @@
 import { beforeAll as __syncBeforeAll } from "vitest";
-import { syncCustomElements as __syncCE } from "../_setup/custom-elements.js";
+import { syncCustomElements as __syncCE } from "../../../tests2/dom/_setup/custom-elements.js";
 __syncBeforeAll(() => __syncCE());
 /**
  * Lexical parity suite for the FlexSearch-backed search layer.

--- a/tests/dom/search/meta-mismatch.dom.test.ts
+++ b/tests/dom/search/meta-mismatch.dom.test.ts
@@ -1,5 +1,5 @@
 import { beforeAll as __syncBeforeAll } from "vitest";
-import { syncCustomElements as __syncCE } from "../_setup/custom-elements.js";
+import { syncCustomElements as __syncCE } from "../../../tests2/dom/_setup/custom-elements.js";
 __syncBeforeAll(() => __syncCE());
 /**
  * Unit tests for `src/server/search/meta.ts::needsRebuild`.

--- a/tests/dom/search/scale-smoke.dom.test.ts
+++ b/tests/dom/search/scale-smoke.dom.test.ts
@@ -1,5 +1,5 @@
 import { beforeAll as __syncBeforeAll } from "vitest";
-import { syncCustomElements as __syncCE } from "../_setup/custom-elements.js";
+import { syncCustomElements as __syncCE } from "../../../tests2/dom/_setup/custom-elements.js";
 __syncBeforeAll(() => __syncCE());
 /**
  * @slow Scale smoke test: ~40K synthetic Indexables, open-time + query

--- a/tests/dom/search/search-close-rebuild-and-empty-tag.dom.test.ts
+++ b/tests/dom/search/search-close-rebuild-and-empty-tag.dom.test.ts
@@ -1,5 +1,5 @@
 import { beforeAll as __syncBeforeAll } from "vitest";
-import { syncCustomElements as __syncCE } from "../_setup/custom-elements.js";
+import { syncCustomElements as __syncCE } from "../../../tests2/dom/_setup/custom-elements.js";
 __syncBeforeAll(() => __syncCE());
 
 import { expect, test } from "vitest";

--- a/tests/dom/search/search-service-extras.dom.test.ts
+++ b/tests/dom/search/search-service-extras.dom.test.ts
@@ -1,5 +1,5 @@
 import { beforeAll as __syncBeforeAll } from "vitest";
-import { syncCustomElements as __syncCE } from "../_setup/custom-elements.js";
+import { syncCustomElements as __syncCE } from "../../../tests2/dom/_setup/custom-elements.js";
 __syncBeforeAll(() => __syncCE());
 
 import { expect, test, vi } from "vitest";

--- a/tests/dom/search/snippet-highlight.dom.test.ts
+++ b/tests/dom/search/snippet-highlight.dom.test.ts
@@ -1,5 +1,5 @@
 import { beforeAll as __syncBeforeAll } from "vitest";
-import { syncCustomElements as __syncCE } from "../_setup/custom-elements.js";
+import { syncCustomElements as __syncCE } from "../../../tests2/dom/_setup/custom-elements.js";
 __syncBeforeAll(() => __syncCE());
 // Migrated from tests/search/snippet-highlight.spec.ts (v2-dom tier).
 // Pure-logic unit test for the REAL `highlight` from src/server/search/snippet.ts.

--- a/tests/dom/search/weight-apply.dom.test.ts
+++ b/tests/dom/search/weight-apply.dom.test.ts
@@ -1,5 +1,5 @@
 import { beforeAll as __syncBeforeAll } from "vitest";
-import { syncCustomElements as __syncCE } from "../_setup/custom-elements.js";
+import { syncCustomElements as __syncCE } from "../../../tests2/dom/_setup/custom-elements.js";
 __syncBeforeAll(() => __syncCE());
 // Migrated from tests/search/weight-apply.spec.ts (v2-dom tier).
 // Pure-logic test for the post-rank weight multiplier in the REAL FlexSearchStore


### PR DESCRIPTION
## Summary
- move all 14 DOM search suites into the canonical `tests/dom/search/` layout
- preserve assertions and happy-dom ownership with relocation-only import updates
- keep each suite selected exactly once by the DOM Vitest project

## Validation
- `npm run test:layout`
- `npm run check`
- targeted v2-dom cohort: 14 files, 134 passed, 1 intentionally skipped
- focused discovery/layout and phase-invariant checks

## Verification note
The workflow's broad E2E step was attempted twice. Both runs exceeded the fixed 900-second Windows limit and surfaced unrelated pre-existing gateway-fixture/streaming flakes; build, check, unit, browser, spec conformance, integrated review, and security review all passed. The migration does not change E2E files, runner configuration, or production code.

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)