### PR TITLE
Fix base-ref Save visibility

### DIFF
--- a/src/app/settings-page.ts
+++ b/src/app/settings-page.ts
@@ -965,12 +965,15 @@ function renderWorktreeSection(
 					placeholder=${baseRefBlank && resolvedRef ? resolvedRef : "origin/master (default)"}
 					.value=${baseRefValue}
 					@input=${(e: Event) => {
-						pendingChanges.base_ref = (e.target as HTMLInputElement).value;
-						// Clear stale inline error as soon as the user edits the field.
-						if (_baseRefErrors.has(projectId)) {
-							_baseRefErrors.delete(projectId);
-							renderApp();
-						}
+						const hadPendingBaseRef = Object.prototype.hasOwnProperty.call(pendingChanges, "base_ref");
+						const previousValue = hadPendingBaseRef ? pendingChanges.base_ref : baseRefValue;
+						const nextValue = (e.target as HTMLInputElement).value;
+						pendingChanges.base_ref = nextValue;
+						// The first edit changes Save visibility. Later edits only need a render
+						// when another visible base-ref affordance changes.
+						const clearedError = _baseRefErrors.delete(projectId);
+						const blanknessChanged = !String(previousValue).trim() !== !nextValue.trim();
+						if (!hadPendingBaseRef || clearedError || blanknessChanged) renderApp();
 					}}
 				/>
 			</div>

--- a/tests/e2e/ui/base-ref-settings.spec.ts
+++ b/tests/e2e/ui/base-ref-settings.spec.ts
@@ -95,6 +95,7 @@ async function deleteProjects(projectIds: string[]): Promise<void> {
 test.describe("Settings → Base Ref field", () => {
 	test("first valid edit exposes Save and persists across reload", async ({ page }) => {
 		const projectIds: string[] = [];
+		let cleanupHeldDetect: (() => Promise<void>) | undefined;
 		try {
 			const dir = uniqueProjectDir("happy");
 			await gitInit(dir, { remoteRefs: ["develop"] });
@@ -107,13 +108,60 @@ test.describe("Settings → Base Ref field", () => {
 			expect(initial.ok, `initial base_ref setup failed: ${initial.status}`).toBe(true);
 
 			await openApp(page);
+
+			// The first General render starts from an empty config cache and requests
+			// detection before the stored base_ref arrives. Keep that last possible
+			// incidental render pending while the input event is exercised.
+			let releaseDetect!: () => void;
+			const detectGate = new Promise<void>((resolve) => { releaseDetect = resolve; });
+			let detectHandled = false;
+			let detectReleased = false;
+			let resolveDetectFinished!: () => void;
+			const detectFinished = new Promise<void>((resolve) => { resolveDetectFinished = resolve; });
+			const matchHeldDetect = (url: URL) =>
+				url.pathname === `/api/projects/${project.id}/base-ref/detect`;
+			const heldDetectRoute = async (
+				route: import("@playwright/test").Route,
+				request: import("@playwright/test").Request,
+			) => {
+				if (request.method() !== "GET" || detectHandled) {
+					await route.fallback();
+					return;
+				}
+				detectHandled = true;
+				try {
+					await detectGate;
+					await route.fulfill({
+						status: 200,
+						contentType: "application/json",
+						body: JSON.stringify({ resolved: "master", detected: null }),
+					});
+				} finally {
+					resolveDetectFinished();
+				}
+			};
+			await page.route(matchHeldDetect, heldDetectRoute);
+			cleanupHeldDetect = async () => {
+				if (!detectReleased) {
+					detectReleased = true;
+					releaseDetect();
+				}
+				if (detectHandled) await detectFinished;
+				await page.unroute(matchHeldDetect, heldDetectRoute);
+			};
+
 			const input = await openBaseRefSettings(page, project);
 			await expect(input).toHaveValue("master");
-			await page.waitForLoadState("networkidle");
+			await expect.poll(() => detectHandled, { timeout: 10_000 }).toBe(true);
 
-			// Settle every initial settings request before editing, then prove the
-			// input event itself exposes Save rather than borrowing a later async
-			// config/detection render. This assertion reproduces the original bug.
+			// Settle the other General-tab bootstrap renders. The detect response is
+			// deliberately still held, so old code cannot borrow its later render.
+			const poolStatusRow = page.getByText("Pool Status", { exact: true }).locator("..");
+			await expect(poolStatusRow).not.toContainText("Loading...");
+			const dockerStatusRow = page.getByText("Docker Status", { exact: true }).locator("..");
+			await expect(dockerStatusRow).not.toContainText("Checking...");
+			await expect(page.getByText("Detecting...", { exact: true })).toHaveCount(0);
+
 			const saveButton = page.locator("button").filter({ hasText: /^Save$/ }).first();
 			await expect(saveButton).toHaveCount(0);
 			await input.fill("origin/develop");
@@ -124,6 +172,11 @@ test.describe("Settings → Base Ref field", () => {
 				await saveButton.isVisible(),
 				"BASE_REF_SAVE_CAUSAL_RENDER: first valid edit must expose Save on its own render",
 			).toBe(true);
+
+			// Release the held request only after the causal assertion, and remove the
+			// route before Save/reload so it cannot leak into persistence coverage.
+			await cleanupHeldDetect();
+			cleanupHeldDetect = undefined;
 
 			const payload = await saveBaseRef(page, project.id, 200);
 			expect(payload).toEqual({ base_ref: "origin/develop" });
@@ -136,6 +189,7 @@ test.describe("Settings → Base Ref field", () => {
 			const inputAfter = await openBaseRefSettings(page, project);
 			await expect(inputAfter).toHaveValue("origin/develop");
 		} finally {
+			if (cleanupHeldDetect) await cleanupHeldDetect();
 			await deleteProjects(projectIds);
 		}
 	});

--- a/tests/e2e/ui/base-ref-settings.spec.ts
+++ b/tests/e2e/ui/base-ref-settings.spec.ts
@@ -59,7 +59,7 @@ async function openBaseRefSettings(page: BrowserPage, project: { id: string; nam
 	return input;
 }
 
-async function saveBaseRef(page: BrowserPage, projectId: string, expectedStatus: number): Promise<void> {
+async function saveBaseRef(page: BrowserPage, projectId: string, expectedStatus: number): Promise<Record<string, unknown>> {
 	const savePromise = page.waitForResponse(
 		resp => resp.url().includes(`/api/projects/${projectId}/config`) &&
 			resp.request().method() === "PUT" &&
@@ -71,8 +71,12 @@ async function saveBaseRef(page: BrowserPage, projectId: string, expectedStatus:
 	await expect(saveButton).toBeVisible({ timeout: 10_000 });
 	await expect(saveButton).toBeEnabled({ timeout: 10_000 });
 	await saveButton.click();
-	await savePromise;
+	const saveResponse = await savePromise;
+	const saveRequest = saveResponse.request();
+	expect(new URL(saveRequest.url()).pathname).toBe(`/api/projects/${projectId}/config`);
+	const payload = saveRequest.postDataJSON?.() ?? JSON.parse(saveRequest.postData() || "{}");
 	await expect(page.locator("button").filter({ hasText: /^Saving\.\.\.$/ })).toHaveCount(0, { timeout: 10_000 });
+	return payload as Record<string, unknown>;
 }
 
 async function expectBaseRefError(page: BrowserPage, expectedText: string) {
@@ -89,18 +93,40 @@ async function deleteProjects(projectIds: string[]): Promise<void> {
 }
 
 test.describe("Settings → Base Ref field", () => {
-	test("persists across reload (happy path)", async ({ page }) => {
+	test("first valid edit exposes Save and persists across reload", async ({ page }) => {
 		const projectIds: string[] = [];
 		try {
 			const dir = uniqueProjectDir("happy");
 			await gitInit(dir, { remoteRefs: ["develop"] });
 			const project = await createProject(`baseref-ui-happy-${Date.now()}`, dir);
 			projectIds.push(project.id);
+			const initial = await apiFetch(`/api/projects/${project.id}/config`, {
+				method: "PUT",
+				body: JSON.stringify({ base_ref: "master" }),
+			});
+			expect(initial.ok, `initial base_ref setup failed: ${initial.status}`).toBe(true);
 
 			await openApp(page);
 			const input = await openBaseRefSettings(page, project);
+			await expect(input).toHaveValue("master");
+			await page.waitForLoadState("networkidle");
+
+			// Settle every initial settings request before editing, then prove the
+			// input event itself exposes Save rather than borrowing a later async
+			// config/detection render. This assertion reproduces the original bug.
+			const saveButton = page.locator("button").filter({ hasText: /^Save$/ }).first();
+			await expect(saveButton).toHaveCount(0);
 			await input.fill("origin/develop");
-			await saveBaseRef(page, project.id, 200);
+			await page.evaluate(() => new Promise<void>((resolve) => {
+				requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
+			}));
+			expect(
+				await saveButton.isVisible(),
+				"BASE_REF_SAVE_CAUSAL_RENDER: first valid edit must expose Save on its own render",
+			).toBe(true);
+
+			const payload = await saveBaseRef(page, project.id, 200);
+			expect(payload).toEqual({ base_ref: "origin/develop" });
 
 			// Reload — value should persist.
 			await page.reload();

--- a/tests/e2e/ui/base-ref-settings.spec.ts
+++ b/tests/e2e/ui/base-ref-settings.spec.ts
@@ -16,6 +16,45 @@ import { runFixtureCommand } from "../../../tests2/harness/spawn-with-retry.js";
 
 type BrowserPage = Parameters<typeof openApp>[0];
 
+async function holdFirstGetRequest(page: BrowserPage, matches: (url: URL) => boolean) {
+	let releaseRequest!: () => void;
+	const requestGate = new Promise<void>((resolve) => { releaseRequest = resolve; });
+	let handled = false;
+	let released = false;
+	let resolveFinished!: () => void;
+	const finished = new Promise<void>((resolve) => { resolveFinished = resolve; });
+	const handler = async (
+		route: import("@playwright/test").Route,
+		request: import("@playwright/test").Request,
+	) => {
+		if (request.method() !== "GET" || handled) {
+			await route.fallback();
+			return;
+		}
+		handled = true;
+		try {
+			await requestGate;
+			await route.continue();
+		} finally {
+			resolveFinished();
+		}
+	};
+	await page.route(matches, handler);
+
+	let cleanupPromise: Promise<void> | undefined;
+	return {
+		isHandled: () => handled,
+		cleanup: () => cleanupPromise ??= (async () => {
+			if (!released) {
+				released = true;
+				releaseRequest();
+			}
+			if (handled) await finished;
+			await page.unroute(matches, handler);
+		})(),
+	};
+}
+
 // Base repo comes from the immutable committed template (master + README.md +
 // .gitattributes + one commit); tags and fake remote refs stay real git.
 async function gitInit(dir: string, opts?: { tags?: string[]; remoteRefs?: string[] }): Promise<void> {
@@ -95,7 +134,7 @@ async function deleteProjects(projectIds: string[]): Promise<void> {
 test.describe("Settings → Base Ref field", () => {
 	test("first valid edit exposes Save and persists across reload", async ({ page }) => {
 		const projectIds: string[] = [];
-		let cleanupHeldDetect: (() => Promise<void>) | undefined;
+		let cleanupHeldRequests: (() => Promise<void>) | undefined;
 		try {
 			const dir = uniqueProjectDir("happy");
 			await gitInit(dir, { remoteRefs: ["develop"] });
@@ -110,52 +149,30 @@ test.describe("Settings → Base Ref field", () => {
 			await openApp(page);
 
 			// The first General render starts from an empty config cache and requests
-			// detection before the stored base_ref arrives. Keep that last possible
-			// incidental render pending while the input event is exercised.
-			let releaseDetect!: () => void;
-			const detectGate = new Promise<void>((resolve) => { releaseDetect = resolve; });
-			let detectHandled = false;
-			let detectReleased = false;
-			let resolveDetectFinished!: () => void;
-			const detectFinished = new Promise<void>((resolve) => { resolveDetectFinished = resolve; });
-			const matchHeldDetect = (url: URL) =>
-				url.pathname === `/api/projects/${project.id}/base-ref/detect`;
-			const heldDetectRoute = async (
-				route: import("@playwright/test").Route,
-				request: import("@playwright/test").Request,
-			) => {
-				if (request.method() !== "GET" || detectHandled) {
-					await route.fallback();
-					return;
-				}
-				detectHandled = true;
-				try {
-					await detectGate;
-					await route.fulfill({
-						status: 200,
-						contentType: "application/json",
-						body: JSON.stringify({ resolved: "master", detected: null }),
-					});
-				} finally {
-					resolveDetectFinished();
-				}
-			};
-			await page.route(matchHeldDetect, heldDetectRoute);
-			cleanupHeldDetect = async () => {
-				if (!detectReleased) {
-					detectReleased = true;
-					releaseDetect();
-				}
-				if (detectHandled) await detectFinished;
-				await page.unroute(matchHeldDetect, heldDetectRoute);
+			// detection before the stored base_ref arrives. Settings also loads harness
+			// status on its first render. Hold both requests so neither can lend the old
+			// input handler an unrelated render after the edit.
+			const heldDetect = await holdFirstGetRequest(
+				page,
+				(url) => url.pathname === `/api/projects/${project.id}/base-ref/detect`,
+			);
+			const heldHarnessStatus = await holdFirstGetRequest(
+				page,
+				(url) => url.pathname === "/api/harness-status",
+			);
+			cleanupHeldRequests = async () => {
+				await Promise.all([heldDetect.cleanup(), heldHarnessStatus.cleanup()]);
 			};
 
 			const input = await openBaseRefSettings(page, project);
 			await expect(input).toHaveValue("master");
-			await expect.poll(() => detectHandled, { timeout: 10_000 }).toBe(true);
+			await expect.poll(() => heldDetect.isHandled(), { timeout: 10_000 }).toBe(true);
+			await expect.poll(() => heldHarnessStatus.isHandled(), { timeout: 10_000 }).toBe(true);
 
-			// Settle the other General-tab bootstrap renders. The detect response is
-			// deliberately still held, so old code cannot borrow its later render.
+			// Settle every other bounded Settings/General bootstrap render. The app-info
+			// header, config, pool, Docker, and host-token loaders have all completed;
+			// detect and harness status remain deliberately held through the assertion.
+			await expect(page.getByTestId("settings-app-version")).toBeVisible({ timeout: 10_000 });
 			const poolStatusRow = page.getByText("Pool Status", { exact: true }).locator("..");
 			await expect(poolStatusRow).not.toContainText("Loading...");
 			const dockerStatusRow = page.getByText("Docker Status", { exact: true }).locator("..");
@@ -173,10 +190,10 @@ test.describe("Settings → Base Ref field", () => {
 				"BASE_REF_SAVE_CAUSAL_RENDER: first valid edit must expose Save on its own render",
 			).toBe(true);
 
-			// Release the held request only after the causal assertion, and remove the
-			// route before Save/reload so it cannot leak into persistence coverage.
-			await cleanupHeldDetect();
-			cleanupHeldDetect = undefined;
+			// Continue the held requests to their real endpoints only after the causal
+			// assertion, then remove both routes before Save/reload persistence coverage.
+			await cleanupHeldRequests();
+			cleanupHeldRequests = undefined;
 
 			const payload = await saveBaseRef(page, project.id, 200);
 			expect(payload).toEqual({ base_ref: "origin/develop" });
@@ -189,7 +206,7 @@ test.describe("Settings → Base Ref field", () => {
 			const inputAfter = await openBaseRefSettings(page, project);
 			await expect(inputAfter).toHaveValue("origin/develop");
 		} finally {
-			if (cleanupHeldDetect) await cleanupHeldDetect();
+			if (cleanupHeldRequests) await cleanupHeldRequests();
 			await deleteProjects(projectIds);
 		}
 	});


### PR DESCRIPTION
## Summary
- causally rerender project General settings on the first base-ref edit so Save appears immediately
- keep later edits focused while preserving validation and blank-value affordances
- add deterministic browser coverage for Save visibility, exact PUT payload, validation, and reload persistence

## Validation
- Quick Fix implementation gate passed
- build, type check, unit, browser, E2E, conformance, integrated review, and security passed
- focused retry-free base-ref browser suite passed repeatedly
- old-handler negative proof fails with the expected causal assertion

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)