### PR TITLE
Migrate workflow gateway tests

### DIFF
--- a/tests/integration/gateway/gates/gate-bypass-api.gateway.test.ts
+++ b/tests/integration/gateway/gates/gate-bypass-api.gateway.test.ts
@@ -13,7 +13,7 @@
  */
 import { mkdtempSync } from "node:fs";
 import { join } from "node:path";
-import { test, expect } from "./_e2e/in-process-harness.js";
+import { test, expect } from "../../../../tests2/integration/_e2e/in-process-harness.js";
 import {
 	apiFetch,
 	base,
@@ -27,8 +27,8 @@ import {
 	startTeam,
 	teardownTeam,
 	type WsConnection,
-} from "./_e2e/e2e-setup.js";
-import { pollUntil } from "../../tests/e2e/test-utils/cleanup.js";
+} from "../../../../tests2/integration/_e2e/e2e-setup.js";
+import { pollUntil } from "../../../e2e/test-utils/cleanup.js";
 
 function workflowId(prefix: string): string {
 	return `${prefix}-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;

--- a/tests/integration/gateway/gates/gate-diagnostics-cleanup.gateway.test.ts
+++ b/tests/integration/gateway/gates/gate-diagnostics-cleanup.gateway.test.ts
@@ -1,10 +1,10 @@
 import fs from "node:fs";
 import path from "node:path";
-import { test, expect } from "./_e2e/in-process-harness.js";
-import { apiFetch, createGoal, defaultProject, defaultProjectId, deleteGoal, nonGitCwd } from "./_e2e/e2e-setup.js";
-import { loadServerTestRuntime } from "../harness/server-runtime.js";
+import { test, expect } from "../../../../tests2/integration/_e2e/in-process-harness.js";
+import { apiFetch, createGoal, defaultProject, defaultProjectId, deleteGoal, nonGitCwd } from "../../../../tests2/integration/_e2e/e2e-setup.js";
+import { loadServerTestRuntime } from "../../../../tests2/harness/server-runtime.js";
 
-let gateDiagnosticsGoalDir: typeof import("../../src/server/agent/gate-diagnostics-cleanup.js").gateDiagnosticsGoalDir;
+let gateDiagnosticsGoalDir: typeof import("../../../../src/server/agent/gate-diagnostics-cleanup.js").gateDiagnosticsGoalDir;
 
 test.beforeAll(async () => {
 	({ gateDiagnosticsGoalDir } = (await loadServerTestRuntime()).gateDiagnosticsCleanup);

--- a/tests/integration/gateway/gates/gate-inspect-slicing.gateway.test.ts
+++ b/tests/integration/gateway/gates/gate-inspect-slicing.gateway.test.ts
@@ -4,13 +4,13 @@
 import fs from "node:fs";
 import path from "node:path";
 
-import { test, expect } from "./_e2e/in-process-harness.js";
-import { apiFetch, createGoal, deleteGoal, nonGitCwd } from "./_e2e/e2e-setup.js";
-import { GateStore } from "../../src/server/agent/gate-store.js";
-import { buildGateVerificationSnapshot } from "../../src/server/gate-verification-snapshot.js";
-import type { GatewayFixture } from "../harness/gateway.js";
-import { createFakeVerificationCommandRunner } from "../harness/fake-verification-command-runner.js";
-import { createMemFs } from "../harness/mem-fs.js";
+import { test, expect } from "../../../../tests2/integration/_e2e/in-process-harness.js";
+import { apiFetch, createGoal, deleteGoal, nonGitCwd } from "../../../../tests2/integration/_e2e/e2e-setup.js";
+import { GateStore } from "../../../../src/server/agent/gate-store.js";
+import { buildGateVerificationSnapshot } from "../../../../src/server/gate-verification-snapshot.js";
+import type { GatewayFixture } from "../../../../tests2/harness/gateway.js";
+import { createFakeVerificationCommandRunner } from "../../../../tests2/harness/fake-verification-command-runner.js";
+import { createMemFs } from "../../../../tests2/harness/mem-fs.js";
 
 const VERIFY_LOG_OUTPUT = Array.from({ length: 160 }, (_, i) => {
 	const line = i + 1;

--- a/tests/integration/gateway/gates/gate-reset-api.gateway.test.ts
+++ b/tests/integration/gateway/gates/gate-reset-api.gateway.test.ts
@@ -1,5 +1,5 @@
 import { vi } from "vitest";
-import { test, expect } from "./_e2e/in-process-harness.js";
+import { test, expect } from "../../../../tests2/integration/_e2e/in-process-harness.js";
 import {
 	apiFetch,
 	base,
@@ -13,14 +13,14 @@ import {
 	startTeam,
 	teardownTeam,
 	type WsConnection,
-} from "./_e2e/e2e-setup.js";
-import { pollUntil } from "../../tests/e2e/test-utils/cleanup.js";
+} from "../../../../tests2/integration/_e2e/e2e-setup.js";
+import { pollUntil } from "../../../e2e/test-utils/cleanup.js";
 import {
 	signalAndWaitForAuthoredGateWithFakeCommandBarrier,
 	trackGateApiConnection,
 	useGateApiTestSupport,
 	waitForAuthoredGateStatus,
-} from "./helpers/gate-api-test-support.js";
+} from "../../../../tests2/integration/helpers/gate-api-test-support.js";
 
 useGateApiTestSupport();
 

--- a/tests/integration/gateway/gates/gate-resign-cancel.gateway.test.ts
+++ b/tests/integration/gateway/gates/gate-resign-cancel.gateway.test.ts
@@ -3,13 +3,13 @@ import os from "node:os";
 import path from "node:path";
 import { expect, test } from "vitest";
 
-import type { CommandRunner } from "../../src/server/gateway-deps.js";
-import { GateStore, type GateSignal } from "../../src/server/agent/gate-store.js";
-import { GoalStore, type PersistedGoal } from "../../src/server/agent/goal-store.js";
-import { VerificationHarness } from "../../src/server/agent/verification-harness.js";
-import type { Workflow, WorkflowGate } from "../../src/server/agent/workflow-store.js";
-import { createManualClock, type ManualClock } from "../harness/clock.js";
-import { createFakeVerificationCommandRunner } from "../harness/fake-verification-command-runner.js";
+import type { CommandRunner } from "../../../../src/server/gateway-deps.js";
+import { GateStore, type GateSignal } from "../../../../src/server/agent/gate-store.js";
+import { GoalStore, type PersistedGoal } from "../../../../src/server/agent/goal-store.js";
+import { VerificationHarness } from "../../../../src/server/agent/verification-harness.js";
+import type { Workflow, WorkflowGate } from "../../../../src/server/agent/workflow-store.js";
+import { createManualClock, type ManualClock } from "../../../../tests2/harness/clock.js";
+import { createFakeVerificationCommandRunner } from "../../../../tests2/harness/fake-verification-command-runner.js";
 
 const GOAL_ID = "gate-resignal-suite-goal";
 const GATE_ID = "slow-gate";

--- a/tests/integration/gateway/gates/gate-signal-progress.gateway.test.ts
+++ b/tests/integration/gateway/gates/gate-signal-progress.gateway.test.ts
@@ -1,12 +1,12 @@
 import path from "node:path";
 
-import { test, expect } from "./_e2e/in-process-harness.js";
-import { createGoal, deleteGoal } from "./_e2e/e2e-setup.js";
-import { GateStore, type GateSignal } from "../../src/server/agent/gate-store.js";
-import type { WorkflowGate } from "../../src/server/agent/workflow-store.js";
-import { buildGateVerificationSnapshot } from "../../src/server/gate-verification-snapshot.js";
-import type { GatewayFixture } from "../harness/gateway.js";
-import { createMemFs } from "../harness/mem-fs.js";
+import { test, expect } from "../../../../tests2/integration/_e2e/in-process-harness.js";
+import { createGoal, deleteGoal } from "../../../../tests2/integration/_e2e/e2e-setup.js";
+import { GateStore, type GateSignal } from "../../../../src/server/agent/gate-store.js";
+import type { WorkflowGate } from "../../../../src/server/agent/workflow-store.js";
+import { buildGateVerificationSnapshot } from "../../../../src/server/gate-verification-snapshot.js";
+import type { GatewayFixture } from "../../../../tests2/harness/gateway.js";
+import { createMemFs } from "../../../../tests2/harness/mem-fs.js";
 
 /**
  * Pins the synchronous gate-signal ordering without launching verification work:

--- a/tests/integration/gateway/gates/gate-signal-reminder.gateway.test.ts
+++ b/tests/integration/gateway/gates/gate-signal-reminder.gateway.test.ts
@@ -1,15 +1,15 @@
 import path from "node:path";
 import { expect, test } from "vitest";
 
-import { GateStore, type GateSignal } from "../../src/server/agent/gate-store.js";
-import type { WorkflowGate } from "../../src/server/agent/workflow-store.js";
+import { GateStore, type GateSignal } from "../../../../src/server/agent/gate-store.js";
+import type { WorkflowGate } from "../../../../src/server/agent/workflow-store.js";
 import {
 	buildRunningGateSignalResponse,
 	reuseCachedGateSignal,
 	type CachedGateSignalNotifier,
-} from "../../src/server/gate-signal-response.js";
-import { createManualClock, type ManualClock } from "../harness/clock.js";
-import { createMemFs } from "../harness/mem-fs.js";
+} from "../../../../src/server/gate-signal-response.js";
+import { createManualClock, type ManualClock } from "../../../../tests2/harness/clock.js";
+import { createMemFs } from "../../../../tests2/harness/mem-fs.js";
 
 const DO_NOT_POLL_PATTERN = /Verification is running asynchronously|Do not poll|gate_status|gate_inspect|Go idle|wait for the server/i;
 const GOAL_ID = "gate-signal-reminder-goal";

--- a/tests/integration/gateway/gates/gate-status-cache-ws.gateway.test.ts
+++ b/tests/integration/gateway/gates/gate-status-cache-ws.gateway.test.ts
@@ -1,14 +1,14 @@
 import { describe, expect, it } from "vitest";
 import path from "node:path";
-import { GateStore } from "../../src/server/agent/gate-store.js";
-import { GoalStore } from "../../src/server/agent/goal-store.js";
+import { GateStore } from "../../../../src/server/agent/gate-store.js";
+import { GoalStore } from "../../../../src/server/agent/goal-store.js";
 import {
 	broadcastGateStatusChanged,
 	wireGateStatusGenerationInvalidation,
 	type GateStatusChangedEvent,
-} from "../../src/server/gate-status-broadcast.js";
-import { createManualClock, type ManualClock } from "../harness/clock.js";
-import { createMemFs } from "../harness/mem-fs.js";
+} from "../../../../src/server/gate-status-broadcast.js";
+import { createManualClock, type ManualClock } from "../../../../tests2/harness/clock.js";
+import { createMemFs } from "../../../../tests2/harness/mem-fs.js";
 
 // Preserve the migrated Playwright declaration identity without importing the
 // gateway-backed compatibility harness.

--- a/tests/integration/gateway/gates/gate-status-summary.gateway.test.ts
+++ b/tests/integration/gateway/gates/gate-status-summary.gateway.test.ts
@@ -1,10 +1,10 @@
 // Select the fork-local fake runner before either harness import can boot the
 // process-global gateway; file collection order must not select the real runner.
-import { resetAndInstallFakeCommandStepTestState } from "./_e2e/fake-cmd-setup.js";
+import { resetAndInstallFakeCommandStepTestState } from "../../../../tests2/integration/_e2e/fake-cmd-setup.js";
 
-import { expect } from "./_e2e/in-process-harness.js";
-import { test } from "./_e2e/in-process-harness.js";
-import { apiFetch, createGoal, defaultProjectId, deleteGoal } from "./_e2e/e2e-setup.js";
+import { expect } from "../../../../tests2/integration/_e2e/in-process-harness.js";
+import { test } from "../../../../tests2/integration/_e2e/in-process-harness.js";
+import { apiFetch, createGoal, defaultProjectId, deleteGoal } from "../../../../tests2/integration/_e2e/e2e-setup.js";
 
 const GATE_ID = "slow-gate";
 const SLOW_CMD = `node -e "setTimeout(()=>process.exit(0),30000)"`;

--- a/tests/integration/gateway/gates/gate-verification.gateway.test.ts
+++ b/tests/integration/gateway/gates/gate-verification.gateway.test.ts
@@ -6,9 +6,9 @@
  *   tests/e2e/gate-resign-cancel.spec.ts
  */
 import assert from "node:assert";
-import { test } from "./_e2e/in-process-harness.js";
-import { apiFetch, createGoal, deleteGoal } from "./_e2e/e2e-setup.js";
-import { createFakeVerificationCommandRunner } from "../harness/fake-verification-command-runner.js";
+import { test } from "../../../../tests2/integration/_e2e/in-process-harness.js";
+import { apiFetch, createGoal, deleteGoal } from "../../../../tests2/integration/_e2e/e2e-setup.js";
+import { createFakeVerificationCommandRunner } from "../../../../tests2/harness/fake-verification-command-runner.js";
 
 let originalCommandStepRunner: unknown;
 test.beforeAll(({ gateway }) => {

--- a/tests/integration/gateway/gates/gates-api-heavy.gateway.test.ts
+++ b/tests/integration/gateway/gates/gates-api-heavy.gateway.test.ts
@@ -1,10 +1,10 @@
-import { test, expect } from "./_e2e/in-process-harness.js";
-import { apiFetch, createSession, connectWs, nonGitCwd } from "./_e2e/e2e-setup.js";
+import { test, expect } from "../../../../tests2/integration/_e2e/in-process-harness.js";
+import { apiFetch, createSession, connectWs, nonGitCwd } from "../../../../tests2/integration/_e2e/e2e-setup.js";
 import {
 	signalAndWaitForAuthoredGate,
 	trackGateApiConnection,
 	useGateApiTestSupport,
-} from "./helpers/gate-api-test-support.js";
+} from "../../../../tests2/integration/helpers/gate-api-test-support.js";
 
 useGateApiTestSupport();
 

--- a/tests/integration/gateway/gates/gates-api.gateway.test.ts
+++ b/tests/integration/gateway/gates/gates-api.gateway.test.ts
@@ -1,6 +1,6 @@
-import { test, expect } from "./_e2e/in-process-harness.js";
-import { readE2EToken, base, nonGitCwd, injectDefaultProjectId } from "./_e2e/e2e-setup.js";
-import { pollUntil } from "../../tests/e2e/test-utils/cleanup.js";
+import { test, expect } from "../../../../tests2/integration/_e2e/in-process-harness.js";
+import { readE2EToken, base, nonGitCwd, injectDefaultProjectId } from "../../../../tests2/integration/_e2e/e2e-setup.js";
+import { pollUntil } from "../../../e2e/test-utils/cleanup.js";
 
 let token: string;
 

--- a/tests/integration/gateway/goals/api-goal-workflow-edit.gateway.test.ts
+++ b/tests/integration/gateway/goals/api-goal-workflow-edit.gateway.test.ts
@@ -1,10 +1,10 @@
-import { test, expect } from "./_e2e/in-process-harness.js";
+import { test, expect } from "../../../../tests2/integration/_e2e/in-process-harness.js";
 import {
 	apiFetch,
 	defaultProjectId,
 	deleteGoal,
 	nonGitCwd,
-} from "./_e2e/e2e-setup.js";
+} from "../../../../tests2/integration/_e2e/e2e-setup.js";
 
 type Workflow = {
 	id: string;

--- a/tests/integration/gateway/goals/api-goals-child-autostart-ready.gateway.test.ts
+++ b/tests/integration/gateway/goals/api-goals-child-autostart-ready.gateway.test.ts
@@ -15,8 +15,8 @@
  *   2. A `ready` child with `autoStartTeam:false` does NOT (control — the
  *      auto-start branch is gated on autoStartTeam).
  */
-import { test, expect } from "./_e2e/in-process-harness.js";
-import { apiFetch, assertStaysFalse, deleteGoal, nonGitCwd, waitForCondition } from "./_e2e/e2e-setup.js";
+import { test, expect } from "../../../../tests2/integration/_e2e/in-process-harness.js";
+import { apiFetch, assertStaysFalse, deleteGoal, nonGitCwd, waitForCondition } from "../../../../tests2/integration/_e2e/e2e-setup.js";
 
 let harness: any;
 /** childGoalIds passed to the spied requestChildStart. */

--- a/tests/integration/gateway/goals/api-goals-child-create-authz.gateway.test.ts
+++ b/tests/integration/gateway/goals/api-goals-child-create-authz.gateway.test.ts
@@ -18,7 +18,7 @@
  * Top-level goal creation (no `parentGoalId`) is UNCHANGED — these tests create
  * the parent via the normal authenticated path and assert it succeeds.
  */
-import { test, expect } from "./_e2e/in-process-harness.js";
+import { test, expect } from "../../../../tests2/integration/_e2e/in-process-harness.js";
 import {
 	apiFetch,
 	rawApiFetch,
@@ -26,7 +26,7 @@ import {
 	defaultProjectId,
 	nonGitCwd,
 	seedTeamLeadHeader,
-} from "./_e2e/e2e-setup.js";
+} from "../../../../tests2/integration/_e2e/e2e-setup.js";
 
 // The in-process gateway (worker-scoped) — needed to seed a team-lead + its
 // capability secret for the authentic-team-lead allow path.

--- a/tests/integration/gateway/goals/api-goals-paused-parent-child.gateway.test.ts
+++ b/tests/integration/gateway/goals/api-goals-paused-parent-child.gateway.test.ts
@@ -7,13 +7,13 @@
  * that creating a child under a paused parent (or any paused ANCESTOR) is
  * refused with `409 GOAL_PAUSED` and no child is created.
  */
-import { test, expect } from "./_e2e/in-process-harness.js";
+import { test, expect } from "../../../../tests2/integration/_e2e/in-process-harness.js";
 import {
 	apiFetch,
 	deleteGoal,
 	defaultProjectId,
 	nonGitCwd,
-} from "./_e2e/e2e-setup.js";
+} from "../../../../tests2/integration/_e2e/e2e-setup.js";
 
 async function createGoalRaw(body: Record<string, unknown>): Promise<{ status: number; body: any }> {
 	const resp = await apiFetch("/api/goals", {

--- a/tests/integration/gateway/goals/api-goals-prompt-paused.gateway.test.ts
+++ b/tests/integration/gateway/goals/api-goals-prompt-paused.gateway.test.ts
@@ -6,7 +6,7 @@
  *   Gap 1: team/prompt to paused goal must return 409 GOAL_PAUSED
  */
 import { vi } from "vitest";
-import { test, expect } from "./_e2e/in-process-harness.js";
+import { test, expect } from "../../../../tests2/integration/_e2e/in-process-harness.js";
 import {
 	apiFetch,
 	defaultProjectId,
@@ -15,7 +15,7 @@ import {
 	createSession,
 	deleteSession,
 	waitForSessionStatus,
-} from "./_e2e/e2e-setup.js";
+} from "../../../../tests2/integration/_e2e/e2e-setup.js";
 
 async function setSubgoalsEnabled(enabled: boolean): Promise<void> {
 	const resp = await apiFetch("/api/preferences", {

--- a/tests/integration/gateway/goals/api-subgoals-disabled.gateway.test.ts
+++ b/tests/integration/gateway/goals/api-subgoals-disabled.gateway.test.ts
@@ -7,9 +7,9 @@
  *
  * See docs/nested-goals.md.
  */
-import { test, expect } from "./_e2e/in-process-harness.js";
-import { apiFetch, nonGitCwd } from "./_e2e/e2e-setup.js";
-import { pollUntil } from "../../tests/e2e/test-utils/cleanup.js";
+import { test, expect } from "../../../../tests2/integration/_e2e/in-process-harness.js";
+import { apiFetch, nonGitCwd } from "../../../../tests2/integration/_e2e/e2e-setup.js";
+import { pollUntil } from "../../../e2e/test-utils/cleanup.js";
 
 /** Flip the system-scope subgoalsEnabled flag via PUT /api/preferences. */
 async function setSubgoalsEnabled(enabled: boolean): Promise<void> {

--- a/tests/integration/gateway/goals/goal-candidate-validation.gateway.test.ts
+++ b/tests/integration/gateway/goals/goal-candidate-validation.gateway.test.ts
@@ -13,9 +13,9 @@ import {
 	type GoalCandidateSource,
 	type GoalCandidateTrustedSnapshots,
 	type RawGoalCandidate,
-} from "../../src/server/agent/goal-candidate-validator.js";
-import type { PersistedGoal } from "../../src/server/agent/goal-store.js";
-import type { Workflow } from "../../src/server/agent/workflow-store.js";
+} from "../../../../src/server/agent/goal-candidate-validator.js";
+import type { PersistedGoal } from "../../../../src/server/agent/goal-store.js";
+import type { Workflow } from "../../../../src/server/agent/workflow-store.js";
 
 const FEATURE_WORKFLOW: Workflow = {
 	id: "feature",

--- a/tests/integration/gateway/goals/goal-creation-flow.gateway.test.ts
+++ b/tests/integration/gateway/goals/goal-creation-flow.gateway.test.ts
@@ -1,6 +1,6 @@
-import { test, expect } from "./_e2e/in-process-harness.js";
-import { readE2EToken, base, apiFetch, nonGitCwd } from "./_e2e/e2e-setup.js";
-import { GoalPreflightStaleError, GOAL_PREFLIGHT_STALE_MESSAGE } from "../../src/server/agent/goal-manager.js";
+import { test, expect } from "../../../../tests2/integration/_e2e/in-process-harness.js";
+import { readE2EToken, base, apiFetch, nonGitCwd } from "../../../../tests2/integration/_e2e/e2e-setup.js";
+import { GoalPreflightStaleError, GOAL_PREFLIGHT_STALE_MESSAGE } from "../../../../src/server/agent/goal-manager.js";
 
 function deferred() {
 	let resolve!: () => void;

--- a/tests/integration/gateway/goals/goal-fanout-ws.gateway.test.ts
+++ b/tests/integration/gateway/goals/goal-fanout-ws.gateway.test.ts
@@ -1,6 +1,6 @@
-import { expect } from "./_e2e/in-process-harness.js";
+import { expect } from "../../../../tests2/integration/_e2e/in-process-harness.js";
 import WebSocket from "ws";
-import { test } from "./_e2e/in-process-harness.js";
+import { test } from "../../../../tests2/integration/_e2e/in-process-harness.js";
 import {
 	apiFetch,
 	connectWs,
@@ -12,7 +12,7 @@ import {
 	wsBase,
 	type WsConnection,
 	type WsMsg,
-} from "./_e2e/e2e-setup.js";
+} from "../../../../tests2/integration/_e2e/e2e-setup.js";
 
 const FANOUT_WS_READY_TIMEOUT_MS = 30_000;
 const FANOUT_WS_EVENT_TIMEOUT_MS = 60_000;

--- a/tests/integration/gateway/goals/goal-pr-url.gateway.test.ts
+++ b/tests/integration/gateway/goals/goal-pr-url.gateway.test.ts
@@ -8,9 +8,9 @@
  *     has a URL for that goal id (seeded via the in-process server's store).
  *  C. Empty PrStatusStore omits the line cleanly.
  */
-import { test, expect } from "./_e2e/in-process-harness.js";
-import { apiFetch, defaultProjectId, nonGitCwd } from "./_e2e/e2e-setup.js";
-import { pollUntil } from "../../tests/e2e/test-utils/cleanup.js";
+import { test, expect } from "../../../../tests2/integration/_e2e/in-process-harness.js";
+import { apiFetch, defaultProjectId, nonGitCwd } from "../../../../tests2/integration/_e2e/e2e-setup.js";
+import { pollUntil } from "../../../e2e/test-utils/cleanup.js";
 
 async function createGoal(opts?: { title?: string }): Promise<{ id: string; projectId: string }> {
 	const projectId = await defaultProjectId();


### PR DESCRIPTION
## Summary
- move 12 gate suites into the canonical gateway gates directory
- move 10 goal suites into the canonical gateway goals directory
- preserve shared transitional support and update only relocation-required imports

## Validation
- npm run test:layout
- npm run check
- 22 moved suites / 147 tests together under v2-integration
- selector/discovery and phase-invariant checks
- full workflow implementation verification

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)