### PR TITLE
Speed up browser startup and CRUD coverage

### DIFF
--- a/docs/testing-metrics/coverage-map.md
+++ b/docs/testing-metrics/coverage-map.md
@@ -12,6 +12,7 @@ Update this map whenever spawned-gateway browser coverage moves to a cheaper lay
 | Add Project and directory selection | `directory-picker.dom.test.ts`, `add-project-flow.fixture.spec.ts`, project preflight gateway tests, and the canonical `project-onboarding-*` journeys. | Canonical onboarding journeys retain routing, assistant creation and persistence boundaries; duplicate `add-project-*` matrices were retired. | Renderer/browser aggregate |
 | Marketplace MCP | `marketplace-mcp-ui.dom.test.ts` owns source and operation UI states; marketplace MCP API/unit tests own backend behavior. | `marketplace-mcp.journey.spec.ts` retains one real browse/install/reload/disable/uninstall lifecycle. | Renderer/browser aggregate |
 | Staff, workflows and subgoals | Staff trigger/sidebar fixtures and unit/gateway tests own editor matrices and eligibility rules. Workflow fixtures, store/validator tests and gateway tests own field mappings. | Small journeys remain where real routing, persistence, worktree setup or reload is the contract. | Browser aggregate |
+| Goal, team, project and session CRUD | Goal metadata conversion and proposal state: `proposal-helpers.unit.test.ts`, `goal-tabs-wiring.fixture.spec.ts`, and goal gateway tests. Dashboard mutations/status/plan: DOM tests plus `goal-team-gates-plan.journey.spec.ts`. Session actions/forking: `session-menu.dom.test.ts`, `session-actions.fixture.spec.ts`, `fork-session-history.fixture.spec.ts`, and `session-lifecycle-api.gateway.test.ts`. Settings matrices: `settings-admin-fixture.fixture.spec.ts`, project-audio DOM tests, and project-config gateway tests. | Ten spawned-gateway tests remain across the five CRUD files: archive/reload, empty-workflow submit guard, browser-authorized goal policy, seeded metadata editing/reload, project sound routing/reload, provisional project assistant routing, delegate-name confirmation, gate badge reload, WebSocket transcript reload, and standard-role picker persistence. | `baseline-unit-browser.json` |
 
 ## September 2026 browser-lane reduction
 
@@ -19,6 +20,7 @@ The canonical-layout cutover temporarily brought the legacy spawned-gateway matr
 
 This reduction:
 
+- reduces the final five spawned-gateway CRUD matrices from 84 discovered tests (83 runnable, one skipped) to 10 focused full-stack smokes; the removed deterministic assertions are mapped to existing cheaper tests, with targeted DOM/fixture assertions added for delegate rendering and registry wiring, no-signoff widget state, and settings controls;
 - deletes legacy journeys only where an exact fixture, DOM, unit, gateway/API, E2E, or consolidated journey replacement exists;
 - moves directory-picker, dashboard mutation, session-loader, marketplace MCP UI, staff-trigger, sidebar action, debug-policy, and subgoal eligibility matrices to cheaper deterministic tests;
 - shrinks broad journeys to a single irreducible full-stack boundary;

--- a/docs/testing-metrics/thresholds.json
+++ b/docs/testing-metrics/thresholds.json
@@ -16,6 +16,11 @@
     "tests/browser/fixtures/dynamic-chat-tabs.fixture.spec.ts",
     "tests/browser/journeys/goal-team-gates-reset.journey.spec.ts",
     "tests/browser/journeys/cost-popover-cache-hit.journey.spec.ts",
+    "tests/browser/journeys/goal-editing.journey.spec.ts",
+    "tests/browser/journeys/goal-metadata.journey.spec.ts",
+    "tests/browser/journeys/project-settings.journey.spec.ts",
+    "tests/browser/journeys/team-operations.journey.spec.ts",
+    "tests/browser/journeys/session-lifecycle.journey.spec.ts",
     "tests/e2e/browser/tail-chat-real-stream.browser-e2e.spec.ts",
     "tests/e2e/browser/tail-chat-session-navigate.browser-e2e.spec.ts",
     "tests/browser/fixtures/jump-to-last-prompt.fixture.spec.ts",
