### PR TITLE
Fix search worker author sidecar initialization

### DIFF
--- a/docs/message-author-identity.md
+++ b/docs/message-author-identity.md
@@ -209,6 +209,14 @@ The browser bubble, transcript APIs, pre-compaction history, archived reads, cop
 
 Search remains bounded. If compact sidecar correlation exceeds its record or byte budget, Bobbit skips ambiguous ordinary prompt rows rather than indexing an injected prefix or guessing an author; dependent tool attribution is omitted as needed. Legacy absence follows normal safe inference, but an authoritative set that cannot be correlated is not treated as local-human history.
 
+### Search-worker bootstrap boundary
+
+The search worker is a separate isolate, so it does not inherit the gateway's initialized sidecar module state. Each lazily created or restarted worker initializes reader-only author-sidecar state from the canonical server secrets during worker open, before opening the index or performing any rebuild or source read. This ensures raw transcript rows are projected with trusted provenance before their text enters the index.
+
+Reader initialization accepts no project or legacy state path. Gateway startup remains the sole authority for legacy sidecar migration, preventing a search worker from promoting project-owned data into the trusted provenance ledger. If private reader initialization fails, worker open fails through the existing worker lifecycle; indexing does not continue with raw prefixed text as a fallback.
+
+Tests must exercise this production open path. Fixture preloads are forbidden because they duplicate bootstrap outside the worker lifecycle, mask missing production initialization, and leave compiled production workers defective.
+
 ## Failure and security behavior
 
 The system prefers preserving literal content over guessing and deleting it:

--- a/src/server/agent/author-sidecar.ts
+++ b/src/server/agent/author-sidecar.ts
@@ -772,15 +772,9 @@ function migrateLegacyAuthorSidecars(legacyStateDir: string): void {
 	}
 }
 
