### PR TITLE
Migrate goal and sidebar DOM tests

### DIFF
--- a/tests/dom/goals/goal-card-back-nav.dom.test.ts
+++ b/tests/dom/goals/goal-card-back-nav.dom.test.ts
@@ -1,5 +1,5 @@
 import { beforeAll as __syncBeforeAll } from "vitest";
-import { syncCustomElements as __syncCE } from "./_setup/custom-elements.js";
+import { syncCustomElements as __syncCE } from "../../../tests2/dom/_setup/custom-elements.js";
 __syncBeforeAll(() => __syncCE());
 // Migrated from tests/goal-card-back-nav.spec.ts (v2-dom tier).
 // The legacy Playwright fixture was a self-contained hash-router replica of the

--- a/tests/dom/goals/goal-create-feedback.dom.test.ts
+++ b/tests/dom/goals/goal-create-feedback.dom.test.ts
@@ -1,19 +1,19 @@
 import { beforeAll as __syncBeforeAll } from "vitest";
-import { syncCustomElements as __syncCE } from "./_setup/custom-elements.js";
+import { syncCustomElements as __syncCE } from "../../../tests2/dom/_setup/custom-elements.js";
 __syncBeforeAll(() => __syncCE());
 
 import { render } from "lit";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { GatewaySession, Project } from "../../src/app/state.js";
-import type { Workflow } from "../../src/app/api.js";
-import type { PanelWorkspaceTab } from "../../src/app/panel-workspace.js";
+import type { GatewaySession, Project } from "../../../src/app/state.js";
+import type { Workflow } from "../../../src/app/api.js";
+import type { PanelWorkspaceTab } from "../../../src/app/panel-workspace.js";
 