@@ -105,6 +110,51 @@
       "requiredTitleRegexes": [
         "goal-dashboard cost popover.*cacheHitRate.*survives reload",
         "session stats-bar cost popover.*server-derived cacheHitRate"
+      ]
+    },
+    {
+      "file": "tests/browser/journeys/goal-editing.journey.spec.ts",
+      "metric": "unit-browser",
+      "minNonSkippedTests": 3,
+      "requiredTitleRegexes": [
+        "archive action persists.*reloads.*read-only state",
+        "empty workflow response disables goal creation",
+        "Children-tab policy toggle.*persists"
+      ]
+    },
+    {
+      "file": "tests/browser/journeys/goal-metadata.journey.spec.ts",
+      "metric": "unit-browser",
+      "minNonSkippedTests": 1,
+      "requiredTitleRegexes": [
+        "proposal controls create a metadata-bearing goal.*survives reload"
+      ]
+    },
+    {
+      "file": "tests/browser/journeys/project-settings.journey.spec.ts",
+      "metric": "unit-browser",
+      "minNonSkippedTests": 2,
+      "requiredTitleRegexes": [
+        "project sound override.*across reload.*Bell stays global",
+        "Add Project routes.*provisional assistant"
+      ]
+    },
+    {
+      "file": "tests/browser/journeys/team-operations.journey.spec.ts",
+      "metric": "unit-browser",
+      "minNonSkippedTests": 2,
+      "requiredTitleRegexes": [
+        "terminate confirmation.*delegate children",
+        "persisted gate signal reloads.*exact dashboard badge"
+      ]
+    },
+    {
+      "file": "tests/browser/journeys/session-lifecycle.journey.spec.ts",
+      "metric": "unit-browser",
+      "minNonSkippedTests": 2,
+      "requiredTitleRegexes": [
+        "WebSocket turn.*durable page reload",
+        "standard session role stays General.*reload.*picker surfaces"
       ]
     },
     {

--- a/tests/browser/fixtures/settings-admin-fixture.fixture.spec.ts
+++ b/tests/browser/fixtures/settings-admin-fixture.fixture.spec.ts
@@ -285,6 +285,33 @@ test.describe("Settings/admin UI fixture", () => {
 		await expect(page.getByText("Palette").first()).toBeVisible();
 	});
 
+	test("retired spawned-gateway settings controls stay wired in the deterministic fixture", async ({ page }) => {
+		await renderSettings(page, "#/settings/system/models");
+		const fallback = page.getByTestId("allow-session-model-fallback-toggle");
+		await expect(fallback).not.toBeChecked();
+		await fallback.click();
+		await expect.poll(async () => (await prefs(page)).allowSessionModelFallback).toBe(true);
+
+		await renderSettings(page, "#/settings/system/general");
+		const subgoals = page.getByTestId("general-subgoals-enabled");
+		const maxDepth = page.getByTestId("general-max-nesting-depth");
+		await expect(subgoals).not.toBeChecked();
+		await expect(maxDepth).toBeDisabled();
+		await subgoals.click();
+		await expect(maxDepth).toBeEnabled();
+		await expect(page.getByTestId("general-customise-system-prompt")).toBeVisible();
+		await expect(page.getByRole("button", { name: /Restart Server|Restart Requested|Requesting/i })).toHaveCount(0);
+
+		await renderSettings(page, "#/settings/system/maintenance");
+		const agentDir = page.getByTestId("agent-dir-settings");
+		await expect(agentDir).toBeVisible();
+		await agentDir.getByTestId("agent-dir-path-input").fill("/fixture/agent-dir");
+		await expect(agentDir.getByTestId("agent-dir-validate")).toBeEnabled();
+
+		await loadRoles(page);
+		await expect(page.getByRole("button", { name: /New Role/i }).first()).toBeVisible();
+	});
+
 	test("general preferences persist across reload and reset clears the skills budget", async ({ page }) => {
 		await renderSettings(page, "#/settings/system/general");
 		const timestamps = page.locator("label").filter({ hasText: "Show message timestamps" }).locator("input");

--- a/tests/browser/journeys/goal-editing.journey.spec.ts
+++ b/tests/browser/journeys/goal-editing.journey.spec.ts
@@ -1,625 +1,105 @@
 /**
- * Journey: Goal Editing + Subgoals — v2 browser smoke
- * Covers: journey-goal-editing, journey-subgoals
- * Consolidated from: goal-edit-*, goal-spec-*, subgoals-*, etc.
+ * Retained full-stack goal CRUD smokes.
+ *
+ * Field validation, proposal shaping, subgoal eligibility, preference controls,
+ * and static dashboard states live in unit, DOM, fixture, and gateway tests.
+ * Keep only browser/server boundaries that require the real app, operator auth,
+ * or a durable reload.
  */
-import { test, expect, openApp, navigateToHash, createGoal, deleteGoal, apiFetch, defaultProjectId, sendMessage, createSessionViaUI } from "../../support/helpers/browser/journeys/journey-fixture.js";
-import { nonGitCwd } from "../../support/harnesses/browser/e2e-setup.js";
+import {
+	test,
+	expect,
+	openApp,
+	navigateToHash,
+	createGoal,
+	deleteGoal,
+	apiFetch,
+	sendMessage,
+} from "../../support/helpers/browser/journeys/journey-fixture.js";
 import { createGoalAssistantViaUI } from "../../support/helpers/browser/fixtures/ui-helpers.js";
 
-test.describe("Journey: Goal Editing", () => {
-	test("goal dashboard renders goal title", async ({ page }) => {
-		const title = "v2-goal-editing-smoke";
-		const goal = await createGoal({ title });
-		try {
-			await openApp(page);
-			await navigateToHash(page, `#/goal/${goal.id}`);
-			await expect(page.locator(".dashboard-container, .goal-dashboard, goal-dashboard").first()).toBeVisible({ timeout: 20_000 });
-			await expect(page.getByText(title).first()).toBeVisible({ timeout: 20_000 });
-		} finally {
-			await deleteGoal(goal.id, true);
-		}
-	});
+const dashboard = (page: import("@playwright/test").Page) =>
+	page.locator(".dashboard-container, .goal-dashboard, goal-dashboard").first();
 
-	test("goal dashboard shows sidebar edge", async ({ page }) => {
-		const goal = await createGoal({ title: "v2-goal-edit-sidebar" });
-		try {
-			await openApp(page);
-			await navigateToHash(page, `#/goal/${goal.id}`);
-			await expect(page.locator(".dashboard-container, .goal-dashboard, goal-dashboard").first()).toBeVisible({ timeout: 20_000 });
-			await expect(page.locator(".sidebar-edge").first()).toBeVisible({ timeout: 15_000 });
-		} finally {
-			await deleteGoal(goal.id, true);
-		}
-	});
-});
-
-test.describe("Journey: Subgoals", () => {
-	test("goal route renders for subgoal context", async ({ page }) => {
-		const goal = await createGoal({ title: "v2-subgoal-smoke" });
-		try {
-			await openApp(page);
-			await navigateToHash(page, `#/goal/${goal.id}`);
-			await expect(page.locator(".dashboard-container, .goal-dashboard, goal-dashboard").first()).toBeVisible({ timeout: 20_000 });
-		} finally {
-			await deleteGoal(goal.id, true);
-		}
-	});
-
-	test("multiple goals navigable without crash", async ({ page }) => {
-		const g1 = await createGoal({ title: "v2-subgoal-a" });
-		const g2 = await createGoal({ title: "v2-subgoal-b" });
-		try {
-			await openApp(page);
-			await navigateToHash(page, `#/goal/${g1.id}`);
-			await expect(page.locator(".dashboard-container, .goal-dashboard, goal-dashboard").first()).toBeVisible({ timeout: 20_000 });
-			await navigateToHash(page, `#/goal/${g2.id}`);
-			await expect(page.locator(".dashboard-container, .goal-dashboard, goal-dashboard").first()).toBeVisible({ timeout: 20_000 });
-		} finally {
-			await deleteGoal(g1.id, true);
-			await deleteGoal(g2.id, true);
-		}
-	});
-});
-
-// Behavioral assertions ported from goal-archive-always-on.spec.ts
-test.describe("Journey: Goal Archive Always-On — behavioral assertions", () => {
-	test("archive button is visible and enabled in goal dashboard", async ({ page }) => {
-		const goal = await createGoal({ title: "v2-archive-btn-smoke", team: false });
-		try {
-			await openApp(page);
-			await navigateToHash(page, `#/goal/${goal.id}`);
-			await expect(page.locator(".dashboard-container, .goal-dashboard, goal-dashboard").first()).toBeVisible({ timeout: 20_000 });
-			// Archive button must be present regardless of team/PR state
-			const archiveBtn = page.locator(".dashboard-container").getByRole("button", { name: "Archive", exact: true }).first();
-			await expect(archiveBtn).toBeVisible({ timeout: 20_000 });
-			await expect(archiveBtn).toBeEnabled();
-		} finally {
-			await deleteGoal(goal.id, true);
-		}
-	});
-
-	test("clicking archive button and confirming marks goal archived in API", async ({ page }) => {
-		const goal = await createGoal({ title: "v2-archive-confirm-smoke", team: false });
+test.describe("Journey: Goal Editing — retained full-stack smokes", () => {
+	test("archive action persists and reloads the dashboard read-only state", async ({ page }) => {
+		const title = `v2-goal-archive-${Date.now()}`;
+		const goal = await createGoal({ title, team: false });
 		const goalId = goal.id as string;
 		try {
 			await openApp(page);
 			await navigateToHash(page, `#/goal/${goalId}`);
-			await expect(page.locator(".dashboard-container, .goal-dashboard, goal-dashboard").first()).toBeVisible({ timeout: 20_000 });
-			const archiveBtn = page.locator(".dashboard-container").getByRole("button", { name: "Archive", exact: true }).first();
-			await expect(archiveBtn).toBeVisible({ timeout: 20_000 });
-			await archiveBtn.click();
-			// Confirmation dialog
-			const dialog = page.locator("body > div")
-				.filter({ has: page.getByRole("heading", { name: "Archive Goal", exact: true }) })
-				.last();
-			await expect(
-				dialog.getByRole("heading", { name: "Archive Goal", exact: true }),
-			).toBeVisible({ timeout: 15_000 });
-			await dialog.getByRole("button", { name: "Archive", exact: true }).click();
-			await expect(dialog).toBeHidden({ timeout: 15_000 });
-			// Goal must be archived in API
+			await expect(dashboard(page)).toBeVisible({ timeout: 20_000 });
+			await expect(page.getByText(title).first()).toBeVisible({ timeout: 20_000 });
+
+			await page.reload();
+			await navigateToHash(page, `#/goal/${goalId}`);
+			await expect(dashboard(page)).toBeVisible({ timeout: 20_000 });
+
+			await dashboard(page).getByRole("button", { name: "Archive", exact: true }).first().click();
+			const archiveHeading = page.getByRole("heading", { name: "Archive Goal", exact: true });
+			await expect(archiveHeading).toBeVisible({ timeout: 15_000 });
+			await page.getByRole("button", { name: "Archive", exact: true }).last().click();
+			await expect(archiveHeading).toBeHidden({ timeout: 15_000 });
+
 			await expect.poll(async () => {
-				const r = await apiFetch(`/api/goals/${goalId}`);
-				if (!r.ok) return "missing";
-				const g = await r.json();
-				return g.archived === true ? "archived" : "active";
-			}, { timeout: 20_000 }).toBe("archived");
-			// Ported from goal-archive-always-on.spec.ts (mutant BR60): the dashboard
-			// must show the read-only banner + a disabled "Archived" button once the
-			// goal is archived.
+				const response = await apiFetch(`/api/goals/${goalId}`);
+				return response.ok && (await response.json()).archived === true;
+			}, { timeout: 20_000 }).toBe(true);
 			await expect(page.getByText(/This goal was archived .*Dashboard is read-only\./)).toBeVisible({ timeout: 15_000 });
-			const archivedBtn = page.locator(".dashboard-container").getByRole("button", { name: "Archived", exact: true }).first();
-			await expect(archivedBtn).toBeVisible({ timeout: 10_000 });
-			await expect(archivedBtn).toBeDisabled();
-		} finally {
-			await deleteGoal(goalId, true);
-		}
-	});
-});
+			await expect(dashboard(page).getByRole("button", { name: "Archived", exact: true }).first()).toBeDisabled();
 
-// Behavioral assertions ported from goal-creation.spec.ts
-test.describe("Journey: Goal Creation — behavioral assertions", () => {
-	test("created goal appears in API goals list", async () => {
-		const title = `v2-creation-api-list-${Date.now()}`;
-		const goal = await createGoal({ title });
-		try {
-			const resp = await apiFetch("/api/goals");
-			expect(resp.ok).toBe(true);
-			const data = await resp.json();
-			const goals = (data.goals || data) as Array<{ id: string; title: string }>;
-			const found = goals.find((g) => g.title === title);
-			expect(found).toBeTruthy();
-			expect(found!.id).toBe(goal.id);
+			await page.reload();
+			await navigateToHash(page, `#/goal/${goalId}`);
+			await expect(page.getByText(/This goal was archived .*Dashboard is read-only\./)).toBeVisible({ timeout: 20_000 });
+			await expect(dashboard(page).getByRole("button", { name: "Archived", exact: true }).first()).toBeDisabled();
 		} finally {
-			await deleteGoal(goal.id, true);
+			await deleteGoal(goalId, true).catch(() => {});
 		}
 	});
 
-	test("created goal title appears in sidebar after API creation", async ({ page }) => {
-		const title = `v2-creation-sidebar-${Date.now()}`;
-		const goal = await createGoal({ title });
-		try {
-			await openApp(page);
-			// Goal must be visible in the sidebar goals list
-			await expect(page.getByText(title).first()).toBeVisible({ timeout: 15_000 });
-		} finally {
-			await deleteGoal(goal.id, true);
-		}
-	});
-
-	// Ported from goal-creation.spec.ts (audit: goal-editing GAP, mutant BR68):
-	// toggling an optional step in the assistant proposal and creating the goal
-	// must round-trip the enabled step into the created goal's enabledOptionalSteps.
-	test("assistant optional-steps toggle round-trips into the created goal", async ({ page }) => {
-		test.setTimeout(120_000);
-		// Configure qa_start_command so the feature workflow's QA step toggle enables.
-		const projectId = await defaultProjectId();
-		if (projectId) {
-			const structuredResp = await apiFetch(`/api/projects/${projectId}/structured`).catch(() => null);
-			if (structuredResp?.ok) {
-				const data = await structuredResp.json();
-				const comps = Array.isArray(data.components) ? data.components : [];
-				if (comps.length > 0) {
-					comps[0].config = { ...(comps[0].config || {}), qa_start_command: "echo ready" };
-					await apiFetch(`/api/projects/${projectId}/config`, { method: "PUT", body: JSON.stringify({ components: comps }) });
-				}
-			}
-		}
+	test("empty workflow response disables goal creation in the real proposal flow", async ({ page }) => {
+		test.setTimeout(90_000);
+		await page.route(/\/api\/workflows(?:\?.*)?$/, async (route, request) => {
+			if (request.method() !== "GET") return route.continue();
+			await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify([]) });
+		});
 
 		await openApp(page);
 		await createGoalAssistantViaUI(page, { timeout: 60_000 });
-		const textarea = page.locator("textarea").first();
-		await expect(textarea).toBeVisible({ timeout: 30_000 });
 		await sendMessage(page, "Please create a GOAL_PROPOSAL for testing");
-
-		const titleInput = page.locator("input[placeholder='Goal title']").first();
-		await expect(titleInput).toHaveValue("E2E Test Goal", { timeout: 20_000 });
-
-		// Switch to the feature workflow which exposes the optional QA step.
-		const workflowSelect = page.locator(".goal-preview-panel select").first();
-		await expect(workflowSelect).toBeVisible({ timeout: 15_000 });
-		await workflowSelect.selectOption("feature");
-
-		// Enable the QA optional step.
-		const qaLabel = page.locator(".goal-preview-panel label", { hasText: "Enable QA Testing" }).first();
-		await expect(qaLabel).toBeVisible({ timeout: 15_000 });
-		const checkbox = qaLabel.locator("input[type='checkbox'].toggle-switch");
-		await expect(checkbox).toBeEnabled({ timeout: 15_000 });
-		await checkbox.click();
-		await expect(checkbox).toBeChecked();
-
-		const createPromise = page.waitForResponse(
-			(resp) => resp.url().includes("/api/goals") && resp.request().method() === "POST" && resp.ok(),
-			{ timeout: 20_000 },
-		);
-		await page.locator("button").filter({ hasText: "Create Goal" }).first().click();
-		await createPromise;
-		await expect(page).toHaveURL(/#\/goal(-dashboard)?\//, { timeout: 15_000 });
-
-		// The created goal must carry the toggled optional step.
-		const listResp = await apiFetch("/api/goals");
-		const listData = await listResp.json();
-		const goals = (listData.goals || listData) as Array<{ id: string; title: string; enabledOptionalSteps?: string[] }>;
-		const created = goals.find((g) => g.title === "E2E Test Goal");
-		expect(created).toBeTruthy();
-		try {
-			expect(created!.enabledOptionalSteps).toContain("QA testing");
-		} finally {
-			await deleteGoal(created!.id, true).catch(() => {});
-		}
-	});
-});
-
-// Behavioral assertions ported from goal-empty-workflows-banner.spec.ts
-test.describe("Journey: Goal Empty Workflows Banner — behavioral assertions", () => {
-	test("workflows API returns a workflows array", async () => {
-		const resp = await apiFetch("/api/workflows");
-		expect(resp.ok).toBe(true);
-		const data = await resp.json();
-		// /api/workflows returns { workflows: [...] }
-		expect(Array.isArray(data.workflows)).toBe(true);
+		await expect(page.locator("input[placeholder='Goal title']").first()).toHaveValue("E2E Test Goal", { timeout: 20_000 });
+		await expect(page.getByTestId("goal-form-no-workflows-banner").first()).toContainText("no workflows yet");
+		await expect(page.getByRole("button", { name: "Create Goal", exact: true }).first()).toBeDisabled();
 	});
 
-	test("empty-workflows route: banner visible and Create Goal button disabled", async ({ page }) => {
-		test.setTimeout(90_000);
-		// Route-mock all GET /api/workflows to return an empty list
-		await page.route(/\/api\/workflows(?:\?.*)?$/, async (route, req) => {
-			if (req.method() === "GET") {
-				await route.fulfill({
-					status: 200,
-					contentType: "application/json",
-					body: JSON.stringify([]),
-				});
-				return;
-			}
-			await route.continue();
-		});
-
-		await openApp(page);
-		await createGoalAssistantViaUI(page);
-		const textarea = page.locator("textarea").first();
-		await expect(textarea).toBeVisible({ timeout: 15_000 });
-		await sendMessage(page, "Please create a GOAL_PROPOSAL for testing");
-
-		const titleInput = page.locator("input[placeholder='Goal title']").first();
-		await expect(titleInput).toBeVisible({ timeout: 15_000 });
-		await expect(titleInput).toHaveValue("E2E Test Goal", { timeout: 15_000 });
-
-		// Banner must appear
-		const banner = page.locator('[data-testid="goal-form-no-workflows-banner"]').first();
-		await expect(banner).toBeVisible({ timeout: 20_000 });
-		await expect(banner).toContainText("no workflows yet");
-
-		// Create Goal button must be disabled
-		const createBtn = page.locator("button").filter({ hasText: "Create Goal" }).first();
-		await expect(createBtn).toBeDisabled();
-	});
-});
-
-// Behavioral assertions ported from goal-form-tooltips.spec.ts
-test.describe("Journey: Goal Form Tooltips — behavioral assertions", () => {
-	test("workflow select dropdown renders in goal proposal panel", async ({ page }) => {
-		test.setTimeout(90_000);
-		await openApp(page);
-		await createGoalAssistantViaUI(page);
-		const textarea = page.locator("textarea").first();
-		await expect(textarea).toBeVisible({ timeout: 15_000 });
-		await sendMessage(page, "Please create a GOAL_PROPOSAL for testing");
-
-		const titleInput = page.locator("input[placeholder='Goal title']").first();
-		await expect(titleInput).toHaveValue("E2E Test Goal", { timeout: 15_000 });
-
-		// Workflow select must exist in the proposal panel
-		const workflowSelect = page.locator(".goal-preview-panel select").first();
-		await expect(workflowSelect).toBeVisible({ timeout: 15_000 });
-		// Should have at least the "general" workflow option
-		await expect(workflowSelect.locator("option[value='general']")).toHaveCount(1);
-	});
-
-	test("optional step tooltip ⓘ icon renders with cursor-help class after workflow switch", async ({ page }) => {
-		test.setTimeout(90_000);
-		// Configure qa_start_command on default project for the tooltip to show workflow description
-		const projectId = await defaultProjectId();
-		if (projectId) {
-			const structuredResp = await apiFetch(`/api/projects/${projectId}/structured`).catch(() => null);
-			if (structuredResp?.ok) {
-				const data = await structuredResp.json();
-				const comps = Array.isArray(data.components) ? data.components : [];
-				if (comps.length > 0) {
-					comps[0].config = { ...(comps[0].config || {}), qa_start_command: "echo ready" };
-					await apiFetch(`/api/projects/${projectId}/config`, {
-						method: "PUT",
-						body: JSON.stringify({ components: comps }),
-					});
-				}
-			}
-		}
-
-		await openApp(page);
-		await createGoalAssistantViaUI(page);
-		const textarea = page.locator("textarea").first();
-		await expect(textarea).toBeVisible({ timeout: 15_000 });
-		await sendMessage(page, "Please create a GOAL_PROPOSAL for testing");
-
-		const titleInput = page.locator("input[placeholder='Goal title']").first();
-		await expect(titleInput).toHaveValue("E2E Test Goal", { timeout: 15_000 });
-
-		// Switch to feature workflow which has an optional QA Testing step with a tooltip
-		const workflowSelect = page.locator(".goal-preview-panel select").first();
-		await expect(workflowSelect).toBeVisible({ timeout: 15_000 });
-		await workflowSelect.selectOption("feature");
-
-		// Tooltip icon must render with cursor-help class
-		const qaLabel = page.locator(".goal-preview-panel label", { hasText: "Enable QA Testing" }).first();
-		await expect(qaLabel).toBeVisible({ timeout: 15_000 });
-		const tooltipIcon = qaLabel.locator("span.cursor-help").first();
-		await expect(tooltipIcon).toBeVisible({ timeout: 15_000 });
-		await expect(tooltipIcon).toHaveText("ⓘ");
-		// Ported from goal-form-tooltips.spec.ts (mutant BR61): the tooltip title
-		// attribute must carry the workflow step description (the real form wires
-		// the description into `title`, not just render a bare icon).
-		await expect(tooltipIcon).toHaveAttribute("title", /QA agent/i, { timeout: 15_000 });
-		await expect(tooltipIcon).toHaveAttribute("title", /ephemeral server/i);
-	});
-});
-
-// Behavioral assertions ported from subgoal-existing-goal-settings.spec.ts
-test.describe("Journey: Subgoal Existing Goal Settings — behavioral assertions", () => {
-	test("goal created with subgoalsAllowed:false has that flag in API response", async () => {
-		const goal = await createGoal({ title: "v2-subgoal-settings-false", team: false, subgoalsAllowed: false });
-		try {
-			const resp = await apiFetch(`/api/goals/${goal.id}`);
-			expect(resp.ok).toBe(true);
-			const data = await resp.json();
-			expect(data.subgoalsAllowed).toBe(false);
-		} finally {
-			await deleteGoal(goal.id, true);
-		}
-	});
-
-	test("children tab visible in dashboard for goal with subgoalsAllowed:true", async ({ page }) => {
-		// Ensure system subgoals flag is on
+	test("Children-tab policy toggle uses browser authority and persists", async ({ page }) => {
 		await apiFetch("/api/preferences", {
 			method: "PUT",
 			body: JSON.stringify({ subgoalsEnabled: true }),
 		});
-		const goal = await createGoal({ title: "v2-subgoal-settings-tab", team: false, subgoalsAllowed: true });
-		try {
-			await openApp(page);
-			await navigateToHash(page, `#/goal/${goal.id}`);
-			await expect(page.locator(".dashboard-container, .goal-dashboard, goal-dashboard").first()).toBeVisible({ timeout: 20_000 });
-			// Children tab must be present when subgoals are allowed
-			const childrenTab = page.locator('[data-testid="tab-children"]').first();
-			await expect(childrenTab).toBeVisible({ timeout: 20_000 });
-		} finally {
-			await deleteGoal(goal.id, true);
-		}
-	});
-
-	// Ported from subgoal-existing-goal-settings.spec.ts (audit: goal-editing GAP,
-	// mutant BR50): the Children-tab Sub-goal settings control lets a human enable
-	// sub-goals on an existing parent that started with subgoalsAllowed:false, and
-	// the operator-authorized PATCH persists (toggle reflects the ON state).
-	test("Children-tab allow-toggle enables subgoals on an existing parent and persists", async ({ page }) => {
-		test.setTimeout(90_000);
-		await apiFetch("/api/preferences", { method: "PUT", body: JSON.stringify({ subgoalsEnabled: true }) });
-		const spec = "Parent goal for the existing-goal sub-goal settings journey — padded to satisfy the spec minimum length validator.";
-		const parent = await createGoal({ title: `v2-existing-subgoal-${Date.now()}`, spec, team: false, subgoalsAllowed: false });
+		const parent = await createGoal({
+			title: `v2-existing-subgoal-${Date.now()}`,
+			spec: "Parent goal for the retained browser-authorized policy update smoke.",
+			team: false,
+			subgoalsAllowed: false,
+		});
 		const parentId = parent.id as string;
 		try {
-			// Starting state: sub-goals OFF on the parent.
-			const before = await (await apiFetch(`/api/goals/${parentId}`)).json();
-			expect(before.subgoalsAllowed).toBe(false);
-
 			await openApp(page);
 			await navigateToHash(page, `#/goal/${parentId}`);
-			await expect(page.locator(".dashboard-container").first()).toBeVisible({ timeout: 20_000 });
-
-			const childrenTab = page.locator('[data-testid="tab-children"]').first();
-			await expect(childrenTab).toBeVisible({ timeout: 15_000 });
-			await childrenTab.click();
-
-			const settings = page.locator('[data-testid="goal-subgoal-settings"]').first();
-			await expect(settings).toBeVisible({ timeout: 15_000 });
-
-			const allowToggle = page.locator('[data-testid="goal-subgoal-settings-allow-toggle"]').first();
-			await expect(allowToggle).toBeVisible({ timeout: 10_000 });
-			await expect(allowToggle).not.toBeChecked();
-
-			// Toggle ON — browser-driven so the human cookie authorizes the PATCH.
-			await allowToggle.check();
-
-			// Server persisted the change (operator auth succeeded — not a 403).
+			await expect(dashboard(page)).toBeVisible({ timeout: 20_000 });
+			await page.getByTestId("tab-children").first().click();
+			const toggle = page.getByTestId("goal-subgoal-settings-allow-toggle").first();
+			await expect(toggle).not.toBeChecked();
+			await toggle.check();
 			await expect.poll(async () => {
-				const g = await (await apiFetch(`/api/goals/${parentId}`)).json();
-				return g.subgoalsAllowed;
+				const response = await apiFetch(`/api/goals/${parentId}`);
+				return (await response.json()).subgoalsAllowed;
 			}, { timeout: 15_000 }).toBe(true);
-
-			// Live UI reflects the persisted ON state.
-			await expect(allowToggle).toBeChecked({ timeout: 10_000 });
+			await expect(toggle).toBeChecked();
 		} finally {
 			await deleteGoal(parentId, true).catch(() => {});
-		}
-	});
-});
-
-// Behavioral assertions ported from subgoal-nesting-limit.spec.ts
-test.describe("Journey: Subgoal Nesting Limit — behavioral assertions", () => {
-	test("max-depth stepper visible and enabled when subgoals flag is on", async ({ page }) => {
-		await apiFetch("/api/preferences", {
-			method: "PUT",
-			body: JSON.stringify({ subgoalsEnabled: true }),
-		});
-		await openApp(page);
-		await navigateToHash(page, "#/settings/system/general");
-		const stepper = page.locator("[data-testid='general-max-nesting-depth']");
-		await expect(stepper).toBeVisible({ timeout: 20_000 });
-		await expect(stepper).toBeEnabled();
-	});
-
-	test("max-depth stepper is disabled when subgoals flag is off", async ({ page }) => {
-		await apiFetch("/api/preferences", {
-			method: "PUT",
-			body: JSON.stringify({ subgoalsEnabled: false }),
-		});
-		try {
-			await openApp(page);
-			await navigateToHash(page, "#/settings/system/general");
-			const stepper = page.locator("[data-testid='general-max-nesting-depth']");
-			await expect(stepper).toBeVisible({ timeout: 20_000 });
-			await expect(stepper).toBeDisabled();
-		} finally {
-			// Restore default
-			await apiFetch("/api/preferences", {
-				method: "PUT",
-				body: JSON.stringify({ subgoalsEnabled: true }),
-			});
-		}
-	});
-});
-
-// Behavioral assertions ported from subgoal-parent-picker-repro.spec.ts
-test.describe("Journey: Subgoal Parent Picker — behavioral assertions", () => {
-	test("goal API accepts parentGoalId and returns linked parent in response", async () => {
-		await apiFetch("/api/preferences", {
-			method: "PUT",
-			body: JSON.stringify({ subgoalsEnabled: true }),
-		});
-		const parentSpec = "Parent goal for parent-picker journey test, padded to satisfy the spec minimum length validator.";
-		const parent = await createGoal({ title: "v2-picker-parent", team: false, subgoalsAllowed: true });
-		let childId: string | undefined;
-		try {
-			const childResp = await apiFetch("/api/goals", {
-				method: "POST",
-				body: JSON.stringify({
-					title: `v2-picker-child-${Date.now()}`,
-					cwd: nonGitCwd(),
-					worktree: false,
-					autoStartTeam: false,
-					workflowId: "feature",
-					spec: parentSpec,
-					projectId: await defaultProjectId(),
-					parentGoalId: parent.id,
-				}),
-			});
-			expect(childResp.status).toBe(201);
-			const childBody = await childResp.json();
-			childId = childBody.id as string;
-			expect(childBody.parentGoalId).toBe(parent.id);
-		} finally {
-			if (childId) await deleteGoal(childId).catch(() => {});
-			await deleteGoal(parent.id, true);
-		}
-	});
-
-	test.skip("ineligible (sub-goals off) parent option is marked in proposal panel picker", async ({ page }) => {
-		// Skipped: state.goals picker population requires full app boot + proposal
-		// flow; projectId filter interacts badly under concurrent worker load.
-		// Covered by legacy suite (tests/e2e/ui/subgoal-parent-picker-repro.spec.ts).
-		test.slow(); // complex full-stack flow: goals fetch + proposal form + picker populate
-		test.setTimeout(90_000);
-		await apiFetch("/api/preferences", {
-			method: "PUT",
-			body: JSON.stringify({ subgoalsEnabled: true }),
-		});
-		const stamp = Date.now();
-		const blockedSpec = "Parent goal for parent-picker eligibility journey test, padded to satisfy spec minimum length.";
-		const blockedResp = await apiFetch("/api/goals", {
-			method: "POST",
-			body: JSON.stringify({
-				title: `v2-picker-blocked-${stamp}`,
-				cwd: nonGitCwd(),
-				worktree: false,
-				autoStartTeam: false,
-				workflowId: "feature",
-				spec: blockedSpec,
-				projectId: await defaultProjectId(),
-				subgoalsAllowed: false,
-			}),
-		});
-		expect(blockedResp.status).toBe(201);
-		const blockedId = (await blockedResp.json()).id as string;
-
-		try {
-			await openApp(page);
-			await createSessionViaUI(page);
-			await sendMessage(page, "Please create a GOAL_PROPOSAL for testing");
-
-			const titleInput = page.locator("input[placeholder='Goal title']").first();
-			await expect(titleInput).toBeVisible({ timeout: 20_000 });
-			await expect(titleInput).toHaveValue("E2E Test Goal", { timeout: 15_000 });
-
-			// Sub-goals tab must be visible (system flag ON)
-			const subgoalsTab = page.locator("[data-testid='goal-proposal-tab-subgoals']");
-			await expect(subgoalsTab).toBeVisible({ timeout: 20_000 });
-			await subgoalsTab.click();
-
-			// Wait for state.goals to include blockedId (goals are fetched async;
-			// the picker renders from state.goals — ensure it's populated first).
-			await page.waitForFunction(
-				(id: string) => ((window as any).__bobbitState?.goals ?? []).some((g: any) => g.id === id),
-				blockedId,
-				{ timeout: 30_000 },
-			);
-			// Parent picker must contain the blocked parent as an option
-			const picker = page.locator("[data-testid='goal-form-parent-picker']");
-			await expect(picker).toBeVisible({ timeout: 20_000 });
-			await expect(
-				picker.locator(`option[value="${blockedId}"]`),
-			).toHaveCount(1, { timeout: 30_000 });
-
-			// Ineligible parent must be marked: disabled or "(sub-goals off)" suffix
-			const blocked = await picker
-				.locator(`option[value="${blockedId}"]`)
-				.evaluate((o: HTMLOptionElement) => ({ disabled: o.disabled, text: o.textContent || "" }));
-			const isMarked = blocked.disabled || /sub-?goals?\s*off/i.test(blocked.text);
-			expect(
-				isMarked,
-				`ineligible parent option must be marked; got disabled=${blocked.disabled} text=${JSON.stringify(blocked.text)}`,
-			).toBe(true);
-		} finally {
-			await deleteGoal(blockedId).catch(() => {});
-			await apiFetch("/api/preferences", {
-				method: "PUT",
-				body: JSON.stringify({ subgoalsEnabled: true }),
-			});
-		}
-	});
-});
-
-// Behavioral assertions ported from subgoals-experimental-toggle.spec.ts
-test.describe("Journey: Subgoals Experimental Toggle — behavioral assertions", () => {
-	test("subgoals toggle and experimental pill render in settings", async ({ page }) => {
-		await apiFetch("/api/preferences", {
-			method: "PUT",
-			body: JSON.stringify({ subgoalsEnabled: true }),
-		});
-		await openApp(page);
-		await navigateToHash(page, "#/settings/system/general");
-		const checkbox = page.locator("[data-testid='general-subgoals-enabled']");
-		await expect(checkbox).toBeVisible({ timeout: 20_000 });
-		await expect(checkbox).toBeChecked();
-		// Experimental pill must be visible alongside the toggle
-		const pill = page.locator("[data-testid='experimental-pill']").first();
-		await expect(pill).toBeVisible();
-		await expect(pill).toHaveText(/experimental/i);
-	});
-
-	test("toggling subgoals OFF fires PUT to preferences and flips dataset attribute", async ({ page }) => {
-		await apiFetch("/api/preferences", {
-			method: "PUT",
-			body: JSON.stringify({ subgoalsEnabled: true }),
-		});
-		await openApp(page);
-		await navigateToHash(page, "#/settings/system/general");
-
-		const checkbox = page.locator("[data-testid='general-subgoals-enabled']");
-		await expect(checkbox).toBeVisible({ timeout: 20_000 });
-		await expect(checkbox).toBeChecked();
-
-		const prefResp = page.waitForResponse(
-			(r) => r.url().includes("/api/preferences")
-				&& r.request().method() === "PUT"
-				&& r.status() === 200,
-		);
-		await checkbox.click();
-		await expect(checkbox).not.toBeChecked();
-		await prefResp;
-		await expect.poll(
-			() => page.evaluate(() => document.documentElement.dataset.subgoalsEnabled),
-		).toBe("false");
-
-		// Restore
-		await apiFetch("/api/preferences", {
-			method: "PUT",
-			body: JSON.stringify({ subgoalsEnabled: true }),
-		});
-	});
-});
-
-// Ported from subgoal-parent-picker-repro.spec.ts (audit: goal-editing GAP):
-// with subgoals enabled, the goal-proposal Sub-goals tab exposes the parent
-// picker.
-test.describe("Journey: Subgoal Parent Picker", () => {
-	test("Sub-goals tab exposes the parent picker when subgoals enabled", async ({ page }) => {
-		test.setTimeout(120_000);
-		const pref = await apiFetch("/api/preferences", { method: "PUT", body: JSON.stringify({ subgoalsEnabled: true }) });
-		expect(pref.status).toBe(200);
-		try {
-			await openApp(page);
-			await createGoalAssistantViaUI(page, { timeout: 60_000 });
-			const textarea = page.locator("textarea").first();
-			await expect(textarea).toBeVisible({ timeout: 30_000 });
-			await sendMessage(page, "Please create a GOAL_PROPOSAL for testing");
-			const titleInput = page.locator("input[placeholder='Goal title']").first();
-			await expect(titleInput).toBeVisible({ timeout: 20_000 });
-			const subgoalsTab = page.locator("[data-testid='goal-proposal-tab-subgoals']").first();
-			await expect(subgoalsTab).toBeVisible({ timeout: 15_000 });
-			await subgoalsTab.click();
-			await expect(page.locator("[data-testid='goal-form-parent-picker']").first()).toBeVisible({ timeout: 15_000 });
-		} finally {
-			await apiFetch("/api/preferences", { method: "PUT", body: JSON.stringify({ subgoalsEnabled: false }) }).catch(() => {});
 		}
 	});
 });

--- a/tests/browser/journeys/goal-metadata.journey.spec.ts
+++ b/tests/browser/journeys/goal-metadata.journey.spec.ts
@@ -1,407 +1,126 @@
 /**
- * Goal-creation dialog — per-goal metadata key/value editor (browser E2E).
+ * Retained end-to-end metadata proposal smoke.
  *
- * Supersedes the removed per-goal worktree-setup controls (PR #816). Verifies:
- *  - every goal proposal surface uses the unified tabbed layout, with Goal as
- *    the default tab and Workflow / Roles / Metadata always present;
- *  - the key/value metadata editor is absent from the Goal tab and only visible
- *    on the dedicated Metadata tab (data-testid goal-proposal-tab-metadata /
- *    goal-proposal-panel-metadata plus goal-form-metadata and
- *    goal-metadata-{add,row,key,value});
- *  - manually-entered rows are forwarded to goal creation, JSON-parsed where
- *    possible, persist on the server-side goal, and survive a page reload;
- *  - an empty editor sends NO `metadata` override (backward-compatible goal);
- *  - the legacy per-goal worktree-setup controls are GONE;
- *  - a propose_goal-seeded proposal (mock trigger GOAL_PROPOSAL_METADATA)
- *    mirrors its `metadata` into the Metadata tab editor, retains edits across
- *    tab switches, and preserves the final rows through acceptance + reload;
- *  - the optional Sub-goals tab follows the Settings sub-goals flag.
- *
- * Mirrors tests/e2e/ui/goal-creation.spec.ts (assistant proposal flow + mock
- * agent). Persistence is asserted against the server-side goal via the API,
- * which is the durable record that survives a reload.
+ * metadataRowsToObject/objectToRows matrices are unit-tested, proposal tab state
+ * is covered by the goal-tabs fixture, and server validation/inheritance is
+ * covered by gateway tests. This journey keeps the one real assistant → UI →
+ * goal-store → reload boundary.
  */
-import { test, expect } from "../../e2e/gateway-harness.js";
-import type { Page } from "@playwright/test";
-import { apiFetch } from "../../e2e/e2e-setup.js";
-import { openApp, sendMessage, createSessionViaUI, createGoalAssistantViaUI } from "../../e2e/ui/ui-helpers.js";
+import { test, expect } from "../../support/harnesses/browser/gateway-harness.js";
+import {
+	apiFetch,
+	defaultProjectId,
+	deleteGoal,
+} from "../../support/harnesses/browser/e2e-setup.js";
+import {
+	openApp,
+	sendMessage,
+	createGoalAssistantViaUI,
+} from "../../support/helpers/browser/fixtures/ui-helpers.js";
 
-const GOAL_TAB_TESTID = "[data-testid='goal-proposal-tab-goal']";
-const GOAL_PANEL_TESTID = "[data-testid='goal-proposal-panel-goal']";
-const WORKFLOW_TAB_TESTID = "[data-testid='goal-proposal-tab-workflow']";
-const WORKFLOW_PANEL_TESTID = "[data-testid='goal-proposal-panel-workflow']";
-const ROLES_TAB_TESTID = "[data-testid='goal-proposal-tab-roles']";
-const ROLES_PANEL_TESTID = "[data-testid='goal-proposal-panel-roles']";
-const METADATA_TAB_TESTID = "[data-testid='goal-proposal-tab-metadata']";
-const METADATA_PANEL_TESTID = "[data-testid='goal-proposal-panel-metadata']";
-const SUBGOALS_TAB_TESTID = "[data-testid='goal-proposal-tab-subgoals']";
-const METADATA_TESTID = "[data-testid='goal-form-metadata']";
-const ADD_TESTID = "[data-testid='goal-metadata-add']";
-const ROW_TESTID = "[data-testid='goal-metadata-row']";
-const KEY_TESTID = "[data-testid='goal-metadata-key']";
-const VALUE_TESTID = "[data-testid='goal-metadata-value']";
-const REMOVE_TESTID = "[data-testid='goal-metadata-remove']";
+test.describe("Goal proposal metadata — retained full-stack smoke", () => {
+	test("agent-seeded proposal controls create an edited metadata-bearing goal that survives reload", async ({ page }) => {
+		test.setTimeout(120_000);
+		const projectId = await defaultProjectId();
+		let goalId = "";
 
-// Legacy per-goal worktree-setup controls that MUST be gone after PR #816 is
-// superseded by the metadata + goalProvisioned lifecycle hook path.
-const LEGACY_CMD_TESTID = "[data-testid='goal-form-worktree-setup-command']";
-const LEGACY_TIMEOUT_TESTID = "[data-testid='goal-form-worktree-setup-timeout-ms']";
-
-async function setSubgoalsEnabled(value: boolean): Promise<void> {
-	const resp = await apiFetch("/api/preferences", {
-		method: "PUT",
-		body: JSON.stringify({ subgoalsEnabled: value }),
-	});
-	expect(resp.status).toBe(200);
-}
-
-/**
- * Open the goal assistant, send `trigger`, and wait for the populated proposal
- * title input. Mirrors goal-creation.spec.ts's helper; `trigger` selects which
- * mock-agent propose_goal path fires.
- */
-async function openGoalAssistant(page: Page, trigger: string) {
-	test.setTimeout(90_000);
-	await openApp(page);
-	await createGoalAssistantViaUI(page, { timeout: 60_000 });
-	const textarea = page.locator("textarea").first();
-	await expect(textarea).toBeVisible({ timeout: 10_000 });
-	await sendMessage(page, trigger);
-	const titleInput = page.locator("input[placeholder='Goal title']").first();
-	await expect(titleInput).toBeVisible({ timeout: 10_000 });
-	await expect(titleInput).toHaveValue("E2E Test Goal", { timeout: 15_000 });
-}
-
-async function openRegularSessionProposal(page: Page, trigger: string) {
-	test.setTimeout(90_000);
-	await openApp(page);
-	await createSessionViaUI(page);
-	await sendMessage(page, trigger);
-	const titleInput = page.locator("input[placeholder='Goal title']").first();
-	await expect(titleInput).toBeVisible({ timeout: 20_000 });
-	await expect(titleInput).toHaveValue("E2E Test Goal", { timeout: 15_000 });
-}
-
-/** Re-fetch a goal by id (the durable server record). Returns undefined if
- *  the goal no longer exists. Using the id (not the shared "E2E Test Goal"
- *  title) keeps the assertions collision-free under parallel workers. */
-async function findGoalById(goalId: string): Promise<any | undefined> {
-	const resp = await apiFetch("/api/goals");
-	const data = await resp.json();
-	const goals = data.goals || data;
-	return (goals as any[]).find((g) => g.id === goalId);
-}
-
-async function deleteGoal(goalId: string) {
-	await apiFetch(`/api/goals/${goalId}?cascade=true`, { method: "DELETE" }).catch(() => {});
-}
-
-/**
- * Click "Create Goal", await the POST /api/goals response, and return the
- * created goal's id parsed from the response body. The id is captured directly
- * from the create response — not matched by title — so parallel tests creating
- * goals with the same mock title never collide.
- */
-async function clickCreate(page: Page): Promise<string> {
-	const createPromise = page.waitForResponse(
-		(resp) => resp.url().includes("/api/goals") && resp.request().method() === "POST" && resp.ok(),
-		{ timeout: 15_000 },
-	);
-	await page.locator("button").filter({ hasText: "Create Goal" }).first().click();
-	const resp = await createPromise;
-	const goal = await resp.json();
-	expect(goal?.id, "create response must carry the new goal id").toBeTruthy();
-	await expect(page).toHaveURL(/#\/goal(-dashboard)?\//, { timeout: 15_000 });
-	return goal.id as string;
-}
-
-async function assertUnifiedGoalTabs(page: Page, options: { subgoalsTab: boolean }) {
-	const goalTab = page.locator(GOAL_TAB_TESTID);
-	await expect(goalTab).toBeVisible({ timeout: 5_000 });
-	await expect(goalTab).toHaveAttribute("aria-selected", "true");
-	await expect(goalTab).toHaveAttribute("id", "goal-proposal-tab-goal");
-	await expect(goalTab).toHaveAttribute("aria-controls", "goal-proposal-panel-goal");
-	await expect(page.locator(GOAL_PANEL_TESTID)).toBeVisible({ timeout: 5_000 });
-	await expect(page.locator(`${GOAL_PANEL_TESTID} ${METADATA_TESTID}`)).toHaveCount(0);
-	await expect(page.locator(METADATA_TESTID).first()).toBeHidden();
-
-	await expect(page.locator(WORKFLOW_TAB_TESTID)).toBeVisible();
-	await expect(page.locator(ROLES_TAB_TESTID)).toBeVisible();
-	await expect(page.locator(METADATA_TAB_TESTID)).toBeVisible();
-	if (options.subgoalsTab) {
-		await expect(page.locator(SUBGOALS_TAB_TESTID)).toBeVisible();
-	} else {
-		await expect(page.locator(SUBGOALS_TAB_TESTID)).toHaveCount(0);
-	}
-
-	await page.locator(WORKFLOW_TAB_TESTID).click();
-	await expect(page.locator(WORKFLOW_TAB_TESTID)).toHaveAttribute("aria-selected", "true", { timeout: 5_000 });
-	await expect(page.locator(WORKFLOW_PANEL_TESTID)).toBeVisible({ timeout: 5_000 });
-	await expect(page.locator(METADATA_TESTID).first()).toBeHidden();
-
-	await page.locator(ROLES_TAB_TESTID).click();
-	await expect(page.locator(ROLES_TAB_TESTID)).toHaveAttribute("aria-selected", "true", { timeout: 5_000 });
-	await expect(page.locator(ROLES_PANEL_TESTID)).toBeVisible({ timeout: 5_000 });
-	await expect(page.locator(METADATA_TESTID).first()).toBeHidden();
-
-	await goalTab.click();
-	await expect(goalTab).toHaveAttribute("aria-selected", "true", { timeout: 5_000 });
-	await expect(page.locator(GOAL_PANEL_TESTID)).toBeVisible({ timeout: 5_000 });
-	await expect(page.locator(`${GOAL_PANEL_TESTID} ${METADATA_TESTID}`)).toHaveCount(0);
-	await expect(page.locator(METADATA_TESTID).first()).toBeHidden();
-}
-
-async function openMetadataTab(page: Page) {
-	await expect(page.locator(`${GOAL_PANEL_TESTID} ${METADATA_TESTID}`)).toHaveCount(0);
-	await expect(page.locator(METADATA_TESTID).first()).toBeHidden();
-	const tab = page.locator(METADATA_TAB_TESTID);
-	await expect(tab).toBeVisible({ timeout: 10_000 });
-	await expect(tab).toHaveAttribute("id", "goal-proposal-tab-metadata");
-	await expect(tab).toHaveAttribute("aria-controls", "goal-proposal-panel-metadata");
-	await tab.click();
-	await expect(tab).toHaveAttribute("aria-selected", "true", { timeout: 5_000 });
-	await expect(page.locator(METADATA_PANEL_TESTID)).toBeVisible({ timeout: 10_000 });
-	await expect(page.locator(METADATA_PANEL_TESTID)).toHaveAttribute("id", "goal-proposal-panel-metadata");
-	await expect(page.locator(METADATA_PANEL_TESTID)).toHaveAttribute("aria-labelledby", "goal-proposal-tab-metadata");
-	await expect(page.locator(`${METADATA_PANEL_TESTID} ${METADATA_TESTID}`).first()).toBeVisible({ timeout: 5_000 });
-}
-
-async function readMetadataRows(page: Page): Promise<Record<string, string>> {
-	const keyInputs = page.locator(KEY_TESTID);
-	const valueInputs = page.locator(VALUE_TESTID);
-	const rowCount = await keyInputs.count();
-	const rows: Record<string, string> = {};
-	for (let i = 0; i < rowCount; i++) {
-		const key = await keyInputs.nth(i).inputValue();
-		rows[key] = await valueInputs.nth(i).inputValue();
-	}
-	return rows;
-}
-
-async function metadataRowIndex(page: Page, key: string): Promise<number> {
-	const keyInputs = page.locator(KEY_TESTID);
-	const rowCount = await keyInputs.count();
-	for (let i = 0; i < rowCount; i++) {
-		if ((await keyInputs.nth(i).inputValue()) === key) return i;
-	}
-	return -1;
-}
-
-/**
- * Append a metadata key/value pair via the editor. Adds a fresh row, then fills
- * the just-created (last) row's key + value inputs. Re-reads the row count
- * before/after the add so we don't depend on a fixed starting position.
- */
-async function addMetadataRow(page: Page, key: string, value: string) {
-	await expect(page.locator(METADATA_PANEL_TESTID)).toBeVisible({ timeout: 5_000 });
-	const before = await page.locator(ROW_TESTID).count();
-	await page.locator(ADD_TESTID).first().click();
-	await expect(page.locator(ROW_TESTID)).toHaveCount(before + 1, { timeout: 5_000 });
-	const idx = before; // newly-added row is last (0-based index == previous count)
-	const keyInput = page.locator(KEY_TESTID).nth(idx);
-	const valueInput = page.locator(VALUE_TESTID).nth(idx);
-	await keyInput.fill(key);
-	await expect(keyInput).toHaveValue(key);
-	await valueInput.fill(value);
-	await expect(valueInput).toHaveValue(value);
-}
-
-test.describe("Goal proposal — Metadata tab", () => {
-	test.afterEach(async () => { await setSubgoalsEnabled(true); });
-
-	test("New Goal assistant proposal renders unified tabs and keeps metadata out of Goal tab", async ({ page }) => {
-		await setSubgoalsEnabled(true);
-		await openGoalAssistant(page, "Please create a GOAL_PROPOSAL for testing");
-
-		await assertUnifiedGoalTabs(page, { subgoalsTab: true });
-		await openMetadataTab(page);
-		await expect(page.locator(`${METADATA_PANEL_TESTID} ${METADATA_TESTID}`).first()).toBeVisible();
-	});
-
-	test("Sub-goals tab is hidden when the Settings sub-goals flag is off", async ({ page }) => {
-		await setSubgoalsEnabled(false);
-		await openGoalAssistant(page, "Please create a GOAL_PROPOSAL for testing");
-
-		await assertUnifiedGoalTabs(page, { subgoalsTab: false });
-		await openMetadataTab(page);
-		await expect(page.locator(`${METADATA_PANEL_TESTID} ${METADATA_TESTID}`).first()).toBeVisible();
-	});
-
-	test("legacy worktree-setup controls are gone; metadata editor is present and empty by default", async ({ page }) => {
-		await setSubgoalsEnabled(true);
-		await openGoalAssistant(page, "Please create a GOAL_PROPOSAL for testing");
-		await assertUnifiedGoalTabs(page, { subgoalsTab: true });
-		await openMetadataTab(page);
-
-		const editor = page.locator(`${METADATA_PANEL_TESTID} ${METADATA_TESTID}`).first();
-		await expect(editor).toBeVisible({ timeout: 5_000 });
-		await expect(page.locator(ROW_TESTID)).toHaveCount(0);
-		await expect(page.locator(ADD_TESTID).first()).toBeVisible();
-
-		// The PR #816 per-goal worktree-setup controls must no longer exist.
-		await expect(page.locator(LEGACY_CMD_TESTID)).toHaveCount(0);
-		await expect(page.locator(LEGACY_TIMEOUT_TESTID)).toHaveCount(0);
-	});
-
-	test("empty editor sends no metadata override", async ({ page }) => {
-		await setSubgoalsEnabled(true);
-		await openGoalAssistant(page, "Please create a GOAL_PROPOSAL for testing");
-		await assertUnifiedGoalTabs(page, { subgoalsTab: true });
-		await openMetadataTab(page);
-
-		// Leave the editor untouched (empty) — create a backward-compatible goal.
-		await expect(page.locator(`${METADATA_PANEL_TESTID} ${METADATA_TESTID}`).first()).toBeVisible({ timeout: 5_000 });
-		await expect(page.locator(ROW_TESTID)).toHaveCount(0);
-
-		const goalId = await clickCreate(page);
-
-		const created = await findGoalById(goalId);
-		expect(created).toBeTruthy();
-		try {
-			// No metadata field forwarded ⇒ goal record has no metadata.
-			expect(created.metadata).toBeUndefined();
-		} finally {
-			await deleteGoal(goalId);
+		await apiFetch("/api/preferences", {
+			method: "PUT",
+			body: JSON.stringify({ subgoalsEnabled: true }),
+		});
+		if (projectId) {
+			const structuredResponse = await apiFetch(`/api/projects/${projectId}/structured`);
+			if (structuredResponse.ok) {
+				const structured = await structuredResponse.json();
+				const components = Array.isArray(structured.components) ? structured.components : [];
+				if (components.length > 0) {
+					components[0].config = { ...(components[0].config || {}), qa_start_command: "echo ready" };
+					await apiFetch(`/api/projects/${projectId}/config`, {
+						method: "PUT",
+						body: JSON.stringify({ components }),
+					});
+				}
+			}
 		}
-	});
 
-	test("blank-key rows are dropped so they don't count as a metadata override", async ({ page }) => {
-		await setSubgoalsEnabled(true);
-		await openGoalAssistant(page, "Please create a GOAL_PROPOSAL for testing");
-		await assertUnifiedGoalTabs(page, { subgoalsTab: true });
-		await openMetadataTab(page);
-
-		// Add a row but only fill the value, leaving the key blank. The submit
-		// collapse drops blank-key rows, so the goal must carry NO metadata.
-		await page.locator(ADD_TESTID).first().click();
-		await expect(page.locator(ROW_TESTID)).toHaveCount(1, { timeout: 5_000 });
-		await page.locator(VALUE_TESTID).first().fill("orphan-value");
-		await expect(page.locator(VALUE_TESTID).first()).toHaveValue("orphan-value");
-
-		const goalId = await clickCreate(page);
-
-		const created = await findGoalById(goalId);
-		expect(created).toBeTruthy();
 		try {
-			expect(created.metadata).toBeUndefined();
-		} finally {
-			await deleteGoal(goalId);
-		}
-	});
+			await openApp(page);
+			await createGoalAssistantViaUI(page, { timeout: 60_000 });
+			await sendMessage(page, "Please GOAL_PROPOSAL_METADATA now");
+			await expect(page.locator("input[placeholder='Goal title']").first()).toHaveValue("E2E Test Goal", { timeout: 20_000 });
 
-	test("manually-entered metadata is forwarded, JSON-parsed, and persists across reload", async ({ page }) => {
-		await setSubgoalsEnabled(true);
-		await openGoalAssistant(page, "Please create a GOAL_PROPOSAL for testing");
-		await assertUnifiedGoalTabs(page, { subgoalsTab: true });
-		await openMetadataTab(page);
+			// The real proposal exposes every cross-cutting control without leaking
+			// metadata into the default Goal panel.
+			await expect(page.getByTestId("goal-proposal-tab-goal")).toHaveAttribute("aria-selected", "true");
+			await expect(page.getByTestId("goal-proposal-panel-goal").getByTestId("goal-form-metadata")).toHaveCount(0);
 
-		// A plain text value stays a string; a JSON value parses into an array.
-		await addMetadataRow(page, "experiment.flavor", "treatment");
-		await addMetadataRow(page, "bobbit.disabledTools", '["browser_navigate"]');
+			// Workflow selection and optional-step opt-in live in the Goal panel;
+			// the Workflow tab owns inline workflow inspection/editing.
+			const workflowSelect = page.getByTestId("goal-proposal-panel-goal").locator("select").first();
+			await workflowSelect.selectOption("feature");
+			const qaLabel = page.getByTestId("goal-proposal-panel-goal").locator("label", { hasText: "Enable QA Testing" }).first();
+			const qaToggle = qaLabel.locator("input[type='checkbox'].toggle-switch");
+			await expect(qaLabel.locator("span.cursor-help")).toHaveAttribute("title", /QA agent.*ephemeral server/i);
+			await qaToggle.check();
 
-		const goalId = await clickCreate(page);
+			await page.getByTestId("goal-proposal-tab-subgoals").click();
+			await expect(page.getByTestId("goal-form-parent-picker")).toBeVisible();
+			await page.getByTestId("goal-proposal-tab-metadata").click();
+			const metadataPanel = page.getByTestId("goal-proposal-panel-metadata");
+			await expect(metadataPanel.getByTestId("goal-form-metadata")).toBeVisible();
+			await expect(metadataPanel.getByTestId("goal-metadata-row")).toHaveCount(2);
+			const seededKeys = await metadataPanel.getByTestId("goal-metadata-key")
+				.evaluateAll(inputs => inputs.map(input => (input as HTMLInputElement).value));
+			const memoryIndex = seededKeys.indexOf("hindsight.memory.enabled");
+			const disabledToolsIndex = seededKeys.indexOf("bobbit.disabledTools");
+			expect(memoryIndex).toBeGreaterThanOrEqual(0);
+			expect(disabledToolsIndex).toBeGreaterThanOrEqual(0);
+			await metadataPanel.getByTestId("goal-metadata-value").nth(memoryIndex).fill("true");
+			await metadataPanel.getByTestId("goal-metadata-remove").nth(disabledToolsIndex).click();
+			await expect(metadataPanel.getByTestId("goal-metadata-row")).toHaveCount(1);
+			await expect(metadataPanel.getByTestId("goal-metadata-key").first()).toHaveValue("hindsight.memory.enabled");
+			await metadataPanel.getByTestId("goal-metadata-add").click();
+			await expect(metadataPanel.getByTestId("goal-metadata-row")).toHaveCount(2);
+			await metadataPanel.getByTestId("goal-metadata-key").nth(1).fill("experiment.flavor");
+			await metadataPanel.getByTestId("goal-metadata-value").nth(1).fill("treatment");
 
-		const created = await findGoalById(goalId);
-		expect(created).toBeTruthy();
-		try {
-			expect(created.metadata).toBeTruthy();
-			expect(created.metadata["experiment.flavor"]).toBe("treatment");
-			expect(created.metadata["bobbit.disabledTools"]).toEqual(["browser_navigate"]);
+			await page.getByTestId("goal-proposal-tab-goal").click();
+			await page.getByTestId("goal-proposal-tab-metadata").click();
+			await expect.poll(() => metadataPanel.getByTestId("goal-metadata-key")
+				.evaluateAll(inputs => inputs.map(input => (input as HTMLInputElement).value))).toEqual([
+				"hindsight.memory.enabled",
+				"experiment.flavor",
+			]);
 
-			// Server-side persistence survives a full page reload.
+			const createResponse = page.waitForResponse(response =>
+				response.request().method() === "POST"
+				&& /\/api\/goals$/.test(new URL(response.url()).pathname)
+				&& response.ok(),
+			);
+			await page.getByRole("button", { name: "Create Goal", exact: true }).click();
+			goalId = String((await (await createResponse).json()).id || "");
+			expect(goalId).not.toBe("");
+			await expect(page).toHaveURL(/#\/goal(-dashboard)?\//, { timeout: 15_000 });
+
+			const readGoal = async () => (await (await apiFetch(`/api/goals/${goalId}`)).json());
+			let created = await readGoal();
+			expect(created.metadata).toEqual({
+				"hindsight.memory.enabled": true,
+				"experiment.flavor": "treatment",
+			});
+			expect(created.enabledOptionalSteps).toContain("QA testing");
+
 			await page.reload();
-			const reloaded = await findGoalById(goalId);
-			expect(reloaded).toBeTruthy();
-			expect(reloaded.metadata["experiment.flavor"]).toBe("treatment");
-			expect(reloaded.metadata["bobbit.disabledTools"]).toEqual(["browser_navigate"]);
-		} finally {
-			await deleteGoal(goalId);
-		}
-	});
-
-	test("removing a metadata row drops that entry from the created goal", async ({ page }) => {
-		await setSubgoalsEnabled(true);
-		await openGoalAssistant(page, "Please create a GOAL_PROPOSAL for testing");
-		await assertUnifiedGoalTabs(page, { subgoalsTab: true });
-		await openMetadataTab(page);
-
-		await addMetadataRow(page, "keep.me", "yes");
-		await addMetadataRow(page, "drop.me", "no");
-		await expect(page.locator(ROW_TESTID)).toHaveCount(2);
-
-		// Remove the second row (drop.me).
-		await page.locator(REMOVE_TESTID).nth(1).click();
-		await expect(page.locator(ROW_TESTID)).toHaveCount(1, { timeout: 5_000 });
-
-		const goalId = await clickCreate(page);
-
-		const created = await findGoalById(goalId);
-		expect(created).toBeTruthy();
-		try {
-			expect(created.metadata).toBeTruthy();
-			expect(created.metadata["keep.me"]).toBe("yes");
-			expect(created.metadata["drop.me"]).toBeUndefined();
-		} finally {
-			await deleteGoal(goalId);
-		}
-	});
-
-	test("metadata-seeded proposal supports edit/add/remove, retains rows across tab switches, and persists", async ({ page }) => {
-		await setSubgoalsEnabled(true);
-		await openRegularSessionProposal(page, "Please GOAL_PROPOSAL_METADATA now");
-
-		await assertUnifiedGoalTabs(page, { subgoalsTab: true });
-		await openMetadataTab(page);
-
-		// The agent-seeded metadata must be mirrored into the Metadata tab rows.
-		await expect(page.locator(ROW_TESTID)).toHaveCount(2, { timeout: 10_000 });
-		let rows = await readMetadataRows(page);
-		expect(rows["hindsight.memory.enabled"]).toBe("false");
-		expect(rows["bobbit.disabledTools"]).toBe('["browser_navigate"]');
-
-		// Edit one seeded row, add one new row, and remove the other seeded row.
-		const memoryIndex = await metadataRowIndex(page, "hindsight.memory.enabled");
-		expect(memoryIndex).toBeGreaterThanOrEqual(0);
-		await page.locator(VALUE_TESTID).nth(memoryIndex).fill("true");
-		await expect(page.locator(VALUE_TESTID).nth(memoryIndex)).toHaveValue("true");
-
-		await addMetadataRow(page, "experiment.flavor", "treatment");
-
-		const disabledToolsIndex = await metadataRowIndex(page, "bobbit.disabledTools");
-		expect(disabledToolsIndex).toBeGreaterThanOrEqual(0);
-		await page.locator(REMOVE_TESTID).nth(disabledToolsIndex).click();
-		await expect(page.locator(ROW_TESTID)).toHaveCount(2, { timeout: 5_000 });
-
-		// Switch away and back: metadata rows are draft state, not panel-local DOM state.
-		await page.locator(GOAL_TAB_TESTID).click();
-		await expect(page.locator(GOAL_PANEL_TESTID)).toBeVisible({ timeout: 5_000 });
-		await expect(page.locator(`${GOAL_PANEL_TESTID} ${METADATA_TESTID}`)).toHaveCount(0);
-		await expect(page.locator(METADATA_TESTID).first()).toBeHidden();
-		await openMetadataTab(page);
-
-		rows = await readMetadataRows(page);
-		expect(rows["hindsight.memory.enabled"]).toBe("true");
-		expect(rows["experiment.flavor"]).toBe("treatment");
-		expect(rows["bobbit.disabledTools"]).toBeUndefined();
-
-		const goalId = await clickCreate(page);
-
-		const created = await findGoalById(goalId);
-		expect(created).toBeTruthy();
-		try {
-			expect(created.metadata).toBeTruthy();
+			created = await readGoal();
 			expect(created.metadata["hindsight.memory.enabled"]).toBe(true);
 			expect(created.metadata["experiment.flavor"]).toBe("treatment");
 			expect(created.metadata["bobbit.disabledTools"]).toBeUndefined();
-
-			await page.reload();
-			const reloaded = await findGoalById(goalId);
-			expect(reloaded).toBeTruthy();
-			expect(reloaded.metadata["hindsight.memory.enabled"]).toBe(true);
-			expect(reloaded.metadata["experiment.flavor"]).toBe("treatment");
-			expect(reloaded.metadata["bobbit.disabledTools"]).toBeUndefined();
 		} finally {
-			await deleteGoal(goalId);
+			if (goalId) await deleteGoal(goalId, true).catch(() => {});
+			await apiFetch("/api/preferences", {
+				method: "PUT",
+				body: JSON.stringify({ subgoalsEnabled: true }),
+			}).catch(() => {});
 		}
 	});
 });

--- a/tests/browser/journeys/project-settings.journey.spec.ts
+++ b/tests/browser/journeys/project-settings.journey.spec.ts
@@ -1,12 +1,15 @@
 /**
- * Journey: Project Settings + Project Assistant — v2 browser smoke
- * Covers: journey-project-settings, journey-project-assistant
- * Consolidated from: settings-*, project-assistant-*, model-settings-*, etc.
+ * Retained full-stack project-settings smokes.
+ *
+ * Settings control matrices live in settings-admin-fixture, DOM tests, and
+ * project-config gateway tests. These two scenarios retain source-session
+ * notification routing and Add Project assistant provisioning, which require
+ * the real app and gateway.
  */
-import { mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import type { Page, Route } from "@playwright/test";
+import type { Page } from "@playwright/test";
 import {
 	test,
 	expect,
@@ -18,10 +21,11 @@ import {
 	deleteSession,
 	waitForSessionStatus,
 } from "../../support/helpers/browser/journeys/journey-fixture.js";
+import { awaitableRm } from "../../e2e/test-utils/cleanup.js";
 
-let _projCounter = 0;
+let projectCounter = 0;
 function uniqueProjectDir(): string {
-	const dir = join(tmpdir(), `bobbit-v2-proj-${process.env.E2E_PORT ?? "0"}-${Date.now()}-${++_projCounter}`);
+	const dir = join(tmpdir(), `bobbit-v2-proj-${process.env.E2E_PORT ?? "0"}-${Date.now()}-${++projectCounter}`);
 	mkdirSync(dir, { recursive: true });
 	return dir;
 }
@@ -38,56 +42,28 @@ async function installFinishSoundInstrumentation(page: Page): Promise<void> {
 		const target = window as any;
 		target.__finishSoundAudioContexts = 0;
 		target.__finishSoundBadgeCalls = 0;
-
 		class InstrumentedAudioContext {
 			readonly currentTime = 0;
 			readonly destination = {};
-
-			constructor() {
-				target.__finishSoundAudioContexts++;
-			}
-
+			constructor() { target.__finishSoundAudioContexts++; }
 			createOscillator() {
-				return {
-					type: "sine",
-					frequency: { value: 0 },
-					connect: (node: unknown) => node,
-					start: () => {},
-					stop: () => {},
-				};
+				return { type: "sine", frequency: { value: 0 }, connect: (node: unknown) => node, start() {}, stop() {} };
 			}
-
 			createGain() {
 				return {
-					gain: {
-						setValueAtTime: () => {},
-						exponentialRampToValueAtTime: () => {},
-					},
+					gain: { setValueAtTime() {}, exponentialRampToValueAtTime() {} },
 					connect: (node: unknown) => node,
 				};
 			}
-
-			close() {
-				return Promise.resolve();
-			}
+			close() { return Promise.resolve(); }
 		}
-
-		Object.defineProperty(window, "AudioContext", {
-			configurable: true,
-			value: InstrumentedAudioContext,
-		});
-		Object.defineProperty(window, "webkitAudioContext", {
-			configurable: true,
-			value: InstrumentedAudioContext,
-		});
+		Object.defineProperty(window, "AudioContext", { configurable: true, value: InstrumentedAudioContext });
+		Object.defineProperty(window, "webkitAudioContext", { configurable: true, value: InstrumentedAudioContext });
 		Object.defineProperty(navigator, "setAppBadge", {
 			configurable: true,
 			value: async () => { target.__finishSoundBadgeCalls++; },
 		});
-		Object.defineProperty(navigator, "clearAppBadge", {
-			configurable: true,
-			value: async () => {},
-		});
+		Object.defineProperty(navigator, "clearAppBadge", { configurable: true, value: async () => {} });
 	});
 }
 
@@ -97,13 +73,7 @@ async function completedTurnCount(sessionId: string): Promise<number> {
 	return Number((await response.json()).completedTurnCount ?? 0);
 }
 
-async function finishSourceSessionTurn(
-	page: Page,
-	sessionId: string,
-	prompt: string,
-): Promise<{ audioContexts: number; badgeCalls: number }> {
-	// A visible visibilitychange clears the module's prior favicon-badge latch,
-	// allowing every turn in this serial journey to prove badge preservation.
+async function finishSourceSessionTurn(page: Page, sessionId: string, prompt: string) {
 	await page.evaluate(() => {
 		document.dispatchEvent(new Event("visibilitychange"));
 		(window as any).__finishSoundAudioContexts = 0;
@@ -114,16 +84,11 @@ async function finishSourceSessionTurn(
 	await expect(editor).toBeVisible({ timeout: 15_000 });
 	await editor.fill(prompt);
 	await editor.press("Enter");
-
-	await expect.poll(() => completedTurnCount(sessionId), {
-		timeout: 30_000,
-		message: `source session should finish turn for ${prompt}`,
-	}).toBeGreaterThan(turnsBefore);
+	await expect.poll(() => completedTurnCount(sessionId), { timeout: 30_000 }).toBeGreaterThan(turnsBefore);
 	await expect.poll(
 		() => page.evaluate(() => Number((window as any).__finishSoundBadgeCalls ?? 0)),
-		{ timeout: 15_000, message: "favicon/PWA badge should remain independent of audio" },
+		{ timeout: 15_000 },
 	).toBeGreaterThan(0);
-	await page.waitForTimeout(100);
 	return page.evaluate(() => ({
 		audioContexts: Number((window as any).__finishSoundAudioContexts ?? 0),
 		badgeCalls: Number((window as any).__finishSoundBadgeCalls ?? 0),
@@ -132,11 +97,9 @@ async function finishSourceSessionTurn(
 
 async function selectProjectSound(page: Page, projectId: string, value: ProjectSoundState): Promise<void> {
 	const select = page.getByTestId("project-play-finish-sound");
-	await expect(select).toBeVisible({ timeout: 15_000 });
 	await expect(select).toBeEnabled({ timeout: 15_000 });
 	const responsePromise = page.waitForResponse(response =>
-		response.request().method() === "PUT"
-		&& response.url().includes(`/api/projects/${projectId}/config`),
+		response.request().method() === "PUT" && response.url().includes(`/api/projects/${projectId}/config`),
 	);
 	await select.selectOption(value);
 	const response = await responsePromise;
@@ -144,129 +107,21 @@ async function selectProjectSound(page: Page, projectId: string, value: ProjectS
 	expect(response.request().postDataJSON()).toEqual({
 		[PROJECT_SOUND_KEY]: value === "inherit" ? null : value === "on" ? "true" : "false",
 	});
-	await expect(select).toHaveValue(value, { timeout: 15_000 });
 }
 
-test.describe("Journey: Project Settings", () => {
-	test("project settings route renders", async ({ page }) => {
-		await openApp(page);
-		await page.evaluate(() => { window.location.hash = "#/settings/projects"; });
-		await page.waitForFunction(() => window.location.hash.includes("settings"), null, { timeout: 20_000 });
-		await expect(page.locator("body")).toBeVisible({ timeout: 20_000 });
-	});
-
-	test("system settings general route renders", async ({ page }) => {
-		await openApp(page);
-		await page.evaluate(() => { window.location.hash = "#/settings/system/general"; });
-		await page.waitForFunction(() => window.location.hash.includes("settings"), null, { timeout: 20_000 });
-		await expect(page.getByText(/settings/i).first()).toBeVisible({ timeout: 15_000 });
-	});
-
-	test("settings navigation does not break sidebar", async ({ page }) => {
-		await openApp(page);
-		await expect(page.locator(".sidebar-edge").first()).toBeVisible({ timeout: 15_000 });
-		await page.evaluate(() => { window.location.hash = "#/settings/projects"; });
-		await page.waitForFunction(() => window.location.hash.includes("settings"), null, { timeout: 20_000 });
-		await expect(page.locator(".sidebar-edge").first()).toBeVisible({ timeout: 15_000 });
-	});
-
-	test("API-created project appears on projects settings page", async ({ page }) => {
-		const projectId = (await registerProject({
-			name: "v2-settings-proj-alpha",
-			rootPath: uniqueProjectDir(),
-			seedWorkflows: false,
-		})).id;
-		try {
-			await openApp(page);
-			await page.evaluate(() => { window.location.hash = "#/settings/projects"; });
-			await page.waitForFunction(() => window.location.hash.includes("settings"), null, { timeout: 20_000 });
-			await expect(page.getByText("v2-settings-proj-alpha").first()).toBeVisible({ timeout: 15_000 });
-		} finally {
-			await deleteProject(projectId);
-		}
-	});
-
-	test("gear icon on project row opens project-specific settings", async ({ page }) => {
-		const projectId = (await registerProject({
-			name: "v2-settings-proj-beta",
-			rootPath: uniqueProjectDir(),
-			seedWorkflows: false,
-		})).id;
-		try {
-			await openApp(page);
-			await page.evaluate(() => { window.location.hash = "#/settings/projects"; });
-			await page.waitForFunction(() => window.location.hash.includes("settings"), null, { timeout: 20_000 });
-			const projectName = page.getByText("v2-settings-proj-beta").first();
-			await expect(projectName).toBeVisible({ timeout: 15_000 });
-			// Hover the group container to reveal gear icon
-			const groupContainer = projectName.locator("xpath=ancestor::*[contains(@class,'group')]").first();
-			await groupContainer.hover();
-			const gearBtn = groupContainer.locator("button[title='Project settings']");
-			if (await gearBtn.isVisible({ timeout: 15_000 }).catch(() => false)) {
-				await gearBtn.click();
-				await page.waitForFunction(
-					(id: string) => window.location.hash.includes(id) && window.location.hash.includes("settings"),
-					projectId,
-					{ timeout: 15_000 },
-				);
-				const hash = await page.evaluate(() => window.location.hash);
-				expect(hash).toContain(projectId);
-				expect(hash).toContain("settings");
-			} else {
-				// Gear button may require different hover target; assert settings route is navigable directly
-				await page.evaluate((id: string) => { window.location.hash = `#/settings/${id}`; }, projectId);
-				await page.waitForFunction(
-					(id: string) => window.location.hash.includes(id),
-					projectId,
-					{ timeout: 15_000 },
-				);
-				const hash = await page.evaluate(() => window.location.hash);
-				expect(hash).toContain(projectId);
-			}
-		} finally {
-			await deleteProject(projectId);
-		}
-	});
-
-	test("project settings page shows project name", async ({ page }) => {
-		const projectId = (await registerProject({
-			name: "v2-settings-proj-gamma",
-			rootPath: uniqueProjectDir(),
-			seedWorkflows: false,
-		})).id;
-		try {
-			await openApp(page);
-			await page.evaluate((id: string) => { window.location.hash = `#/settings/${id}`; }, projectId);
-			await page.waitForFunction(
-				(id: string) => window.location.hash.includes(id),
-				projectId,
-				{ timeout: 15_000 },
-			);
-			await expect(page.getByText("v2-settings-proj-gamma").first()).toBeVisible({ timeout: 15_000 });
-		} finally {
-			await deleteProject(projectId);
-		}
-	});
-
-	test("project sound override controls source-session audio while the Bell stays global", async ({ page }) => {
+test.describe("Journey: Project Settings — retained full-stack smokes", () => {
+	test("project sound override controls source-session audio across reload while Bell stays global", async ({ page }) => {
 		test.setTimeout(120_000);
 		const rootPath = uniqueProjectDir();
 		let projectId = "";
 		let sessionId = "";
 		const preferencesResponse = await apiFetch("/api/preferences");
-		expect(preferencesResponse.ok).toBe(true);
 		const originalPreferences = await preferencesResponse.json();
 		const originalGlobal = Object.prototype.hasOwnProperty.call(originalPreferences, "playAgentFinishSound")
 			? originalPreferences.playAgentFinishSound as boolean
 			: undefined;
-
 		try {
-			const globalOn = await apiFetch("/api/preferences", {
-				method: "PUT",
-				body: JSON.stringify({ playAgentFinishSound: true }),
-			});
-			expect(globalOn.ok).toBe(true);
-
+			await apiFetch("/api/preferences", { method: "PUT", body: JSON.stringify({ playAgentFinishSound: true }) });
 			projectId = (await registerProject({
 				name: `v2-project-sound-${Date.now()}`,
 				rootPath,
@@ -278,64 +133,33 @@ test.describe("Journey: Project Settings", () => {
 			await openApp(page);
 			await navigateToHash(page, `#/settings/${projectId}/general`);
 
-			const soundSelect = page.getByTestId("project-play-finish-sound");
-			await expect(soundSelect).toBeVisible({ timeout: 15_000 });
-			await expect(soundSelect).toHaveValue("inherit");
-			await expect(page.locator('bell-toggle button[title="Mute agent finish beeps"]').first())
-				.toBeVisible({ timeout: 15_000 });
-
+			await expect(page.getByTestId("project-play-finish-sound")).toHaveValue("inherit");
 			await selectProjectSound(page, projectId, "off");
-			let raw = await (await apiFetch(`/api/projects/${projectId}/config`)).json();
-			expect(raw[PROJECT_SOUND_KEY]).toBe("false");
-
-			// A hard reload reconstructs client state from the raw project config.
 			await page.reload({ waitUntil: "domcontentloaded" });
 			await expect(page.getByTestId("project-play-finish-sound")).toHaveValue("off", { timeout: 20_000 });
-			await expect(page.locator('bell-toggle button[title="Mute agent finish beeps"]').first())
-				.toBeVisible({ timeout: 15_000 });
 
 			await navigateToHash(page, `#/session/${sessionId}`);
-			const mutedTurn = await finishSourceSessionTurn(page, sessionId, "PROJECT_SOUND_OFF");
-			expect(mutedTurn.audioContexts, "project Off must silence its source session").toBe(0);
-			expect(mutedTurn.badgeCalls, "project Off must not suppress non-audio notification state").toBeGreaterThan(0);
-			await expect(page.locator('bell-toggle button[title="Mute agent finish beeps"]').first())
-				.toBeVisible({ timeout: 15_000 });
+			const muted = await finishSourceSessionTurn(page, sessionId, "PROJECT_SOUND_OFF");
+			expect(muted.audioContexts).toBe(0);
+			expect(muted.badgeCalls).toBeGreaterThan(0);
 
 			await navigateToHash(page, `#/settings/${projectId}/general`);
-			await expect(page.getByTestId("project-play-finish-sound")).toHaveValue("off", { timeout: 15_000 });
 			const bell = page.locator('bell-toggle button[title="Mute agent finish beeps"]').first();
-			const globalOffResponse = page.waitForResponse(response =>
+			const globalSave = page.waitForResponse(response =>
 				response.request().method() === "PUT" && response.url().endsWith("/api/preferences"),
 			);
 			await bell.click();
-			const bellSave = await globalOffResponse;
-			expect(bellSave.ok()).toBe(true);
-			expect(bellSave.request().postDataJSON()).toEqual({ playAgentFinishSound: false });
-			await expect(page.locator('bell-toggle button[title="Unmute agent finish beeps"]').first())
-				.toBeVisible({ timeout: 15_000 });
-
-			// The explicit project On selection applies to the very next turn even
-			// though the global Bell remains off.
+			expect((await globalSave).request().postDataJSON()).toEqual({ playAgentFinishSound: false });
 			await selectProjectSound(page, projectId, "on");
-			raw = await (await apiFetch(`/api/projects/${projectId}/config`)).json();
-			expect(raw[PROJECT_SOUND_KEY]).toBe("true");
-			await navigateToHash(page, `#/session/${sessionId}`);
-			const forcedOnTurn = await finishSourceSessionTurn(page, sessionId, "PROJECT_SOUND_ON");
-			expect(forcedOnTurn.audioContexts, "project On must override global Off").toBeGreaterThan(0);
-			await expect(page.locator('bell-toggle button[title="Unmute agent finish beeps"]').first())
-				.toBeVisible({ timeout: 15_000 });
 
-			// Clearing to Inherit removes the raw key and immediately follows the
-			// still-off global preference for another source-session completion.
+			await navigateToHash(page, `#/session/${sessionId}`);
+			const forcedOn = await finishSourceSessionTurn(page, sessionId, "PROJECT_SOUND_ON");
+			expect(forcedOn.audioContexts).toBeGreaterThan(0);
+
 			await navigateToHash(page, `#/settings/${projectId}/general`);
 			await selectProjectSound(page, projectId, "inherit");
-			raw = await (await apiFetch(`/api/projects/${projectId}/config`)).json();
+			const raw = await (await apiFetch(`/api/projects/${projectId}/config`)).json();
 			expect(raw).not.toHaveProperty(PROJECT_SOUND_KEY);
-			await navigateToHash(page, `#/session/${sessionId}`);
-			const inheritedTurn = await finishSourceSessionTurn(page, sessionId, "PROJECT_SOUND_INHERIT");
-			expect(inheritedTurn.audioContexts, "Inherit must immediately fall back to global Off").toBe(0);
-			await expect(page.locator('bell-toggle button[title="Unmute agent finish beeps"]').first())
-				.toBeVisible({ timeout: 15_000 });
 		} finally {
 			if (sessionId) await deleteSession(sessionId).catch(() => {});
 			if (projectId) await deleteProject(projectId);
@@ -343,308 +167,39 @@ test.describe("Journey: Project Settings", () => {
 				method: "PUT",
 				body: JSON.stringify({ playAgentFinishSound: originalGlobal ?? null }),
 			}).catch(() => {});
-			try { rmSync(rootPath, { recursive: true, force: true }); } catch { /* best-effort */ }
+			const cleanup = await awaitableRm(rootPath);
+			expect(cleanup.removed, `project sound fixture cleanup failed after ${cleanup.attempts} attempts`).toBe(true);
 		}
 	});
 
-	test("models settings route renders a toggle", async ({ page }) => {
-		await openApp(page);
-		await page.evaluate(() => { window.location.hash = "#/settings/system/models"; });
-		await page.waitForFunction(() => window.location.hash.includes("models"), null, { timeout: 20_000 });
-		// Any toggle/checkbox-style input on the models settings page
-		const toggle = page.locator('input[type="checkbox"], [role="switch"]').first();
-		await expect(toggle).toBeVisible({ timeout: 15_000 });
-	});
-});
-
-test.describe("Journey: Project Assistant", () => {
-	test("assistant settings route reachable", async ({ page }) => {
-		await openApp(page);
-		await page.evaluate(() => { window.location.hash = "#/settings/system/general"; });
-		await page.waitForFunction(() => window.location.hash.includes("settings"), null, { timeout: 20_000 });
-		await expect(page.locator("body")).toBeVisible({ timeout: 20_000 });
-	});
-
-	test("app shell stable during project assistant flow", async ({ page }) => {
-		await openApp(page);
-		await expect(page.locator(".sidebar-edge").first()).toBeVisible({ timeout: 15_000 });
-		const title = await page.title();
-		expect(title).toBeTruthy();
-	});
-
-	// Ported from project-assistant.spec.ts (audit: project-settings GAP, mutant
-	// BR65): Add Project on a non-empty dir without .bobbit routes to the project
-	// assistant, creating a provisional project shown with the "(setting up)"
-	// sidebar indicator.
-	test("Add Project (non-.bobbit dir) creates a provisional '(setting up)' project", async ({ page }) => {
+	test("Add Project routes a non-configured directory into a provisional assistant", async ({ page }) => {
 		test.setTimeout(120_000);
 		const dir = uniqueProjectDir();
-		let provisionalProjectId = "";
+		let projectId = "";
+		let sessionId = "";
 		writeFileSync(join(dir, "package.json"), `{"name":"v2-provisional-${Date.now()}"}`);
 		try {
 			await openApp(page);
-			await page.locator("button").filter({ hasText: "Add Project" }).first().click();
+			await page.getByRole("button", { name: /Add Project/ }).first().click();
 			const pathInput = page.locator('input[placeholder="/path/to/project"]');
-			await expect(pathInput).toBeVisible({ timeout: 15_000 });
 			await pathInput.fill(dir);
-			await page.locator("button").filter({ hasText: "Continue" }).first().click();
-
-			// Dialog closes and we land in the assistant session.
-			await expect(pathInput).not.toBeVisible({ timeout: 15_000 });
+			await page.getByRole("button", { name: "Continue", exact: true }).click();
 			await expect.poll(() => page.evaluate(() => window.location.hash), { timeout: 15_000 }).toMatch(/^#\/session\//);
-			const sessionId = (await page.evaluate(() => window.location.hash)).replace(/^#\/session\//, "");
+			sessionId = (await page.evaluate(() => window.location.hash)).replace(/^#\/session\//, "");
 			const sessionResponse = await apiFetch(`/api/sessions/${sessionId}`);
-			expect(sessionResponse.ok).toBe(true);
-			provisionalProjectId = String((await sessionResponse.json()).projectId ?? "");
-			expect(provisionalProjectId).not.toBe("");
-
-			// The provisional project shows the "(setting up)" indicator in the sidebar.
-			const sidebar = page.locator(".sidebar-edge");
-			await expect(sidebar.getByText("(setting up)").first()).toBeVisible({ timeout: 20_000 });
+			projectId = String((await sessionResponse.json()).projectId ?? "");
+			expect(projectId).not.toBe("");
+			await expect(page.locator(".sidebar-edge").getByText("(setting up)").first()).toBeVisible({ timeout: 20_000 });
 		} finally {
-			// Project DELETE is the authoritative writer-drain barrier. Never remove
-			// the fixture root until the server confirms its session and context are gone.
-			if (!provisionalProjectId) {
-				const projectsResponse = await apiFetch("/api/projects");
-				expect(projectsResponse.ok).toBe(true);
-				const projectsBody = await projectsResponse.json();
-				const projects = projectsBody.projects || projectsBody || [];
-				provisionalProjectId = String(projects.find((project: any) => project.rootPath === dir)?.id ?? "");
+			if (sessionId) await deleteSession(sessionId).catch(() => {});
+			if (!projectId) {
+				const response = await apiFetch("/api/projects");
+				const body = await response.json();
+				projectId = String((body.projects || body || []).find((project: any) => project.rootPath === dir)?.id ?? "");
 			}
-			if (provisionalProjectId) {
-				const cleanup = await apiFetch(`/api/projects/${provisionalProjectId}`, { method: "DELETE" });
-				expect(cleanup.ok).toBe(true);
-			}
-			rmSync(dir, { recursive: true, force: true });
+			if (projectId) await deleteProject(projectId);
+			const cleanup = await awaitableRm(dir);
+			expect(cleanup.removed, `provisional project fixture cleanup failed after ${cleanup.attempts} attempts`).toBe(true);
 		}
-	});
-
-	// Ported from settings-model-fallback.spec.ts (audit: project-settings GAP):
-	// the models settings page must expose the session-model-fallback toggle,
-	// defaulting to unchecked.
-	test("models settings exposes the session-model-fallback toggle (default off)", async ({ page }) => {
-		await openApp(page);
-		await page.evaluate(() => { window.location.hash = "#/settings/system/models"; });
-		await page.waitForFunction(() => window.location.hash.includes("models"), null, { timeout: 20_000 });
-		const toggle = page.locator('[data-testid="allow-session-model-fallback-toggle"]').first();
-		await expect(toggle).toBeVisible({ timeout: 15_000 });
-		await expect(toggle).not.toBeChecked();
-	});
-
-	// Ported from role-assistant-new.spec.ts (audit: project-settings GAP): the
-	// #/roles page exposes a "New Role" button.
-	test("roles page exposes a 'New Role' button", async ({ page }) => {
-		await openApp(page);
-		await page.evaluate(() => { window.location.hash = "#/roles"; });
-		await page.waitForFunction(() => window.location.hash.includes("roles"), null, { timeout: 20_000 });
-		await expect(page.locator("button").filter({ hasText: "New Role" }).first()).toBeVisible({ timeout: 15_000 });
-	});
-});
-
-test.describe("Journey: Settings App Version", () => {
-	test("installed builds show the package version", async ({ page }) => {
-		await page.route("**/api/app-info", route => route.fulfill({
-			json: { version: "0.14.1", buildType: "installed" },
-		}));
-		await openApp(page);
-		await navigateToHash(page, "#/settings/system/general");
-
-		const appHeader = page.getByTestId("app-header-row");
-		const version = appHeader.getByTestId("settings-app-version");
-		await expect(version).toHaveText("Bobbit v0.14.1");
-		await expect(version).toHaveAttribute("title", "Running from an installed build");
-	});
-
-	test("source builds show the commit in the app header row", async ({ page }) => {
-		await page.route("**/api/app-info", route => route.fulfill({
-			json: { version: "0.14.1", buildType: "source", commitSha: "e3563ba" },
-		}));
-		await page.route("**/api/harness-status", route => route.fulfill({
-			json: { restartAvailable: true },
-		}));
-		await openApp(page);
-		await navigateToHash(page, "#/settings/system/general");
-
-		const appHeader = page.getByTestId("app-header-row");
-		const version = appHeader.getByTestId("settings-app-version");
-		const restart = page.getByRole("button", { name: "Restart Server" });
-		await expect(version).toHaveText("Bobbit v0.14.1 [e3563ba]");
-		await expect(version).toHaveAttribute("title", "Running from source");
-		await expect(restart).toBeVisible();
-		const [headerBox, restartBox] = await Promise.all([appHeader.boundingBox(), restart.boundingBox()]);
-		expect(headerBox).not.toBeNull();
-		expect(restartBox).not.toBeNull();
-		expect(headerBox!.y + headerBox!.height).toBeLessThanOrEqual(restartBox!.y);
-	});
-
-	test("retries app info after a transient failure", async ({ page }) => {
-		let appInfoAvailable = false;
-		let attempts = 0;
-		await page.route("**/api/app-info", route => {
-			attempts++;
-			return appInfoAvailable
-				? route.fulfill({ json: { version: "0.14.1", buildType: "installed" } })
-				: route.fulfill({ status: 503, json: { error: "temporarily unavailable" } });
-		});
-		await openApp(page);
-		await navigateToHash(page, "#/settings/system/general");
-
-		await expect.poll(() => attempts).toBeGreaterThan(0);
-		await expect(page.getByTestId("settings-app-version")).toHaveCount(0);
-
-		await navigateToHash(page, "#/");
-		appInfoAvailable = true;
-		await navigateToHash(page, "#/settings/system/general");
-
-		await expect(page.getByTestId("app-header-row").getByTestId("settings-app-version"))
-			.toHaveText("Bobbit v0.14.1");
-		expect(attempts).toBeGreaterThan(1);
-	});
-});
-
-// Ported from settings-restart-button.spec.ts (audit: project-settings GAP,
-// mutant BR63): without the dev harness the Restart Server control must be
-// absent — and stay absent across reload + navigation.
-test.describe("Journey: Settings Restart Button", () => {
-	async function expectRestartHidden(page: import("@playwright/test").Page): Promise<void> {
-		await expect(page.getByRole("button", { name: /Restart Server|Restart Requested|Requesting/i })).toHaveCount(0);
-	}
-
-	test("restart button is hidden by default and after reload + navigation", async ({ page }) => {
-		await openApp(page);
-		await navigateToHash(page, "#/settings/system/general");
-		await expect(page.locator("h1").filter({ hasText: "Settings" })).toBeVisible({ timeout: 15_000 });
-		await expectRestartHidden(page);
-
-		await page.reload();
-		await expect(page.locator("button").filter({ hasText: "Settings" }).first()).toBeVisible({ timeout: 15_000 });
-		await navigateToHash(page, "#/settings/system/general");
-		await expectRestartHidden(page);
-
-		await navigateToHash(page, "#/");
-		await navigateToHash(page, "#/settings/system/general");
-		await expectRestartHidden(page);
-	});
-});
-
-// Ported from system-prompt-customise.spec.ts (audit: project-settings GAP):
-// settings exposes the Customise-system-prompt control.
-test.describe("Journey: Customise System Prompt", () => {
-	test("settings exposes the customise-system-prompt control", async ({ page }) => {
-		await openApp(page);
-		await page.evaluate(() => { window.location.hash = "#/settings/system/general"; });
-		await page.waitForFunction(() => window.location.hash.includes("general"), null, { timeout: 20_000 });
-		await expect(page.locator('[data-testid="general-customise-system-prompt"]').first()).toBeVisible({ timeout: 15_000 });
-	});
-});
-
-// Ported from settings-maintenance-archived-worktrees.spec.ts (audit:
-// project-settings GAP, mutant BR47): the System → Maintenance page renders the
-// worktree-cleanup card, and a scan surfaces the ready-to-clean count from the
-// (route-mocked) /api/maintenance/worktrees inventory.
-test.describe("Journey: Settings Maintenance — worktree cleanup", () => {
-	function worktreeItem(overrides: Record<string, any>): Record<string, any> {
-		const actionable = overrides.actionable ?? overrides.disposition === "ready-to-clean";
-		return {
-			id: overrides.id,
-			projectId: "default",
-			projectName: "default",
-			repo: ".",
-			repoPath: "/fixture/project",
-			repoDisplayName: "app",
-			path: `/fixture/worktrees/${overrides.id}`,
-			branch: `session/${overrides.id}`,
-			sources: ["git-worktree"],
-			owners: [],
-			classification: overrides.classification,
-			disposition: overrides.disposition,
-			reason: overrides.reason,
-			detail: actionable ? "Safe to remove." : "Not removable in this fixture category.",
-			actionable,
-			selectable: actionable,
-			defaultSelected: actionable,
-			pathExists: actionable,
-			gitWorktreeMetadataExists: actionable,
-			localBranchExists: actionable,
-			willDeleteBranch: actionable,
-			...overrides,
-		};
-	}
-
-	function scanResponse(items: Record<string, any>[]): any {
-		const counts = {
-			total: items.length,
-			readyToClean: items.filter((i) => i.disposition === "ready-to-clean").length,
-			protectedInUse: items.filter((i) => i.disposition === "protected" || i.classification === "protected-in-use").length,
-			archivedOwned: items.filter((i) => i.classification === "archived-owned").length,
-			unownedGitWorktrees: items.filter((i) => i.classification === "unowned-git-worktree").length,
-			poolEntries: items.filter((i) => i.classification === "pool-entry").length,
-			alreadyCleaned: items.filter((i) => i.disposition === "already-cleaned").length,
-			needsAttention: items.filter((i) => i.disposition === "needs-attention" || i.disposition === "failed").length,
-			scanErrors: items.filter((i) => i.classification === "scan-error").length,
-			defaultSelected: items.filter((i) => i.defaultSelected !== false && i.disposition === "ready-to-clean").length,
-			byClassification: {} as Record<string, number>,
-			byReason: {} as Record<string, number>,
-			bySource: {} as Record<string, number>,
-		};
-		for (const item of items) {
-			counts.byClassification[item.classification] = (counts.byClassification[item.classification] || 0) + 1;
-			counts.byReason[item.reason] = (counts.byReason[item.reason] || 0) + 1;
-			for (const source of item.sources || []) counts.bySource[source] = (counts.bySource[source] || 0) + 1;
-		}
-		return { items, counts, generatedAt: Date.now(), scanned: { projects: 1, repos: 2, worktreeRoots: 1 } };
-	}
-
-	async function installMaintenanceRoutes(page: Page, scan: any): Promise<void> {
-		await page.route(new RegExp("/api/maintenance/worktrees(?:\\?.*)?$"), async (route: Route) => {
-			if (route.request().method() !== "GET") return route.fallback();
-			await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify(scan) });
-		});
-	}
-
-	// Ported from settings-agent-dir.spec.ts (audit: project-settings GAP,
-	// mutant BR53): the System → Maintenance page exposes the Agent Directory
-	// section, and entering a valid path enables the Validate control.
-	test("agent-dir maintenance section enables Validate after a path is entered", async ({ page }) => {
-		test.setTimeout(90_000);
-		const dir = uniqueProjectDir();
-		await openApp(page);
-		await navigateToHash(page, "#/settings/system/general");
-		await expect(page.locator("h1").filter({ hasText: "Settings" })).toBeVisible({ timeout: 15_000 });
-
-		await page.getByRole("button", { name: "Maintenance" }).click();
-		await expect.poll(() => page.evaluate(() => window.location.hash), { timeout: 15_000 }).toContain("/maintenance");
-
-		const section = page.locator('[data-testid="agent-dir-settings"]').first();
-		await expect(section).toBeVisible({ timeout: 15_000 });
-		await expect(section.getByRole("heading", { name: /Agent Directory/i })).toBeVisible({ timeout: 10_000 });
-
-		const input = section.locator('[data-testid="agent-dir-path-input"]').first();
-		await expect(input).toBeVisible({ timeout: 10_000 });
-		await expect(input).toBeEnabled({ timeout: 10_000 });
-		await input.fill(dir);
-		await expect(input).toHaveValue(dir);
-
-		// The Validate control (mutant target) must be present and enabled once a
-		// path is entered.
-		await expect(section.locator('[data-testid="agent-dir-validate"]').first()).toBeEnabled({ timeout: 15_000 });
-	});
-
-	test("maintenance page renders worktree-cleanup card and scan shows ready count", async ({ page }) => {
-		const scan = scanResponse([
-			worktreeItem({ id: "arch-ready", classification: "archived-owned", disposition: "ready-to-clean", reason: "safe-archived-session-worktree", sources: ["archived-session", "git-worktree"], willDeleteBranch: true }),
-			worktreeItem({ id: "git-ready", classification: "unowned-git-worktree", disposition: "ready-to-clean", reason: "safe-unowned-session-worktree" }),
-			worktreeItem({ id: "live-1", classification: "protected-in-use", disposition: "protected", reason: "referenced-by-live-session", actionable: false, selectable: false, defaultSelected: false }),
-		]);
-		await installMaintenanceRoutes(page, scan);
-		await openApp(page);
-		await navigateToHash(page, "#/settings/system/maintenance");
-
-		const card = page.getByTestId("worktree-cleanup-maintenance");
-		await expect(card).toBeVisible({ timeout: 15_000 });
-
-		await card.getByTestId("worktree-cleanup-scan").click();
-		await expect(card.getByTestId("worktree-cleanup-summary-ready")).toContainText(/Ready to clean:\s*2/, { timeout: 15_000 });
-		await expect(card.getByTestId("worktree-cleanup-summary-protected")).toContainText(/Protected\/in use:\s*1/, { timeout: 10_000 });
 	});
 });

--- a/tests/browser/journeys/session-lifecycle.journey.spec.ts
+++ b/tests/browser/journeys/session-lifecycle.journey.spec.ts
@@ -1,139 +1,59 @@
 /**
- * Journey: Session Lifecycle — v2 browser smoke
- * Covers: session creation, default role persistence, messaging, sidebar row,
- *         reload persistence, fork via sidebar, sidebar actions menu, copy-link action.
- * Consolidated from: fork-session-history, copy-session-link, sidebar-session-actions, etc.
+ * Retained session lifecycle smoke.
+ *
+ * CRUD routes are covered by session-lifecycle-api.gateway.test.ts; action
+ * eligibility/copy/fork UI is covered by session-actions and fork-history
+ * fixtures. Keep one real WebSocket turn plus transcript/sidebar reload.
  */
-import { test, expect, openApp, navigateToHash, createSession, createSessionViaUI, deleteSession, waitForSessionStatus } from "../../support/helpers/browser/journeys/journey-fixture.js";
-import { base } from "../../support/harnesses/browser/e2e-setup.js";
+import {
+	test,
+	expect,
+	openApp,
+	navigateToHash,
+	createSession,
+	createSessionViaUI,
+	deleteSession,
+	waitForSessionStatus,
+} from "../../support/helpers/browser/journeys/journey-fixture.js";
 
-// ---------------------------------------------------------------------------
-// Selectors used across multiple tests
-// ---------------------------------------------------------------------------
-function sessionRow(page: import("@playwright/test").Page, sessionId: string) {
-	return page.locator(`[data-session-id="${sessionId}"]`).first();
-}
-
-function sidebarTrigger(row: import("@playwright/test").Locator, sessionId: string) {
-	return row
-		.locator(`[data-testid="sidebar-actions-trigger"][data-sidebar-actions-kind="session"][data-sidebar-actions-id="${sessionId}"]`)
-		.first();
-}
-
-/** Hover the session row and click its sidebar-actions-trigger to open the popover. */
-async function openSidebarPopover(
-	page: import("@playwright/test").Page,
-	sessionId: string,
-): Promise<boolean> {
-	const row = sessionRow(page, sessionId);
-	if (!await row.isVisible({ timeout: 15_000 }).catch(() => false)) return false;
-	await row.scrollIntoViewIfNeeded();
-	await row.hover();
-	const trigger = sidebarTrigger(row, sessionId);
-	if (!await trigger.isVisible({ timeout: 3_000 }).catch(() => false)) return false;
-	await trigger.click();
-	return page.locator("sidebar-actions-popover [role='menu']").isVisible({ timeout: 15_000 }).catch(() => false);
-}
-
-/** Open Modify Session from the row's standard quick action and return its role control. */
-async function openModifySessionRole(
-	page: import("@playwright/test").Page,
-	sessionId: string,
-) {
-	const row = sessionRow(page, sessionId);
+async function openModifySessionRole(page: import("@playwright/test").Page, sessionId: string) {
+	const row = page.locator(`[data-session-id="${sessionId}"]`).first();
 	await expect(row).toBeVisible({ timeout: 20_000 });
-	await row.scrollIntoViewIfNeeded();
 	await row.hover();
 	const modify = row.locator('[data-sidebar-action-id="modify"][data-sidebar-action-quick="true"]').first();
 	await expect(modify).toBeVisible({ timeout: 15_000 });
 	await modify.click();
-	await expect(page.getByText("Modify Session", { exact: true }).first()).toBeVisible({ timeout: 15_000 });
 	const roleControl = page.locator('#role-picker-container button[title="Select role"]').first();
 	await expect(roleControl).toBeVisible({ timeout: 15_000 });
 	return roleControl;
 }
 
-/** Click a copy-link action: try direct header button first, fall back to popover. */
-async function clickCopyLink(page: import("@playwright/test").Page): Promise<boolean> {
-	const direct = page.locator('[data-session-action-surface="header"][data-session-action-id="copy-link"]').first();
-	if (await direct.isVisible({ timeout: 3_000 }).catch(() => false)) {
-		await direct.click();
-		return true;
-	}
-	// Try via hamburger trigger
-	const trigger = page.locator('[data-testid="session-actions-trigger"]').first();
-	if (!await trigger.isVisible({ timeout: 3_000 }).catch(() => false)) return false;
-	await trigger.click();
-	const item = page.locator('sidebar-actions-popover [role="menuitem"][data-session-action-id="copy-link"]').first();
-	if (!await item.isVisible({ timeout: 15_000 }).catch(() => false)) return false;
-	await item.click();
-	return true;
-}
-
-// ---------------------------------------------------------------------------
-// Existing lifecycle tests
-// ---------------------------------------------------------------------------
-
-test.describe("Journey: Session Lifecycle", () => {
-	test("navigate to session shows editor", async ({ page }) => {
+test.describe("Journey: Session Lifecycle — retained full-stack smoke", () => {
+	test("WebSocket turn and session route survive a durable page reload", async ({ page }) => {
 		const sessionId = await createSession();
+		const marker = `SESSION_RELOAD_${Date.now()}`;
 		await waitForSessionStatus(sessionId, "idle");
 		try {
 			await openApp(page);
 			await navigateToHash(page, `#/session/${sessionId}`);
-			await expect(page.locator("message-editor textarea").first()).toBeVisible({ timeout: 15_000 });
-			const hash = await page.evaluate(() => window.location.hash);
-			expect(hash).toContain(sessionId);
-		} finally {
-			await deleteSession(sessionId);
-		}
-	});
+			const editor = page.locator("message-editor textarea").first();
+			await expect(editor).toBeVisible({ timeout: 15_000 });
+			await editor.fill(marker);
+			await editor.press("Enter");
+			await expect(page.locator("user-message").filter({ hasText: marker }).first()).toBeVisible({ timeout: 20_000 });
+			await expect(page.getByText("OK", { exact: true }).first()).toBeVisible({ timeout: 20_000 });
 
-	test("send message gets mock-agent response", async ({ page }) => {
-		const sessionId = await createSession();
-		await waitForSessionStatus(sessionId, "idle");
-		try {
-			await openApp(page);
-			await navigateToHash(page, `#/session/${sessionId}`);
-			await expect(page.locator("message-editor textarea").first()).toBeVisible({ timeout: 15_000 });
-			await page.locator("message-editor textarea").first().fill("Hello");
-			await page.locator("message-editor textarea").first().press("Enter");
-			await expect(page.getByText("OK").first()).toBeVisible({ timeout: 20_000 });
-		} finally {
-			await deleteSession(sessionId);
-		}
-	});
-
-	test("session row visible in sidebar", async ({ page }) => {
-		const sessionId = await createSession();
-		await waitForSessionStatus(sessionId, "idle");
-		try {
-			await openApp(page);
-			await navigateToHash(page, `#/session/${sessionId}`);
-			await expect(page.locator("message-editor textarea").first()).toBeVisible({ timeout: 15_000 });
-			await expect(page.locator(`[data-session-id="${sessionId}"]`).first()).toBeVisible({ timeout: 20_000 });
-		} finally {
-			await deleteSession(sessionId);
-		}
-	});
-
-	test("reload and re-navigate to session works", async ({ page }) => {
-		const sessionId = await createSession();
-		await waitForSessionStatus(sessionId, "idle");
-		try {
-			await openApp(page);
-			await navigateToHash(page, `#/session/${sessionId}`);
-			await expect(page.locator("message-editor textarea").first()).toBeVisible({ timeout: 15_000 });
 			await page.reload();
-			await expect(page.locator(".sidebar-edge").first()).toBeVisible({ timeout: 20_000 });
 			await navigateToHash(page, `#/session/${sessionId}`);
-			await expect(page.locator("message-editor textarea").first()).toBeVisible({ timeout: 15_000 });
+			await expect(page.locator(`[data-session-id="${sessionId}"]`).first()).toBeVisible({ timeout: 20_000 });
+			await expect(page.locator("user-message").filter({ hasText: marker }).first()).toBeVisible({ timeout: 20_000 });
+			await expect(page.getByText("OK", { exact: true }).first()).toBeVisible({ timeout: 20_000 });
 		} finally {
-			await deleteSession(sessionId);
+			await deleteSession(sessionId).catch(() => {});
 		}
 	});
 
-	test("quick standard session defaults to General across reload and creation picker", async ({ page }) => {
+	test("standard session role stays General across reload and both picker surfaces", async ({ page }) => {
 		let sessionId = "";
 		try {
 			await openApp(page);
@@ -145,281 +65,30 @@ test.describe("Journey: Session Lifecycle", () => {
 			await page.getByRole("button", { name: "Cancel" }).click();
 
 			await page.reload();
-			await expect(page.locator(".sidebar-edge").first()).toBeVisible({ timeout: 20_000 });
 			await navigateToHash(page, `#/session/${sessionId}`);
-			await expect(page.locator("message-editor textarea").first()).toBeVisible({ timeout: 15_000 });
 			roleControl = await openModifySessionRole(page, sessionId);
 			await expect(roleControl).toContainText("General");
 			await page.getByRole("button", { name: "Cancel" }).click();
 
-			const roleTriggers = page.locator('button[title="New session with role"]');
-			if (await roleTriggers.count() === 0) {
+			const newSessionWithRole = page.locator('button[title="New session with role"]').first();
+			if (await newSessionWithRole.count() === 0) {
 				const projectHeader = page.locator('[data-testid="project-header"]').first();
 				await expect(projectHeader).toBeVisible({ timeout: 15_000 });
 				await projectHeader.click();
 			}
-			const newSessionWithRole = roleTriggers.first();
 			await expect(newSessionWithRole).toBeVisible({ timeout: 15_000 });
 			await newSessionWithRole.click();
-
-			const pickerPanel = page
-				.locator("div.fixed.z-50")
+			const pickerPanel = page.locator("div.fixed.z-50")
 				.filter({ has: page.locator("#picker-role-container") })
 				.last();
 			await expect(pickerPanel).toBeVisible({ timeout: 15_000 });
-			const pickerRoleControl = pickerPanel.locator('#picker-role-container button[title="Select role"]');
-			await expect(pickerRoleControl).toContainText("General");
-			await pickerRoleControl.click();
+			const pickerRole = pickerPanel.locator('#picker-role-container button[title="Select role"]');
+			await expect(pickerRole).toContainText("General");
+			await pickerRole.click();
 			await expect(pickerPanel.locator('#picker-role-container button[title="Select General role"]')).toBeVisible();
 			await expect(pickerPanel.locator('#picker-role-container button[title="No role"]')).toHaveCount(0);
 		} finally {
 			if (sessionId) await deleteSession(sessionId).catch(() => {});
-		}
-	});
-});
-
-// ---------------------------------------------------------------------------
-// Sidebar actions menu
-// ---------------------------------------------------------------------------
-
-test.describe("Journey: Sidebar Actions Menu", () => {
-	test("hovering session row reveals sidebar-actions-trigger", async ({ page }) => {
-		const sessionId = await createSession();
-		await waitForSessionStatus(sessionId, "idle");
-		try {
-			await openApp(page);
-			await navigateToHash(page, `#/session/${sessionId}`);
-			await expect(page.locator("message-editor textarea").first()).toBeVisible({ timeout: 15_000 });
-			const row = sessionRow(page, sessionId);
-			if (!await row.isVisible({ timeout: 15_000 }).catch(() => false)) {
-				test.skip(true, "session row not in sidebar; actions test skipped");
-				return;
-			}
-			await row.hover();
-			const trigger = sidebarTrigger(row, sessionId);
-			await expect(trigger).toBeVisible({ timeout: 15_000 });
-		} finally {
-			await deleteSession(sessionId);
-		}
-	});
-
-	test("sidebar actions popover contains expected action items", async ({ page }) => {
-		const sessionId = await createSession();
-		await waitForSessionStatus(sessionId, "idle");
-		try {
-			await openApp(page);
-			await navigateToHash(page, `#/session/${sessionId}`);
-			await expect(page.locator("message-editor textarea").first()).toBeVisible({ timeout: 15_000 });
-
-			const opened = await openSidebarPopover(page, sessionId);
-			if (!opened) {
-				test.skip(true, "sidebar-actions popover not openable in this config; test skipped");
-				return;
-			}
-
-			const popover = page.locator("sidebar-actions-popover [role='menu']");
-			await expect(popover).toBeVisible({ timeout: 15_000 });
-
-			// Canonical session actions: modify, terminate, fork, copy-link should be present
-			const expectedActions = ["modify", "terminate", "copy-link"];
-			for (const actionId of expectedActions) {
-				const item = page.locator(`sidebar-actions-popover [role="menuitem"][data-session-action-id="${actionId}"]`).first();
-				await expect(item, `action '${actionId}' should appear in sidebar popover`).toBeVisible({ timeout: 15_000 });
-			}
-
-			// Fork item (may be a menuitemcheckbox)
-			const forkItem = page.locator(`sidebar-actions-popover [data-session-action-id="fork"]`).first();
-			await expect(forkItem, "fork action should appear in sidebar popover").toBeVisible({ timeout: 15_000 });
-
-			await page.keyboard.press("Escape");
-		} finally {
-			await deleteSession(sessionId);
-		}
-	});
-
-	test("Modify action visible in sidebar popover", async ({ page }) => {
-		const sessionId = await createSession();
-		await waitForSessionStatus(sessionId, "idle");
-		try {
-			await openApp(page);
-			await navigateToHash(page, `#/session/${sessionId}`);
-			await expect(page.locator("message-editor textarea").first()).toBeVisible({ timeout: 15_000 });
-
-			const opened = await openSidebarPopover(page, sessionId);
-			if (!opened) {
-				test.skip(true, "sidebar-actions popover not openable; skipped");
-				return;
-			}
-			const modifyItem = page.locator(`sidebar-actions-popover [role="menuitem"][data-session-action-id="modify"]`).first();
-			await expect(modifyItem).toBeVisible({ timeout: 15_000 });
-			await page.keyboard.press("Escape");
-		} finally {
-			await deleteSession(sessionId);
-		}
-	});
-});
-
-// ---------------------------------------------------------------------------
-// Fork via sidebar
-// ---------------------------------------------------------------------------
-
-test.describe("Journey: Fork Session", () => {
-	/**
-	 * Fork via sidebar: we route the fork API to avoid needing a real git worktree
-	 * (the test harness sessions have no worktree) — this mirrors the technique used
-	 * in tests/e2e/ui/session-actions.spec.ts "fork trailing toggle" test.
-	 * The UI behavior under test is: sidebar-actions → fork row → client POSTs to
-	 * /fork → navigates to the new session route.
-	 */
-	test("fork action in sidebar popover triggers fork API and navigates to new session", async ({ page }) => {
-		const sourceId = await createSession();
-		await waitForSessionStatus(sourceId, "idle");
-		const FAKE_FORK_ID = "aaaabbbb-cccc-dddd-eeee-ffffffffffff";
-
-		try {
-			// Route the fork endpoint to return a fake fork session (avoids needing a
-			// real git worktree which plain test-harness sessions don't have).
-			await page.route(`**/api/sessions/${sourceId}/fork`, async (route) => {
-				if (route.request().method() !== "POST") return route.fallback();
-				await route.fulfill({
-					status: 201,
-					contentType: "application/json",
-					body: JSON.stringify({
-						id: FAKE_FORK_ID,
-						cwd: "/tmp/fork",
-						status: "idle",
-						title: "Fork: Source",
-						projectId: "default",
-					}),
-				});
-			});
-
-			await openApp(page);
-			await navigateToHash(page, `#/session/${sourceId}`);
-			await expect(page.locator("message-editor textarea").first()).toBeVisible({ timeout: 15_000 });
-
-			const row = sessionRow(page, sourceId);
-			if (!await row.isVisible({ timeout: 15_000 }).catch(() => false)) {
-				test.skip(true, "session row not found in sidebar; fork test skipped");
-				return;
-			}
-
-			await row.hover();
-			const trigger = sidebarTrigger(row, sourceId);
-			if (!await trigger.isVisible({ timeout: 3_000 }).catch(() => false)) {
-				test.skip(true, "sidebar-actions-trigger not visible; fork test skipped");
-				return;
-			}
-			await trigger.click();
-			await expect(page.locator("sidebar-actions-popover [role='menu']")).toBeVisible({ timeout: 15_000 });
-
-			// Uncheck "New worktree" toggle if present
-			const worktreeCheckbox = page
-				.locator('sidebar-actions-popover [role="menuitemcheckbox"][data-sidebar-action-id="fork"]')
-				.first();
-			if (await worktreeCheckbox.isVisible({ timeout: 2_000 }).catch(() => false)) {
-				if ((await worktreeCheckbox.getAttribute("aria-checked")) === "true") {
-					await worktreeCheckbox.click();
-					await expect(worktreeCheckbox).toHaveAttribute("aria-checked", "false");
-				}
-			}
-
-			// Intercept the routed fork API call
-			const forkPromise = page.waitForResponse(
-				(resp) =>
-					resp.url().includes(`/api/sessions/${sourceId}/fork`) &&
-					resp.request().method() === "POST",
-				{ timeout: 20_000 },
-			);
-
-			// Click the fork row action
-			const forkRow = page.locator('sidebar-actions-popover [role="menuitem"][data-session-action-id="fork"]').first();
-			if (!await forkRow.isVisible({ timeout: 3_000 }).catch(() => false)) {
-				test.skip(true, "fork menuitem not visible in popover; fork test skipped");
-				return;
-			}
-			await forkRow.click();
-
-			const forkResp = await forkPromise;
-			expect(forkResp.status(), "fork endpoint should return 201").toBe(201);
-			const forkBody = await forkResp.json();
-			expect(forkBody.id, "fork should return the mocked session ID").toBe(FAKE_FORK_ID);
-
-			// UI should navigate to the fork's session route
-			await expect
-				.poll(() => page.evaluate(() => window.location.hash), { timeout: 20_000 })
-				.toBe(`#/session/${FAKE_FORK_ID}`);
-		} finally {
-			await page.unroute(`**/api/sessions/${sourceId}/fork`).catch(() => {});
-			await deleteSession(sourceId).catch(() => {});
-		}
-	});
-});
-
-// ---------------------------------------------------------------------------
-// Copy-link
-// ---------------------------------------------------------------------------
-
-test.describe("Journey: Copy Session Link", () => {
-	test.use({ permissions: ["clipboard-read", "clipboard-write"] });
-
-	test("copy-link action puts session URL in clipboard", async ({ page }) => {
-		const sessionId = await createSession();
-		await waitForSessionStatus(sessionId, "idle");
-		try {
-			await openApp(page);
-			await navigateToHash(page, `#/session/${sessionId}`);
-			await expect(page.locator("textarea").first()).toBeVisible({ timeout: 15_000 });
-
-			// Copy-link button visible (direct or via hamburger trigger)
-			const copyLinkDirectOrTrigger = page.locator(
-				'[data-session-action-surface="header"][data-session-action-id="copy-link"], [data-testid="session-actions-trigger"]',
-			).first();
-			await expect(copyLinkDirectOrTrigger).toBeVisible({ timeout: 20_000 });
-
-			const clicked = await clickCopyLink(page);
-			if (!clicked) {
-				test.skip(true, "copy-link action not reachable; skipped");
-				return;
-			}
-
-			// Clipboard should contain the session URL
-			const expectedUrl = `${base()}/#/session/${sessionId}`;
-			await expect.poll(() => page.evaluate(() => navigator.clipboard.readText()), { timeout: 15_000 }).toBe(expectedUrl);
-		} finally {
-			await deleteSession(sessionId).catch(() => {});
-		}
-	});
-
-	test("copy-link persists across reload", async ({ page }) => {
-		const sessionId = await createSession();
-		await waitForSessionStatus(sessionId, "idle");
-		try {
-			await openApp(page);
-			await navigateToHash(page, `#/session/${sessionId}`);
-			await expect(page.locator("textarea").first()).toBeVisible({ timeout: 15_000 });
-
-			await page.reload();
-			await expect(page.locator(".sidebar-edge").first()).toBeVisible({ timeout: 20_000 });
-			await navigateToHash(page, `#/session/${sessionId}`);
-			await expect(page.locator("textarea").first()).toBeVisible({ timeout: 15_000 });
-
-			// copy-link action still reachable after reload
-			const copyLinkOrTrigger = page.locator(
-				'[data-session-action-surface="header"][data-session-action-id="copy-link"], [data-testid="session-actions-trigger"]',
-			).first();
-			await expect(copyLinkOrTrigger).toBeVisible({ timeout: 20_000 });
-
-			await page.evaluate(() => navigator.clipboard.writeText(""));
-			const clicked = await clickCopyLink(page);
-			if (!clicked) {
-				test.skip(true, "copy-link not reachable after reload; skipped");
-				return;
-			}
-			const expectedUrl = `${base()}/#/session/${sessionId}`;
-			await expect.poll(() => page.evaluate(() => navigator.clipboard.readText()), { timeout: 15_000 }).toBe(expectedUrl);
-		} finally {
-			await deleteSession(sessionId).catch(() => {});
 		}
 	});
 });

--- a/tests/browser/journeys/team-operations.journey.spec.ts
+++ b/tests/browser/journeys/team-operations.journey.spec.ts
@@ -1,623 +1,84 @@
 /**
- * Journey: Team Operations (Team Delegate + Dashboard Fanout) — v2 browser smoke
- * Covers: journey-team-delegate, journey-dashboard-fanout
- * Consolidated from: archive-child-cascade, team-delegate-*, dashboard-fanout-*, etc.
+ * Retained full-stack team/dashboard smokes.
+ *
+ * Delegation semantics, mutation cards, goal-status states, gate bypass, plan
+ * nodes, and orchestration APIs are covered below the spawned-browser tier.
+ * These scenarios keep the two UI/server joins not represented there.
  */
-import { test, expect, openApp, navigateToHash, createGoal, deleteGoal, createSession, deleteSession, waitForSessionStatus, apiFetch } from "../../support/helpers/browser/journeys/journey-fixture.js";
-import { seedTeamLeadHeader, startTeam, teardownTeam, nonGitCwd } from "../../support/harnesses/browser/e2e-setup.js";
+import {
+	test,
+	expect,
+	openApp,
+	navigateToHash,
+	createGoal,
+	deleteGoal,
+	createSession,
+	deleteSession,
+	waitForSessionStatus,
+	apiFetch,
+} from "../../support/helpers/browser/journeys/journey-fixture.js";
+import { nonGitCwd } from "../../support/harnesses/browser/e2e-setup.js";
 
-test.describe("Journey: Team Delegate", () => {
-	test("goal dashboard accessible for team delegate context", async ({ page }) => {
-		const goal = await createGoal({ title: "v2-team-delegate-smoke" });
-		try {
-			await openApp(page);
-			await navigateToHash(page, `#/goal/${goal.id}`);
-			await expect(page.locator(".dashboard-container, .goal-dashboard, goal-dashboard").first()).toBeVisible({ timeout: 20_000 });
-		} finally {
-			await deleteGoal(goal.id, true);
-		}
-	});
-
-	test("sidebar visible during team delegate scenario", async ({ page }) => {
-		const goal = await createGoal({ title: "v2-team-delegate-sidebar" });
-		try {
-			await openApp(page);
-			await navigateToHash(page, `#/goal/${goal.id}`);
-			await expect(page.locator(".dashboard-container, .goal-dashboard, goal-dashboard").first()).toBeVisible({ timeout: 20_000 });
-			await expect(page.locator(".sidebar-edge").first()).toBeVisible({ timeout: 15_000 });
-		} finally {
-			await deleteGoal(goal.id, true);
-		}
-	});
-});
-
-test.describe("Journey: Dashboard Fanout", () => {
-	test("goal list renders (fanout scenario entry point)", async ({ page }) => {
-		const g1 = await createGoal({ title: "v2-fanout-goal-1" });
-		const g2 = await createGoal({ title: "v2-fanout-goal-2" });
-		try {
-			await openApp(page);
-			// Sidebar goals list is the entry point for dashboard fanout
-			await expect(page.locator(".sidebar-edge").first()).toBeVisible({ timeout: 15_000 });
-		} finally {
-			await deleteGoal(g1.id, true);
-			await deleteGoal(g2.id, true);
-		}
-	});
-
-	test("navigating between goals works (fanout)", async ({ page }) => {
-		const g1 = await createGoal({ title: "v2-fanout-nav-1" });
-		const g2 = await createGoal({ title: "v2-fanout-nav-2" });
-		try {
-			await openApp(page);
-			await navigateToHash(page, `#/goal/${g1.id}`);
-			await expect(page.locator(".dashboard-container, .goal-dashboard, goal-dashboard").first()).toBeVisible({ timeout: 20_000 });
-			await navigateToHash(page, `#/goal/${g2.id}`);
-			await expect(page.locator(".dashboard-container, .goal-dashboard, goal-dashboard").first()).toBeVisible({ timeout: 20_000 });
-		} finally {
-			await deleteGoal(g1.id, true);
-			await deleteGoal(g2.id, true);
-		}
-	});
-
-	test("terminate session: confirmation dialog appears", async ({ page }) => {
-		const sessionId = await createSession();
-		await waitForSessionStatus(sessionId, "idle");
-		try {
-			await openApp(page);
-			await navigateToHash(page, `#/session/${sessionId}`);
-			await expect(page.locator("message-editor textarea").first()).toBeVisible({ timeout: 15_000 });
-			// Hover the session row (data-session-id) in the sidebar to reveal the actions trigger
-			const row = page.locator(`[data-session-id="${sessionId}"]`).first();
-			if (!await row.isVisible({ timeout: 15_000 }).catch(() => false)) {
-				test.skip(true, "session row not found in sidebar; terminate test skipped");
-				return;
-			}
-			await row.scrollIntoViewIfNeeded();
-			await row.hover();
-			const trigger = row.locator(`[data-testid="sidebar-actions-trigger"][data-sidebar-actions-kind="session"]`).first();
-			if (!await trigger.isVisible({ timeout: 3_000 }).catch(() => false)) {
-				test.skip(true, "sidebar-actions-trigger not visible after hover; terminate test skipped in headless");
-				return;
-			}
-			await trigger.click();
-			const terminateItem = page.locator(`sidebar-actions-popover [role="menuitem"][data-sidebar-action-id="terminate"]`).first();
-			await expect(terminateItem).toBeVisible({ timeout: 15_000 });
-			await terminateItem.click();
-			// Confirmation dialog should appear
-			const confirmDialog = page.locator("p.text-muted-foreground").filter({ hasText: /Are you sure you want to terminate/ }).first();
-			await expect(confirmDialog).toBeVisible({ timeout: 15_000 });
-			// Dismiss without terminating
-			await page.keyboard.press("Escape");
-		} finally {
-			await deleteSession(sessionId);
-		}
-	});
-});
-
-// Behavioral assertions ported from archive-child-cascade.spec.ts
-test.describe("Journey: Archive Child Cascade — behavioral assertions", () => {
-	test("children-count API returns 0 for a childless session", async () => {
-		const sessionId = await createSession();
-		await waitForSessionStatus(sessionId, "idle");
-		try {
-			const resp = await apiFetch(`/api/sessions/${sessionId}/children-count`);
-			expect(resp.status).toBe(200);
-			const data = await resp.json();
-			expect(data.count).toBe(0);
-		} finally {
-			await deleteSession(sessionId);
-		}
-	});
-
-	test("children-count returns correct count after creating delegate children", async () => {
-		const parentId = await createSession();
-		await waitForSessionStatus(parentId, "idle");
-		const cwd = nonGitCwd();
-		let child1 = "";
-		let child2 = "";
-		try {
-			const d1 = await apiFetch("/api/sessions", {
-				method: "POST",
-				body: JSON.stringify({ delegateOf: parentId, instructions: "Delegate 1 archive-cascade journey", cwd }),
-			});
-			expect(d1.status).toBe(201);
-			child1 = (await d1.json()).id as string;
-			const d2 = await apiFetch("/api/sessions", {
-				method: "POST",
-				body: JSON.stringify({ delegateOf: parentId, instructions: "Delegate 2 archive-cascade journey", cwd }),
-			});
-			expect(d2.status).toBe(201);
-			child2 = (await d2.json()).id as string;
-
-			const resp = await apiFetch(`/api/sessions/${parentId}/children-count`);
-			expect(resp.status).toBe(200);
-			const data = await resp.json();
-			expect(data.count).toBe(2);
-		} finally {
-			if (child1) await deleteSession(child1).catch(() => {});
-			if (child2) await deleteSession(child2).catch(() => {});
-			await deleteSession(parentId).catch(() => {});
-		}
-	});
-
-	// Ported from archive-child-cascade.spec.ts (audit: team-operations GAP,
-	// mutant BR56): the non-goal terminate confirmation modal must LIST the child
-	// agents BY NAME (not just the count) so the user sees what cascades.
-	test("terminate modal lists child agents by name", async ({ page }) => {
+test.describe("Journey: Team Operations — retained full-stack smokes", () => {
+	test("terminate confirmation resolves and lists real delegate children", async ({ page }) => {
 		test.setTimeout(90_000);
 		await page.setViewportSize({ width: 1280, height: 900 });
-		const cwd = nonGitCwd();
 		const parentId = await createSession();
 		await waitForSessionStatus(parentId, "idle");
-		let child1 = "";
-		let child2 = "";
+		const childIds: string[] = [];
 		try {
-			const d1 = await apiFetch("/api/sessions", {
-				method: "POST",
-				body: JSON.stringify({ delegateOf: parentId, instructions: "CascadeChildAlpha", cwd }),
-			});
-			expect(d1.status).toBe(201);
-			child1 = (await d1.json()).id as string;
-			const d2 = await apiFetch("/api/sessions", {
-				method: "POST",
-				body: JSON.stringify({ delegateOf: parentId, instructions: "CascadeChildBeta", cwd }),
-			});
-			expect(d2.status).toBe(201);
-			child2 = (await d2.json()).id as string;
-			await waitForSessionStatus(child1, "idle");
-			await waitForSessionStatus(child2, "idle");
+			for (const instructions of ["CascadeChildAlpha", "CascadeChildBeta"]) {
+				const response = await apiFetch("/api/sessions", {
+					method: "POST",
+					body: JSON.stringify({ delegateOf: parentId, instructions, cwd: nonGitCwd() }),
+				});
+				expect(response.status).toBe(201);
+				const childId = String((await response.json()).id);
+				childIds.push(childId);
+				await waitForSessionStatus(childId, "idle");
+			}
 
 			await openApp(page);
 			await navigateToHash(page, `#/session/${parentId}`);
-			await expect(page.locator("message-editor textarea, textarea").first()).toBeVisible({ timeout: 15_000 });
-
+			await expect(page.locator("message-editor textarea").first()).toBeVisible({ timeout: 15_000 });
 			const row = page.locator(`[data-session-id="${parentId}"]`).first();
-			await expect(row).toBeVisible({ timeout: 15_000 });
-			await row.scrollIntoViewIfNeeded();
 			await row.hover();
-			const trigger = row.locator(`[data-testid="sidebar-actions-trigger"][data-sidebar-actions-kind="session"][data-sidebar-actions-id="${parentId}"]`).first();
-			await expect(trigger, "session hamburger should appear on hover").toBeVisible({ timeout: 10_000 });
-			await trigger.click();
-			const terminateItem = page.locator(`sidebar-actions-popover [role="menuitem"][data-sidebar-action-id="terminate"]`).first();
-			await expect(terminateItem).toBeVisible({ timeout: 10_000 });
-			await terminateItem.click();
+			await row.getByTestId("sidebar-actions-trigger").click();
+			await page.locator('sidebar-actions-popover [role="menuitem"][data-sidebar-action-id="terminate"]').first().click();
 
-			// The confirm modal body must enumerate BOTH children by name + the count.
-			const body = page.locator("p.text-muted-foreground").filter({ hasText: /Are you sure you want to terminate/ }).first();
-			await expect(body).toBeVisible({ timeout: 15_000 });
+			const body = page.locator("p.text-muted-foreground")
+				.filter({ hasText: /Are you sure you want to terminate/ })
+				.first();
 			await expect(body).toContainText("This will also archive its 2 child agents");
 			await expect(body).toContainText("CascadeChildAlpha");
 			await expect(body).toContainText("CascadeChildBeta");
-
-			// Dismiss without terminating.
 			await page.getByRole("button", { name: "Cancel", exact: true }).last().click();
 		} finally {
-			if (child1) await deleteSession(child1).catch(() => {});
-			if (child2) await deleteSession(child2).catch(() => {});
+			for (const childId of childIds) await deleteSession(childId).catch(() => {});
 			await deleteSession(parentId).catch(() => {});
 		}
 	});
-});
 
-// Behavioral assertions ported from goal-dashboard-fanout.spec.ts
-test.describe("Journey: Dashboard Fanout — behavioral assertions", () => {
-	test("gate signal via API updates gate status in gates list", async () => {
-		const goal = await createGoal({ title: "v2-fanout-gate-signal", workflowId: "test-fast" });
-		try {
-			const signalResp = await apiFetch(`/api/goals/${goal.id}/gates/design-doc/signal`, {
-				method: "POST",
-				body: JSON.stringify({ content: "# Design\n\nFanout journey gate signal test — design doc content." }),
-			});
-			expect(signalResp.status).toBe(201);
-			// Gate signal accepted (201). Async verification state tested in integration tier.
-			if (false && false) await expect.poll(async () => {
-				const gatesResp = await apiFetch(`/api/goals/${goal.id}/gates`);
-				if (!gatesResp.ok) return null;
-				const data = await gatesResp.json();
-				const gate = (data.gates as Array<{ gateId: string; status: string }>)
-					.find((g) => g.gateId === "design-doc");
-				return gate?.status;
-			}, { timeout: 30_000 }).toMatch(/^(verifying|passed)$/);
-		} finally {
-			await deleteGoal(goal.id, true);
-		}
-	});
-
-	test("goal dashboard shows workflow checklist items for a workflow-linked goal", async ({ page }) => {
-		const goal = await createGoal({ title: "v2-fanout-checklist-ui", workflowId: "test-fast" });
-		try {
-			await openApp(page);
-			await navigateToHash(page, `#/goal/${goal.id}`);
-			await expect(page.locator(".dashboard-container, .goal-dashboard, goal-dashboard").first()).toBeVisible({ timeout: 20_000 });
-			// Workflow checklist items should render
-			await expect(page.locator(".wf-checklist-item").first()).toBeVisible({ timeout: 15_000 });
-			// Design Doc gate row must be present
-			await expect(
-				page.locator(".wf-checklist-item").filter({ hasText: "Design Doc" }).first(),
-			).toBeVisible({ timeout: 15_000 });
-		} finally {
-			await deleteGoal(goal.id, true);
-		}
-	});
-
-	// Ported from goal-dashboard-fanout.spec.ts (audit: team-operations PARTIAL):
-	// after a single gate signal the checklist must render the "1 signal" badge
-	// (exact count) — not just the checklist rows.
-	test("gate signal renders '1 signal' badge on the design-doc checklist row", async ({ page }) => {
+	test("persisted gate signal reloads as the exact dashboard badge", async ({ page }) => {
 		test.setTimeout(90_000);
-		const goal = await createGoal({ title: "v2-gate-signal-badge", workflowId: "test-fast" });
-		try {
-			const signalResp = await apiFetch(`/api/goals/${goal.id}/gates/design-doc/signal`, {
-				method: "POST",
-				body: JSON.stringify({ content: "# Design\n\nGate-signal badge journey test — one signal for the design-doc gate." }),
-			});
-			expect(signalResp.status).toBe(201);
-
-			await openApp(page);
-			await navigateToHash(page, `#/goal/${goal.id}`);
-			await expect(page.locator(".dashboard-container, .goal-dashboard, goal-dashboard").first()).toBeVisible({ timeout: 20_000 });
-			const designRow = page.locator(".wf-checklist-item").filter({ hasText: "Design Doc" }).first();
-			await expect(designRow).toBeVisible({ timeout: 15_000 });
-
-			// The badge must read exactly "1 signal" for the single signal. A reload
-			// forces the dashboard to re-fetch gate signal history from REST alone.
-			await expect(async () => {
-				await page.reload();
-				await navigateToHash(page, `#/goal/${goal.id}`);
-				const badge = page.locator(".wf-checklist-item").filter({ hasText: "Design Doc" }).locator(".gate-signal-badge").first();
-				await expect(badge).toBeVisible({ timeout: 10_000 });
-				await expect(badge).toHaveText(/^1 signal$/, { timeout: 5_000 });
-			}).toPass({ intervals: [1000, 2000, 3000], timeout: 60_000 });
-		} finally {
-			await deleteGoal(goal.id, true);
-		}
-	});
-});
-
-// Behavioral assertions ported from dashboard-mutation-pending.spec.ts
-test.describe("Journey: Dashboard Mutation Pending — behavioral assertions", () => {
-	test.beforeEach(async () => {
-		// The mutation card is Subgoals-gated. Pin the system preference instead
-		// of inheriting another journey's global toggle state within the worker.
-		const prefs = await apiFetch("/api/preferences", {
-			method: "PUT",
-			body: JSON.stringify({ subgoalsEnabled: true }),
-		});
-		expect(prefs.status, `enable subgoals for mutation dashboard: ${await prefs.clone().text()}`).toBe(200);
-	});
-
-	test("pending mutation card renders from route-mocked endpoint on load", async ({ page }) => {
-		const goal = await createGoal({ title: "v2-mutation-card-smoke", team: false });
+		const goal = await createGoal({ title: `v2-gate-signal-${Date.now()}`, workflowId: "test-fast" });
 		const goalId = goal.id as string;
 		try {
-			await page.route(/\/api\/goals\/[^/]+\/mutations\/pending(?:\?.*)?$/, async (route, req) => {
-				if (req.method() !== "GET") return route.fallback();
-				await route.fulfill({
-					status: 200,
-					contentType: "application/json",
-					body: JSON.stringify({
-						pending: [{
-							requestId: "req-journey-smoke",
-							goalId,
-							kind: "expansion",
-							summary: "Add a verification step for journey test",
-							diff: { added: [], removed: [], changed: [] },
-							proposedSteps: [],
-							createdAt: Date.now(),
-							expiresAt: Date.now() + 60_000,
-						}],
-					}),
-				});
+			const signalResponse = await apiFetch(`/api/goals/${goalId}/gates/design-doc/signal`, {
+				method: "POST",
+				body: JSON.stringify({ content: "# Design\n\nRetained gate signal persistence smoke." }),
 			});
+			expect(signalResponse.status).toBe(201);
 
 			await openApp(page);
 			await navigateToHash(page, `#/goal/${goalId}`);
-			const card = page.locator('[data-testid="dashboard-mutation-pending-card"]').first();
-			await expect(card).toBeVisible({ timeout: 15_000 });
-			await expect(
-				page.locator('[data-testid="dashboard-mutation-pending-summary"]').first(),
-			).toContainText("Add a verification step");
-		} finally {
-			await deleteGoal(goalId, true);
-		}
-	});
-
-	test("approve clears the pending mutation card", async ({ page }) => {
-		const goal = await createGoal({ title: "v2-mutation-approve-smoke", team: false });
-		const goalId = goal.id as string;
-		let pendingActive = true;
-		try {
-			await page.route(/\/api\/goals\/[^/]+\/mutations\/pending(?:\?.*)?$/, async (route, req) => {
-				if (req.method() !== "GET") return route.fallback();
-				const pending = pendingActive ? [{
-					requestId: "req-approve-journey",
-					goalId,
-					kind: "expansion",
-					summary: "Journey approve mutation test",
-					diff: { added: [], removed: [], changed: [] },
-					proposedSteps: [],
-					createdAt: Date.now(),
-					expiresAt: Date.now() + 60_000,
-				}] : [];
-				await route.fulfill({
-					status: 200,
-					contentType: "application/json",
-					body: JSON.stringify({ pending }),
-				});
-			});
-			await page.route(/\/api\/goals\/[^/]+\/mutation\/[^/]+\/decision$/, async (route, req) => {
-				if (req.method() !== "POST") return route.fallback();
-				pendingActive = false;
-				await route.fulfill({
-					status: 200,
-					contentType: "application/json",
-					body: JSON.stringify({ applied: true }),
-				});
-			});
-
-			await openApp(page);
+			await expect(page.locator(".dashboard-container").first()).toBeVisible({ timeout: 20_000 });
+			await page.reload();
 			await navigateToHash(page, `#/goal/${goalId}`);
-			await expect(
-				page.locator('[data-testid="dashboard-mutation-pending-card"]').first(),
-			).toBeVisible({ timeout: 15_000 });
-			await page.locator('[data-testid="dashboard-mutation-pending-approve"]').first().click();
-			await expect(
-				page.locator('[data-testid="dashboard-mutation-pending-card"]'),
-			).toHaveCount(0, { timeout: 20_000 });
+			const row = page.locator(".wf-checklist-item").filter({ hasText: "Design Doc" }).first();
+			await expect(row).toBeVisible({ timeout: 15_000 });
+			await expect(row.locator(".gate-signal-badge")).toHaveText(/^1 signal$/, { timeout: 20_000 });
 		} finally {
-			await deleteGoal(goalId, true);
-		}
-	});
-});
-
-// Behavioral assertions ported from plan-tab-archived-children.spec.ts
-test.describe("Journey: Plan-Tab Archived Children — behavioral assertions", () => {
-	test("REST /descendants includes the archived child", async ({ gateway }) => {
-		const parent = await createGoal({ title: "v2-desc-archived-api", team: false });
-		const parentId = parent.id as string;
-		let childId = "";
-		try {
-			const r = await apiFetch(`/api/goals/${parentId}/spawn-child`, {
-				method: "POST",
-				headers: seedTeamLeadHeader(gateway, parentId),
-				body: JSON.stringify({
-					planId: "p-desc",
-					title: "Desc Child",
-					spec: "desc child spec for plan-tab archived children journey test, padded to satisfy spec validator minimum length.",
-				}),
-			});
-			expect(r.status).toBe(201);
-			childId = (await r.json()).id as string;
-			const arch = await apiFetch(`/api/goals/${childId}?cascade=true`, { method: "DELETE" });
-			expect([200, 204]).toContain(arch.status);
-
-			const descResp = await apiFetch(`/api/goals/${parentId}/descendants`);
-			expect(descResp.status).toBe(200);
-			const desc = await descResp.json() as { goals: Array<{ id: string; archived?: boolean }> };
-			const found = desc.goals.find((g) => g.id === childId);
-			expect(found).toBeTruthy();
-			expect(found!.archived).toBe(true);
-		} finally {
-			await deleteGoal(parentId, true);
-		}
-	});
-
-	test("plan tab renders archived child node in DAG", async ({ page, gateway }) => {
-		const parent = await createGoal({ title: "v2-plan-archived-dag", team: false });
-		const parentId = parent.id as string;
-		let childId = "";
-		try {
-			const r = await apiFetch(`/api/goals/${parentId}/spawn-child`, {
-				method: "POST",
-				headers: seedTeamLeadHeader(gateway, parentId),
-				body: JSON.stringify({
-					planId: "p-dag",
-					title: "Dag Child",
-					spec: "dag child spec for plan-tab archived children journey test, padded to satisfy spec validator minimum.",
-				}),
-			});
-			expect(r.status).toBe(201);
-			childId = (await r.json()).id as string;
-			await apiFetch(`/api/goals/${childId}?cascade=true`, { method: "DELETE" });
-
-			await openApp(page);
-			await navigateToHash(page, `#/goal/${parentId}`);
-			const planTab = page.locator('[data-testid="tab-plan"]').first();
-			await expect(planTab).toBeVisible({ timeout: 15_000 });
-			await planTab.click();
-			await expect(page.locator('[data-testid="plan-tab"]').first()).toBeVisible({ timeout: 15_000 });
-			await expect(
-				page.locator('[data-testid="plan-node"][data-archived="true"]').first(),
-			).toBeVisible({ timeout: 20_000 });
-		} finally {
-			await deleteGoal(parentId, true);
-		}
-	});
-});
-
-// Behavioral assertions ported from verification-progress-indicator.spec.ts
-test.describe("Journey: Verification Progress — behavioral assertions", () => {
-	test("gate signal via API moves gate into verifying or passed state", async () => {
-		// Deterministic: signal the gate and immediately check it returned 201.
-		const goal = await createGoal({ title: "v2-verify-signal-state", workflowId: "test-fast" });
-		try {
-			const signalResp = await apiFetch(`/api/goals/${goal.id}/gates/design-doc/signal`, {
-				method: "POST",
-				body: JSON.stringify({ content: "# Design\n\nVerification progress journey gate signal test content." }),
-			});
-			expect(signalResp.status).toBe(201);
-			// Gate signal accepted (201). Async verification state tested in integration tier.
-			if (false && false) await expect.poll(async () => {
-				const gatesResp = await apiFetch(`/api/goals/${goal.id}/gates`);
-				if (!gatesResp.ok) return null;
-				const data = await gatesResp.json();
-				const gate = (data.gates as Array<{ gateId: string; status: string }>)
-					.find((g) => g.gateId === "design-doc");
-				return gate?.status;
-			}, { timeout: 30_000 }).toMatch(/^(verifying|passed)$/);
-		} finally {
-			await deleteGoal(goal.id, true);
-		}
-	});
-
-	test("workflow checklist shows all gate rows for workflow-linked goal", async ({ page }) => {
-		const goal = await createGoal({ title: "v2-verify-checklist-rows", workflowId: "test-fast" });
-		try {
-			await openApp(page);
-			await navigateToHash(page, `#/goal/${goal.id}`);
-			await expect(page.locator(".dashboard-container, .goal-dashboard, goal-dashboard").first()).toBeVisible({ timeout: 20_000 });
-			await expect(page.locator(".wf-checklist-item").first()).toBeVisible({ timeout: 15_000 });
-			// test-fast has 3 gates: design-doc, implementation, ready-to-merge
-			const items = page.locator(".wf-checklist-item");
-			await expect(items).toHaveCount(3, { timeout: 20_000 });
-		} finally {
-			await deleteGoal(goal.id, true);
-		}
-	});
-});
-
-// Behavioral assertions ported from goal-status-widget.spec.ts
-test.describe("Journey: Goal Status Widget — behavioral assertions", () => {
-	test("team-lead session REST response exposes teamGoalId", async () => {
-		const goal = await createGoal({ title: `v2-widget-api-${Date.now()}`, team: true, autoStartTeam: false });
-		let teamLeadId: string | undefined;
-		try {
-			teamLeadId = await startTeam(goal.id);
-			await waitForSessionStatus(teamLeadId, "idle");
-			const resp = await apiFetch(`/api/sessions/${teamLeadId}`);
-			expect(resp.ok).toBe(true);
-			const data = await resp.json();
-			expect(data.teamGoalId).toBe(goal.id);
-		} finally {
-			if (teamLeadId) await deleteSession(teamLeadId).catch(() => {});
-			await teardownTeam(goal.id).catch(() => {});
-			await deleteGoal(goal.id).catch(() => {});
-		}
-	});
-
-	test("goal-status-widget pill visible on team-lead session", async ({ page }) => {
-		const goal = await createGoal({ title: `v2-widget-pill-${Date.now()}`, team: true, autoStartTeam: false });
-		let teamLeadId: string | undefined;
-		try {
-			// Mock gate reads to avoid heavy computation
-			await page.route(new RegExp(`/api/goals/${goal.id}/gates(?:\\?.*)?$`), async (route) => {
-				if (route.request().method() !== "GET") return route.fallback();
-				await route.fulfill({
-					status: 200,
-					contentType: "application/json",
-					body: JSON.stringify({ gates: [{ gateId: "design-doc", name: "Design Document", status: "pending" }] }),
-				});
-			});
-			await page.route(new RegExp(`/api/goals/${goal.id}/verifications/active(?:\\?.*)?$`), async (route) => {
-				if (route.request().method() !== "GET") return route.fallback();
-				await route.fulfill({
-					status: 200,
-					contentType: "application/json",
-					body: JSON.stringify({ verifications: [] }),
-				});
-			});
-
-			teamLeadId = await startTeam(goal.id);
-			await waitForSessionStatus(teamLeadId, "idle");
-
-			await openApp(page);
-			await navigateToHash(page, `#/session/${teamLeadId}`);
-			await expect(page.locator("message-editor textarea").first()).toBeVisible({ timeout: 15_000 });
-			const pill = page.locator("[data-testid='goal-status-widget-pill']").first();
-			await expect(pill).toBeVisible({ timeout: 15_000 });
-			// Ported from goal-status-widget.spec.ts (audit: team-operations PARTIAL):
-			// with no pending human sign-offs the pill must report awaiting=false.
-			await expect(pill).toHaveAttribute("data-awaiting-signoffs", "false", { timeout: 15_000 });
-		} finally {
-			if (teamLeadId) await deleteSession(teamLeadId).catch(() => {});
-			await teardownTeam(goal.id).catch(() => {});
-			await deleteGoal(goal.id).catch(() => {});
-		}
-	});
-});
-
-// Behavioral assertions ported from team-delegate.spec.ts
-test.describe("Journey: Team Delegate Card — behavioral assertions", () => {
-	test("TEAM_DELEGATE_CARD message renders Delegated card in transcript", async ({ page }) => {
-		const sessionId = await createSession();
-		await waitForSessionStatus(sessionId, "idle");
-		try {
-			await openApp(page);
-			await navigateToHash(page, `#/session/${sessionId}`);
-			await expect(page.locator("message-editor textarea").first()).toBeVisible({ timeout: 15_000 });
-			const textarea = page.locator("message-editor textarea").first();
-			await textarea.fill("TEAM_DELEGATE_CARD please run a helper");
-			await textarea.press("Enter");
-			// DelegateRenderer single-child card should appear
-			await expect(page.getByText("Delegated", { exact: false }).first()).toBeVisible({ timeout: 20_000 });
-		} finally {
-			await deleteSession(sessionId);
-		}
-	});
-
-	test("TEAM_DELEGATE_CARD_PARALLEL message renders multi-agent card", async ({ page }) => {
-		const sessionId = await createSession();
-		await waitForSessionStatus(sessionId, "idle");
-		try {
-			await openApp(page);
-			await navigateToHash(page, `#/session/${sessionId}`);
-			await expect(page.locator("message-editor textarea").first()).toBeVisible({ timeout: 15_000 });
-			const textarea = page.locator("message-editor textarea").first();
-			await textarea.fill("TEAM_DELEGATE_CARD_PARALLEL run two helpers");
-			await textarea.press("Enter");
-			// DelegateRenderer multi-child header
-			await expect(
-				page.getByText("Delegated to 2 agents", { exact: false }).first(),
-			).toBeVisible({ timeout: 20_000 });
-		} finally {
-			await deleteSession(sessionId);
-		}
-	});
-});
-// Ported from gate-bypass.spec.ts (audit: gate-bypass GAP): the goal-status
-// widget exposes a human-only bypass control on a failed gate row.
-test.describe("Journey: Gate Bypass", () => {
-	test("failed gate row exposes the goal-widget-gate-bypass control", async ({ page }) => {
-		test.setTimeout(90_000);
-		const goal = await createGoal({ title: `v2-gate-bypass-${Date.now()}`, workflowId: "test-fast", team: false });
-		const goalId = goal.id as string;
-		const gates = [
-			{ gateId: "design-doc", name: "Design Doc", status: "passed" },
-			{ gateId: "implementation", name: "Implementation", status: "failed" },
-			{ gateId: "ready-to-merge", name: "Ready to Merge", status: "pending" },
-		];
-		let sessionId = "";
-		try {
-			await page.route(new RegExp(`/api/goals/${goalId}/gates(?:\\?.*)?$`), async (route) => {
-				if (route.request().method() !== "GET") return route.fallback();
-				const summary = route.request().url().includes("view=summary");
-				const body = summary
-					? { summary: { passed: 1, bypassed: 0, bypassedCount: 0, total: gates.length, verifying: false, verifyingCount: 0, awaitingSignoffCount: 0, awaitingHumanSignoff: false, runningGateIds: [], gates: gates.map(g => ({ gateId: g.gateId, name: g.name, status: g.status, effectiveStatus: g.status, running: false, awaitingSignoffCount: 0, dependsOn: [], signalCount: 0 })) } }
-					: { gates: gates.map(g => ({ gateId: g.gateId, name: g.name, status: g.status, signals: [] })) };
-				await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify(body) });
-			});
-			await page.route(new RegExp(`/api/goals/${goalId}/verifications/active(?:\\?.*)?$`), async (route) => {
-				if (route.request().method() !== "GET") return route.fallback();
-				await route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ verifications: [] }) });
-			});
-
-			sessionId = await createSession({ goalId });
-			await waitForSessionStatus(sessionId, "idle");
-			await openApp(page);
-			await navigateToHash(page, `#/session/${sessionId}`);
-			await expect(page.locator("message-editor textarea").first()).toBeVisible({ timeout: 15_000 });
-
-			const pill = page.locator("[data-testid='goal-status-widget-pill']").first();
-			await expect(pill).toBeVisible({ timeout: 15_000 });
-			await pill.click();
-			await expect(page.locator("[data-testid='goal-widget-gates']").first()).toBeVisible({ timeout: 10_000 });
-
-			const failedRow = page.locator('[data-testid="goal-widget-gate"][data-gate-id="implementation"]').first();
-			await expect(failedRow).toHaveAttribute("data-gate-status", "failed", { timeout: 10_000 });
-			await expect(failedRow.locator('[data-testid="goal-widget-gate-bypass"]').first()).toBeVisible({ timeout: 10_000 });
-		} finally {
-			if (sessionId) await deleteSession(sessionId).catch(() => {});
 			await deleteGoal(goalId, true).catch(() => {});
 		}
 	});

--- a/tests/dom/goals/goal-status-widget.dom.test.ts
+++ b/tests/dom/goals/goal-status-widget.dom.test.ts
@@ -331,6 +331,9 @@ describe("GoalStatusWidget fixture", () => {
 			goalState: "complete",
 		});
 
+		const pill = el.querySelector('[data-testid="goal-status-widget-pill"]') as HTMLElement;
+		expect(pill).toBeTruthy();
+		expect(pill.getAttribute("data-awaiting-signoffs")).toBe("false");
 		await openDropdown(el);
 		const dd = dropdown()!;
 		expect(dd.querySelector('[data-testid="goal-widget-completed"]')?.textContent).toContain("Completed");

--- a/tests/dom/team-tool-renderers.dom.test.ts
+++ b/tests/dom/team-tool-renderers.dom.test.ts
@@ -6,9 +6,12 @@ __syncBeforeAll(() => __syncCE());
 // (replacing the esbuild file:// bundle) and asserts the same rendered text.
 import { afterEach, describe, expect, it } from "vitest";
 import { render } from "lit";
+import { getToolRenderer } from "../../src/ui/tools/index.js";
 import { TeamDismissRenderer } from "../../src/ui/tools/renderers/TeamToolRenderers.js";
+import { DelegateRenderer } from "../../src/ui/tools/renderers/DelegateRenderer.js";
 
 const renderer = new TeamDismissRenderer();
+const delegateRenderer = new DelegateRenderer();
 
 function makeResult(text: string, details?: any, isError = false) {
 	return {
@@ -88,4 +91,53 @@ describe("TeamDismissRenderer", () => {
 			expect(text()).toContain(scenario.retryable ? "Retry may help." : "Do not retry.");
 		});
 	}
+});
+
+describe("DelegateRenderer", () => {
+	it("resolves team_delegate through the production lazy registry mapping", async () => {
+		expect(getToolRenderer("team_delegate")).toBeTruthy();
+		await expect.poll(() => getToolRenderer("team_delegate")?.constructor.name).toBe("DelegateRenderer");
+	});
+
+	it("renders exact single and parallel completion summaries from structured details", () => {
+		container = document.createElement("div");
+		document.body.appendChild(container);
+
+		const single = delegateRenderer.render(
+			{ instructions: "inspect the project" },
+			{
+				role: "toolResult",
+				toolCallId: "delegate-single",
+				toolName: "team_delegate",
+				isError: false,
+				content: [{ type: "text", text: "done" }],
+				details: { delegates: [{ id: "child-a", sessionId: "session-a", instructions: "inspect", status: "completed", durationMs: 1_000 }] },
+				timestamp: 0,
+			} as any,
+			false,
+		);
+		render(single.content, container);
+		expect(text()).toContain("Delegated");
+		expect(text()).toContain("inspect the project");
+
+		const parallel = delegateRenderer.render(
+			{ parallel: [{ instructions: "first" }, { instructions: "second" }], instructions: "" },
+			{
+				role: "toolResult",
+				toolCallId: "delegate-parallel",
+				toolName: "team_delegate",
+				isError: false,
+				content: [{ type: "text", text: "both done" }],
+				details: { delegates: [
+					{ id: "child-a", sessionId: "session-a", instructions: "first", status: "completed", durationMs: 1_000 },
+					{ id: "child-b", sessionId: "session-b", instructions: "second", status: "completed", durationMs: 2_000 },
+				] },
+				timestamp: 0,
+			} as any,
+			false,
+		);
+		render(parallel.content, container);
+		expect(text()).toContain("Delegated to 2 agents");
+		expect(text()).toContain("all completed");
+	});
 });

--- a/tests/e2e/gateway-harness.ts
+++ b/tests/e2e/gateway-harness.ts
@@ -29,7 +29,7 @@ import type { AddressInfo } from "node:net";
 import { basename, dirname, extname, join, resolve, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 import { awaitableRm } from "./test-utils/cleanup.js";
-import { withDistServerImportWarmup } from "./test-utils/dist-import-lock.js";
+import { withDistServerImportWarmup } from "../support/harnesses/browser/dist-import-warmup.js";
 import { createRunChild, getRunRoot, installRunIsolation } from "../../tests/support/harnesses/shared/run-isolation.js";
 
 installRunIsolation();

--- a/tests/e2e/gateway-harness.ts
+++ b/tests/e2e/gateway-harness.ts
@@ -29,7 +29,7 @@ import type { AddressInfo } from "node:net";
 import { basename, dirname, extname, join, resolve, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 import { awaitableRm } from "./test-utils/cleanup.js";
-import { withDistServerImportLock } from "./test-utils/dist-import-lock.js";
+import { withDistServerImportWarmup } from "./test-utils/dist-import-lock.js";
 import { createRunChild, getRunRoot, installRunIsolation } from "../../tests/support/harnesses/shared/run-isolation.js";
 
 installRunIsolation();
@@ -501,6 +501,9 @@ export const test = base.extend<{ failureContext: void; restoreDefaultProject: v
 			process.env.BOBBIT_SKIP_WORKTREE_POOL = "1";
 		}
 
+		// Playwright workers share one transform cache. Let the first worker finish
+		// ordered dist/server imports before siblings begin; after readiness, every
+		// sibling imports concurrently rather than joining an all-worker lock queue.
 		const {
 			setProjectRoot,
 			scaffoldBobbitDir,
@@ -508,7 +511,7 @@ export const test = base.extend<{ failureContext: void; restoreDefaultProject: v
 			createGateway,
 			registerRpcBridgeFactory,
 			defaultBgProcessSpawn,
-		} = await withDistServerImportLock(async () => {
+		} = await withDistServerImportWarmup(async () => {
 			const { setProjectRoot } = await import("../../dist/server/bobbit-dir.js");
 			const { scaffoldBobbitDir } = await import("../../dist/server/scaffold.js");
 			const { loadOrCreateToken } = await import("../../dist/server/auth/token.js");

--- a/tests/e2e/in-process-harness-realpush.ts
+++ b/tests/e2e/in-process-harness-realpush.ts
@@ -32,7 +32,7 @@
 import { test as base } from "@playwright/test";
 import { mkdirSync, realpathSync, writeFileSync } from "node:fs";
 import { awaitableRm } from "./test-utils/cleanup.js";
-import { withDistServerImportWarmup } from "./test-utils/dist-import-lock.js";
+import { withDistServerImportWarmup } from "../support/harnesses/browser/dist-import-warmup.js";
 import { join, resolve } from "node:path";
 import { createRunChild, installRunIsolation } from "../../tests/support/harnesses/shared/run-isolation.js";
 

--- a/tests/e2e/in-process-harness-realpush.ts
+++ b/tests/e2e/in-process-harness-realpush.ts
@@ -32,7 +32,7 @@
 import { test as base } from "@playwright/test";
 import { mkdirSync, realpathSync, writeFileSync } from "node:fs";
 import { awaitableRm } from "./test-utils/cleanup.js";
-import { withDistServerImportLock } from "./test-utils/dist-import-lock.js";
+import { withDistServerImportWarmup } from "./test-utils/dist-import-lock.js";
 import { join, resolve } from "node:path";
 import { createRunChild, installRunIsolation } from "../../tests/support/harnesses/shared/run-isolation.js";
 
@@ -130,13 +130,16 @@ export const test = base.extend<{}, { enableWorktreePool: boolean; gateway: Gate
 		// with scaffolding and produces spurious ENOENT.
 		mkdirSync(join(bobbitDir, "state", "session-prompts"), { recursive: true });
 
+		// Playwright workers share one transform cache. Let the first worker finish
+		// ordered dist/server imports before siblings begin; after readiness, every
+		// sibling imports concurrently rather than joining an all-worker lock queue.
 		const {
 			setProjectRoot,
 			scaffoldBobbitDir,
 			loadOrCreateToken,
 			createGateway,
 			registerRpcBridgeFactory,
-		} = await withDistServerImportLock(async () => {
+		} = await withDistServerImportWarmup(async () => {
 			const { setProjectRoot } = await import("../../dist/server/bobbit-dir.js");
 			const { scaffoldBobbitDir } = await import("../../dist/server/scaffold.js");
 			const { loadOrCreateToken } = await import("../../dist/server/auth/token.js");

--- a/tests/e2e/in-process-harness.ts
+++ b/tests/e2e/in-process-harness.ts
@@ -24,7 +24,7 @@ import { mkdirSync, readFileSync, realpathSync, rmSync, writeFileSync } from "no
 import { basename, dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { awaitableRm } from "./test-utils/cleanup.js";
-import { withDistServerImportLock } from "./test-utils/dist-import-lock.js";
+import { withDistServerImportWarmup } from "./test-utils/dist-import-lock.js";
 import { createRunChild, getRunRoot, installRunIsolation } from "../../tests/support/harnesses/shared/run-isolation.js";
 
 installRunIsolation();
@@ -238,13 +238,16 @@ export const test = base.extend<{ restoreDefaultProject: void }, { enableWorktre
 		// with scaffolding and produces spurious ENOENT.
 		mkdirSync(join(bobbitDir, "state", "session-prompts"), { recursive: true });
 
+		// Playwright workers share one transform cache. Let the first worker finish
+		// ordered dist/server imports before siblings begin; after readiness, every
+		// sibling imports concurrently rather than joining an all-worker lock queue.
 		const {
 			setProjectRoot,
 			scaffoldBobbitDir,
 			loadOrCreateToken,
 			createGateway,
 			registerRpcBridgeFactory,
-		} = await withDistServerImportLock(async () => {
+		} = await withDistServerImportWarmup(async () => {
 			const { setProjectRoot } = await import("../../dist/server/bobbit-dir.js");
 			const { scaffoldBobbitDir } = await import("../../dist/server/scaffold.js");
 			const { loadOrCreateToken } = await import("../../dist/server/auth/token.js");

--- a/tests/e2e/in-process-harness.ts
+++ b/tests/e2e/in-process-harness.ts
@@ -24,7 +24,7 @@ import { mkdirSync, readFileSync, realpathSync, rmSync, writeFileSync } from "no
 import { basename, dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { awaitableRm } from "./test-utils/cleanup.js";
-import { withDistServerImportWarmup } from "./test-utils/dist-import-lock.js";
+import { withDistServerImportWarmup } from "../support/harnesses/browser/dist-import-warmup.js";
 import { createRunChild, getRunRoot, installRunIsolation } from "../../tests/support/harnesses/shared/run-isolation.js";
 
 installRunIsolation();

--- a/tests/e2e/test-utils/dist-import-lock.ts
+++ b/tests/e2e/test-utils/dist-import-lock.ts
@@ -1,66 +1,161 @@
-import { existsSync, mkdirSync, rmSync, statSync, writeFileSync } from "node:fs";
+import {
+	existsSync,
+	mkdirSync,
+	readFileSync,
+	renameSync,
+	rmSync,
+	statSync,
+	writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const PROJECT_ROOT = resolve(__dirname, "..", "..", "..");
-const LOCK_STALE_MS = 60_000;
+const READY_CONTENT = "dist-server-imports-ready-v1\n";
+const LOCK_STALE_MS = 45_000;
 const LOCK_WAIT_MS = 25;
-const LOCK_TIMEOUT_MS = 30_000;
+const LOCK_TIMEOUT_MS = 60_000;
+
+export interface DistServerImportWarmupOptions {
+	/** Test-only override; production uses a coordinator-owned directory. */
+	stateDir?: string;
+	staleMs?: number;
+	waitMs?: number;
+	timeoutMs?: number;
+}
 
 function e2eTempRoot(): string {
 	// An explicit coordinator root is always owned. Do not replace it with
-	// Docker's shared `/tmp`, or concurrent coordinators can remove this lock.
+	// Docker's shared `/tmp`, or concurrent coordinators can remove this state.
 	if (process.env.BOBBIT_E2E_TMP_ROOT) return process.env.BOBBIT_E2E_TMP_ROOT;
 	if (existsSync("/.dockerenv")) return "/tmp";
 	return process.platform === "win32" ? "C:\\bobbit-e2e" : join(tmpdir(), "bobbit-e2e");
 }
 
-function lockDir(): string {
+function defaultStateDir(): string {
 	const rootKey = PROJECT_ROOT.replace(/[^a-zA-Z0-9._-]/g, "-").slice(-80);
-	return join(e2eTempRoot(), `.bobbit-dist-import-${rootKey}.lock`);
+	return join(e2eTempRoot(), `.bobbit-dist-import-${rootKey}`);
 }
 
 function delay(ms: number): Promise<void> {
-	return new Promise((resolve) => setTimeout(resolve, ms));
+	return new Promise(resolveDelay => setTimeout(resolveDelay, ms));
 }
 
-async function acquireDistImportLock(): Promise<() => void> {
-	const dir = lockDir();
-	const start = Date.now();
-	for (;;) {
-		try {
-			mkdirSync(dir, { recursive: false });
-			writeFileSync(join(dir, "owner.txt"), `${process.pid}\n${new Date().toISOString()}\n`);
-			return () => {
-				try { rmSync(dir, { recursive: true, force: true }); } catch { /* best-effort */ }
-			};
-		} catch (err: any) {
-			if (err?.code !== "EEXIST") throw err;
-			try {
-				const ageMs = Date.now() - statSync(dir).mtimeMs;
-				if (ageMs > LOCK_STALE_MS) {
-					rmSync(dir, { recursive: true, force: true });
-					continue;
-				}
-			} catch {
-				rmSync(dir, { recursive: true, force: true });
-				continue;
-			}
-			if (Date.now() - start > LOCK_TIMEOUT_MS) {
-				throw new Error(`Timed out waiting for dist/server import lock at ${dir}`);
-			}
-			await delay(LOCK_WAIT_MS);
-		}
+function removePath(path: string): void {
+	try {
+		rmSync(path, { recursive: true, force: true, maxRetries: 5, retryDelay: 20 });
+	} catch {
+		// Cleanup is best-effort. A ready marker lets waiters bypass a lock that
+		// Windows still has open; failed warmups are recovered by stale-lock logic.
 	}
 }
 
-export async function withDistServerImportLock<T>(fn: () => Promise<T>): Promise<T> {
-	const release = await acquireDistImportLock();
+function releaseLock(lockPath: string): void {
+	const releasedPath = `${lockPath}.released-${process.pid}-${Date.now()}`;
 	try {
-		return await fn();
+		// Renaming first frees the well-known lock path atomically. This matters
+		// after a failed warmup, where there is no ready marker for waiters to use
+		// if Windows briefly retains a handle while recursive removal retries.
+		renameSync(lockPath, releasedPath);
+		removePath(releasedPath);
+	} catch (error: any) {
+		if (error?.code !== "ENOENT") removePath(lockPath);
+	}
+}
+
+function isReady(path: string): boolean {
+	try {
+		return readFileSync(path, "utf8") === READY_CONTENT;
+	} catch {
+		return false;
+	}
+}
+
+function publishReady(readyPath: string): void {
+	const temporaryPath = `${readyPath}.${process.pid}.${Date.now()}.tmp`;
+	writeFileSync(temporaryPath, READY_CONTENT, { flag: "wx" });
+	try {
+		// Only the lock owner publishes. Remove an invalid marker first because
+		// rename-over-existing is not portable to Windows.
+		removePath(readyPath);
+		renameSync(temporaryPath, readyPath);
 	} finally {
-		release();
+		removePath(temporaryPath);
+	}
+}
+
+function recoverStaleLock(lockPath: string, staleMs: number): boolean {
+	try {
+		if (Date.now() - statSync(lockPath).mtimeMs <= staleMs) return false;
+	} catch {
+		return true;
+	}
+
+	// Rename before removal so two recoverers cannot delete a newly acquired
+	// lock at the original path. The unique tombstone also avoids Windows rename
+	// collisions between workers.
+	const abandonedPath = `${lockPath}.stale-${process.pid}-${Date.now()}`;
+	try {
+		renameSync(lockPath, abandonedPath);
+	} catch (error: any) {
+		if (error?.code === "ENOENT") return true;
+		return false;
+	}
+	removePath(abandonedPath);
+	return true;
+}
+
+/**
+ * Let exactly one worker populate Playwright's shared transform cache before
+ * any siblings import dist/server. Once that worker publishes readiness, every
+ * waiting worker performs its own imports concurrently; normal startup is not
+ * serialized behind a per-worker lock.
+ */
+export async function withDistServerImportWarmup<T>(
+	importDistServer: () => Promise<T>,
+	options: DistServerImportWarmupOptions = {},
+): Promise<T> {
+	const stateDir = options.stateDir ?? defaultStateDir();
+	const lockPath = `${stateDir}.lock`;
+	const readyPath = `${stateDir}.ready`;
+	const staleMs = options.staleMs ?? LOCK_STALE_MS;
+	const waitMs = options.waitMs ?? LOCK_WAIT_MS;
+	const timeoutMs = options.timeoutMs ?? LOCK_TIMEOUT_MS;
+	mkdirSync(dirname(stateDir), { recursive: true });
+
+	if (isReady(readyPath)) return importDistServer();
+
+	const startedAt = Date.now();
+	for (;;) {
+		let acquired = false;
+		try {
+			mkdirSync(lockPath, { recursive: false });
+			acquired = true;
+		} catch (error: any) {
+			if (error?.code !== "EEXIST") throw error;
+		}
+
+		if (acquired) {
+			try {
+				writeFileSync(join(lockPath, "owner.txt"), `${process.pid}\n${new Date().toISOString()}\n`);
+				// Recheck after acquisition: a prior owner may have published readiness
+				// while this worker was contending for the lock.
+				if (isReady(readyPath)) return await importDistServer();
+				const result = await importDistServer();
+				publishReady(readyPath);
+				return result;
+			} finally {
+				releaseLock(lockPath);
+			}
+		}
+
+		if (isReady(readyPath)) return importDistServer();
+		if (recoverStaleLock(lockPath, staleMs)) continue;
+		if (Date.now() - startedAt > timeoutMs) {
+			throw new Error(`Timed out waiting for dist/server import warmup at ${lockPath}`);
+		}
+		await delay(waitMs);
 	}
 }

--- a/tests/support/harnesses/browser/dist-import-warmup.ts
+++ b/tests/support/harnesses/browser/dist-import-warmup.ts
@@ -12,7 +12,7 @@ import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
-const PROJECT_ROOT = resolve(__dirname, "..", "..", "..");
+const PROJECT_ROOT = resolve(__dirname, "..", "..", "..", "..");
 const READY_CONTENT = "dist-server-imports-ready-v1\n";
 const LOCK_STALE_MS = 45_000;
 const LOCK_WAIT_MS = 25;

--- a/tests/unit/core/browser-harness-startup.unit.test.ts
+++ b/tests/unit/core/browser-harness-startup.unit.test.ts
@@ -10,7 +10,7 @@ import {
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { afterEach, describe, it } from "vitest";
-import { withDistServerImportWarmup } from "../../e2e/test-utils/dist-import-lock.js";
+import { withDistServerImportWarmup } from "../../support/harnesses/browser/dist-import-warmup.js";
 
 const PROJECT_ROOT = resolve(import.meta.dirname, "..", "..", "..");
 const HARNESSES = [

--- a/tests/unit/core/browser-harness-startup.unit.test.ts
+++ b/tests/unit/core/browser-harness-startup.unit.test.ts
@@ -1,0 +1,165 @@
+import assert from "node:assert/strict";
+import {
+	existsSync,
+	mkdirSync,
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+	utimesSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { afterEach, describe, it } from "vitest";
+import { withDistServerImportWarmup } from "../../e2e/test-utils/dist-import-lock.js";
+
+const PROJECT_ROOT = resolve(import.meta.dirname, "..", "..", "..");
+const HARNESSES = [
+	"tests/e2e/gateway-harness.ts",
+	"tests/e2e/in-process-harness.ts",
+	"tests/e2e/in-process-harness-realpush.ts",
+] as const;
+const temporaryRoots: string[] = [];
+
+function temporaryStateDir(): string {
+	const root = mkdtempSync(join(tmpdir(), "bobbit-import-warmup-unit-"));
+	temporaryRoots.push(root);
+	return join(root, "barrier", "dist-server");
+}
+
+function deferred(): { promise: Promise<void>; resolve: () => void } {
+	let resolvePromise!: () => void;
+	const promise = new Promise<void>(resolve => { resolvePromise = resolve; });
+	return { promise, resolve: resolvePromise };
+}
+
+async function waitUntil(predicate: () => boolean, timeoutMs = 1_000): Promise<void> {
+	const startedAt = Date.now();
+	while (!predicate()) {
+		if (Date.now() - startedAt > timeoutMs) throw new Error("condition was not reached");
+		await new Promise(resolveDelay => setTimeout(resolveDelay, 2));
+	}
+}
+
+function startupImportBlock(file: string): string {
+	const source = readFileSync(resolve(PROJECT_ROOT, file), "utf8");
+	const start = source.indexOf("// Playwright workers share one transform cache");
+	const end = source.indexOf("// Register the in-process mock bridge factory", start);
+	assert.ok(start >= 0 && end > start, `${file} must retain the documented server startup boundary`);
+	return source.slice(start, end);
+}
+
+afterEach(() => {
+	for (const root of temporaryRoots.splice(0)) {
+		rmSync(root, { recursive: true, force: true, maxRetries: 3, retryDelay: 10 });
+	}
+});
+
+describe("browser harness startup", () => {
+	it("warms once, then releases all waiting workers to import concurrently", async () => {
+		const stateDir = temporaryStateDir();
+		const warmupStarted = deferred();
+		const finishWarmup = deferred();
+		const finishFollowers = deferred();
+		let followerStarts = 0;
+		let activeFollowers = 0;
+		let maxActiveFollowers = 0;
+
+		const first = withDistServerImportWarmup(async () => {
+			warmupStarted.resolve();
+			await finishWarmup.promise;
+			return "first";
+		}, { stateDir, waitMs: 1 });
+		await warmupStarted.promise;
+
+		const follower = (value: string) => withDistServerImportWarmup(async () => {
+			followerStarts++;
+			activeFollowers++;
+			maxActiveFollowers = Math.max(maxActiveFollowers, activeFollowers);
+			await finishFollowers.promise;
+			activeFollowers--;
+			return value;
+		}, { stateDir, waitMs: 1 });
+		const second = follower("second");
+		const third = follower("third");
+
+		await new Promise(resolveDelay => setTimeout(resolveDelay, 15));
+		assert.equal(followerStarts, 0, "followers must not import against a partially populated cache");
+		finishWarmup.resolve();
+		await waitUntil(() => followerStarts === 2);
+		assert.equal(maxActiveFollowers, 2, "ready followers must not serialize behind the warmup lock");
+		finishFollowers.resolve();
+
+		assert.deepEqual(await Promise.all([first, second, third]), ["first", "second", "third"]);
+		assert.equal(existsSync(`${stateDir}.ready`), true);
+		assert.equal(existsSync(`${stateDir}.lock`), false);
+	});
+
+	it("lets another worker become the warmer after the first worker fails", async () => {
+		const stateDir = temporaryStateDir();
+		const firstStarted = deferred();
+		const failFirst = deferred();
+		let replacementStarted = false;
+
+		const first = withDistServerImportWarmup(async () => {
+			firstStarted.resolve();
+			await failFirst.promise;
+			throw new Error("warmup import failed");
+		}, { stateDir, waitMs: 1 });
+		await firstStarted.promise;
+		const replacement = withDistServerImportWarmup(async () => {
+			replacementStarted = true;
+			return "recovered";
+		}, { stateDir, waitMs: 1 });
+
+		failFirst.resolve();
+		await assert.rejects(first, /warmup import failed/);
+		assert.equal(await replacement, "recovered");
+		assert.equal(replacementStarted, true);
+		assert.equal(existsSync(`${stateDir}.ready`), true);
+		assert.equal(existsSync(`${stateDir}.lock`), false);
+	});
+
+	it("atomically recovers an abandoned stale lock", async () => {
+		const stateDir = temporaryStateDir();
+		const lockPath = `${stateDir}.lock`;
+		mkdirSync(lockPath, { recursive: true });
+		const staleDate = new Date(Date.now() - 10_000);
+		utimesSync(lockPath, staleDate, staleDate);
+
+		const result = await withDistServerImportWarmup(async () => "recovered", {
+			stateDir,
+			staleMs: 5,
+			waitMs: 1,
+			timeoutMs: 500,
+		});
+
+		assert.equal(result, "recovered");
+		assert.equal(existsSync(`${stateDir}.ready`), true);
+		assert.equal(existsSync(lockPath), false);
+		assert.equal(
+			readFileSync(`${stateDir}.ready`, "utf8"),
+			"dist-server-imports-ready-v1\n",
+		);
+	});
+
+	it("keeps each harness import graph ordered behind the warmup barrier", () => {
+		for (const file of HARNESSES) {
+			const block = startupImportBlock(file);
+			assert.match(block, /withDistServerImportWarmup/, `${file} must use the first-writer barrier`);
+			const imports = [
+				"dist/server/bobbit-dir.js",
+				"dist/server/scaffold.js",
+				"dist/server/auth/token.js",
+				"dist/server/server.js",
+				"dist/server/agent/rpc-bridge.js",
+			];
+			let previous = -1;
+			for (const imported of imports) {
+				const position = block.indexOf(imported);
+				assert.ok(position > previous, `${file} must import ${imported} in canonical order`);
+				previous = position;
+			}
+			assert.doesNotMatch(block, /Promise\.all/, `${file} must keep shared-graph roots ordered`);
+		}
+	});
+});


### PR DESCRIPTION
## Summary

- replace the all-worker `dist/server` import lock with a first-worker warmup barrier, then release sibling workers to import concurrently from the completed Playwright transform cache
- reduce five spawned-gateway CRUD matrices from 84 tests to 10 retained full-stack smokes
- add cheaper fixture and DOM coverage for settings controls, delegate renderer registration, and goal status state
- keep reload, WebSocket, operator-authenticated policy, metadata, project provisioning, notification routing, gate persistence, and picker wiring coverage

## Impact

- CRUD journey cost: approximately 142 to 31 cumulative test-seconds
- five CRUD files: 84 to 10 tests
- complete browser inventory: 986 to 913 tests
- six-worker runs no longer hit the serialized import timeout or partial transform-cache failures

## Validation

- `npm run check`
- `npm run metrics:smoke`
- focused startup/DOM tests: 20 passed
- six-worker startup qualification: 7 passed
- focused retained CRUD and settings coverage passed retry-free
- full six-worker browser measurement completed in 350s with no startup/import failures; two unrelated existing flakes remained, and the one changed-test cleanup failure was fixed and rerun 2/2 green

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)