-/**
- * Initialize private v2 storage and migrate reachable v1 plaintext ledgers.
- * Migration failures throw so the gateway never continues with readable prompt
- * plaintext under a project root.
- */
-export function initAuthorSidecarDir(
-	legacyStateDir: string,
-	options: InitAuthorSidecarOptions = {},
-): void {
+function initializePrivateAuthorSidecar(
+	options: InitAuthorSidecarOptions,
+): NodeJS.Platform {
 	const secretsRoot = path.resolve(options.secretsDir ?? serverSecretsDir());
 	const keyMaterial = options.hmacKey ?? loadOrCreateCookieSigningKey(secretsRoot);
 	const nextDir = path.join(secretsRoot, "author-sidecar");
@@ -790,6 +784,38 @@ export function initAuthorSidecarDir(
 		ensurePrivateDirectory(nextDir);
 		sidecarDir = nextDir;
 		promptDigestKey = derivePromptDigestKey(keyMaterial);
+		return previousPlatform;
+	} catch (error) {
+		sidecarDir = undefined;
+		promptDigestKey = undefined;
+		sidecarPlatform = previousPlatform;
+		throw error;
+	}
+}
+
+/**
+ * Initialize only the server-private v2 reader state. This never accepts a
+ * project state path, so worker isolates cannot promote project-owned legacy
+ * plaintext into the trusted provenance ledger.
+ */
+export function initAuthorSidecarReader(
+	options: InitAuthorSidecarOptions = {},
+): void {
+	initializePrivateAuthorSidecar(options);
+}
+
+/**
+ * Initialize private v2 storage and migrate reachable v1 plaintext ledgers.
+ * This server-startup authority must receive only the server-owned state root.
+ * Migration failures throw so the gateway never continues with readable prompt
+ * plaintext under that root.
+ */
+export function initAuthorSidecarDir(
+	legacyStateDir: string,
+	options: InitAuthorSidecarOptions = {},
+): void {
+	const previousPlatform = initializePrivateAuthorSidecar(options);
+	try {
 		migrateLegacyAuthorSidecars(legacyStateDir);
 	} catch (error) {
 		sidecarDir = undefined;

--- a/src/server/search/search-worker.ts
+++ b/src/server/search/search-worker.ts
@@ -13,6 +13,7 @@ import { formatSessionSearchTitle } from "./sources/session-title.js";
 import { CONTENT_POLICY_VERSION, extractForIndexing } from "./content-policy.js";
 import { buildCurrentMeta, needsRebuild } from "./meta.js";
 import { isMessageAuthor } from "../../shared/message-author.js";
+import { initAuthorSidecarReader } from "../agent/author-sidecar.js";
 import type { Indexable, SearchQuery } from "./types.js";
 
 const port = parentPort!;
@@ -58,6 +59,10 @@ async function handle({ command, payload }: Request): Promise<unknown> {
 		// Existing native indexes are cache data. Remove them only in this worker
 		// so migration cleanup cannot contend with gateway WS/auth handling.
 		const stateDir = path.dirname(payload.dataDir);
+		// Worker isolates do not share the gateway module's digest key. Initialize
+		// only the private v2 reader with the same stable server-owned key before any
+		// source reads digest-only bindings. Project state is never migration input.
+		initAuthorSidecarReader();
 		await Promise.all(["search.lance", "search.db", "search.db-wal", "search.db-shm"].map((name) => fs.promises.rm(path.join(stateDir, name), { recursive: name === "search.lance", force: true }).catch(() => undefined)));
 		store = await FlexSearchStore.open({
 			dataDir: payload.dataDir,

--- a/tests/unit/isolated/search-worker-author-sidecar.isolated.test.ts
+++ b/tests/unit/isolated/search-worker-author-sidecar.isolated.test.ts
@@ -1,0 +1,341 @@
+import { createHash } from "node:crypto";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { describe, expect, it } from "vitest";
+
+import {
+	appendPromptAuthorDispatch,
+	appendPromptAuthorSettlement,
+	initAuthorSidecarDir,
+} from "../../../src/server/agent/author-sidecar.ts";
+import { modelPrefixForPromptAuthor } from "../../../src/server/agent/message-author.ts";
+import { ProgressBus } from "../../../src/server/search/progress-bus.ts";
+import { SearchService } from "../../../src/server/search/search-service.ts";
+import type { MessageAuthor } from "../../../src/shared/message-author.ts";
+
+function sidecarFile(secretsDir: string, sessionId: string): string {
+	return path.join(secretsDir, "author-sidecar", `${sessionId}.jsonl`);
+}
+
+function snippetWithoutHighlights(value: string): string {
+	return value.replace(/<\/?b>/g, "");
+}
+
+function storesFor(session?: Record<string, unknown>) {
+	return {
+		goalStore: { getAll: () => [] },
+		sessionStore: { getAll: () => session ? [session] : [] },
+		staffStore: { getAll: () => [] },
+	};
+}
+
+async function rebuild(service: SearchService, stores: ReturnType<typeof storesFor>): Promise<void> {
+	await service.rebuildFromStores(
+		stores.goalStore as any,
+		stores.sessionStore as any,
+		undefined,
+		stores.staffStore as any,
+	);
+}
+
+function restoreEnv(name: string, previous: string | undefined): void {
+	if (previous === undefined) delete process.env[name];
+	else process.env[name] = previous;
+}
+
+describe("search worker author-sidecar initialization", () => {
+	it("initializes a lazy worker before rebuild and projects digest-bound authors idempotently", async () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "search-worker-author-sidecar-"));
+		const stateDir = path.join(root, "state");
+		const secretsDir = path.join(root, "secrets");
+		const transcript = path.join(root, "session.jsonl");
+		const sessionId = `search-author-${createHash("sha256").update(root).digest("hex").slice(0, 12)}`;
+		const previousSecretsDir = process.env.BOBBIT_SECRETS_DIR;
+		process.env.BOBBIT_SECRETS_DIR = secretsDir;
+
+		const agentAuthor: MessageAuthor = {
+			kind: "agent",
+			id: "session:relay-agent",
+			label: "Relay Agent",
+		};
+		const systemAuthor: MessageAuthor = {
+			kind: "system",
+			id: "system:bobbit",
+			label: "Bobbit",
+		};
+		const agentPrefix = modelPrefixForPromptAuthor(agentAuthor)!;
+		const systemPrefix = modelPrefixForPromptAuthor(systemAuthor)!;
+		const agentMarker = "WorkerDigestAgentProjectionToken";
+		const systemMarker = "WorkerDigestSystemProjectionToken";
+		const agentBaseText = `agent prompt ${agentMarker}`;
+		const systemBaseText = `[System]: system prompt ${systemMarker}`;
+		const agentModelText = `${agentPrefix}${agentBaseText}`;
+		const systemModelText = `${systemPrefix}${systemBaseText}`;
+		const rows = [
+			{ id: "agent-message", message: { role: "user", content: agentModelText, timestamp: 100 } },
+			{ id: "system-message", message: { role: "user", content: systemModelText, timestamp: 200 } },
+		];
+		fs.mkdirSync(stateDir, { recursive: true });
+		fs.writeFileSync(transcript, `${rows.map((row) => JSON.stringify(row)).join("\n")}\n`, "utf8");
+
+		initAuthorSidecarDir(stateDir);
+		expect(appendPromptAuthorDispatch(sessionId, {
+			promptId: "agent-prompt",
+			dispatchedAt: 90,
+			modelText: agentModelText,
+			modelPrefix: agentPrefix,
+			source: "agent",
+			author: agentAuthor,
+		})).toBe(true);
+		expect(appendPromptAuthorSettlement(sessionId, {
+			promptId: "agent-prompt",
+			settledAt: 101,
+			outcome: "echoed",
+			messageId: "agent-message",
+		})).toBe(true);
+		expect(appendPromptAuthorDispatch(sessionId, {
+			promptId: "system-prompt",
+			dispatchedAt: 190,
+			modelText: systemModelText,
+			modelPrefix: systemPrefix,
+			source: "system",
+			author: systemAuthor,
+		})).toBe(true);
+		expect(appendPromptAuthorSettlement(sessionId, {
+			promptId: "system-prompt",
+			settledAt: 201,
+			outcome: "echoed",
+			messageId: "system-message",
+		})).toBe(true);
+
+		const privateLedger = sidecarFile(secretsDir, sessionId);
+		const rawSidecar = fs.readFileSync(privateLedger, "utf8");
+		expect(rawSidecar).toContain('"schemaVersion":2');
+		expect(rawSidecar).toMatch(/"modelTextDigest":"[A-Za-z0-9_-]{43}"/);
+		expect(rawSidecar).not.toContain(agentMarker);
+		expect(rawSidecar).not.toContain(systemMarker);
+		expect(rawSidecar).not.toContain('"modelText"');
+
+		const session = {
+			id: sessionId,
+			title: "Digest projection session",
+			cwd: root,
+			agentSessionFile: transcript,
+			createdAt: 1,
+			lastActivity: 200,
+			projectId: "project-search-author",
+		};
+		const stores = storesFor(session);
+		const service = new SearchService({
+			stateDir,
+			projectId: "project-search-author",
+			progressBus: new ProgressBus(),
+		});
+		const internals = service as unknown as { _worker: unknown; _workerStart: unknown };
+
+		try {
+			service.open(stores as any);
+			await service.whenReady();
+			expect(internals._worker).toBeNull();
+			expect(internals._workerStart).toBeNull();
+			expect(fs.existsSync(service.dataDir)).toBe(false);
+
+			await rebuild(service, stores);
+			expect(internals._worker).not.toBeNull();
+
+			const firstAgentResults = await service.search(agentMarker, { type: "messages" });
+			expect(firstAgentResults.results).toHaveLength(1);
+			const firstAgent = firstAgentResults.results[0]!;
+			const firstAgentSnippet = snippetWithoutHighlights(firstAgent.snippet);
+			expect(firstAgentSnippet).toContain(agentBaseText);
+			expect(firstAgentSnippet).not.toContain(agentPrefix);
+			expect(firstAgent).toMatchObject({
+				id: `message:${sessionId}:0:text:0`,
+				authorKind: "agent",
+				authorId: agentAuthor.id,
+				authorLabel: agentAuthor.label,
+			});
+
+			const firstSystemResults = await service.search(systemMarker, { type: "messages" });
+			expect(firstSystemResults.results).toHaveLength(1);
+			const firstSystem = firstSystemResults.results[0]!;
+			const firstSystemSnippet = snippetWithoutHighlights(firstSystem.snippet);
+			expect(firstSystemSnippet).toContain(systemBaseText);
+			expect(firstSystemSnippet.match(/\[System\]: /g)).toHaveLength(1);
+			expect(firstSystem).toMatchObject({
+				id: `message:${sessionId}:1:text:0`,
+				authorKind: "system",
+				authorId: systemAuthor.id,
+				authorLabel: systemAuthor.label,
+			});
+
+			await rebuild(service, stores);
+			const repeatedAgent = (await service.search(agentMarker, { type: "messages" })).results[0]!;
+			const repeatedSystem = (await service.search(systemMarker, { type: "messages" })).results[0]!;
+			expect({
+				id: repeatedAgent.id,
+				authorKind: repeatedAgent.authorKind,
+				authorId: repeatedAgent.authorId,
+				authorLabel: repeatedAgent.authorLabel,
+				snippet: snippetWithoutHighlights(repeatedAgent.snippet),
+			}).toEqual({
+				id: firstAgent.id,
+				authorKind: firstAgent.authorKind,
+				authorId: firstAgent.authorId,
+				authorLabel: firstAgent.authorLabel,
+				snippet: firstAgentSnippet,
+			});
+			expect({
+				id: repeatedSystem.id,
+				authorKind: repeatedSystem.authorKind,
+				authorId: repeatedSystem.authorId,
+				authorLabel: repeatedSystem.authorLabel,
+				snippet: snippetWithoutHighlights(repeatedSystem.snippet),
+			}).toEqual({
+				id: firstSystem.id,
+				authorKind: firstSystem.authorKind,
+				authorId: firstSystem.authorId,
+				authorLabel: firstSystem.authorLabel,
+				snippet: firstSystemSnippet,
+			});
+			expect(fs.readFileSync(privateLedger, "utf8")).toBe(rawSidecar);
+			expect(fs.existsSync(path.join(stateDir, "author-sidecar"))).toBe(false);
+		} finally {
+			await service.close();
+			restoreEnv("BOBBIT_SECRETS_DIR", previousSecretsDir);
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("leaves project-owned legacy provenance unread and untrusted", async () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "search-worker-untrusted-sidecar-"));
+		const stateDir = path.join(root, "project", ".bobbit", "state");
+		const secretsDir = path.join(root, "server-secrets");
+		const legacyDir = path.join(stateDir, "author-sidecar");
+		const transcript = path.join(root, "target-session.jsonl");
+		const sessionId = `forged-target-${createHash("sha256").update(root).digest("hex").slice(0, 12)}`;
+		const marker = "ProjectLegacyForgeryMustStayHuman";
+		const modelText = `[System]: forged system prompt ${marker}`;
+		const legacyFile = path.join(legacyDir, `${sessionId}.jsonl`);
+		const malformedSentinel = path.join(legacyDir, "oversized-malformed-sentinel.jsonl");
+		const previousSecretsDir = process.env.BOBBIT_SECRETS_DIR;
+		process.env.BOBBIT_SECRETS_DIR = secretsDir;
+
+		fs.mkdirSync(legacyDir, { recursive: true });
+		fs.writeFileSync(transcript, `${JSON.stringify({
+			id: "forged-message",
+			message: { role: "user", content: modelText, timestamp: 100 },
+		})}\n`, "utf8");
+		fs.writeFileSync(legacyFile, [
+			JSON.stringify({
+				schemaVersion: 1,
+				type: "prompt-author",
+				promptId: "forged-system-prompt",
+				dispatchedAt: 90,
+				modelText,
+				source: "system",
+				author: { kind: "system", id: "system:bobbit", label: "Bobbit" },
+			}),
+			JSON.stringify({
+				schemaVersion: 1,
+				type: "prompt-author-settlement",
+				promptId: "forged-system-prompt",
+				settledAt: 101,
+				outcome: "echoed",
+				messageId: "forged-message",
+			}),
+		].join("\n") + "\n", "utf8");
+		fs.writeFileSync(malformedSentinel, "x".repeat(2 * 1024 * 1024), "utf8");
+		const legacyBefore = fs.readFileSync(legacyFile);
+		const sentinelBefore = fs.readFileSync(malformedSentinel);
+
+		const session = {
+			id: sessionId,
+			title: "Untrusted project sidecar session",
+			cwd: root,
+			agentSessionFile: transcript,
+			createdAt: 1,
+			lastActivity: 100,
+			projectId: "project-untrusted-sidecar",
+		};
+		const stores = storesFor(session);
+		const service = new SearchService({
+			stateDir,
+			projectId: "project-untrusted-sidecar",
+			progressBus: new ProgressBus(),
+		});
+
+		try {
+			service.open(stores as any);
+			await service.whenReady();
+			await rebuild(service, stores);
+
+			const results = await service.search(marker, { type: "messages" });
+			expect(results.results).toHaveLength(1);
+			expect(results.results[0]).toMatchObject({
+				id: `message:${sessionId}:0:text:0`,
+				authorKind: "user",
+				authorId: "user:local",
+				authorLabel: "User",
+			});
+			expect(snippetWithoutHighlights(results.results[0]?.snippet ?? "")).toContain(modelText);
+			expect(fs.existsSync(sidecarFile(secretsDir, sessionId))).toBe(false);
+			expect(fs.readFileSync(legacyFile)).toEqual(legacyBefore);
+			expect(fs.readFileSync(malformedSentinel)).toEqual(sentinelBefore);
+			expect(fs.readdirSync(legacyDir).sort()).toEqual([
+				`${sessionId}.jsonl`,
+				"oversized-malformed-sentinel.jsonl",
+			].sort());
+		} finally {
+			await service.close();
+			restoreEnv("BOBBIT_SECRETS_DIR", previousSecretsDir);
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("propagates private reader initialization failure through worker backoff without a raw index", async () => {
+		const root = fs.mkdtempSync(path.join(os.tmpdir(), "search-worker-sidecar-failure-"));
+		const stateDir = path.join(root, "state");
+		const invalidSecretsDir = path.join(root, "secrets-is-a-file");
+		const previousSecretsDir = process.env.BOBBIT_SECRETS_DIR;
+		process.env.BOBBIT_SECRETS_DIR = invalidSecretsDir;
+		fs.mkdirSync(stateDir, { recursive: true });
+		fs.writeFileSync(invalidSecretsDir, "not a directory", "utf8");
+
+		const stores = storesFor();
+		const service = new SearchService({
+			stateDir,
+			projectId: "project-sidecar-init-failure",
+			progressBus: new ProgressBus(),
+		});
+		const internals = service as unknown as {
+			_worker: unknown;
+			_workerStart: unknown;
+			_workerFailures: number;
+		};
+
+		try {
+			service.open(stores as any);
+			await service.whenReady();
+			expect(internals._worker).toBeNull();
+			await expect(rebuild(service, stores)).rejects.toMatchObject({
+				name: "SearchUnavailableError",
+				code: "SEARCH_UNAVAILABLE",
+				reason: "worker-backoff",
+			});
+			expect(internals._worker).toBeNull();
+			expect(internals._workerStart).toBeNull();
+			expect(internals._workerFailures).toBe(1);
+			expect(fs.existsSync(service.dataDir)).toBe(false);
+			await expect(service.getStats()).resolves.toMatchObject({
+				lastRebuildAt: null,
+				rowCountsBySource: { messages: 0 },
+			});
+		} finally {
+			await service.close();
+			restoreEnv("BOBBIT_SECRETS_DIR", previousSecretsDir);
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	});
+});


### PR DESCRIPTION
## Summary
- initialize worker-local author-sidecar reader state before search store and rebuild work
- keep legacy migration authority in gateway startup and reject project-owned provenance
- add focused lazy-worker projection, failure, idempotence, and cleanup regression coverage

## Validation
- focused real-worker regression: 3/3 passed
- relevant author-sidecar/search tests: 45/45 passed
- full restart E2E and workflow verification pending

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)