-vi.mock("../../src/app/lazy-review.js", () => ({
+vi.mock("../../../src/app/lazy-review.js", () => ({
 	ensureReviewComponents: vi.fn(),
 }));
 
-type StateModule = typeof import("../../src/app/state.js");
-type ProposalPanelsModule = typeof import("../../src/app/proposal-panels.js");
+type StateModule = typeof import("../../../src/app/state.js");
+type ProposalPanelsModule = typeof import("../../../src/app/proposal-panels.js");
 
 type Deferred<T> = {
 	promise: Promise<T>;
@@ -245,8 +245,8 @@ beforeEach(async () => {
 	vi.spyOn(console, "error").mockImplementation(() => {});
 	vi.spyOn(console, "warn").mockImplementation(() => {});
 
-	const stateMod = await import("../../src/app/state.js");
-	const proposalPanelsMod = await import("../../src/app/proposal-panels.js");
+	const stateMod = await import("../../../src/app/state.js");
+	const proposalPanelsMod = await import("../../../src/app/proposal-panels.js");
 	state = stateMod.state;
 	setRenderApp = stateMod.setRenderApp;
 	proposalPanelContent = proposalPanelsMod.proposalPanelContent;

--- a/tests/dom/goals/goal-dashboard-agent-duration.dom.test.ts
+++ b/tests/dom/goals/goal-dashboard-agent-duration.dom.test.ts
@@ -1,15 +1,15 @@
 import { beforeAll as __syncBeforeAll } from "vitest";
-import { syncCustomElements as __syncCE } from "./_setup/custom-elements.js";
+import { syncCustomElements as __syncCE } from "../../../tests2/dom/_setup/custom-elements.js";
 __syncBeforeAll(() => __syncCE());
 
 import { render } from "lit";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import "../../src/ui/components/GitStatusWidget.js";
-import type { GatewaySession, Goal } from "../../src/app/state.js";
-import type { TeamAgent } from "../../src/app/goal-dashboard.js";
+import "../../../src/ui/components/GitStatusWidget.js";
+import type { GatewaySession, Goal } from "../../../src/app/state.js";
+import type { TeamAgent } from "../../../src/app/goal-dashboard.js";
 
-type StateModule = typeof import("../../src/app/state.js");
-type DashboardModule = typeof import("../../src/app/goal-dashboard.js");
+type StateModule = typeof import("../../../src/app/state.js");
+type DashboardModule = typeof import("../../../src/app/goal-dashboard.js");
 
 const NOW = 1_750_000_000_000;
 const GOAL_ID = "11111111-2222-4333-8444-555555555555";
@@ -163,8 +163,8 @@ beforeEach(async () => {
 	vi.stubGlobal("WebSocket", MockWebSocket as unknown as typeof WebSocket);
 	vi.spyOn(console, "warn").mockImplementation(() => {});
 
-	const stateMod = await import("../../src/app/state.js");
-	const dashboardMod = await import("../../src/app/goal-dashboard.js");
+	const stateMod = await import("../../../src/app/state.js");
+	const dashboardMod = await import("../../../src/app/goal-dashboard.js");
 	state = stateMod.state;
 	setRenderApp = stateMod.setRenderApp;
 	clearDashboardState = dashboardMod.clearDashboardState;

--- a/tests/dom/goals/goal-dashboard-agents-dedupe.dom.test.ts
+++ b/tests/dom/goals/goal-dashboard-agents-dedupe.dom.test.ts
@@ -1,15 +1,15 @@
 import { beforeAll as __syncBeforeAll } from "vitest";
-import { syncCustomElements as __syncCE } from "./_setup/custom-elements.js";
+import { syncCustomElements as __syncCE } from "../../../tests2/dom/_setup/custom-elements.js";
 __syncBeforeAll(() => __syncCE());
 
 import { render } from "lit";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import "../../src/ui/components/GitStatusWidget.js";
-import type { GatewaySession, Goal } from "../../src/app/state.js";
-import type { TeamAgent } from "../../src/app/goal-dashboard.js";
+import "../../../src/ui/components/GitStatusWidget.js";
+import type { GatewaySession, Goal } from "../../../src/app/state.js";
+import type { TeamAgent } from "../../../src/app/goal-dashboard.js";
 
-type StateModule = typeof import("../../src/app/state.js");
-type DashboardModule = typeof import("../../src/app/goal-dashboard.js");
+type StateModule = typeof import("../../../src/app/state.js");
+type DashboardModule = typeof import("../../../src/app/goal-dashboard.js");
 
 const NOW = 1_750_000_000_000;
 const GOAL_ID = "11111111-2222-4333-8444-555555555555";
@@ -157,8 +157,8 @@ beforeEach(async () => {
 	vi.stubGlobal("WebSocket", MockWebSocket as unknown as typeof WebSocket);
 	vi.spyOn(console, "warn").mockImplementation(() => {});
 
-	const stateMod = await import("../../src/app/state.js");
-	const dashboardMod = await import("../../src/app/goal-dashboard.js");
+	const stateMod = await import("../../../src/app/state.js");
+	const dashboardMod = await import("../../../src/app/goal-dashboard.js");
 	state = stateMod.state;
 	setRenderApp = stateMod.setRenderApp;
 	clearDashboardState = dashboardMod.clearDashboardState;

--- a/tests/dom/goals/goal-dashboard-root-recovery.dom.test.ts
+++ b/tests/dom/goals/goal-dashboard-root-recovery.dom.test.ts
@@ -1,15 +1,15 @@
 import { beforeAll as __syncBeforeAll } from "vitest";
-import { syncCustomElements as __syncCE } from "./_setup/custom-elements.js";
+import { syncCustomElements as __syncCE } from "../../../tests2/dom/_setup/custom-elements.js";
 __syncBeforeAll(() => __syncCE());
 
 import { render } from "lit";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import "../../src/ui/components/GitStatusWidget.js";
-import type { Goal } from "../../src/app/state.js";
-import { refreshSessions } from "../../src/app/api.js";
+import "../../../src/ui/components/GitStatusWidget.js";
+import type { Goal } from "../../../src/app/state.js";
+import { refreshSessions } from "../../../src/app/api.js";
 
-type StateModule = typeof import("../../src/app/state.js");
-type DashboardModule = typeof import("../../src/app/goal-dashboard.js");
+type StateModule = typeof import("../../../src/app/state.js");
+type DashboardModule = typeof import("../../../src/app/goal-dashboard.js");
 
 let state!: StateModule["state"];
 let setRenderApp!: StateModule["setRenderApp"];
@@ -144,8 +144,8 @@ beforeEach(async () => {
 		close() {}
 	} as unknown as typeof WebSocket);
 
-	const stateMod = await import("../../src/app/state.js");
-	const dashboardMod = await import("../../src/app/goal-dashboard.js");
+	const stateMod = await import("../../../src/app/state.js");
+	const dashboardMod = await import("../../../src/app/goal-dashboard.js");
 	state = stateMod.state;
 	setRenderApp = stateMod.setRenderApp;
 	clearDashboardState = dashboardMod.clearDashboardState;

--- a/tests/dom/goals/goal-dashboard-setup-poll-repro.dom.test.ts
+++ b/tests/dom/goals/goal-dashboard-setup-poll-repro.dom.test.ts
@@ -1,5 +1,5 @@
 import { beforeAll as __syncBeforeAll } from "vitest";
-import { syncCustomElements as __syncCE } from "./_setup/custom-elements.js";
+import { syncCustomElements as __syncCE } from "../../../tests2/dom/_setup/custom-elements.js";
 __syncBeforeAll(() => __syncCE());
 // Migrated from tests/goal-dashboard-setup-poll-repro.spec.ts (v2-dom tier).
 // Reproduction test for the stale-worktree-status bug. The legacy fixture models

--- a/tests/dom/goals/goal-dashboard-setup-poll.dom.test.ts
+++ b/tests/dom/goals/goal-dashboard-setup-poll.dom.test.ts
@@ -1,5 +1,5 @@
 import { beforeAll as __syncBeforeAll } from "vitest";
-import { syncCustomElements as __syncCE } from "./_setup/custom-elements.js";
+import { syncCustomElements as __syncCE } from "../../../tests2/dom/_setup/custom-elements.js";
 __syncBeforeAll(() => __syncCE());
 // Migrated from tests/goal-dashboard-setup-poll.spec.ts (v2-dom tier).
 // The legacy Playwright fixture modelled goal-dashboard.ts's setup-status
@@ -8,7 +8,7 @@ __syncBeforeAll(() => __syncCE());
 // identical banner-transition and polling-lifecycle behaviours. Element presence
 // == visibility here because the render swaps innerHTML wholesale.
 import { afterEach, describe, expect, it } from "vitest";
-import { clearSchedulerRecoveryForGoal, retryPlanNodeSchedulerStart } from "../../src/app/goal-dashboard-plan-tab.ts";
+import { clearSchedulerRecoveryForGoal, retryPlanNodeSchedulerStart } from "../../../src/app/goal-dashboard-plan-tab.ts";
 
 type Status = "preparing" | "ready" | "error";
 

--- a/tests/dom/goals/goal-pause-resume-feedback.dom.test.ts
+++ b/tests/dom/goals/goal-pause-resume-feedback.dom.test.ts
@@ -1,18 +1,18 @@
 import { beforeAll as __syncBeforeAll } from "vitest";
-import { syncCustomElements as __syncCE } from "./_setup/custom-elements.js";
+import { syncCustomElements as __syncCE } from "../../../tests2/dom/_setup/custom-elements.js";
 __syncBeforeAll(() => __syncCE());
 
 import { render } from "lit";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 // doRenderApp can lazy-load the dashboard git widget after teardown; import it
 // while happy-dom customElements is live so decorators cannot race teardown.
-import "../../src/ui/components/GitStatusWidget.js";
-import type { GatewaySession, Goal } from "../../src/app/state.js";
+import "../../../src/ui/components/GitStatusWidget.js";
+import type { GatewaySession, Goal } from "../../../src/app/state.js";
 
-type StateModule = typeof import("../../src/app/state.js");
-type DashboardModule = typeof import("../../src/app/goal-dashboard.js");
-type RenderModule = typeof import("../../src/app/render.js");
-type ApiModule = typeof import("../../src/app/api.js");
+type StateModule = typeof import("../../../src/app/state.js");
+type DashboardModule = typeof import("../../../src/app/goal-dashboard.js");
+type RenderModule = typeof import("../../../src/app/render.js");
+type ApiModule = typeof import("../../../src/app/api.js");
 
 let state!: StateModule["state"];
 let setRenderApp!: StateModule["setRenderApp"];
@@ -223,10 +223,10 @@ beforeEach(async () => {
 	vi.stubGlobal("WebSocket", MockWebSocket as unknown as typeof WebSocket);
 	vi.spyOn(console, "warn").mockImplementation(() => {});
 
-	const stateMod = await import("../../src/app/state.js");
-	const dashboardMod = await import("../../src/app/goal-dashboard.js");
-	const renderMod = await import("../../src/app/render.js");
-	const apiMod = await import("../../src/app/api.js");
+	const stateMod = await import("../../../src/app/state.js");
+	const dashboardMod = await import("../../../src/app/goal-dashboard.js");
+	const renderMod = await import("../../../src/app/render.js");
+	const apiMod = await import("../../../src/app/api.js");
 	state = stateMod.state;
 	setRenderApp = stateMod.setRenderApp;
 	clearDashboardState = dashboardMod.clearDashboardState;

--- a/tests/dom/goals/goal-proposal-dismiss.dom.test.ts
+++ b/tests/dom/goals/goal-proposal-dismiss.dom.test.ts
@@ -1,5 +1,5 @@
 import { beforeAll as __syncBeforeAll } from "vitest";
-import { syncCustomElements as __syncCE } from "./_setup/custom-elements.js";
+import { syncCustomElements as __syncCE } from "../../../tests2/dom/_setup/custom-elements.js";
 __syncBeforeAll(() => __syncCE());
 // Migrated from tests/goal-proposal-dismiss.spec.ts (v2-dom tier).
 // The legacy Playwright fixture mirrored the dismiss-persistence logic in plain
@@ -13,7 +13,7 @@ import {
 	clearProposalDismissed,
 	isProposalDismissed,
 	markProposalDismissed,
-} from "../../src/app/proposal-helpers.js";
+} from "../../../src/app/proposal-helpers.js";
 
 const SESSION_ID = "test-session-123";
 

--- a/tests/dom/goals/goal-setup-recovery-repro.dom.test.ts
+++ b/tests/dom/goals/goal-setup-recovery-repro.dom.test.ts
@@ -1,16 +1,16 @@
 import { beforeAll as __syncBeforeAll } from "vitest";
-import { syncCustomElements as __syncCE } from "./_setup/custom-elements.js";
+import { syncCustomElements as __syncCE } from "../../../tests2/dom/_setup/custom-elements.js";
 __syncBeforeAll(() => __syncCE());
 
 import { render } from "lit";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 // Load this while happy-dom's custom-elements registry is still available.
-import "../../src/ui/components/GitStatusWidget.js";
-import type { GatewaySession, Goal } from "../../src/app/state.js";
+import "../../../src/ui/components/GitStatusWidget.js";
+import type { GatewaySession, Goal } from "../../../src/app/state.js";
 
-type StateModule = typeof import("../../src/app/state.js");
-type DashboardModule = typeof import("../../src/app/goal-dashboard.js");
-type RenderHelpersModule = typeof import("../../src/app/render-helpers.js");
+type StateModule = typeof import("../../../src/app/state.js");
+type DashboardModule = typeof import("../../../src/app/goal-dashboard.js");
+type RenderHelpersModule = typeof import("../../../src/app/render-helpers.js");
 
 const now = 1_783_682_557_000;
 const goalId = "goal-setup-recovery";
@@ -136,9 +136,9 @@ beforeEach(async () => {
 	vi.stubGlobal("WebSocket", MockWebSocket as unknown as typeof WebSocket);
 	vi.spyOn(console, "warn").mockImplementation(() => {});
 
-	const stateModule = await import("../../src/app/state.js");
-	const dashboardModule = await import("../../src/app/goal-dashboard.js");
-	const renderHelpersModule = await import("../../src/app/render-helpers.js");
+	const stateModule = await import("../../../src/app/state.js");
+	const dashboardModule = await import("../../../src/app/goal-dashboard.js");
+	const renderHelpersModule = await import("../../../src/app/render-helpers.js");
 	state = stateModule.state;
 	setRenderApp = stateModule.setRenderApp;
 	clearDashboardState = dashboardModule.clearDashboardState;

--- a/tests/dom/goals/goal-status-widget.dom.test.ts
+++ b/tests/dom/goals/goal-status-widget.dom.test.ts
@@ -7,19 +7,19 @@
 // dot, sign-off card, and the review-document event the Start Review button
 // dispatches).
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import { GATE_STATUS_CLIENT_EVENT } from "../../src/app/gate-status-events.js";
-import { syncCustomElements } from "./_setup/custom-elements.js";
+import { GATE_STATUS_CLIENT_EVENT } from "../../../src/app/gate-status-events.js";
+import { syncCustomElements } from "../../../tests2/dom/_setup/custom-elements.js";
 
 // The custom-elements bridge keeps explicit registration deterministic. Import
 // session-manager first to initialize the pack-panels ⇄ session-manager cycle
 // before the widget's app/* imports hit it as a TDZ error.
-let state: typeof import("../../src/app/state.js").state;
+let state: typeof import("../../../src/app/state.js").state;
 
 beforeAll(async () => {
-	await import("../../src/app/session-manager.js");
-	({ state } = await import("../../src/app/state.js"));
-	await import("../../src/ui/components/GoalStatusWidget.js");
-	await import("../../src/ui/lazy/safe-markdown-block.js");
+	await import("../../../src/app/session-manager.js");
+	({ state } = await import("../../../src/app/state.js"));
+	await import("../../../src/ui/components/GoalStatusWidget.js");
+	await import("../../../src/ui/lazy/safe-markdown-block.js");
 	syncCustomElements();
 	await customElements.whenDefined("goal-status-widget");
 });

--- a/tests/dom/sidebar/sidebar-archive-cta.dom.test.ts
+++ b/tests/dom/sidebar/sidebar-archive-cta.dom.test.ts
@@ -1,5 +1,5 @@
 import { beforeAll as __syncBeforeAll } from "vitest";
-import { syncCustomElements as __syncCE } from "./_setup/custom-elements.js";
+import { syncCustomElements as __syncCE } from "../../../tests2/dom/_setup/custom-elements.js";
 __syncBeforeAll(() => __syncCE());
 // Migrated from tests/sidebar-archive-cta.spec.ts (v2-dom tier).
 // The legacy file:// fixture inlined the emptyState priority chain that mirrors

--- a/tests/dom/sidebar/sidebar-archived-delegates.dom.test.ts
+++ b/tests/dom/sidebar/sidebar-archived-delegates.dom.test.ts
@@ -1,5 +1,5 @@
 import { beforeAll as __syncBeforeAll } from "vitest";
-import { syncCustomElements as __syncCE } from "./_setup/custom-elements.js";
+import { syncCustomElements as __syncCE } from "../../../tests2/dom/_setup/custom-elements.js";
 __syncBeforeAll(() => __syncCE());
 // Migrated from tests/sidebar-archived-delegates.spec.ts (v2-dom tier).
 // The legacy file:// fixture inlined the merge/BFS/tree-expansion helpers that

--- a/tests/dom/sidebar/sidebar-collapse.dom.test.ts
+++ b/tests/dom/sidebar/sidebar-collapse.dom.test.ts
@@ -1,5 +1,5 @@
 import { beforeAll as __syncBeforeAll } from "vitest";
-import { syncCustomElements as __syncCE } from "./_setup/custom-elements.js";
+import { syncCustomElements as __syncCE } from "../../../tests2/dom/_setup/custom-elements.js";
 __syncBeforeAll(() => __syncCE());
 // Migrated from tests/sidebar-collapse.spec.ts (v2-dom tier).
 // FIDELITY NOTE: the legacy file:// fixture drove an INLINED copy of the

--- a/tests/dom/sidebar/sidebar-goal-group-filters.dom.test.ts
+++ b/tests/dom/sidebar/sidebar-goal-group-filters.dom.test.ts
@@ -1,5 +1,5 @@
 import { beforeAll as __syncBeforeAll } from "vitest";
-import { syncCustomElements as __syncCE } from "./_setup/custom-elements.js";
+import { syncCustomElements as __syncCE } from "../../../tests2/dom/_setup/custom-elements.js";
 __syncBeforeAll(() => __syncCE());
 // Migrated from tests/sidebar-goal-group-filters.spec.ts (v2-dom tier).
 // FIDELITY NOTE: the legacy file:// fixture mirrored the (fixed) renderGoalGroup

--- a/tests/dom/sidebar/sidebar-goal-rendering.dom.test.ts
+++ b/tests/dom/sidebar/sidebar-goal-rendering.dom.test.ts
@@ -1,5 +1,5 @@
 import { beforeAll as __syncBeforeAll } from "vitest";
-import { syncCustomElements as __syncCE } from "./_setup/custom-elements.js";
+import { syncCustomElements as __syncCE } from "../../../tests2/dom/_setup/custom-elements.js";
 __syncBeforeAll(() => __syncCE());
 // Migrated from tests/sidebar-goal-rendering.spec.ts (v2-dom tier).
 // FIDELITY NOTE: the legacy file:// fixture EXTRACTED the goal-badge / PR-badge /

--- a/tests/dom/sidebar/sidebar-hierarchy.dom.test.ts
+++ b/tests/dom/sidebar/sidebar-hierarchy.dom.test.ts
@@ -1,5 +1,5 @@
 import { beforeAll as __syncBeforeAll } from "vitest";
-import { syncCustomElements as __syncCE } from "./_setup/custom-elements.js";
+import { syncCustomElements as __syncCE } from "../../../tests2/dom/_setup/custom-elements.js";
 __syncBeforeAll(() => __syncCE());
 // Migrated from tests/sidebar-hierarchy.spec.ts (v2-dom tier).
 // FIDELITY NOTE: the legacy file:// fixture drove a bespoke categorization /

--- a/tests/dom/sidebar/sidebar-mobile.dom.test.ts
+++ b/tests/dom/sidebar/sidebar-mobile.dom.test.ts
@@ -1,5 +1,5 @@
 import { beforeAll as __syncBeforeAll } from "vitest";
-import { syncCustomElements as __syncCE } from "./_setup/custom-elements.js";
+import { syncCustomElements as __syncCE } from "../../../tests2/dom/_setup/custom-elements.js";
 __syncBeforeAll(() => __syncCE());
 // Migrated from tests/sidebar-mobile.spec.ts (v2-dom tier).
 // FIDELITY NOTE: the legacy file:// fixture drove an INLINED pure function

--- a/tests/dom/sidebar/sidebar-reveal-current.dom.test.ts
+++ b/tests/dom/sidebar/sidebar-reveal-current.dom.test.ts
@@ -1,40 +1,40 @@
 import { beforeAll as __syncBeforeAll } from "vitest";
-import { syncCustomElements as __syncCE } from "./_setup/custom-elements.js";
+import { syncCustomElements as __syncCE } from "../../../tests2/dom/_setup/custom-elements.js";
 __syncBeforeAll(() => __syncCE());
 
 import { render } from "lit";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
 	clearArchivedSessionsState,
-} from "../../src/app/api.js";
+} from "../../../src/app/api.js";
 import {
 	SIDEBAR_TREE_STATE_STORAGE_KEY,
 	clearSidebarTreePreference,
 	isSidebarTreeExpanded,
 	setSidebarTreeExpanded,
-} from "../../src/app/sidebar-tree-state.js";
-import { sidebarTreeKey, type SidebarTreeNodeKey } from "../../src/app/sidebar-tree-builder.js";
+} from "../../../src/app/sidebar-tree-state.js";
+import { sidebarTreeKey, type SidebarTreeNodeKey } from "../../../src/app/sidebar-tree-builder.js";
 import {
 	SIDEBAR_PROJECT_FILTER_STORAGE_KEYS,
 	SIDEBAR_STATUS_COLLAPSED_SECTIONS_STORAGE_KEY,
 	SIDEBAR_STATUS_FILTER_STORAGE_KEYS,
 	setSidebarStatusSectionExpanded,
 	setSidebarViewFilter,
-} from "../../src/app/sidebar-view-preferences.js";
+} from "../../../src/app/sidebar-view-preferences.js";
 import {
 	buildSidebarStatusSections,
 	buildSidebarTreeModel,
 	renderSidebarViewControls,
-} from "../../src/app/sidebar.js";
-import { revealCurrentSidebarSession } from "../../src/app/sidebar-reveal.js";
-import { _setSubgoalsEnabledForTesting } from "../../src/app/subgoals-flag.js";
+} from "../../../src/app/sidebar.js";
+import { revealCurrentSidebarSession } from "../../../src/app/sidebar-reveal.js";
+import { _setSubgoalsEnabledForTesting } from "../../../src/app/subgoals-flag.js";
 import {
 	setRenderApp,
 	state,
 	type GatewaySession,
 	type Goal,
 	type Project,
-} from "../../src/app/state.js";
+} from "../../../src/app/state.js";
 
 const touchedTreeKeys: SidebarTreeNodeKey[] = [];
 
@@ -473,11 +473,11 @@ describe("reveal current sidebar session control", () => {
 		const unrelatedDeepGoalKey = sidebarTreeKey({ kind: "goal", goalId: "unrelated-deep-7" });
 
 		vi.resetModules();
-		let freshStateModule = await import("../../src/app/state.js");
-		let freshTreeState = await import("../../src/app/sidebar-tree-state.js");
-		let freshSubgoals = await import("../../src/app/subgoals-flag.js");
-		let freshSidebar = await import("../../src/app/sidebar.js");
-		let freshReveal = await import("../../src/app/sidebar-reveal.js");
+		let freshStateModule = await import("../../../src/app/state.js");
+		let freshTreeState = await import("../../../src/app/sidebar-tree-state.js");
+		let freshSubgoals = await import("../../../src/app/subgoals-flag.js");
+		let freshSidebar = await import("../../../src/app/sidebar.js");
+		let freshReveal = await import("../../../src/app/sidebar-reveal.js");
 		freshSubgoals._setSubgoalsEnabledForTesting(true);
 		freshStateModule.state.projects = projects;
 		freshStateModule.state.goals = goals;
@@ -502,10 +502,10 @@ describe("reveal current sidebar session control", () => {
 
 		// Discard module memory and rebuild all canonical inputs from storage.
 		vi.resetModules();
-		freshStateModule = await import("../../src/app/state.js");
-		freshTreeState = await import("../../src/app/sidebar-tree-state.js");
-		freshSubgoals = await import("../../src/app/subgoals-flag.js");
-		freshSidebar = await import("../../src/app/sidebar.js");
+		freshStateModule = await import("../../../src/app/state.js");
+		freshTreeState = await import("../../../src/app/sidebar-tree-state.js");
+		freshSubgoals = await import("../../../src/app/subgoals-flag.js");
+		freshSidebar = await import("../../../src/app/sidebar.js");
 		freshSubgoals._setSubgoalsEnabledForTesting(true);
 		freshStateModule.state.projects = projects;
 		freshStateModule.state.goals = goals;

--- a/tests/dom/sidebar/sidebar-session-rendering.dom.test.ts
+++ b/tests/dom/sidebar/sidebar-session-rendering.dom.test.ts
@@ -1,5 +1,5 @@
 import { beforeAll as __syncBeforeAll } from "vitest";
-import { syncCustomElements as __syncCE } from "./_setup/custom-elements.js";
+import { syncCustomElements as __syncCE } from "../../../tests2/dom/_setup/custom-elements.js";
 __syncBeforeAll(() => __syncCE());
 // Migrated from tests/sidebar-session-rendering.spec.ts (v2-dom tier).
 // `terseRelativeTime` and `formatSessionAge` are imported REAL from
@@ -11,8 +11,8 @@ __syncBeforeAll(() => __syncCE());
 // every assertion (SB-05..08, SB-15, SB-34, SB-36).
 import { render } from "lit";
 import { describe, expect, it } from "vitest";
-import { terseRelativeTime, formatSessionAge, renderSessionTime } from "../../src/app/render-helpers.js";
-import { state, type GatewaySession } from "../../src/app/state.js";
+import { terseRelativeTime, formatSessionAge, renderSessionTime } from "../../../src/app/render-helpers.js";
+import { state, type GatewaySession } from "../../../src/app/state.js";
 
 function hasUnseenActivity(session: any, activeId: string, goals: any[], visitedMap: Record<string, number>): boolean {
 	if (session.status === "streaming" || session.status === "busy") return false;

--- a/tests/dom/sidebar/sidebar-spawned-children.dom.test.ts
+++ b/tests/dom/sidebar/sidebar-spawned-children.dom.test.ts
@@ -1,5 +1,5 @@
 import { beforeAll as __syncBeforeAll } from "vitest";
-import { syncCustomElements as __syncCE } from "./_setup/custom-elements.js";
+import { syncCustomElements as __syncCE } from "../../../tests2/dom/_setup/custom-elements.js";
 __syncBeforeAll(() => __syncCE());
 // Migrated from tests/sidebar-spawned-children.spec.ts (v2-dom tier).
 // The legacy file:// fixture re-implemented the helpers in inline JS. This port
@@ -13,7 +13,7 @@ import {
 	extendAncestors,
 	computeTitleSuffixes,
 	type SpawnedChildLike,
-} from "../../src/app/sidebar-spawned-children.js";
+} from "../../../src/app/sidebar-spawned-children.js";
 
 // Render-walk simulator — same shape as the real renderGoalGroup →
 // renderSpawnedChildGoalRow chain, built on the real helpers. Returns a flat

--- a/tests/dom/sidebar/sidebar-staff-rendering.dom.test.ts
+++ b/tests/dom/sidebar/sidebar-staff-rendering.dom.test.ts
@@ -1,5 +1,5 @@
 import { beforeAll as __syncBeforeAll } from "vitest";
-import { syncCustomElements as __syncCE } from "./_setup/custom-elements.js";
+import { syncCustomElements as __syncCE } from "../../../tests2/dom/_setup/custom-elements.js";
 __syncBeforeAll(() => __syncCE());
 // Migrated from tests/sidebar-staff-rendering.spec.ts (v2-dom tier).
 // FIDELITY NOTE: the legacy file:// fixture drove an INLINED pure function
@@ -8,9 +8,9 @@ __syncBeforeAll(() => __syncCE());
 // byte-identical replica of the fixture helper and preserves every assertion.
 import { render } from "lit";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { getSidebarData, state, type GatewaySession } from "../../src/app/state.js";
-import { startSessionListPushSync, stopSessionListPushSync } from "../../src/app/api.js";
-import { buildSidebarTreeModel, renderSidebar } from "../../src/app/sidebar.js";
+import { getSidebarData, state, type GatewaySession } from "../../../src/app/state.js";
+import { startSessionListPushSync, stopSessionListPushSync } from "../../../src/app/api.js";
+import { buildSidebarTreeModel, renderSidebar } from "../../../src/app/sidebar.js";
 
 function getStaffRowInfo(
 	staffMember: { name: string; retired?: boolean },


### PR DESCRIPTION
## Summary
- move 11 goal/dashboard happy-dom suites into `tests/dom/goals/`
- move 11 sidebar happy-dom suites into `tests/dom/sidebar/`
- preserve test content except for relocation-required import paths

## Validation
- `npm run test:layout`
- `npm run check`
- 22 moved DOM suites: 242 tests passed
- focused discovery suite: 41 tests passed
- phase-invariant suite: 2 tests passed
- E2E Groups A-D passed; authoritative implementation gate passed

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)