### PR TITLE
Upgrade Pi to 0.85.1 for GPT-6 Astra

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,6 @@
-FROM node:22-slim
+# Pi 0.85.1 requires Node >=22.19.0; pin the sandbox runtime so builds fail
+# closed instead of depending on a floating Node 22 tag.
+FROM node:22.19.0-slim
 
 # Install build tools, git, curl, gh CLI, ripgrep.
 #
@@ -52,7 +54,7 @@ RUN npx -y playwright@1.52.0 install-deps chromium 2>/dev/null \
 # detects its own pi-coding-agent version from node_modules and passes it in via
 # --build-arg PI_AGENT_VERSION=<host-version>; the ARG default below is only a
 # fallback for manual `docker build docker/` invocations.
-ARG PI_AGENT_VERSION=0.74.0
+ARG PI_AGENT_VERSION=0.85.1
 RUN npm install -g @earendil-works/pi-coding-agent@${PI_AGENT_VERSION} --no-audit --no-fund 2>/dev/null \
     && ln -sf $(npm root -g) /node_modules
 LABEL bobbit.pi-agent-version=${PI_AGENT_VERSION}
@@ -61,7 +63,7 @@ LABEL bobbit.pi-agent-version=${PI_AGENT_VERSION}
 # Must run as root (before USER node) to write to /usr/local/lib/node_modules/.
 RUN npm install -g typescript --no-audit --no-fund 2>/dev/null
 
-# Run as non-root user. node:22-slim includes a 'node' user (uid=1000).
+# Run as non-root user. node:22.19.0-slim includes a 'node' user (uid=1000).
 # This ensures files created in /workspace via bind mount are owned by uid=1000
 # on the host, matching typical developer user IDs.
 USER node

--- a/docker/README.md
+++ b/docker/README.md
@@ -14,7 +14,7 @@ The default image name `bobbit-agent` matches Bobbit's default `sandbox_image` c
 
 ## What's Included
 
-- **Node.js 20** (slim base) — runtime for the agent process
+- **Node.js 22.19.0** (slim base) — pinned to Pi's minimum supported runtime
 - **git** — version control operations
 - **curl** — HTTP requests
 - **gh CLI** — GitHub CLI for PR creation, issue management, etc.
@@ -53,7 +53,7 @@ docker volume rm bobbit-nm-cache-<hash> bobbit-npm-cache-<hash>
 The agent CLI (`@earendil-works/pi-coding-agent`) is installed **inside** the image — bind-mounting `node_modules` from a Windows/macOS host into a Linux container is ~20× slower than a native layer. The version is pinned to a build-arg and stamped onto the image as a `bobbit.pi-agent-version` label:
 
 ```dockerfile
-ARG PI_AGENT_VERSION=0.74.0
+ARG PI_AGENT_VERSION=0.85.1
 RUN npm install -g @earendil-works/pi-coding-agent@${PI_AGENT_VERSION} ...
 LABEL bobbit.pi-agent-version=${PI_AGENT_VERSION}
 ```
@@ -94,7 +94,7 @@ USER node
 To use a different base image (e.g. for a different Node.js version):
 
 ```dockerfile
-FROM node:22-slim
+FROM node:22.19.0-slim
 
 # Copy the same setup from the original Dockerfile...
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/docs/auto-retry.md
+++ b/docs/auto-retry.md
@@ -68,9 +68,9 @@ If a bounded retry budget is exhausted, the server clears the stale countdown wi
 
 ## Pi internal retry events
 
-Current Pi runtimes, including the selected `0.84.1` line, can emit `agent_end` with `willRetry: true` before its own retry loop has produced the final turn outcome. Bobbit treats that event as non-final: the session stays streaming, one-time tool grants remain active, queued prompts are not drained, and `waitForIdle()` keeps waiting. A later `agent_end` where `willRetry !== true` completes terminal turn bookkeeping, but next-turn dispatch remains fenced until Pi emits `agent_settled` after clearing its active-run guard.
+Current Pi runtimes, including the selected `0.85.1` line, can emit `agent_end` with `willRetry: true` before its own retry loop has produced the final turn outcome. Bobbit treats that event as non-final: the session stays streaming, one-time tool grants remain active, queued prompts are not drained, and `waitForIdle()` keeps waiting. A later `agent_end` where `willRetry !== true` completes terminal turn bookkeeping, but next-turn dispatch remains fenced until Pi emits `agent_settled` after clearing its active-run guard.
 
-This keeps Pi's internal retry attempts from looking like separate user-visible turns and prevents a final terminal event from opening a prompt window during Pi's post-run processing. The retry contract is pinned by `tests2/core/pi-rpc-agent-end-retry.test.ts`; the settlement fence is pinned by `tests2/core/reliable-compaction-release.test.ts`.
+This keeps Pi's internal retry attempts from looking like separate user-visible turns and prevents a final terminal event from opening a prompt window during Pi's post-run processing. The retry contract is pinned by `tests/unit/core/pi-rpc-agent-end-retry.unit.test.ts`; the settlement fence is pinned by `tests/unit/core/reliable-compaction-release.unit.test.ts`.
 
 ## Dispatch-time prompt failures
 
@@ -135,11 +135,11 @@ See [Auto-Nudge Recovery for Errored Team Leads](design/auto-nudge-stuck-team-le
 
 Relevant coverage runs under `npm run test:unit` unless noted:
 
-- `tests2/core/auto-retry-policy.test.ts` covers provider overload, generic unexpected retries at 1 s / 5 s / 60 s, retry exhaustion, deterministic exclusions, and `fetch failed` message-end scheduling.
-- `tests2/core/session-manager-direct-prompt-lifecycle.test.ts` covers direct and queued `fetch failed` delivery failures before `message_end`, recovered queue rows, client-visible `auto_retry_pending`, `auto_retry_cancelled` on exhaustion/cancellation, no duplicate replay, fresh-prompt supersession, and stale tool-call-state clearing.
-- `tests2/core/verification-logic.test.ts` and `tests2/core/transient-review-error.test.ts` cover `fetch failed`, undici transport codes, deterministic exclusions, and `shouldRetryVerificationStep()` behavior.
-- `tests2/core/verification-verifier-lifecycle-repro.test.ts` covers verifier use of same-session auto-retry for retryable `agent-qa` fetch failures.
-- `tests2/core/team-manager-idle-nudge-backoff.test.ts` covers no-start auto-nudge accounting and errored-idle recovery: retryable errors use `retryLastPrompt(..., { auto: true })`, unknown/non-retryable/exhausted errors suppress team nudges, and repeated timer ticks do not emit duplicate `[AUTO-NUDGE]` cards.
-- `tests2/core/team-manager.test.ts` covers worker-idle notification recovery for errored idle team leads.
-- `tests2/dom/queue-dispatch.test.ts` covers queue-level cancellation and retry/unstick invariants.
-- `tests/e2e/ui/auto-retry-banner.spec.ts` covers the UI banner state for `auto_retry_pending`, `auto_retry_cancelled`, and `agent_start`.
+- `tests/unit/core/auto-retry-policy.unit.test.ts` covers provider overload, generic unexpected retries at 1 s / 5 s / 60 s, retry exhaustion, deterministic exclusions, and `fetch failed` message-end scheduling.
+- `tests/unit/core/session-manager-direct-prompt-lifecycle.unit.test.ts` covers direct and queued `fetch failed` delivery failures before `message_end`, recovered queue rows, client-visible `auto_retry_pending`, `auto_retry_cancelled` on exhaustion/cancellation, no duplicate replay, fresh-prompt supersession, and stale tool-call-state clearing.
+- `tests/unit/core/verification-logic.unit.test.ts` and `tests/unit/core/transient-review-error.unit.test.ts` cover `fetch failed`, undici transport codes, deterministic exclusions, and `shouldRetryVerificationStep()` behavior.
+- `tests/unit/core/verification-verifier-lifecycle-repro.unit.test.ts` covers verifier use of same-session auto-retry for retryable `agent-qa` fetch failures.
+- `tests/unit/core/team-manager-idle-nudge-backoff.unit.test.ts` covers no-start auto-nudge accounting and errored-idle recovery: retryable errors use `retryLastPrompt(..., { auto: true })`, unknown/non-retryable/exhausted errors suppress team nudges, and repeated timer ticks do not emit duplicate `[AUTO-NUDGE]` cards.
+- `tests/unit/core/team-manager-worker-idle-debounce.unit.test.ts` covers worker-idle notification recovery for errored idle team leads.
+- `tests/dom/queue-dispatch.dom.test.ts` covers queue-level cancellation and retry/unstick invariants.
+- `tests/browser/journeys/auto-retry-banner.journey.spec.ts` covers the UI banner state for `auto_retry_pending`, `auto_retry_cancelled`, and `agent_start`.

--- a/docs/compaction.md
+++ b/docs/compaction.md
@@ -32,6 +32,8 @@ upstream event's `reason` field:
 
 All paths end with a `compaction_end` event carrying `reason`, optional result and usage data, abort/failure signals, and `willRetry` when Pi will continue an interrupted overflow turn. The client maps `reason` to the summary card's `trigger` field.
 
+Pi `0.85.1` also emits `session_compact_failed` to installed coding-agent extension handlers, with the reason, error, abort/retry state, and whether an extension initiated the attempt. This is an additive Pi extension seam, not a second Bobbit client lifecycle. Bobbit continues to finish and publish compaction through `compaction_end` so queue release, cards, replay, and older clients retain one authority.
+
 ## Reliable-turn fence and release
 
 ### Admission stays open; dispatch is fenced
@@ -52,7 +54,7 @@ Input affinity depends on the compaction type:
 - during **threshold** or **overflow** compaction, steers target the continuing turn while prompts target the next turn; and
 - when Pi reports `willRetry: true`, only continuation steers may re-enter the interrupted turn. Next-turn work waits for `agent_settled` after the final `agent_end`.
 
-Pi's final `agent_end` is not a fresh-prompt admission boundary. In Pi `0.84.1`, it is emitted before the run's `finally` path clears `_isAgentRunActive`; threshold compaction and queued-continuation processing may still follow. Pi clears that guard immediately before `agent_settled`. Bobbit therefore uses the two events for different purposes:
+Pi's final `agent_end` is not a fresh-prompt admission boundary. In Pi `0.85.1`, it is emitted before the run's `finally` path clears `_isAgentRunActive`; threshold compaction and queued-continuation processing may still follow. Pi clears that guard immediately before `agent_settled`. Bobbit therefore uses the two events for different purposes:
 
 - final `agent_end` completes user-visible terminal bookkeeping, retargets undispatched continuation work, persists idle state, and resolves turn waiters;
 - `agent_settled` proves that Pi can start a fresh prompt, clears Bobbit's active-run admission fence, and owns the next-turn queue drain.
@@ -99,7 +101,7 @@ For a stable-ID prompt, Bobbit updates the already admitted durable row rather t
 
 ### Recoverable `length` overflow
 
-Pi `0.84.1` treats a recoverable assistant `stopReason: "length"` as context overflow: it removes the truncated assistant tail, compacts, and retries the interrupted input at most once. Bobbit mirrors Pi's canonical history rewrite without disabling live streaming:
+Pi `0.85.1` treats a recoverable assistant `stopReason: "length"` as context overflow: it removes the truncated assistant tail, compacts, and retries the interrupted input at most once. Bobbit mirrors Pi's canonical history rewrite without disabling live streaming:
 
 1. Bobbit assigns one `assistantStreamId` to the assistant start, reconstructed updates, and terminal event.
 2. The first `length` terminal remains provisional while Pi decides whether to recover.
@@ -185,7 +187,7 @@ uses a fixed id, `COMPACTION_ACTIVE_ID = "compact_active"` (exported from
 `compaction-result` cases both filter out any prior row with that id
 before appending. Lit then diffs to the same DOM node, repainting only
 the card body — there is never a plaintext `"Compacting context…"` row
-in the transcript. Pinned by `tests2/core/message-reducer.test.ts` and `tests2/dom/ui-fixtures/compaction-widget.test.ts`.
+in the transcript. Pinned by `tests/unit/core/message-reducer.unit.test.ts` and `tests/dom/ui-fixtures/compaction-widget.dom.test.ts`.
 
 ### Overflow `tokensBefore` resolution
 
@@ -199,7 +201,7 @@ priority order — first non-null wins:
 4. `this._lastKnownContextTokens` — last-seen live count, kept current
    as the in-progress payload is built.
 
-This means `reductionPct` resolves for overflow as well. Pinned by `tests2/core/compaction-types.test.ts` and the reducer coverage.
+This means `reductionPct` resolves for overflow as well. Pinned by `tests/unit/core/compaction-types.unit.test.ts` and the reducer coverage.
 
 `schemaVersion: 1` is reserved for forward compatibility — bump it if a
 future renderer adds fields that older snapshots cannot supply.
@@ -275,20 +277,19 @@ position. The richer in-place upgrade helpers
 removed when the sidecar landed; the sidecar splice supplies a real
 structured row instead of trying to reconstruct one from text.
 
-Reducer invariants are pinned in `tests2/core/message-reducer.test.ts` and `message-reducer-dedup.test.ts`, including in-place lifecycle transition, overflow payload propagation, and live-versus-sidecar deduplication.
+Reducer invariants are pinned in `tests/unit/core/message-reducer.unit.test.ts` and `tests/unit/core/message-reducer-dedup.unit.test.ts`, including in-place lifecycle transition, overflow payload propagation, and live-versus-sidecar deduplication.
 
 ## Tests
 
 Deterministic CI coverage uses named runtime barriers rather than timing sleeps:
 
-- `tests2/core/reliable-compaction-release.test.ts` pins admission fencing, deferred error-recovery payload identity, guarded rejection rollback, and the single release owner across manual, threshold, overflow, failure, and Stop outcomes.
-- `tests2/core/session-manager-force-abort-grace.test.ts` pins graceful settlement replay plus hard-Stop settlement synthesis and interrupted-compaction finalization.
-- `tests2/core/pi-installed-contract.test.ts` pins Pi event order, `willRetry`, direct-prompt rejection during compaction, recoverable-length tail removal, and the one-retry cap.
-- `tests2/core/assistant-stream-session-broadcast.test.ts` pins invalidation-before-release ordering and one invalidation for the first recoverable tail.
-- `tests2/integration/reliable-intent-recovery.test.ts` exercises held compaction boundaries and visible outbox continuity through failure and recovery.
-- `tests2/browser/journeys/reliable-agent-turns.journey.spec.ts` drives manual, threshold, overflow, Stop, reload, reconnect, and second-tab stories through the visible composer.
-- `tests2/dom/ui-fixtures/compaction-widget.test.ts`, `tests2/core/compaction-types.test.ts`, and `tests2/browser/e2e/pre-compaction-history.spec.ts` retain summary-card, payload, sidecar, affordance, and reload coverage.
-- `tests/manual-integration/reliable-agent-context-pressure.spec.ts` is the opt-in real Pi/real-model pressure smoke documented in [Pi runtime compatibility](pi-runtime-compatibility.md#real-model-context-pressure-smoke).
+- `tests/unit/core/reliable-compaction-release.unit.test.ts` pins admission fencing, deferred error-recovery payload identity, guarded rejection rollback, and the single release owner across manual, threshold, overflow, failure, and Stop outcomes.
+- `tests/unit/core/session-manager-force-abort-grace.unit.test.ts` pins graceful settlement replay plus hard-Stop settlement synthesis and interrupted-compaction finalization.
+- `tests/unit/core/pi-installed-contract.unit.test.ts` pins Pi event order, `willRetry`, the Pi 0.85 compaction-failure hook, direct-prompt rejection during compaction, recoverable-length tail removal, and the one-retry cap.
+- `tests/unit/core/assistant-stream-session-broadcast.unit.test.ts` pins invalidation-before-release ordering and one invalidation for the first recoverable tail.
+- `tests/integration/gateway/reliable-intent-recovery.gateway.test.ts` exercises held compaction boundaries and visible outbox continuity through failure and recovery.
+- `tests/browser/journeys/reliable-agent-turn-admission.journey.spec.ts` and `tests/browser/journeys/reliable-agent-turn-recovery.journey.spec.ts` drive manual, threshold, overflow, Stop, reload, reconnect, and second-tab stories through the visible composer.
+- `tests/dom/ui-fixtures/compaction-widget.dom.test.ts`, `tests/unit/core/compaction-types.unit.test.ts`, and `tests/e2e/browser/pre-compaction-history.browser-e2e.spec.ts` retain summary-card, payload, sidecar, affordance, and reload coverage.
 
 ## Files
 
@@ -302,11 +303,11 @@ Deterministic CI coverage uses named runtime barriers rather than timing sleeps:
 | Live card carries server `compactionId`; pre-compaction affordance + count-probe retry | `src/app/remote-agent.ts`, `src/ui/components/PreCompactionHistory.ts` |
 | Renderer (three states + adjacent layout + overflow pill) | `src/ui/tools/renderers/CompactionSummaryRenderer.ts` |
 | Renderer registration | `src/ui/tools/index.ts` — `__compaction_summary` |
-| Helper unit tests | `tests2/core/compaction-types.test.ts` |
-| Reducer unit tests | `tests2/core/message-reducer.test.ts`, `message-reducer-dedup.test.ts` |
-| Renderer lifecycle | `tests2/dom/ui-fixtures/compaction-widget.test.ts` |
-| Live sidecar/affordance browser E2E | `tests2/browser/e2e/pre-compaction-history.spec.ts` |
-| Compact-cost regressions | `tests2/integration/compact-cost-ws.test.ts`, `tests2/dom/context-cost-stats.test.ts` |
-| Reliable-turn compaction lifecycle | `tests2/core/reliable-compaction-release.test.ts`, `tests2/integration/reliable-intent-recovery.test.ts`, `tests2/browser/journeys/reliable-agent-turns.journey.spec.ts` |
+| Helper unit tests | `tests/unit/core/compaction-types.unit.test.ts` |
+| Reducer unit tests | `tests/unit/core/message-reducer.unit.test.ts`, `tests/unit/core/message-reducer-dedup.unit.test.ts` |
+| Renderer lifecycle | `tests/dom/ui-fixtures/compaction-widget.dom.test.ts` |
+| Live sidecar/affordance browser E2E | `tests/e2e/browser/pre-compaction-history.browser-e2e.spec.ts` |
+| Compact-cost regressions | `tests/integration/gateway/compact-cost-ws.gateway.test.ts`, `tests/dom/context-cost-stats.dom.test.ts` |
+| Reliable-turn compaction lifecycle | `tests/unit/core/reliable-compaction-release.unit.test.ts`, `tests/integration/gateway/reliable-intent-recovery.gateway.test.ts`, `tests/browser/journeys/reliable-agent-turn-admission.journey.spec.ts`, `tests/browser/journeys/reliable-agent-turn-recovery.journey.spec.ts` |
 | Mock agent compaction event emission | `tests/e2e/mock-agent-core.mjs` |
 | Full design rationale | `docs/design/compaction-e2e-rich-summary.md` |

--- a/docs/dev-workflow.md
+++ b/docs/dev-workflow.md
@@ -136,11 +136,12 @@ packages missing.
 
 **Why it bricks direct spawns**: automatic direct host-side agent and verification
 spawns resolve Bobbit's installed `@earendil-works/pi-coding-agent` package in place
-using Node's normal package-resolution semantics. Resolution verifies both the resolved
-package entry and its derived `dist/cli.js`, so a missing **or partial** installation fails
-with guidance to install the package or supply an explicit `--agent-cli` path. An explicit
-CLI override remains first choice. Docker spawns are not exposed because the sandbox image
-contains its own Pi runtime and does not bind-mount host `node_modules` for it.
+using Node's normal package-resolution semantics. Pi `0.85.1` declares its bundled CLI at
+`dist/bundle/cli.js` and requires Node.js `>=22.19.0`; resolution verifies both the package
+entry and that declared CLI, so a missing **or partial** installation fails with guidance
+to install the package or supply an explicit `--agent-cli` path. An explicit CLI override
+remains first choice. Docker spawns are not exposed because the sandbox image contains its
+own version-matched Pi runtime and does not bind-mount host `node_modules` for it.
 
 **Current policy**: the runtime ring-fence and automatic dependency healing are
 retired on every platform. The `dev:harness`, `dev:nord`, and `dev:watchdog` wrappers

--- a/docs/pi-runtime-compatibility.md
+++ b/docs/pi-runtime-compatibility.md
@@ -4,31 +4,91 @@ Bobbit depends on Pi for provider metadata, browser-side first-message streaming
 
 This page records the durable Bobbit-side contracts added or reaffirmed across Pi runtime upgrades. The current runtime line pins these packages exactly and together:
 
-- `@earendil-works/pi-agent-core@0.84.1`
-- `@earendil-works/pi-ai@0.84.1`
-- `@earendil-works/pi-coding-agent@0.84.1`
+- `@earendil-works/pi-agent-core@0.85.1`
+- `@earendil-works/pi-ai@0.85.1`
+- `@earendil-works/pi-coding-agent@0.85.1`
 
-A mixed Pi line can compile while still breaking the spawned-agent runtime contract.
+A mixed Pi line can compile while still breaking the spawned-agent runtime contract. Pi `0.85.1` also requires Node.js `>=22.19.0`; Bobbit declares that same floor, uses compliant CI and packed-consumer runtimes, and pins the sandbox image to Node `22.19.0` so an older runtime fails before an agent session starts.
 
-## Pi `0.84.1` reliable-turn compatibility
+The coding-agent package declares its CLI at `dist/bundle/cli.js` and its RPC entry at `dist/bundle/rpc-entry.js`. Automatic direct-host resolution and Docker execution use that declared bundled layout. An explicit `--agent-cli` or `cliPath` remains authoritative and bypasses automatic package resolution, which preserves custom runtime testing and recovery.
 
-Bobbit upgraded the trio together from `0.82.1` to the newest compatible stable release containing Pi `0.84.0`'s reliable-turn fixes. The source/release audit covered the upstream changes that:
+<!-- Compatibility anchor retained for historical design links. -->
+<a id="pi-0841-reliable-turn-compatibility"></a>
 
-- flush prompts accepted while compaction is active;
-- serialize manual and automatic compaction and preserve events across compaction;
-- reject direct prompt submission inside Pi core while manual compaction is active;
-- classify recoverable `length` stops as overflow, remove the truncated assistant tail, compact, and retry once; and
-- change JSON/RPC `message_update` to delta-only payloads.
+## Pi `0.85.1` Astra and reliable-turn compatibility
 
-Bobbit adopts those Pi contracts rather than recreating Pi's internal retry or compaction queues. Bobbit's own responsibility is the durable browser/server outbox above the Pi boundary: it accepts and persists user intent while Pi cannot accept direct input, then releases it at the correct lifecycle boundary.
+Pi `0.85.1` retains the reliable-turn contracts introduced on the `0.84.x` line and adds GPT-6 Astra plus additive JSON/RPC fields. Bobbit adopts those Pi contracts rather than recreating Pi's model catalog, transport, retry, or compaction queues. Bobbit's responsibility is the durable browser/server boundary above Pi: select and persist exact model tuples, normalize Pi's delta stream, and accept user intent while Pi cannot accept direct input.
+
+### Catalog authority and GPT-6 Astra
+
+Pi's built-in catalog is authoritative for `openai-codex/gpt-6-astra`. Bobbit spreads that row unchanged into `/api/models`; it does not add an Astra provider, duplicate the row, infer capabilities from the name, or override Pi's route. The exact Pi `0.85.1` row is:
+
+```ts
+{
+  id: "gpt-6-astra",
+  name: "GPT-6 Astra",
+  provider: "openai-codex",
+  api: "openai-codex-responses",
+  baseUrl: "https://chatgpt.com/backend-api",
+  reasoning: true,
+  input: ["text", "image"],
+  contextWindow: 272_000,
+  maxTokens: 128_000,
+  cost: {
+    input: 10,
+    output: 50,
+    cacheRead: 1,
+    cacheWrite: 12.5,
+    tiers: [{
+      inputTokensAbove: 272_000,
+      input: 20,
+      output: 75,
+      cacheRead: 2,
+      cacheWrite: 25,
+    }],
+  },
+  thinkingLevelMap: {
+    off: null,
+    minimal: "low",
+    low: "low",
+    medium: "medium",
+    high: "high",
+    xhigh: "xhigh",
+    max: "max",
+  },
+  compat: {
+    supportsOpenAIGrammarTools: true,
+    supportsAdditionalTools: true,
+    supportsToolSearch: true,
+  },
+}
+```
+
+Bobbit adds only its existing presentation fields. `authenticated` reflects the existing OpenAI Codex credential path. `modelCapacity: 1_050_000` is a display-only fact from [OpenAI's exact Astra model page](https://developers.openai.com/api/docs/models/gpt-6-astra.md). It is emitted only for the exact provider/model tuple when Pi still reports `contextWindow: 272_000`; if that guard becomes stale, Bobbit omits the capacity instead of guessing. Pi's 272,000-token value remains the operating, pricing-tier, and compaction target, while the 1,050,000-token value only lets the UI distinguish physical capacity from that target.
+
+Astra's explicit `off: null` means Off is unsupported. Bobbit's upward-first clamp turns an Off request into effective Minimal, while Max remains Max. Tool compatibility flags remain metadata; they do not add asynchronous tool calling or another Bobbit tool lifecycle.
+
+### Codex OAuth, selection, and persistence
+
+Astra uses the existing account-backed Codex flow:
+
+1. `POST /api/oauth/start` with `provider: "openai-codex"` delegates login to Pi's built-in `Models.login("openai-codex", "oauth", interaction)` contract.
+2. Pi writes the provider-scoped credential to the active agent directory's `auth.json`; Bobbit clears its OAuth/model caches without exposing token material.
+3. `/api/models` marks Pi's Astra row authenticated and the existing catalog filters make it session-selectable.
+4. `set_model` validates the exact provider/model, clamps thinking, applies both settings, and verifies runtime read-back.
+5. Only the verified `{ modelProvider, modelId, effectiveThinkingLevel }` tuple is persisted. Reconnect, browser reload, gateway restart, and process respawn revalidate and reuse it.
+
+This is why Astra needs no special session state or auth cache. Requested Off is never persisted as though it succeeded; the verified Minimal result is. See [REST API — Models](rest-api.md#models), [REST API — OAuth](rest-api.md#oauth), and [WebSocket protocol — Model and thinking selection](websocket-protocol.md#model-and-thinking-selection).
 
 ### Delta-only RPC and terminal authority
 
-Pi `0.84.1` JSON/RPC `message_update` frames contain `assistantMessageEvent` deltas but no cumulative `message` and no `assistantMessageEvent.partial`. `RpcBridge` scopes one `PiAssistantStreamNormalizer` to each Pi process and reconstructs Bobbit's cumulative internal update stream from the preceding assistant `message_start.message`.
+Pi `0.85.1` JSON/RPC `message_update` frames remain delta-only: they contain `assistantMessageEvent` but no cumulative `message` or `assistantMessageEvent.partial`. They now also carry cumulative `usage` at the top level, and `toolcall_start` carries the exact `id` and `toolName`.
+
+`RpcBridge` scopes one `PiAssistantStreamNormalizer` to each Pi process and reconstructs Bobbit's cumulative internal update stream from the preceding assistant `message_start.message`. The normalizer copies authoritative object-valued usage into reconstructed `message.usage`, seeds progressive tool blocks from the start event's identity, and retains conservative empty identity fallbacks for older or custom frames. The same usage rule applies when the browser expands a negotiated compact frame, so legacy cumulative clients and compact clients converge on the same message.
 
 The adapter handles text, thinking, and progressive tool-call JSON. It tolerates a delta arriving without its matching start only when an authoritative message-start baseline exists. It resets on a new assistant start, `message_end`, final `agent_end`, process exit, or process failure.
 
-`message_end.message` is terminal authority. Bobbit passes that provider/Pi terminal through the normal metadata projection; it never synthesizes the final answer from accumulated deltas. After a terminal reset, a stray delta cannot inherit the previous stream.
+`message_end.message` remains terminal authority. Bobbit passes that provider/Pi terminal through the normal metadata projection; it never synthesizes the final answer from accumulated deltas. After a terminal reset, a stray delta cannot inherit the previous stream.
 
 The Pi bridge normalization and browser transport compaction are separate layers:
 
@@ -42,9 +102,11 @@ A failed browser reconstruction closes/reconnects instead of presenting a plausi
 
 Pi emits `compaction_start` before compaction and `compaction_end` after releasing its compaction controller. Direct prompt submission during manual compaction is expected to reject inside Pi; Bobbit therefore queues above that boundary and does not call Pi while `session.isCompacting`.
 
+Pi `0.85.1` additionally emits the extension hook `session_compact_failed` with the reason, error message, abort/retry state, and whether an extension initiated the attempt. Bobbit pins that installed-runtime seam but does not introduce a second public compaction lifecycle: `compaction_end` and the existing settlement rules remain the gateway/browser boundary.
+
 `compaction_end.willRetry` describes the interrupted agent turn, not another compaction operation. Bobbit completes the compaction boundary and preserves continuation affinity while waiting for the final non-retry `agent_end`.
 
-Pi `0.84.1` emits that final `agent_end` before clearing its active-run guard. The event completes Bobbit's terminal turn bookkeeping, but it does not admit a fresh prompt. Pi may still compact or process queued continuation work before `_emitAgentSettled()` clears the guard and emits `agent_settled`; Bobbit drains next-turn work only at that later boundary. Graceful Stop waits for and replays settlement, while hard Stop synthesizes it after killing the old process and marks interrupted compaction aborted. See [Context compaction](compaction.md#reliable-turn-fence-and-release).
+Pi emits that final `agent_end` before clearing its active-run guard. The event completes Bobbit's terminal turn bookkeeping, but it does not admit a fresh prompt. Pi may still compact or process queued continuation work before `_emitAgentSettled()` clears the guard and emits `agent_settled`; Bobbit drains next-turn work only at that later boundary. Graceful Stop waits for and replays settlement, while hard Stop synthesizes it after killing the old process and marks interrupted compaction aborted. See [Context compaction](compaction.md#reliable-turn-fence-and-release).
 
 For a recoverable assistant `stopReason: "length"`, Pi removes the first truncated tail, performs overflow compaction, and retries the input at most once. Bobbit assigns `assistantStreamId` values and emits `assistant_stream_invalidated` before retry output so the browser and snapshots mirror Pi's rewritten branch. Only the retry's final non-retrying terminal is canonical. See [Context compaction](compaction.md#recoverable-length-overflow).
 
@@ -54,11 +116,31 @@ Pi's `Agent.steer()` acknowledgement means the steer entered Pi's pending queue;
 
 ### TypeBox v1 boundary
 
-Pi `0.84.1` uses TypeBox v1. Bobbit pins `typebox@1.3.7` and migrates Pi-facing tool schemas and generated extension templates to `Type`/`Static` from `typebox`, avoiding incompatible v0/v1 `TSchema` values. `@sinclair/typebox` remains installed for unrelated legacy consumers; do not pass its schema objects into Pi v1 APIs.
+Pi `0.85.1` uses TypeBox v1. Bobbit pins `typebox@1.3.7` and uses `Type`/`Static` from `typebox` for Pi-facing tool schemas and generated extension templates, avoiding incompatible v0/v1 `TSchema` values. `@sinclair/typebox` remains installed for unrelated legacy consumers; do not pass its schema objects into Pi v1 APIs.
 
 ### Pinning coverage
 
-`tests2/core/pi-installed-contract.test.ts` executes the installed runtime to pin the aligned trio, delta-only event shape, terminal authority, manual-compaction ordering and prompt rejection, recoverable-length removal and one-retry cap, overflow `willRetry`, and steer queue acknowledgement boundary. `tests2/core/assistant-stream-delta.test.ts`, `assistant-stream-session-broadcast.test.ts`, and `tests2/dom/remote-agent-assistant-stream-delta.test.ts` pin bridge reconstruction and browser live/replay behavior.
+Credential-free tests use isolated fake Codex account state and never inspect or require a real token:
+
+- `tests/unit/core/pi-installed-contract.unit.test.ts` executes the installed runtime to pin the aligned trio, Node floor, declared bundle entries, 0.85 stream fields, compaction failure hook, terminal authority, manual-compaction rejection, recoverable-length retry, settlement, and steer acknowledgement.
+- `tests/unit/core/models-api.unit.test.ts`, `model-utils.unit.test.ts`, and `thinking-levels.unit.test.ts` pin the exact Astra row, presentation-only capacity, selectability, Off-to-Minimal clamp, and Max support.
+- `tests/unit/core/assistant-stream-delta.unit.test.ts` and `assistant-stream-session-broadcast.unit.test.ts` pin cumulative usage, tool-start identity, old-frame fallback, and compact/cumulative convergence.
+- `tests/integration/gateway/agent/astra-session-persistence.gateway.test.ts` pins the verified effective tuple through reconnect.
+- `tests/browser/journeys/astra-session-selection.journey.spec.ts` selects authenticated Astra, proves Off is absent and Max is present, then verifies reload and gateway-restart persistence.
+- `tests/e2e/browser/packaged-inline-html-theme.browser-e2e.spec.ts` verifies the packed consumer's Node floor and declared `dist/bundle/cli.js` entry.
+
+### Live Astra canary
+
+Automated qualification is intentionally credential-free and does not prove account entitlement. **The live Astra check is blocked in a credential-free environment until an operator supplies an existing Codex OAuth login with Astra entitlement; no credential or entitlement was inspected for this documentation update.** When suitable access is available, run the opt-in bash-tool canary against the isolated manual harness:
+
+```bash
+BOBBIT_MANUAL_INHERIT_SERVER_CONFIG=1 \
+MANUAL_TEST_MODEL=openai-codex/gpt-6-astra \
+MANUAL_TEST_THINKING_LEVEL=max \
+npm run test:manual -- --grep "1\\. bash tool"
+```
+
+The canary must select the exact provider/model, complete a turn at Max, and execute the bash tool. Do not copy, print, inspect, or add credentials to fixtures. If the current agent directory has no usable Codex credential, the account lacks Astra entitlement, or the environment cannot reach the provider, record the live check as **blocked** with only the non-secret reason and the command above; do not treat a skip or a different model as Astra evidence. When available, also run a representative authenticated Anthropic or Google turn to confirm the upgrade did not disturb a non-OpenAI provider.
 
 ## Historical Pi `0.82.1` compatibility outcome
 
@@ -184,7 +266,7 @@ The PR #1057 focused canaries covered:
 
 The PR #1057 browser journey selected `anthropic/claude-opus-5`, verified its authoritative limits, image/reasoning flags and complete thinking ladder, sent the combined `xhigh` tuple through a mock-backed session, reloaded and re-verified authoritative state, then deleted the session and restored preferences.
 
-## Pi `0.82.1` dependency-only Phase 0 baseline
+## Historical Pi `0.82.1` dependency-only Phase 0 baseline
 
 The dependency-only baseline was measured on 2026-07-27 before any feature production or test change.
 
@@ -490,9 +572,11 @@ Worktree setup commands are non-fatal, but timeout handling must still wait unti
 
 The reason is operational rather than cosmetic: a worktree that appears claimable while setup children still hold handles can fail later move, cleanup, or reuse operations. The regression is pinned by the worktree-pool tests.
 
-## Real-model context-pressure smoke
+## Historical Pi `0.82.1` real-model context-pressure smoke
 
-`tests/manual-integration/reliable-agent-context-pressure.spec.ts` is an opt-in real Pi/real-model test of exact-once prompt and steer delivery through genuine automatic context pressure. Deterministic mock-Pi coverage remains the CI gate; this smoke validates the installed provider/runtime path when credentials and budget are available.
+> Historical procedure: the test path and command below record the `0.82.1` qualification layout and are not the current Astra canary. Use [Live Astra canary](#live-astra-canary) for the selected runtime.
+
+`tests/manual-integration/reliable-agent-context-pressure.spec.ts` was an opt-in real Pi/real-model test of exact-once prompt and steer delivery through genuine automatic context pressure. Deterministic mock-Pi coverage remained the CI gate; this smoke validated the installed provider/runtime path when credentials and budget were available.
 
 ### Credentials and model selection
 
@@ -549,9 +633,11 @@ The test observes a real threshold or overflow compaction start, then submits on
 
 Failure output contains bounded IDs, counters, state, and lifecycle summaries, not prompt or provider bodies. The `finally` path aborts the turn, purges the session best-effort, stops the isolated gateway, and removes the temporary fixture even on budget failure.
 
-## Upgrade verification
+## Historical Pi `0.82.1` upgrade verification
 
-Run focused contract coverage before the broad gates:
+> Historical procedure: these paths and commands preserve the `0.82.1` qualification record. They are not current test entrypoints; current `0.85.1` coverage is listed under [Pinning coverage](#pinning-coverage).
+
+The `0.82.1` delivery ran focused contract coverage before the broad gates:
 
 ```bash
 npx vitest run --config vitest.config.ts --project v2-core \

--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -1650,9 +1650,54 @@ interface AgentDirApiState {
 
 `GET /api/models` returns the current Bobbit session catalog. Each `ApiModel` includes provider, ID, API, `contextWindow` as the runtime-authoritative context target, output limits, input modes, reasoning capability, authentication state, and `cost` in Pi's per-million-token shape: `{ input, output, cacheRead, cacheWrite }`; optional fields include `modelCapacity`, `baseUrl`, `thinkingLevelMap`, `compat`, `sessionSelectable`, `upstreamProvider`, and tiered `cost.tiers[]`. When present, `modelCapacity` is the provider-published hard request capacity for display only. Bobbit emits it only from exact catalog metadata matching the provider, model ID, and `contextWindow`; a mismatch omits it rather than inferring a capacity, and it never changes `contextWindow` compaction behavior. See [Context target and model capacity](internals.md#context-target-and-model-capacity) for ownership and fallback semantics.
 
-#### Pi 0.84.1 Claude Opus 5 catalog
+#### Pi 0.85.1 GPT-6 Astra catalog
 
-Pi's published `0.84.1` catalog is authoritative for the direct Anthropic row and all five supported Amazon Bedrock profiles:
+Pi's published row is the authority for `openai-codex/gpt-6-astra`. After OpenAI account authentication, `/api/models` returns that row once with `authenticated: true` and the existing selection rules make it session-selectable:
+
+```ts
+{
+  id: "gpt-6-astra",
+  name: "GPT-6 Astra",
+  provider: "openai-codex",
+  api: "openai-codex-responses",
+  baseUrl: "https://chatgpt.com/backend-api",
+  reasoning: true,
+  input: ["text", "image"],
+  contextWindow: 272_000,
+  maxTokens: 128_000,
+  cost: {
+    input: 10,
+    output: 50,
+    cacheRead: 1,
+    cacheWrite: 12.5,
+    tiers: [{ inputTokensAbove: 272_000, input: 20, output: 75, cacheRead: 2, cacheWrite: 25 }],
+  },
+  thinkingLevelMap: {
+    off: null,
+    minimal: "low",
+    low: "low",
+    medium: "medium",
+    high: "high",
+    xhigh: "xhigh",
+    max: "max",
+  },
+  compat: {
+    supportsOpenAIGrammarTools: true,
+    supportsAdditionalTools: true,
+    supportsToolSearch: true,
+  },
+  authenticated: true,
+  modelCapacity: 1_050_000,
+}
+```
+
+All fields except `authenticated` and `modelCapacity` come directly from Pi and remain unmodified. Authentication uses the existing provider-scoped Codex OAuth row. `modelCapacity` is an exact, display-only fact from [OpenAI's Astra documentation](https://developers.openai.com/api/docs/models/gpt-6-astra.md); Bobbit emits it only while the exact provider/model row still has Pi's 272,000-token context target. The capacity does not change selection, pricing, compaction, or Pi's operating context. Because Pi explicitly maps `off` to `null`, Off is not selectable for Astra and a requested Off level clamps to Minimal; Max remains available.
+
+Selection and persistence remain generic: `set_model` validates and applies the exact row, verifies provider/model/thinking read-back, and only then persists `{ modelProvider, modelId, effectiveThinkingLevel }`. Reload, reconnect, and restart reuse that verified tuple rather than choosing an Astra-specific fallback. See [Pi `0.85.1` Astra compatibility](pi-runtime-compatibility.md#pi-0851-astra-and-reliable-turn-compatibility).
+
+#### Pi 0.85.1 Claude Opus 5 catalog
+
+Pi's published `0.85.1` catalog is authoritative for the direct Anthropic row and all five supported Amazon Bedrock profiles:
 
 | Exact provider/model | Published name | API | Base URL | Cost `{input, output, cacheRead, cacheWrite}` |
 |---|---|---|---|---|
@@ -1663,7 +1708,7 @@ Pi's published `0.84.1` catalog is authoritative for the direct Anthropic row an
 | `amazon-bedrock/jp.anthropic.claude-opus-5` | Claude Opus 5 (JP) | `bedrock-converse-stream` | `https://bedrock-runtime.us-east-1.amazonaws.com` | `{5, 25, 0.5, 6.25}` |
 | `amazon-bedrock/us.anthropic.claude-opus-5` | Claude Opus 5 (US) | `bedrock-converse-stream` | `https://bedrock-runtime.us-east-1.amazonaws.com` | `{5, 25, 0.5, 6.25}` |
 
-All six rows have a 1,000,000-token context window, 128,000-token output limit, `reasoning: true`, `input: ["text", "image"]`, and `thinkingLevelMap: { xhigh: "xhigh", max: "max" }`. Combined with the ordinary provider defaults, this exposes `off`, `minimal`, `low`, `medium`, `high`, `xhigh`, and `max`; the effective level is clamped against the exact selected row. Only the direct Anthropic row publishes `compat: { forceAdaptiveThinking: true, supportsTemperature: false, supportsStrictTools: true }`. The Bedrock rows have no model-level `compat`, so Bobbit does not invent one; Pi's Bedrock adapter owns their adaptive-thinking behavior. See [Pi `0.84.1` reliable-turn compatibility](pi-runtime-compatibility.md#pi-0841-reliable-turn-compatibility) for the selected runtime contract.
+All six rows have a 1,000,000-token context window, 128,000-token output limit, `reasoning: true`, and `input: ["text", "image"]`. The direct Anthropic row publishes `thinkingLevelMap: { off: null, xhigh: "xhigh", max: "max" }`, so its supported ladder starts at Minimal, and `compat: { supportsMidConvoEffort: true, forceAdaptiveThinking: true, supportsTemperature: false, supportsStrictTools: true }`. The Bedrock rows publish `thinkingLevelMap: { xhigh: "xhigh", max: "max" }` and no model-level `compat`; Bobbit preserves those exact upstream differences rather than inventing common metadata.
 
 Bobbit omits the exact deferred provider `kimi-coding` from `/api/models` and `/api/pi-ai/providers`, and Bobbit-owned default, role, and session-selection paths reject that provider without changing durable state. This is an exact provider-identity boundary, not a model-ID filter: Kimi-named IDs remain valid under a session-selectable AIGW, custom/local, Moonshot, or legacy gateway provider.
 
@@ -1756,9 +1801,11 @@ validation, token exchange, and refresh contract. Google OAuth is implemented na
 with PKCE and feeds the Code Assist provider extension; authenticated account models are
 available for normal session selection. OpenAI Codex constructs Pi's `Models` service with
 `builtinModels()` and calls `Models.login("openai-codex", "oauth", interaction)` using an
-`AuthInteraction`. Bobbit does not use Pi's removed `getOAuthProvider` or
-`OAuthLoginCallbacks` contracts. See [Anthropic OAuth](anthropic-oauth.md) and
-[Pi runtime compatibility](pi-runtime-compatibility.md#openai-codex-oauth-migration).
+`AuthInteraction`. The resulting provider-scoped `auth.json` row authenticates Pi's exact Codex
+catalog, including `openai-codex/gpt-6-astra`; Bobbit does not create a separate Astra credential
+or provider. Bobbit does not use Pi's removed `getOAuthProvider` or `OAuthLoginCallbacks`
+contracts. See [Anthropic OAuth](anthropic-oauth.md) and
+[Pi runtime compatibility](pi-runtime-compatibility.md#codex-oauth-selection-and-persistence).
 
 **`GET /api/oauth/status?provider=<id>`** responses:
 

--- a/docs/testing-v2/node-modules-corruption-rca.md
+++ b/docs/testing-v2/node-modules-corruption-rca.md
@@ -69,8 +69,9 @@ runtime tree or conceal a damaged installation.
 The running gateway resolves the pi-coding-agent runtime from **its own install** for
 **every** automatic direct (non-sandbox) agent and verification spawn. The direct-host
 runtime resolver delegates package lookup to `import.meta.resolve`, converts the resolved
-entry URL to a filesystem path, derives the package's `node_modules` root and `dist/cli.js`,
-and verifies that both the resolved entry and derived CLI exist. This preserves Node's
+entry URL to a filesystem path, derives the package's `node_modules` root and Pi `0.85.1`'s
+declared `dist/bundle/cli.js`, and verifies that both the resolved entry and bundled CLI exist.
+This preserves Node's
 package and subpath semantics while turning a partial installation into the same actionable
 failure as a missing package. An explicit `--agent-cli` / `cliPath` override takes precedence
 and does not invoke automatic resolution or its availability checks.
@@ -340,9 +341,9 @@ mutation under live processes.
 
 Automatic direct host resolution uses Bobbit's installed
 `@earendil-works/pi-coding-agent` package in place through `import.meta.resolve`. It verifies
-the resolved entry and derived `dist/cli.js`; a missing or partial package produces actionable
-install or `--agent-cli` guidance. The explicit CLI override remains first choice and bypasses
-automatic resolution.
+the resolved entry and Pi's declared `dist/bundle/cli.js`; a missing or partial package produces
+actionable install or `--agent-cli` guidance. The explicit CLI override remains first choice and
+bypasses automatic resolution.
 
 The retired ring-fence previously copied or hardlinked the installed tree recursively into
 `<stateDir>/runtime`; on high-latency NFS that synchronous traversal could delay gateway port

--- a/docs/websocket-protocol.md
+++ b/docs/websocket-protocol.md
@@ -68,7 +68,7 @@ Overflow diagnostics include `outerType`, `innerType` for `{ type: "event" }` fr
 
 ## Cumulative assistant stream compaction
 
-Pi `0.84.1` JSON/RPC emits delta-only assistant `message_update` frames. `RpcBridge` first reconstructs Bobbit's cumulative internal event from the preceding assistant start, while preserving `message_end.message` as terminal authority. Repeating those growing cumulative copies to every browser would make WebSocket serialization and wire traffic grow with transcript length, so Bobbit compacts only the live browser projection for clients that negotiate it. Replay and snapshots remain cumulative and authoritative.
+Pi `0.85.1` JSON/RPC emits delta-only assistant `message_update` frames. Each update also carries authoritative cumulative top-level `usage`; `toolcall_start` includes its exact `id` and `toolName`. `RpcBridge` reconstructs Bobbit's cumulative internal event from the preceding assistant start, copies that usage into reconstructed message state, and seeds progressive tool identity at the start event, while preserving `message_end.message` as terminal authority. Repeating growing cumulative copies to every browser would make WebSocket serialization and wire traffic grow with transcript length, so Bobbit compacts only the live browser projection for clients that negotiate it. Replay and snapshots remain cumulative and authoritative.
 
 ### Negotiation and compatibility
 
@@ -92,7 +92,9 @@ Compatibility is fail-safe:
 - Equivalent capable recipients share compact-frame construction and serialization. Legacy and baseline-needing recipients remain separate output classes.
 - Updates are emitted immediately. There is no process-global timer that coalesces, replaces, or defers `message_update` delivery.
 
-The client reconstructs the cumulative `message` and `assistantMessageEvent.partial` before normal reducer processing. It keeps reconstruction state only for the active assistant stream and clears it on an explicit client reset, snapshot application, reconstruction failure, `process_exit`, `agent_end`, and `message_end`. Normal socket teardown does not clear that state: reconnect may continue the same logical stream through cumulative replay. Progressive tool JSON is rebuilt from fragments while preserving the useful parseable prefix. A replacement socket independently starts its compact live projection with a self-contained baseline. If exact reconstruction cannot be proven, the client clears the invalid state, discards the compact frame, and reconnects; cumulative replay or a snapshot remains the authoritative recovery path.
+The client reconstructs the cumulative `message` and `assistantMessageEvent.partial` before normal reducer processing. It applies the outer cumulative `usage` to both reconstructed objects and retains the `toolcall_start` identity while rebuilding progressive tool JSON from fragments. This keeps compact and cumulative clients convergent and prevents a stale start baseline from under-reporting usage or displaying a blank tool identity. Older/custom frames without those additive fields keep their conservative baseline behavior.
+
+The client keeps reconstruction state only for the active assistant stream and clears it on an explicit client reset, snapshot application, reconstruction failure, `process_exit`, `agent_end`, and `message_end`. Normal socket teardown does not clear that state: reconnect may continue the same logical stream through cumulative replay. A replacement socket independently starts its compact live projection with a self-contained baseline. If exact reconstruction cannot be proven, the client clears the invalid state, discards the compact frame, and reconnects; cumulative replay or a snapshot remains the authoritative recovery path.
 
 ### Sources of truth and replay
 
@@ -294,13 +296,16 @@ The optional field preserves compatibility with older clients. When it is
 absent, the gateway reuses the previous durable effective level when available,
 otherwise the current authoritative level, and clamps it against the exact new
 model. It does not infer `max`: that level is selectable only when the model's
-`thinkingLevelMap` explicitly contains a non-null `max` entry. Pi `0.84.1`'s
-direct Anthropic and supported Amazon Bedrock Opus 5 rows publish
-`{ xhigh: "xhigh", max: "max" }`, so both levels—and the ordinary
-`off` through `high` levels retained by the map rules—are available for those
-exact rows. Opus 4.8 publishes `xhigh` only. `max` is unavailable without an
-explicit map entry; `xhigh` may additionally come from the narrow map-less
-family fallbacks documented in the thinking-level guide.
+`thinkingLevelMap` explicitly contains a non-null `max` entry. Pi `0.85.1`'s
+`openai-codex/gpt-6-astra` row publishes `{ off: null, minimal: "low",
+low: "low", medium: "medium", high: "high", xhigh: "xhigh", max: "max" }`.
+Astra therefore exposes Minimal through Max; an Off request clamps upward to
+Minimal and Max remains Max. The direct Anthropic Opus 5 row likewise now marks
+Off unsupported and adds `supportsMidConvoEffort` to its Pi-owned compatibility
+metadata. Supported Bedrock Opus 5 rows retain their exact upstream maps. Opus
+4.8 publishes `xhigh` only. `max` is unavailable without an explicit map entry;
+`xhigh` may additionally come from the narrow map-less family fallbacks
+documented in the thinking-level guide.
 
 On success, the gateway:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -6368,6 +6368,7 @@
       "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-13.0.3.tgz",
       "integrity": "sha512-RbOBxmLBG8uvFUc15X9+9SFemKcQ0WBuISBVkpuiaUB2qblC8UWlHEjdWVoZ8AdhSwmoEgsiXKfopX0CQxaACQ==",
       "license": "MIT",
+      "gypfile": false,
       "dependencies": {
         "node-addon-api": "^8.0.0"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,9 @@
       "name": "@gresearch/bobbit",
       "version": "0.19.0",
       "dependencies": {
-        "@earendil-works/pi-agent-core": "0.84.1",
-        "@earendil-works/pi-ai": "0.84.1",
-        "@earendil-works/pi-coding-agent": "0.84.1",
+        "@earendil-works/pi-agent-core": "0.85.1",
+        "@earendil-works/pi-ai": "0.85.1",
+        "@earendil-works/pi-coding-agent": "0.85.1",
         "@homebridge/node-pty-prebuilt-multiarch": "^0.14.1",
         "@lmstudio/sdk": "^1.5.0",
         "@sinclair/typebox": "^0.34.41",
@@ -87,12 +87,13 @@
       }
     },
     "node_modules/@anthropic-ai/sdk": {
-      "version": "0.91.1",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.91.1.tgz",
-      "integrity": "sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw==",
+      "version": "0.123.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.123.0.tgz",
+      "integrity": "sha512-Y9oX9mPNGZClHQOFqrWRk43Srcu/UHuPq3rfxxOq7JgW0gi+lJA2MAOK4Ul3k/+AUrwRWFJvd0tK3oC0Pw25dw==",
       "license": "MIT",
       "dependencies": {
-        "json-schema-to-ts": "^3.1.1"
+        "json-schema-to-ts": "^3.1.1",
+        "standardwebhooks": "^1.0.0"
       },
       "bin": {
         "anthropic-ai-sdk": "bin/cli"
@@ -181,17 +182,17 @@
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.977.7",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.977.7.tgz",
-      "integrity": "sha512-I88Iov89NVmjSmJLKSv7Cn9M2J+a2942OkA8nZCbz+sl4ZeY4zEOcoLOrbt1GRfQ8zEQKnjAJdXixA3J/p1fDQ==",
+      "version": "3.977.9",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.977.9.tgz",
+      "integrity": "sha512-reqPFEQrZxDZpeGj4PFMepBeR5LGYHRqq/L0motTzgFkCRBA4rFdaVXDSLYyGHhxVz7sT2PDnPN9CluGSfgyJA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.974.3",
-        "@aws-sdk/xml-builder": "^3.972.38",
+        "@aws-sdk/types": "^3.974.5",
+        "@aws-sdk/xml-builder": "^3.972.40",
         "@aws/lambda-invoke-store": "^0.3.0",
-        "@smithy/core": "^3.31.1",
+        "@smithy/core": "^3.33.3",
         "@smithy/signature-v4": "^5.6.12",
-        "@smithy/types": "^4.16.1",
+        "@smithy/types": "^4.17.2",
         "bowser": "^2.11.0",
         "tslib": "^2.6.2"
       },
@@ -200,15 +201,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.972.68",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.68.tgz",
-      "integrity": "sha512-2a20A/IdNOwUvaDq91iqqS7BA0XlNMfW3iLGZGZLJv0EbUqhSxB0PIx4rQQqssvWj1uXImb3/UCCdHz/+1dOiA==",
+      "version": "3.972.70",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.70.tgz",
+      "integrity": "sha512-H404B7dJl2mCrBqahDEYsanB0xhdDp6tXnXcTUnXmmpy2Q3J0Ho0bUajZ2jr/RdwzCyS59Gi8xXIFwPLGBl6Uw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.7",
-        "@aws-sdk/types": "^3.974.3",
-        "@smithy/core": "^3.31.1",
-        "@smithy/types": "^4.16.1",
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -216,17 +217,17 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.972.70",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.70.tgz",
-      "integrity": "sha512-0yRem2Fs52r/Nn6UAqIlpjexfaYj8ziEozOe9tamtAVT/5bzFLKx8O2r7MaRqgS3hGKHIa1Jij9nKHSsNnb04A==",
+      "version": "3.972.72",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.72.tgz",
+      "integrity": "sha512-X98zYOrVOeuosCX+6ktf29FC2N2GHPLia7qv6mzPzTc+RPAuHWCDS++Z6JK7eGYqb/v6uaW7bAXaOvDBfol+0w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.7",
-        "@aws-sdk/types": "^3.974.3",
-        "@smithy/core": "^3.31.1",
-        "@smithy/fetch-http-handler": "^5.6.13",
-        "@smithy/node-http-handler": "^4.9.13",
-        "@smithy/types": "^4.16.1",
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/fetch-http-handler": "^5.7.2",
+        "@smithy/node-http-handler": "^4.11.3",
+        "@smithy/types": "^4.17.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -234,13 +235,13 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/node-http-handler": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.10.0.tgz",
-      "integrity": "sha512-nrh7VxqzPQS/ip1hS293aI/OAWDWARQvjUxCfuKhyrfHa2gTdk28066RNeWLI1uuoHXaKAkOF8IcSAHuOp0+SA==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.12.1.tgz",
+      "integrity": "sha512-ThMkboGeONWXAelq9FvGsuJC4rOi+qyC4/zhUF58xYpxUg5sQKx2VXZYJmtNjr4dSuBJ1HeJXETQILCz3wOHvw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.32.0",
-        "@smithy/types": "^4.17.0",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.18.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -248,23 +249,23 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.973.13",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.13.tgz",
-      "integrity": "sha512-2M39DE02XpYYaSWYk/4AsImXYUU/1L2xmTMLUpMMWq7DfLv191/vCRy3baKtdr45AkJQyVgSjmuVOLm15SwrRQ==",
+      "version": "3.973.15",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.15.tgz",
+      "integrity": "sha512-Rykg6s5ceBuynMOGWgoowO4N+27JfnqXAnVaSunZl0hOO1XodSrxGNz6sCEbnmS0lAfQZDKyb3fbr46gSuv6Sg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.7",
-        "@aws-sdk/credential-provider-env": "^3.972.68",
-        "@aws-sdk/credential-provider-http": "^3.972.70",
-        "@aws-sdk/credential-provider-login": "^3.972.75",
-        "@aws-sdk/credential-provider-process": "^3.972.68",
-        "@aws-sdk/credential-provider-sso": "^3.973.12",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.74",
-        "@aws-sdk/nested-clients": "^3.997.42",
-        "@aws-sdk/types": "^3.974.3",
-        "@smithy/core": "^3.31.1",
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/credential-provider-env": "^3.972.70",
+        "@aws-sdk/credential-provider-http": "^3.972.72",
+        "@aws-sdk/credential-provider-login": "^3.972.77",
+        "@aws-sdk/credential-provider-process": "^3.972.70",
+        "@aws-sdk/credential-provider-sso": "^3.973.14",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.76",
+        "@aws-sdk/nested-clients": "^3.997.44",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
         "@smithy/credential-provider-imds": "^4.4.16",
-        "@smithy/types": "^4.16.1",
+        "@smithy/types": "^4.17.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -272,16 +273,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-login": {
-      "version": "3.972.75",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.75.tgz",
-      "integrity": "sha512-jaTESuJlQsoUZ44f/i2puyPt8VlF/dMMJ9HM3cStYtk7eKX4N9UWi83OLixUkoOJH3BwWlPLCq9YIK9nfWhVBg==",
+      "version": "3.972.77",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.77.tgz",
+      "integrity": "sha512-Jb59xfEISoN5mmbnA+HYqdtrSX3CgCtJoof+V5D8/TgUI56W63GEEd5Y58WijU3Ou6+WEgaLD1feVzaRXV5IDQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.7",
-        "@aws-sdk/nested-clients": "^3.997.42",
-        "@aws-sdk/types": "^3.974.3",
-        "@smithy/core": "^3.31.1",
-        "@smithy/types": "^4.16.1",
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/nested-clients": "^3.997.44",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -289,21 +290,21 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.972.79",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.79.tgz",
-      "integrity": "sha512-RIw5dof1EHkWubrZzPC941CDtnFG1iAXsxbFgLkhdYZXHc4icU13c/uxSMI0J5eUx9bxa7LjfpdjfClBB1QsDA==",
+      "version": "3.972.82",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.82.tgz",
+      "integrity": "sha512-znDkEOGXB8W3kG1LJUKP3foBZY/9qLM0eil/DxWXSp37XsdsRLQHE/d/OaCGGVgKpA6znR38h/+INk8do1FjiA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "^3.972.68",
-        "@aws-sdk/credential-provider-http": "^3.972.70",
-        "@aws-sdk/credential-provider-ini": "^3.973.13",
-        "@aws-sdk/credential-provider-process": "^3.972.68",
-        "@aws-sdk/credential-provider-sso": "^3.973.12",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.74",
-        "@aws-sdk/types": "^3.974.3",
-        "@smithy/core": "^3.31.1",
+        "@aws-sdk/credential-provider-env": "^3.972.70",
+        "@aws-sdk/credential-provider-http": "^3.972.72",
+        "@aws-sdk/credential-provider-ini": "^3.973.15",
+        "@aws-sdk/credential-provider-process": "^3.972.70",
+        "@aws-sdk/credential-provider-sso": "^3.973.14",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.76",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
         "@smithy/credential-provider-imds": "^4.4.16",
-        "@smithy/types": "^4.16.1",
+        "@smithy/types": "^4.17.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -311,15 +312,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.972.68",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.68.tgz",
-      "integrity": "sha512-nLP3Pda2MQTFJ25hKBMmUuB9Uv+bTZQNlufbeCwklP549Vwnkd8bRLJoCKp5k6xjmdyptrPrOfGOhN0mKuca8A==",
+      "version": "3.972.70",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.70.tgz",
+      "integrity": "sha512-2ry03fGRJr4sV3jI+ocjj5JqALnFD6ymM5KiNCDZMvq8bX2GSbE0vji4aM43TVCl2nXqqLRZaUxdq/KeWRAY4Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.7",
-        "@aws-sdk/types": "^3.974.3",
-        "@smithy/core": "^3.31.1",
-        "@smithy/types": "^4.16.1",
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -327,17 +328,17 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.973.12",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.12.tgz",
-      "integrity": "sha512-EmgyyHn+f9WCcelp3L/vci+LGbX8GigWaVphRArjVo5Pktkr9YnLy/mQ6VDkDyBD72dtfRNTgHmD2ts4rTDXKQ==",
+      "version": "3.973.14",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.14.tgz",
+      "integrity": "sha512-jkhg/8ocAAoc0RFyLMhCw+/zZh7gystQgd4F4hznNa8P4Cc501PQmxd+jGLiMHodPJ+7Zv/3znM62gZojyasmA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.7",
-        "@aws-sdk/nested-clients": "^3.997.42",
-        "@aws-sdk/token-providers": "3.1108.0",
-        "@aws-sdk/types": "^3.974.3",
-        "@smithy/core": "^3.31.1",
-        "@smithy/types": "^4.16.1",
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/nested-clients": "^3.997.44",
+        "@aws-sdk/token-providers": "3.1116.0",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -345,16 +346,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/token-providers": {
-      "version": "3.1108.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1108.0.tgz",
-      "integrity": "sha512-rI80zxDxGJ6904eC/YbjkdjY6JdaZvQ01kOmrMvw7cFQGIHo27fhnIVbMSVDS4T6foQImjxYSRoOu/uSJscXDw==",
+      "version": "3.1116.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1116.0.tgz",
+      "integrity": "sha512-ygIivKqh8aHzNkucOCXHyIBgBpLPfrSI0mCqXF+vLBsPTUKqj0VSqAY0GFPe7lQl4HntjOcQ+KSyS7oUV2C54Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.7",
-        "@aws-sdk/nested-clients": "^3.997.42",
-        "@aws-sdk/types": "^3.974.3",
-        "@smithy/core": "^3.31.1",
-        "@smithy/types": "^4.16.1",
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/nested-clients": "^3.997.44",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -362,16 +363,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.972.74",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.74.tgz",
-      "integrity": "sha512-0YfczxGXF3RjGj8z7QG/Ho2HnLGKDHfPSHiTs47UU1U/+mmwISDN+rvGKt2zh+3FX8NdT4xd95LGBGyhQw2dgQ==",
+      "version": "3.972.76",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.76.tgz",
+      "integrity": "sha512-d3AGyVu759PGr35mEB2s22xxlNEA5rpdxtSPJthfPFJvoQ8dt357iVPECqWfUxXp1toJAvKmbtcIYVGigaGsCA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.7",
-        "@aws-sdk/nested-clients": "^3.997.42",
-        "@aws-sdk/types": "^3.974.3",
-        "@smithy/core": "^3.31.1",
-        "@smithy/types": "^4.16.1",
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/nested-clients": "^3.997.44",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -379,14 +380,14 @@
       }
     },
     "node_modules/@aws-sdk/eventstream-handler-node": {
-      "version": "3.972.32",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.32.tgz",
-      "integrity": "sha512-rlbmsMG7ZNgrVhWSqqXpq6y9hfiREyzCg3CNTk9UK+AoP7+65kOkqpWmqwLfV1UrRSHATdLnZF2rt9ZTUxYQJA==",
+      "version": "3.972.34",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.34.tgz",
+      "integrity": "sha512-cTeVzpu1xEAkryTZBYhGwnQ6gOGyp8ZYZvmn0Sg/nI/ABmy/CRHHxPDJDUi9PxwxUtGGaatvfRUB3FCgT/rSWw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.974.3",
-        "@smithy/core": "^3.31.1",
-        "@smithy/types": "^4.16.1",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -394,14 +395,14 @@
       }
     },
     "node_modules/@aws-sdk/middleware-eventstream": {
-      "version": "3.972.27",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.27.tgz",
-      "integrity": "sha512-M7Ay1VpBpf/YFfic9kkjwE3wyCh4G0gEM4RypRXYm7aPjyfqi+D8FEYMR2E3IqbvN+qi2rEFYAiwWL0XHtQYdQ==",
+      "version": "3.972.29",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.29.tgz",
+      "integrity": "sha512-dlRzHCgyB8W6hLuDC5pcT5q+ziPt00n4QGgGBE17ucLVU4zMa6lsbuUdQ2Pm75Z5VA8GF+R/+SgrRcaTdIzSIQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.974.3",
-        "@smithy/core": "^3.31.1",
-        "@smithy/types": "^4.16.1",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -409,17 +410,17 @@
       }
     },
     "node_modules/@aws-sdk/middleware-websocket": {
-      "version": "3.972.50",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.50.tgz",
-      "integrity": "sha512-gdcWRbmIf1dWA/prf44Bnnzgqj+AbsXX2yfhZhOQLwSm7NfKIYPmkRlPqP0CTepHzjxMIBdWBDdtQB+Y/dFUeg==",
+      "version": "3.972.52",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.52.tgz",
+      "integrity": "sha512-vsPPM+nMbKJlUCFU+eoGZbdxdxDIAX9LbpjSXaR5Ufpmqgp8TdYQnoExhLu4T3umW/JIIPny1ydbhWidZZYokQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.7",
-        "@aws-sdk/types": "^3.974.3",
-        "@smithy/core": "^3.31.1",
-        "@smithy/fetch-http-handler": "^5.6.13",
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/fetch-http-handler": "^5.7.2",
         "@smithy/signature-v4": "^5.6.12",
-        "@smithy/types": "^4.16.1",
+        "@smithy/types": "^4.17.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -427,18 +428,18 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients": {
-      "version": "3.997.42",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.42.tgz",
-      "integrity": "sha512-XWRyon2MTHXD/zMoo0Mbge6Vwf+iE0qQaM/RyGO6NfZ9WukCFiQL27nQVZjYy2JwSIg+iXZxKOX95OBXqlSM4w==",
+      "version": "3.997.44",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.44.tgz",
+      "integrity": "sha512-NhEgryjlBF9w38ZXqGymQV28IhkYa1mKhlbYnqIis57AYwWGVYfUPgg/qC2rLRqOUfblxx++irvju10kVTa8Vw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.7",
-        "@aws-sdk/signature-v4-multi-region": "^3.996.44",
-        "@aws-sdk/types": "^3.974.3",
-        "@smithy/core": "^3.31.1",
-        "@smithy/fetch-http-handler": "^5.6.13",
-        "@smithy/node-http-handler": "^4.9.13",
-        "@smithy/types": "^4.16.1",
+        "@aws-sdk/core": "^3.977.9",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.46",
+        "@aws-sdk/types": "^3.974.5",
+        "@smithy/core": "^3.33.3",
+        "@smithy/fetch-http-handler": "^5.7.2",
+        "@smithy/node-http-handler": "^4.11.3",
+        "@smithy/types": "^4.17.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -446,13 +447,13 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/node-http-handler": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.10.0.tgz",
-      "integrity": "sha512-nrh7VxqzPQS/ip1hS293aI/OAWDWARQvjUxCfuKhyrfHa2gTdk28066RNeWLI1uuoHXaKAkOF8IcSAHuOp0+SA==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.12.1.tgz",
+      "integrity": "sha512-ThMkboGeONWXAelq9FvGsuJC4rOi+qyC4/zhUF58xYpxUg5sQKx2VXZYJmtNjr4dSuBJ1HeJXETQILCz3wOHvw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.32.0",
-        "@smithy/types": "^4.17.0",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.18.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -460,14 +461,14 @@
       }
     },
     "node_modules/@aws-sdk/signature-v4-multi-region": {
-      "version": "3.996.44",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.44.tgz",
-      "integrity": "sha512-ZSfQ35Qn4MhSY+A0Whyr+KBx+wJKZUyBsOrjB2pSHOafRzbFe47T8XcXM8hZqUAC69qnqIy0C9ArxTuud0CC2w==",
+      "version": "3.996.46",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.46.tgz",
+      "integrity": "sha512-L+2xZTye/2T96f3lwCws0Zw6GG2JHZW9e8FpVgGBeeExSKyeoZ6CWRpBml/7DNiK/O26jrgPM9F+Ay8VkgzUWQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.974.3",
+        "@aws-sdk/types": "^3.974.5",
         "@smithy/signature-v4": "^5.6.12",
-        "@smithy/types": "^4.16.1",
+        "@smithy/types": "^4.17.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -492,12 +493,12 @@
       }
     },
     "node_modules/@aws-sdk/types": {
-      "version": "3.974.3",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.3.tgz",
-      "integrity": "sha512-ECAqfpNsef+7MO8qtR0h9KcFIBAygaE7Cm6UOiQl+ft+uVap+1G7bNEjs4mdJE2OnA4m6k7i8peH8uGIAsOMGw==",
+      "version": "3.974.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.5.tgz",
+      "integrity": "sha512-LkwLL2BLbC6wNNm4JaH9mbEqBMdOZCct6VAYqhdN4U1xrWM+fUJQEfbHwQgDypapOWTRtlk25akb5afM0P8CIQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.16.1",
+        "@smithy/types": "^4.17.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -505,9 +506,9 @@
       }
     },
     "node_modules/@aws-sdk/util-locate-window": {
-      "version": "3.965.9",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.9.tgz",
-      "integrity": "sha512-wB/ho7pTJKqWz3WYDt2ZWDWI8bxQpN/xwf+5ZQ1zWaj+HDY9B8Fn434i6qZ6j6ZG3aCiIJtZaQVqwajx5xYsQA==",
+      "version": "3.965.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.10.tgz",
+      "integrity": "sha512-ycwH6Zd2GhuSqdXX9ihbCjeGTB6xOJs+O3+Jb8/zDG9978XU80qs75dfkPJRMNKe5MvBZPuNeFpd4JZKPoUF4g==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -517,12 +518,12 @@
       }
     },
     "node_modules/@aws-sdk/xml-builder": {
-      "version": "3.972.38",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.38.tgz",
-      "integrity": "sha512-grf7mzfVxBS5AlsuTvBN7uDpzqohFww9fRPCO+EBSUdvtsYMcPSKdz54h/7XiscqNcUM1Ae1MF7JLHmiYYuzbQ==",
+      "version": "3.972.40",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.40.tgz",
+      "integrity": "sha512-wlFmCIGUlwF4zx/kncw+bmxTQh1HeSJq4mYV/V5cZUSJadDP3kXvGW8Rn21cimj/7y9ju+47oYWXi97vF7czaA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.16.1",
+        "@smithy/types": "^4.17.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -672,14 +673,27 @@
         "win32"
       ]
     },
-    "node_modules/@earendil-works/pi-agent-core": {
-      "version": "0.84.1",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.84.1.tgz",
-      "integrity": "sha512-evyzXYWCLQGmcaBYHlmSku02r8qoN4SGI60GZABo6iV+H+nqX+P9ud8fEZ4GmRq9mUSREvvfX+w9dA9ThF9C6w==",
+    "node_modules/@earendil-works/chord": {
+      "version": "0.85.1",
+      "resolved": "https://registry.npmjs.org/@earendil-works/chord/-/chord-0.85.1.tgz",
+      "integrity": "sha512-VDlkEC3dhCzQ5fcyH1OhG19dq+6jCn+rqc/iXFivwDYGR5anwo2RCiXij9PpHhqNR5GuhhE+Er69Zi1Sn4eY6w==",
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/pi-ai": "^0.84.1",
-        "@earendil-works/pi-telemetry": "^0.84.1",
+        "esbuild": "0.28.1"
+      },
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-agent-core": {
+      "version": "0.85.1",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.85.1.tgz",
+      "integrity": "sha512-hIXIP3eAWueAYiAl8aMvWCvvZ8Q5gT3Dip5bE5uJyIGh4+YlWRjtMLI4BaeoXoSs93zndjue61u1B/vhefLnuA==",
+      "license": "MIT",
+      "dependencies": {
+        "@earendil-works/chord": "^0.85.1",
+        "@earendil-works/pi-ai": "^0.85.1",
+        "@earendil-works/pi-telemetry": "^0.85.1",
         "diff": "8.0.4",
         "ignore": "7.0.5",
         "typebox": "1.3.7",
@@ -690,21 +704,19 @@
       }
     },
     "node_modules/@earendil-works/pi-ai": {
-      "version": "0.84.1",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.84.1.tgz",
-      "integrity": "sha512-wMsAdJMxuNri08vLqTyYVI201DQQezGhPSTkzYsHdw5dYX3rCNwEmSvpaAwhi7ELKI/2tE/CEgSWg/6iRxSgdQ==",
+      "version": "0.85.1",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.85.1.tgz",
+      "integrity": "sha512-+VgVIJDkDO2efYJKEEqvPTH4zmnIaXdAppGbO+vKFA9qy5PdhFiAenuFAkU+oiCSfOC4dMHDyrjdQeL4ZoC5CQ==",
       "license": "MIT",
       "dependencies": {
-        "@anthropic-ai/sdk": "0.91.1",
+        "@anthropic-ai/sdk": "0.123.0",
         "@aws-sdk/client-bedrock-runtime": "3.1048.0",
-        "@earendil-works/pi-telemetry": "^0.84.1",
+        "@earendil-works/pi-telemetry": "^0.85.1",
         "@google/genai": "1.52.0",
-        "@mistralai/mistralai": "2.2.6",
-        "@opentelemetry/api": "1.9.0",
         "@smithy/node-http-handler": "4.7.3",
         "http-proxy-agent": "7.0.2",
         "https-proxy-agent": "7.0.6",
-        "openai": "6.26.0",
+        "openai": "6.40.0",
         "partial-json": "0.1.7",
         "typebox": "1.3.7"
       },
@@ -716,22 +728,20 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent": {
-      "version": "0.84.1",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.84.1.tgz",
-      "integrity": "sha512-ncAqFrG+iybuPGOhMiZoEHkEzTpJgz3guYD32pD+M7ucc0WeHmauP6wa7qwP8V/KWvsZDVNa5XGsdZ7fkC7w7A==",
+      "version": "0.85.1",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.85.1.tgz",
+      "integrity": "sha512-FGRN+OHbWaefBPGaTggAdLjrIHW+s2PzLyglz/5dfLzb9of7uuXMXYC0fJIeZTw+shS32o2cuQ9jF7YSDuL/oQ==",
       "hasShrinkwrap": true,
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/pi-agent-core": "^0.84.1",
-        "@earendil-works/pi-ai": "^0.84.1",
-        "@earendil-works/pi-client": "^0.84.1",
-        "@earendil-works/pi-protocol": "^0.84.1",
-        "@earendil-works/pi-tui": "^0.84.1",
+        "@earendil-works/chord": "^0.85.1",
+        "@earendil-works/pi-agent-core": "^0.85.1",
+        "@earendil-works/pi-ai": "^0.85.1",
+        "@earendil-works/pi-tui": "^0.85.1",
         "@silvia-odwyer/photon-node": "0.3.4",
         "chalk": "5.6.2",
         "cross-spawn": "7.0.6",
         "diff": "8.0.4",
-        "glob": "13.0.6",
         "grok-mermaid": "0.2.2",
         "highlight.js": "10.7.3",
         "hosted-git-info": "9.0.3",
@@ -745,7 +755,7 @@
         "yaml": "2.9.0"
       },
       "bin": {
-        "pi": "dist/cli.js"
+        "pi": "dist/bundle/cli.js"
       },
       "engines": {
         "node": ">=22.19.0"
@@ -755,12 +765,13 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@anthropic-ai/sdk": {
-      "version": "0.91.1",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.91.1.tgz",
-      "integrity": "sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw==",
+      "version": "0.123.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.123.0.tgz",
+      "integrity": "sha512-Y9oX9mPNGZClHQOFqrWRk43Srcu/UHuPq3rfxxOq7JgW0gi+lJA2MAOK4Ul3k/+AUrwRWFJvd0tK3oC0Pw25dw==",
       "license": "MIT",
       "dependencies": {
-        "json-schema-to-ts": "^3.1.1"
+        "json-schema-to-ts": "^3.1.1",
+        "standardwebhooks": "^1.0.0"
       },
       "bin": {
         "anthropic-ai-sdk": "bin/cli"
@@ -1189,13 +1200,25 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-agent-core": {
-      "version": "0.84.1",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.84.1.tgz",
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/chord": {
+      "version": "0.85.1",
+      "resolved": "https://registry.npmjs.org/@earendil-works/chord/-/chord-0.85.1.tgz",
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/pi-ai": "^0.84.1",
-        "@earendil-works/pi-telemetry": "^0.84.1",
+        "esbuild": "0.28.1"
+      },
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-agent-core": {
+      "version": "0.85.1",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.85.1.tgz",
+      "license": "MIT",
+      "dependencies": {
+        "@earendil-works/chord": "^0.85.1",
+        "@earendil-works/pi-ai": "^0.85.1",
+        "@earendil-works/pi-telemetry": "^0.85.1",
         "diff": "8.0.4",
         "ignore": "7.0.5",
         "typebox": "1.3.7",
@@ -1206,20 +1229,18 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-ai": {
-      "version": "0.84.1",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.84.1.tgz",
+      "version": "0.85.1",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.85.1.tgz",
       "license": "MIT",
       "dependencies": {
-        "@anthropic-ai/sdk": "0.91.1",
+        "@anthropic-ai/sdk": "0.123.0",
         "@aws-sdk/client-bedrock-runtime": "3.1048.0",
-        "@earendil-works/pi-telemetry": "^0.84.1",
+        "@earendil-works/pi-telemetry": "^0.85.1",
         "@google/genai": "1.52.0",
-        "@mistralai/mistralai": "2.2.6",
-        "@opentelemetry/api": "1.9.0",
         "@smithy/node-http-handler": "4.7.3",
         "http-proxy-agent": "7.0.2",
         "https-proxy-agent": "7.0.6",
-        "openai": "6.26.0",
+        "openai": "6.40.0",
         "partial-json": "0.1.7",
         "typebox": "1.3.7"
       },
@@ -1230,39 +1251,17 @@
         "node": ">=22.19.0"
       }
     },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-client": {
-      "version": "0.84.1",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-client/-/pi-client-0.84.1.tgz",
-      "license": "MIT",
-      "dependencies": {
-        "@earendil-works/pi-protocol": "^0.84.1"
-      },
-      "engines": {
-        "node": ">=22.19.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-protocol": {
-      "version": "0.84.1",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-protocol/-/pi-protocol-0.84.1.tgz",
-      "license": "MIT",
-      "dependencies": {
-        "typebox": "1.3.7"
-      },
-      "engines": {
-        "node": ">=22.19.0"
-      }
-    },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-telemetry": {
-      "version": "0.84.1",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-telemetry/-/pi-telemetry-0.84.1.tgz",
+      "version": "0.85.1",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-telemetry/-/pi-telemetry-0.85.1.tgz",
       "license": "MIT",
       "engines": {
         "node": ">=22.19.0"
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-tui": {
-      "version": "0.84.1",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.84.1.tgz",
+      "version": "0.85.1",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.85.1.tgz",
       "license": "MIT",
       "dependencies": {
         "get-east-asian-width": "1.6.0",
@@ -1270,6 +1269,422 @@
       },
       "engines": {
         "node": ">=22.19.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@google/genai": {
@@ -1475,26 +1890,6 @@
         "node": ">= 10"
       }
     },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mistralai/mistralai": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/@mistralai/mistralai/-/mistralai-2.2.6.tgz",
-      "integrity": "sha512-W8pX7zHxjJvMIpw8JMxeJEleapXX0Q9NPszdNzqkM3MIEoIGPObdodujj+WHteXEvGfaP/AMwlNyRfEzSY6dQQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/semantic-conventions": "^1.40.0",
-        "ws": "^8.18.0",
-        "zod": "^3.25.0 || ^4.0.0",
-        "zod-to-json-schema": "^3.25.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.9.0"
-      },
-      "peerDependenciesMeta": {
-        "@opentelemetry/api": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@nodable/entities": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
@@ -1506,24 +1901,6 @@
         }
       ],
       "license": "MIT"
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@opentelemetry/api": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
-      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.41.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.41.1.tgz",
-      "integrity": "sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=14"
-      }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
@@ -1708,6 +2085,12 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+      "license": "MIT"
+    },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@types/node": {
       "version": "22.19.19",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.19.tgz",
@@ -1858,11 +2241,58 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "license": "Unlicense"
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/fast-xml-builder": {
       "version": "1.2.0",
@@ -1974,23 +2404,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/glob": {
-      "version": "13.0.6",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
-      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "minimatch": "^10.2.2",
-        "minipass": "^7.1.3",
-        "path-scurry": "^2.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/google-auth-library": {
@@ -2190,15 +2603,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/minipass": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
-      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      }
-    },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -2244,13 +2648,10 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/openai": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/openai/-/openai-6.26.0.tgz",
-      "integrity": "sha512-zd23dbWTjiJ6sSAX6s0HrCZi41JwTA1bQVs0wLQPZ2/5o2gxOJA5wh7yOAUgwYybfhDXyhwlpeQf7Mlgx8EOCA==",
+      "version": "6.40.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.40.0.tgz",
+      "integrity": "sha512-MWtTjd/gQt4jpbji61NTgFWJLoY/PdRJ6wG9/ZDRMYNMlBKrCrSlkLI+KgHP1vR1qT6LKSAyAqIxno6lcK9JiA==",
       "license": "Apache-2.0",
-      "bin": {
-        "openai": "bin/cli"
-      },
       "peerDependencies": {
         "ws": "^8.18.0",
         "zod": "^3.25 || ^4.0"
@@ -2311,22 +2712,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/path-scurry": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
-      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "lru-cache": "^11.0.0",
-        "minipass": "^7.1.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/proper-lockfile": {
@@ -2439,6 +2824,16 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "license": "ISC"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/standardwebhooks": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.1.1.tgz",
+      "integrity": "sha512-bCbX9ZEyFkWPsRz7Bl3NuQUJohmwGSev/yhr7vhaGPlc4AfIrspIRa6cPTBuI1ItmrTDJ4d/S2hCsfe4+vQGnQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
+      }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/strnum": {
       "version": "2.3.0",
@@ -2560,28 +2955,10 @@
         "url": "https://github.com/sponsors/eemeli"
       }
     },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/zod-to-json-schema": {
-      "version": "3.25.2",
-      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
-      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
-      "license": "ISC",
-      "peerDependencies": {
-        "zod": "^3.25.28 || ^4"
-      }
-    },
     "node_modules/@earendil-works/pi-telemetry": {
-      "version": "0.84.1",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-telemetry/-/pi-telemetry-0.84.1.tgz",
-      "integrity": "sha512-180/xGJtsq7IoR3p9EKWjRd0e9M4DkxInhlo9xyD7prDC7Qrhqq+nhvwrW0lFjPfXcEI2FSHmGCSyvSJE9GsaQ==",
+      "version": "0.85.1",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-telemetry/-/pi-telemetry-0.85.1.tgz",
+      "integrity": "sha512-Bg/YN6kA7Swja/NQxka8xFdecb4E/auIEGF2G5A25EaQXhRnPj300/7/KpgsDDMYUzHTDAv4RyUxaQPJKW81Rw==",
       "license": "MIT",
       "engines": {
         "node": ">=22.19.0"
@@ -2628,7 +3005,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2645,7 +3021,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2662,7 +3037,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2679,7 +3053,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2696,7 +3069,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2713,7 +3085,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2730,7 +3101,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2747,7 +3117,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2764,7 +3133,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2781,7 +3149,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2798,7 +3165,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2815,7 +3181,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2832,7 +3197,6 @@
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2849,7 +3213,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2866,7 +3229,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2883,7 +3245,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2900,7 +3261,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2917,7 +3277,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2934,7 +3293,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2951,7 +3309,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2968,7 +3325,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2985,7 +3341,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3002,7 +3357,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3019,7 +3373,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3036,7 +3389,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3053,7 +3405,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3700,26 +4051,6 @@
         "node": ">= 20"
       }
     },
-    "node_modules/@mistralai/mistralai": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/@mistralai/mistralai/-/mistralai-2.2.6.tgz",
-      "integrity": "sha512-W8pX7zHxjJvMIpw8JMxeJEleapXX0Q9NPszdNzqkM3MIEoIGPObdodujj+WHteXEvGfaP/AMwlNyRfEzSY6dQQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/semantic-conventions": "^1.40.0",
-        "ws": "^8.18.0",
-        "zod": "^3.25.0 || ^4.0.0",
-        "zod-to-json-schema": "^3.25.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.9.0"
-      },
-      "peerDependenciesMeta": {
-        "@opentelemetry/api": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@napi-rs/canvas": {
       "version": "0.1.100",
       "resolved": "https://registry.npmjs.org/@napi-rs/canvas/-/canvas-0.1.100.tgz",
@@ -4025,24 +4356,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/@opentelemetry/api": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
-      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.43.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.43.0.tgz",
-      "integrity": "sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=14"
       }
     },
     "node_modules/@oxc-parser/binding-android-arm-eabi": {
@@ -5210,12 +5523,12 @@
       "license": "MIT"
     },
     "node_modules/@smithy/core": {
-      "version": "3.32.0",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.32.0.tgz",
-      "integrity": "sha512-NAiCSC78fzbNIEWoheoF74Ob5ZorLijCHpMY26Fqvqg/+9LuyIqMfHDg2p8Yk1rqOyowtiL3y7WX0AW+teL6zw==",
+      "version": "3.33.3",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.33.3.tgz",
+      "integrity": "sha512-CsOeKq/9kA3y6VJHt+/+VTCtBaxJ4OTFpgrjIUhPpDIKxBci1k2bJaQASF2h/ELWrulGp+t97DZ0mevfAD8idg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.17.0",
+        "@smithy/types": "^4.17.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5223,13 +5536,13 @@
       }
     },
     "node_modules/@smithy/credential-provider-imds": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.5.0.tgz",
-      "integrity": "sha512-2jsPi+7Zv2hSzD9IXR9D7DTqSn7mv4XalzRm+bESh53jiaUS3NKEUbpQFTJP0HhQy9qzZvluxQ3yS24zdRrqsA==",
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.5.2.tgz",
+      "integrity": "sha512-A9uSdn72ozbRUSit0eib0TW7nXuNPlaeM0zcGkJ+nE6tFcSDbnmtwoxbTCFBukVQcszDAyvsd7+rTduPTXpygg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.32.0",
-        "@smithy/types": "^4.17.0",
+        "@smithy/core": "^3.33.2",
+        "@smithy/types": "^4.17.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5237,13 +5550,13 @@
       }
     },
     "node_modules/@smithy/fetch-http-handler": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.7.0.tgz",
-      "integrity": "sha512-W/exA8T0LEzCQtJ02w4IzaEQPIspgarqZprb7W8FwnYiDowgCrjl2fTQ6FvuSSUnJORuepBF81abmBJwqh+0XQ==",
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.8.0.tgz",
+      "integrity": "sha512-ycSJu3tFAQ4v04CBB0agqFMVsSQ1iG3yw+SpgxRqKfaURpQD4CZ8Wn0zPMmSnOuTpTh65Vz+EA0rMrw089wvkA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.32.0",
-        "@smithy/types": "^4.17.0",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.18.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5277,13 +5590,13 @@
       }
     },
     "node_modules/@smithy/signature-v4": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.7.0.tgz",
-      "integrity": "sha512-hCynhm22wMJ8wTF9crcwu8mxggtUrSLLJgDcGUvYFBqpofxycYJCGKOMYg4xtPPFtgNiDJSYmhsWLTrcU/g59Q==",
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.7.3.tgz",
+      "integrity": "sha512-7ImGm+FkHRLcBaRttIAMZ6bzJZWb2cJGoYjq46F2UjycujWzrL9GEN9h4w7eQyXJYnltrUhxbbieBAIRrdqpow==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.32.0",
-        "@smithy/types": "^4.17.0",
+        "@smithy/core": "^3.33.3",
+        "@smithy/types": "^4.17.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5291,9 +5604,9 @@
       }
     },
     "node_modules/@smithy/types": {
-      "version": "4.17.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.17.0.tgz",
-      "integrity": "sha512-Aw4joiM0ZdErpo39lCj8phT2lxoiKZV+KZzBxnnQhWVtU2Is/WffQSL04uUWRcXUse9Ln8vXZK6V/FwqRVnQpg==",
+      "version": "4.18.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.18.0.tgz",
+      "integrity": "sha512-CgB6HHWer/vrKps24ulRIbpcpb7K4xAU7SkZ7YHzBPlwHsvsrCJFEXK421s+cJzX+ZrqtA/TuU5w1HzI7k9N8A==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -5327,6 +5640,12 @@
       "engines": {
         "node": ">=14.0.0"
       }
+    },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+      "license": "MIT"
     },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
@@ -6019,7 +6338,6 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
       "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "18 || 20 || >=22"
@@ -6050,7 +6368,6 @@
       "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-13.0.3.tgz",
       "integrity": "sha512-RbOBxmLBG8uvFUc15X9+9SFemKcQ0WBuISBVkpuiaUB2qblC8UWlHEjdWVoZ8AdhSwmoEgsiXKfopX0CQxaACQ==",
       "license": "MIT",
-      "gypfile": false,
       "dependencies": {
         "node-addon-api": "^8.0.0"
       },
@@ -6102,7 +6419,6 @@
       "version": "5.0.7",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
       "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -6820,7 +7136,6 @@
       "version": "0.28.1",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
       "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -7018,6 +7333,12 @@
       "engines": {
         "node": ">=8.6.0"
       }
+    },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "license": "Unlicense"
     },
     "node_modules/fastq": {
       "version": "1.20.1",
@@ -8505,7 +8826,6 @@
       "version": "10.2.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
       "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "brace-expansion": "^5.0.5"
@@ -8776,13 +9096,10 @@
       }
     },
     "node_modules/openai": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/openai/-/openai-6.26.0.tgz",
-      "integrity": "sha512-zd23dbWTjiJ6sSAX6s0HrCZi41JwTA1bQVs0wLQPZ2/5o2gxOJA5wh7yOAUgwYybfhDXyhwlpeQf7Mlgx8EOCA==",
+      "version": "6.40.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.40.0.tgz",
+      "integrity": "sha512-MWtTjd/gQt4jpbji61NTgFWJLoY/PdRJ6wG9/ZDRMYNMlBKrCrSlkLI+KgHP1vR1qT6LKSAyAqIxno6lcK9JiA==",
       "license": "Apache-2.0",
-      "bin": {
-        "openai": "bin/cli"
-      },
       "peerDependencies": {
         "ws": "^8.18.0",
         "zod": "^3.25 || ^4.0"
@@ -9170,9 +9487,9 @@
       "license": "MIT"
     },
     "node_modules/protobufjs": {
-      "version": "7.6.5",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
-      "integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
+      "version": "7.6.6",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.6.tgz",
+      "integrity": "sha512-dYDWdjSl5RNb7SgPxGQcRU+GtvP7s2fpkrY0r432PcOIaZ0/rBcxEZnQN67iJhFuQiVw754JDoPruPCNdGsbjg==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -10016,6 +10333,16 @@
       "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/standardwebhooks": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.1.1.tgz",
+      "integrity": "sha512-bCbX9ZEyFkWPsRz7Bl3NuQUJohmwGSev/yhr7vhaGPlc4AfIrspIRa6cPTBuI1ItmrTDJ4d/S2hCsfe4+vQGnQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
+      }
     },
     "node_modules/std-env": {
       "version": "4.2.0",

--- a/package.json
+++ b/package.json
@@ -90,9 +90,9 @@
     "@bobbit/binaries-win32-x64": "0.9.0"
   },
   "dependencies": {
-    "@earendil-works/pi-agent-core": "0.84.1",
-    "@earendil-works/pi-ai": "0.84.1",
-    "@earendil-works/pi-coding-agent": "0.84.1",
+    "@earendil-works/pi-agent-core": "0.85.1",
+    "@earendil-works/pi-ai": "0.85.1",
+    "@earendil-works/pi-coding-agent": "0.85.1",
     "@homebridge/node-pty-prebuilt-multiarch": "^0.14.1",
     "@lmstudio/sdk": "^1.5.0",
     "@sinclair/typebox": "^0.34.41",

--- a/src/server/agent/model-registry.ts
+++ b/src/server/agent/model-registry.ts
@@ -120,10 +120,11 @@ interface AuthoritativeModelCapacityFact {
  * - https://developers.openai.com/api/docs/models/gpt-5.6-luna.md
  * - https://developers.openai.com/api/docs/models/gpt-5.6-sol.md
  * - https://developers.openai.com/api/docs/models/gpt-5.6-terra.md
+ * - https://developers.openai.com/api/docs/models/gpt-6-astra.md
  *
- * The three openai-codex GPT-5.6 routes use the matching OpenAI model page plus
- * Codex #33961 and Pi #6838 to establish 272K as the deliberate client/pricing
- * target rather than the physical model window:
+ * The openai-codex GPT-5.6 and GPT-6 Astra routes use the matching OpenAI
+ * model page plus Codex #33961 and Pi #6838 to establish 272K as the deliberate
+ * client/pricing target rather than the physical model window:
  * - https://github.com/openai/codex/issues/33961
  * - https://github.com/earendil-works/pi/issues/6838
  *
@@ -137,9 +138,11 @@ const AUTHORITATIVE_MODEL_CAPACITY_FACTS: readonly AuthoritativeModelCapacityFac
 	{ provider: "openai", id: "gpt-5.6-luna", expectedTarget: 272_000, modelCapacity: 1_050_000 },
 	{ provider: "openai", id: "gpt-5.6-sol", expectedTarget: 272_000, modelCapacity: 1_050_000 },
 	{ provider: "openai", id: "gpt-5.6-terra", expectedTarget: 272_000, modelCapacity: 1_050_000 },
+	{ provider: "openai", id: "gpt-6-astra", expectedTarget: 272_000, modelCapacity: 1_050_000 },
 	{ provider: "openai-codex", id: "gpt-5.6-luna", expectedTarget: 272_000, modelCapacity: 1_050_000 },
 	{ provider: "openai-codex", id: "gpt-5.6-sol", expectedTarget: 272_000, modelCapacity: 1_050_000 },
 	{ provider: "openai-codex", id: "gpt-5.6-terra", expectedTarget: 272_000, modelCapacity: 1_050_000 },
+	{ provider: "openai-codex", id: "gpt-6-astra", expectedTarget: 272_000, modelCapacity: 1_050_000 },
 ];
 
 /** Resolve only a reviewed exact capacity fact; never infer from an ID family. */

--- a/src/server/agent/rpc-bridge.ts
+++ b/src/server/agent/rpc-bridge.ts
@@ -98,7 +98,7 @@ export function redactDockerArgs(args: string[]): string {
 	}).join(" ");
 }
 
-/** Container home directory for the Docker sandbox (node:20-slim, USER node) */
+/** Container home directory for the Docker sandbox (node:22.19.0-slim, USER node) */
 export const CONTAINER_HOME = "/home/node";
 /** Container-side agent directory prefix (always forward slashes) */
 export const CONTAINER_AGENT_DIR = "/home/node/.bobbit/agent/";
@@ -132,7 +132,7 @@ export interface RuntimePiExtensionDiagnostic {
 }
 
 export interface RpcBridgeOptions {
-	/** Path to pi-coding-agent cli.js. Auto-resolved if omitted. */
+	/** Path to the pi-coding-agent bundled CLI. Auto-resolved if omitted. */
 	cliPath?: string;
 	/** Working directory for the agent process */
 	cwd?: string;
@@ -191,8 +191,10 @@ export interface RpcBridgeOptions {
 export interface RpcBridgeStartDeps {
 	/** `import.meta.resolve`-compatible package resolver used by direct starts. */
 	resolvePackage?: (specifier: string, parent?: string | URL) => string;
-	/** Direct child spawn seam. Docker continues to use its existing spawn path. */
+	/** Direct child spawn seam. */
 	spawnDirect?: typeof spawn;
+	/** Docker child spawn seam for verifying the baked-in Pi entrypoint. */
+	spawnDocker?: typeof spawn;
 }
 
 export type RpcEventListener = (event: any) => void;
@@ -1114,7 +1116,7 @@ export class RpcBridge {
 
 		execArgs.push(
 			containerId,
-			"node", "--disable-warning=DEP0123", "/node_modules/@earendil-works/pi-coding-agent/dist/cli.js",
+			"node", "--disable-warning=DEP0123", `/node_modules/${PI_CODING_AGENT_PACKAGE}/${PI_CODING_AGENT_CLI_RELATIVE_PATH}`,
 			...this.remapArgsForContainer(agentArgs),
 		);
 
@@ -1122,7 +1124,8 @@ export class RpcBridge {
 
 		// Host-side spawn doesn't need a specific cwd — the container working
 		// directory is set via `docker exec -w` above.
-		return spawn("docker", execArgs, {
+		const spawnDocker = this.startDeps.spawnDocker ?? spawn;
+		return spawnDocker("docker", execArgs, {
 			stdio: ["pipe", "pipe", "pipe"],
 			env: { ...process.env, MSYS_NO_PATHCONV: "1", MSYS2_ARG_CONV_EXCL: "*" },
 		});
@@ -1607,6 +1610,7 @@ export function hostPathToContainer(hostPath: string, opts: MountTableOptions = 
 }
 
 const PI_CODING_AGENT_PACKAGE = "@earendil-works/pi-coding-agent";
+const PI_CODING_AGENT_CLI_RELATIVE_PATH = "dist/bundle/cli.js";
 
 export interface DirectHostPiRuntime {
 	/** Present for automatic package resolution; an explicit CLI may live anywhere. */
@@ -1660,7 +1664,7 @@ export function resolveDirectHostPiRuntime(
 			throw new Error(`Resolved package entry is unavailable: ${entryPath}`);
 		}
 		const packageRoot = piPackageRootFromEntry(entryPath);
-		const cliPath = path.join(packageRoot, "dist", "cli.js");
+		const cliPath = path.join(packageRoot, ...PI_CODING_AGENT_CLI_RELATIVE_PATH.split("/"));
 		if (!exists(cliPath)) {
 			throw new Error(`Resolved package CLI is unavailable: ${cliPath}`);
 		}

--- a/src/shared/assistant-stream-delta.ts
+++ b/src/shared/assistant-stream-delta.ts
@@ -207,6 +207,10 @@ function contentOf(message: JsonObject): unknown[] | undefined {
 	return Array.isArray(message.content) ? message.content : undefined;
 }
 
+function applyAuthoritativeUsage(message: JsonObject, event: JsonObject): void {
+	if (isObject(event.usage)) message.usage = clone(event.usage);
+}
+
 function blockWithout(block: JsonObject, field: string): JsonObject {
 	return Object.fromEntries(Object.entries(block).filter(([key]) => key !== field && key !== "partialJson"));
 }
@@ -317,12 +321,14 @@ function applyDelta(message: JsonObject, assistantEvent: JsonObject, checkpoint?
 }
 
 /**
- * Reconstruct a cumulative update from Pi 0.84's JSON/RPC delta-only frame.
+ * Reconstruct a cumulative update from Pi's JSON/RPC delta-only frame.
  *
  * Pi deliberately removes both `message` and `assistantMessageEvent.partial`
  * from `message_update` on the wire. The preceding assistant
- * `message_start.message` is therefore required. Exact `message_end.message`
- * frames do not pass through this helper and remain terminal authority.
+ * `message_start.message` is therefore required. Pi 0.85 adds authoritative
+ * cumulative `usage` to the outer update and tool identity to tool-call starts.
+ * Exact `message_end.message` frames do not pass through this helper and remain
+ * terminal authority.
  */
 export function reconstructPiAssistantMessageUpdate(event: unknown, previousMessage: unknown): unknown {
 	if (!isObject(event) || event.type !== "message_update" || "message" in event
@@ -348,7 +354,13 @@ export function reconstructPiAssistantMessageUpdate(event: unknown, previousMess
 			? { type: "text", text: "" }
 			: eventType === "thinking_start"
 				? { type: "thinking", thinking: "" }
-				: { type: "toolCall", id: "", name: "", arguments: {}, partialJson: "" };
+				: {
+					type: "toolCall",
+					id: typeof assistantEvent.id === "string" ? assistantEvent.id : "",
+					name: typeof assistantEvent.toolName === "string" ? assistantEvent.toolName : "",
+					arguments: {},
+					partialJson: "",
+				};
 	} else if (at >= 0 && (eventType === "text_end" || eventType === "thinking_end")) {
 		const block = content[at];
 		if (isObject(block)) checkpoint = blockWithout(block, eventType === "text_end" ? "text" : "thinking");
@@ -366,6 +378,7 @@ export function reconstructPiAssistantMessageUpdate(event: unknown, previousMess
 
 	const message = applyDelta(baseline, assistantEvent, checkpoint);
 	if (!message) return event;
+	applyAuthoritativeUsage(message, event);
 	return {
 		...event,
 		message,
@@ -469,6 +482,7 @@ export function reconstructAssistantStreamDelta(event: unknown, previousMessage?
 	const checkpoint = isObject(event.assistantBlockCheckpoint) ? event.assistantBlockCheckpoint : undefined;
 	const message = applyDelta(base, event.assistantMessageEvent, checkpoint);
 	if (!message) return event;
+	applyAuthoritativeUsage(message, event);
 	const {
 		assistantStreamDelta: _version,
 		assistantMessageBaseline: _baseline,

--- a/tests/browser/journeys/astra-session-selection.journey.spec.ts
+++ b/tests/browser/journeys/astra-session-selection.journey.spec.ts
@@ -1,0 +1,213 @@
+import { join } from "node:path";
+import type { Page } from "@playwright/test";
+import {
+	apiFetch,
+	createSession,
+	deleteSession,
+	expect,
+	navigateToHash,
+	openApp,
+	sendMessage,
+	test,
+	waitForAgentResponse,
+	waitForHealth,
+	waitForSessionStatus,
+} from "../../support/helpers/browser/journeys/journey-fixture.js";
+import { installFakeCodexOAuth } from "../../support/fixtures/models/fake-codex-oauth.js";
+
+const ASTRA = {
+	provider: "openai-codex",
+	id: "gpt-6-astra",
+} as const;
+
+const ASTRA_THINKING_MAP = {
+	off: null,
+	minimal: "low",
+	low: "low",
+	medium: "medium",
+	high: "high",
+	xhigh: "xhigh",
+	max: "max",
+} as const;
+
+async function loadAstraModel(): Promise<Record<string, any>> {
+	const response = await apiFetch("/api/models");
+	expect(response.status).toBe(200);
+	const models = await response.json() as Array<Record<string, any>>;
+	const matches = models.filter((model) => model.provider === ASTRA.provider && model.id === ASTRA.id);
+	expect(matches, "Astra must occur exactly once in the Pi-backed browser catalog").toHaveLength(1);
+	return matches[0];
+}
+
+function persistedAstra(gateway: { sessionManager?: any }, sessionId: string): Record<string, unknown> | undefined {
+	const row = gateway.sessionManager?.getPersistedSession(sessionId);
+	if (!row) return undefined;
+	return {
+		modelProvider: row.modelProvider,
+		modelId: row.modelId,
+		effectiveThinkingLevel: row.effectiveThinkingLevel,
+	};
+}
+
+function readRemoteAstra(page: Page): Promise<Record<string, unknown>> {
+	return page.evaluate(() => {
+		const win = window as any;
+		const state = (win.bobbitState ?? win.__bobbitState)?.remoteAgent?.state;
+		return {
+			provider: state?.model?.provider,
+			id: state?.model?.id,
+			thinkingLevel: state?.thinkingLevel,
+			contextWindow: state?.model?.contextWindow,
+			maxTokens: state?.model?.maxTokens,
+			reasoning: state?.model?.reasoning,
+			input: state?.model?.input,
+			thinkingLevelMap: state?.model?.thinkingLevelMap,
+		};
+	});
+}
+
+const expectedLiveAstra = (thinkingLevel: "minimal" | "max") => ({
+	...ASTRA,
+	thinkingLevel,
+	contextWindow: 272_000,
+	maxTokens: 128_000,
+	reasoning: true,
+	input: ["text", "image"],
+	thinkingLevelMap: ASTRA_THINKING_MAP,
+});
+
+test.describe.serial("Journey: Astra session selection and persistence", () => {
+	test("selects authenticated Astra, hides Off, exposes Max, and survives reload and restart", async ({ page, gateway }) => {
+		test.setTimeout(120_000);
+		const restoreAuth = installFakeCodexOAuth(join(gateway.bobbitDir, "agent"));
+		const registry = await import("../../../dist/server/agent/model-registry.js");
+		registry.clearOAuthCache();
+		registry.invalidateModelCache();
+
+		const sentFrames: Array<Record<string, unknown>> = [];
+		page.on("websocket", (socket) => {
+			socket.on("framesent", (event) => {
+				try {
+					const payload = typeof event.payload === "string" ? event.payload : event.payload.toString("utf8");
+					sentFrames.push(JSON.parse(payload));
+				} catch { /* non-JSON frame */ }
+			});
+		});
+
+		let sessionId: string | undefined;
+		let gatewayOnline = true;
+		try {
+			const model = await loadAstraModel();
+			expect(model).toMatchObject({
+				...ASTRA,
+				name: "GPT-6 Astra",
+				api: "openai-codex-responses",
+				baseUrl: "https://chatgpt.com/backend-api",
+				authenticated: true,
+				contextWindow: 272_000,
+				maxTokens: 128_000,
+				reasoning: true,
+				input: ["text", "image"],
+				thinkingLevelMap: ASTRA_THINKING_MAP,
+				compat: {
+					supportsOpenAIGrammarTools: true,
+					supportsAdditionalTools: true,
+					supportsToolSearch: true,
+				},
+			});
+
+			sessionId = await createSession();
+			await waitForSessionStatus(sessionId, "idle");
+			await openApp(page);
+			await navigateToHash(page, `#/session/${sessionId}`);
+
+			const footerModel = page.getByTestId("footer-model-id");
+			await expect(footerModel).toBeVisible({ timeout: 20_000 });
+			await footerModel.click();
+			const selector = page.locator("agent-model-selector");
+			await expect(selector.getByText("Select Model").first()).toBeVisible({ timeout: 15_000 });
+			await selector.getByPlaceholder("Search models...").fill(ASTRA.id);
+			const item = selector
+				.locator(`[data-model-item][data-model-id="${ASTRA.id}"][data-session-unavailable="false"]`)
+				.filter({ hasText: ASTRA.provider })
+				.first();
+			await expect(item, "Astra should be selectable after fake Codex OAuth authentication").toBeVisible({ timeout: 15_000 });
+			await expect(item).toContainText("272K/128K");
+			await expect(item).not.toHaveAttribute("title", /required/i);
+
+			await selector.getByText("Thinking", { exact: true }).click();
+			await expect(item).toBeVisible();
+			await selector.getByText("Vision", { exact: true }).click();
+			await expect(item).toBeVisible();
+			await item.click();
+
+			await expect(footerModel).toHaveText(ASTRA.id, { timeout: 20_000 });
+			await expect(page.locator(".thinking-select-compact")).toHaveAttribute("title", "Minimal", { timeout: 20_000 });
+			await expect.poll(
+				() => sentFrames.find((frame) => frame.type === "set_model" && frame.modelId === ASTRA.id),
+				{ timeout: 15_000, message: "selecting Astra from Off should send the clamped Minimal tuple" },
+			).toEqual({ type: "set_model", provider: ASTRA.provider, modelId: ASTRA.id, thinkingLevel: "minimal" });
+			await expect.poll(() => readRemoteAstra(page), { timeout: 20_000 }).toEqual(expectedLiveAstra("minimal"));
+			await expect.poll(() => persistedAstra(gateway, sessionId!), { timeout: 20_000 }).toEqual({
+				modelProvider: ASTRA.provider,
+				modelId: ASTRA.id,
+				effectiveThinkingLevel: "minimal",
+			});
+
+			const thinking = page.locator(".thinking-select-compact");
+			await thinking.locator("button").click();
+			const listbox = page.locator('[role="listbox"]').last();
+			await expect(listbox).toBeVisible();
+			const labels = (await listbox.locator('[role="option"]').allTextContents())
+				.map((text) => text.replace(/\s+/g, " ").trim());
+			expect(labels, "Pi marks Off unsupported for Astra").not.toContain("Off");
+			expect(labels, "Pi exposes Astra reasoning through Max").toContain("Max");
+			await listbox.getByRole("option", { name: "Max", exact: true }).click();
+
+			await expect(thinking).toHaveAttribute("title", "Max", { timeout: 20_000 });
+			await expect.poll(() => readRemoteAstra(page), { timeout: 20_000 }).toEqual(expectedLiveAstra("max"));
+			await expect.poll(() => persistedAstra(gateway, sessionId!), { timeout: 20_000 }).toEqual({
+				modelProvider: ASTRA.provider,
+				modelId: ASTRA.id,
+				effectiveThinkingLevel: "max",
+			});
+
+			await page.reload({ waitUntil: "domcontentloaded" });
+			await navigateToHash(page, `#/session/${sessionId}`);
+			await expect(footerModel).toHaveText(ASTRA.id, { timeout: 20_000 });
+			await expect(thinking).toHaveAttribute("title", "Max", { timeout: 20_000 });
+			await expect.poll(() => readRemoteAstra(page), { timeout: 20_000 }).toEqual(expectedLiveAstra("max"));
+
+			await sendMessage(page, "Astra persistence restart marker");
+			await waitForAgentResponse(page);
+			await waitForSessionStatus(sessionId, "idle");
+
+			await gateway.crash();
+			gatewayOnline = false;
+			await gateway.restart();
+			gatewayOnline = true;
+			await waitForHealth(20_000);
+			await waitForSessionStatus(sessionId, "idle", 40_000);
+
+			await page.reload({ waitUntil: "domcontentloaded" });
+			await navigateToHash(page, `#/session/${sessionId}`);
+			await expect(footerModel).toHaveText(ASTRA.id, { timeout: 20_000 });
+			await expect(thinking).toHaveAttribute("title", "Max", { timeout: 20_000 });
+			await expect.poll(() => readRemoteAstra(page), { timeout: 20_000 }).toEqual(expectedLiveAstra("max"));
+			expect(persistedAstra(gateway, sessionId)).toEqual({
+				modelProvider: ASTRA.provider,
+				modelId: ASTRA.id,
+				effectiveThinkingLevel: "max",
+			});
+		} finally {
+			if (!gatewayOnline) {
+				await gateway.restart().catch(() => undefined);
+				await waitForHealth(20_000).catch(() => undefined);
+			}
+			if (sessionId) await deleteSession(sessionId).catch(() => undefined);
+			restoreAuth();
+			registry.clearOAuthCache();
+			registry.invalidateModelCache();
+		}
+	});
+});

--- a/tests/e2e/browser/packaged-inline-html-theme.browser-e2e.spec.ts
+++ b/tests/e2e/browser/packaged-inline-html-theme.browser-e2e.spec.ts
@@ -47,7 +47,8 @@ const DEV_ONLY_BUNDLED_PACKAGES = [
 	"qrcode",
 	"sortablejs",
 ] as const;
-const REQUIRED_PI_VERSION = "0.84.1";
+const REQUIRED_PI_VERSION = "0.85.1";
+const MINIMUM_PI_NODE_VERSION = "22.19.0";
 
 interface JsonRecord {
 	[key: string]: unknown;
@@ -89,6 +90,8 @@ interface RuntimeReport {
 		installedPackageCount: number;
 	};
 	selectedPiVersion?: string;
+	nodeVersion?: string;
+	piCli?: { declaredPath: string; stdout: string; stderr: string };
 	tree?: unknown;
 	binaries?: unknown;
 	bridgeAssets: string[];
@@ -478,16 +481,26 @@ test.describe("packed Bobbit inline HTML runtime", () => {
 			report.commands.push(install);
 			expect(install.code, commandFailure(install)).toBe(0);
 			expect(existsSync(join(consumerDir, "package-lock.json")), "consumer install must create its own lockfile").toBe(true);
+			const installedPiRoot = join(consumerDir, "node_modules", "@earendil-works", "pi-coding-agent");
 			expect(
-				existsSync(join(
-					consumerDir,
-					"node_modules",
-					"@earendil-works",
-					"pi-coding-agent",
-					"npm-shrinkwrap.json",
-				)),
+				existsSync(join(installedPiRoot, "npm-shrinkwrap.json")),
 				"published pi-coding-agent must include its dependency-owned shrinkwrap",
 			).toBe(true);
+
+			const nodeVersionResult = await runPiPackedConsumerCommand(process.execPath, ["--version"], {
+				cwd: consumerDir,
+				env: consumerEnv,
+				timeoutMs: 30_000,
+			});
+			report.commands.push(nodeVersionResult);
+			expect(nodeVersionResult.code, commandFailure(nodeVersionResult)).toBe(0);
+			const nodeVersion = nodeVersionResult.stdout.trim().replace(/^v/, "");
+			parseVersion(nodeVersion, "packed consumer Node version");
+			expect(
+				compareVersions(nodeVersion, MINIMUM_PI_NODE_VERSION),
+				`packed consumer Node ${nodeVersion} must satisfy Pi's >=${MINIMUM_PI_NODE_VERSION} engine`,
+			).toBeGreaterThanOrEqual(0);
+			report.nodeVersion = nodeVersion;
 
 			const installedRoot = join(consumerDir, "node_modules", ...PACKAGE_INSTALL_SEGMENTS);
 			const installedManifest = JSON.parse(await readFile(join(installedRoot, "package.json"), "utf8")) as {
@@ -518,6 +531,28 @@ test.describe("packed Bobbit inline HTML runtime", () => {
 			parseVersion(selectedPiVersion, "selected Pi pin");
 			expect(selectedPiVersion, "packed Bobbit must pin Pi exactly to the supported version").toBe(REQUIRED_PI_VERSION);
 			report.selectedPiVersion = selectedPiVersion;
+
+			const installedPiManifest = JSON.parse(await readFile(join(installedPiRoot, "package.json"), "utf8")) as {
+				bin?: Record<string, string>;
+				engines?: { node?: string };
+			};
+			expect(installedPiManifest.engines?.node, "installed Pi must declare its supported Node floor").toBe(">=22.19.0");
+			expect(installedPiManifest.bin?.pi, "installed Pi must declare its bundled CLI").toBe("dist/bundle/cli.js");
+			const declaredPiCli = join(installedPiRoot, ...installedPiManifest.bin!.pi.split("/"));
+			expect(existsSync(declaredPiCli), `installed Pi CLI does not exist at ${declaredPiCli}`).toBe(true);
+			const piCliSmoke = await runPiPackedConsumerCommand(process.execPath, [declaredPiCli, "--version"], {
+				cwd: consumerDir,
+				env: consumerEnv,
+				timeoutMs: 30_000,
+			});
+			report.commands.push(piCliSmoke);
+			expect(piCliSmoke.code, commandFailure(piCliSmoke)).toBe(0);
+			expect(`${piCliSmoke.stdout}\n${piCliSmoke.stderr}`, "Pi bundled CLI --version must report 0.85.1").toContain(REQUIRED_PI_VERSION);
+			report.piCli = {
+				declaredPath: installedPiManifest.bin!.pi,
+				stdout: piCliSmoke.stdout,
+				stderr: piCliSmoke.stderr,
+			};
 
 			const lsResult = await runPiPackedConsumerNpm(
 				["ls", ...INSPECTED_PACKAGES, "--all", "--json"],

--- a/tests/integration/gateway/agent/astra-session-persistence.gateway.test.ts
+++ b/tests/integration/gateway/agent/astra-session-persistence.gateway.test.ts
@@ -1,0 +1,156 @@
+import { join } from "node:path";
+import { getBuiltinModel } from "@earendil-works/pi-ai/providers/all";
+import { test, expect } from "../../../support/harnesses/integration/gateway/in-process-harness.js";
+import {
+	apiFetch,
+	connectWs,
+	createSession,
+	deleteSession,
+	type WsConnection,
+	type WsMsg,
+} from "../../../support/harnesses/integration/gateway/e2e-setup.js";
+import { installFakeCodexOAuth } from "../../../support/fixtures/models/fake-codex-oauth.js";
+import { pollUntil } from "../../../e2e/test-utils/cleanup.js";
+import {
+	clearOAuthCache,
+	findSessionSelectableModel,
+	invalidateModelCache,
+} from "../../../../src/server/agent/model-registry.js";
+
+const ASTRA = {
+	provider: "openai-codex",
+	id: "gpt-6-astra",
+} as const;
+
+const ASTRA_THINKING_MAP = {
+	off: null,
+	minimal: "low",
+	low: "low",
+	medium: "medium",
+	high: "high",
+	xhigh: "xhigh",
+	max: "max",
+} as const;
+
+function astraState(message: WsMsg, thinkingLevel: "minimal" | "max"): boolean {
+	if (message.type !== "state") return false;
+	const state = message.data as any;
+	return state?.model?.provider === ASTRA.provider
+		&& state?.model?.id === ASTRA.id
+		&& state?.thinkingLevel === thinkingLevel;
+}
+
+function assertAstraState(message: WsMsg, thinkingLevel: "minimal" | "max", context: string): void {
+	expect(message.type, context).toBe("state");
+	const state = message.data as any;
+	expect(state.thinkingLevel, `${context}: effective thinking`).toBe(thinkingLevel);
+	expect(state.model, `${context}: Pi metadata`).toMatchObject({
+		provider: ASTRA.provider,
+		id: ASTRA.id,
+		contextWindow: 272_000,
+		maxTokens: 128_000,
+		reasoning: true,
+		input: ["text", "image"],
+		thinkingLevelMap: ASTRA_THINKING_MAP,
+	});
+}
+
+async function closeWs(ws: WsConnection): Promise<void> {
+	const closed = new Promise<void>((resolve) => ws.ws.once("close", () => resolve()));
+	ws.close();
+	await closed;
+}
+
+async function waitForPersistedThinking(gateway: any, sessionId: string, thinkingLevel: "minimal" | "max"): Promise<void> {
+	await pollUntil(async () => {
+		const row = gateway.sessionManager.getPersistedSession(sessionId);
+		return row?.modelProvider === ASTRA.provider
+			&& row.modelId === ASTRA.id
+			&& row.effectiveThinkingLevel === thinkingLevel;
+	}, { timeoutMs: 5_000, intervalMs: 25, label: `Astra/${thinkingLevel} tuple persisted` });
+}
+
+function stripBobbitPresentation(model: Record<string, unknown>): Record<string, unknown> {
+	const { authenticated: _authenticated, modelCapacity: _modelCapacity, ...piRow } = model;
+	return piRow;
+}
+
+test.describe("Astra session persistence", () => {
+	test("uses the authenticated Pi row, clamps off to minimal, and retains max across reconnect", async ({ gateway }) => {
+		gateway.restoreAgentDirRuntime();
+		const restoreAuth = installFakeCodexOAuth(join(gateway.bobbitDir, "agent"));
+		clearOAuthCache();
+		invalidateModelCache();
+
+		let sessionId: string | undefined;
+		let ws1: WsConnection | undefined;
+		let ws2: WsConnection | undefined;
+		try {
+			const response = await apiFetch("/api/models");
+			expect(response.status).toBe(200);
+			const models = await response.json() as Array<Record<string, any>>;
+			const matches = models.filter((model) => model.provider === ASTRA.provider && model.id === ASTRA.id);
+			expect(matches, "Astra must occur exactly once in the real Pi-backed API catalog").toHaveLength(1);
+			const model = matches[0];
+			expect(model.authenticated, "the isolated Codex OAuth fixture should authenticate Astra").toBe(true);
+			expect(findSessionSelectableModel(models as any, ASTRA.provider, ASTRA.id)).toBe(model);
+
+			const upstream = getBuiltinModel(ASTRA.provider, ASTRA.id);
+			expect(upstream, "Pi 0.85.1 must publish the Astra row").toBeTruthy();
+			expect(stripBobbitPresentation(model)).toEqual(upstream);
+			expect(model).toMatchObject({
+				name: "GPT-6 Astra",
+				api: "openai-codex-responses",
+				baseUrl: "https://chatgpt.com/backend-api",
+				contextWindow: 272_000,
+				maxTokens: 128_000,
+				reasoning: true,
+				input: ["text", "image"],
+				cost: {
+					input: 10,
+					output: 50,
+					cacheRead: 1,
+					cacheWrite: 12.5,
+					tiers: [{ inputTokensAbove: 272_000, input: 20, output: 75, cacheRead: 2, cacheWrite: 25 }],
+				},
+				thinkingLevelMap: ASTRA_THINKING_MAP,
+				compat: {
+					supportsOpenAIGrammarTools: true,
+					supportsAdditionalTools: true,
+					supportsToolSearch: true,
+				},
+			});
+
+			sessionId = await createSession();
+			ws1 = await connectWs(sessionId);
+
+			let cursor = ws1.messageCount();
+			ws1.send({ type: "set_model", provider: ASTRA.provider, modelId: ASTRA.id, thinkingLevel: "off" });
+			const minimal = await ws1.waitForFrom(cursor, (message) => astraState(message, "minimal"), 10_000);
+			assertAstraState(minimal, "minimal", "off selection");
+			await waitForPersistedThinking(gateway, sessionId, "minimal");
+
+			cursor = ws1.messageCount();
+			ws1.send({ type: "set_model", provider: ASTRA.provider, modelId: ASTRA.id, thinkingLevel: "max" });
+			const max = await ws1.waitForFrom(cursor, (message) => astraState(message, "max"), 10_000);
+			assertAstraState(max, "max", "max selection");
+			await waitForPersistedThinking(gateway, sessionId, "max");
+
+			await closeWs(ws1);
+			ws1 = undefined;
+			ws2 = await connectWs(sessionId);
+			cursor = ws2.messageCount();
+			ws2.send({ type: "get_state" });
+			const reconnected = await ws2.waitForFrom(cursor, (message) => astraState(message, "max"), 10_000);
+			assertAstraState(reconnected, "max", "reconnect");
+			await waitForPersistedThinking(gateway, sessionId, "max");
+		} finally {
+			if (ws2) await closeWs(ws2).catch(() => undefined);
+			if (ws1) await closeWs(ws1).catch(() => undefined);
+			if (sessionId) await deleteSession(sessionId).catch(() => undefined);
+			restoreAuth();
+			clearOAuthCache();
+			invalidateModelCache();
+		}
+	});
+});

--- a/tests/support/fixtures/models/fake-codex-oauth.ts
+++ b/tests/support/fixtures/models/fake-codex-oauth.ts
@@ -1,0 +1,29 @@
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * Installs a credential-shaped, explicitly fake Codex OAuth row in an isolated
+ * test agent directory. The prior auth.json bytes are restored verbatim.
+ */
+export function installFakeCodexOAuth(agentDir: string): () => void {
+	mkdirSync(agentDir, { recursive: true });
+	const authPath = join(agentDir, "auth.json");
+	const existed = existsSync(authPath);
+	const previous = existed ? readFileSync(authPath) : undefined;
+	let auth: Record<string, unknown> = {};
+	if (previous) {
+		try { auth = JSON.parse(previous.toString("utf8")); } catch { auth = {}; }
+	}
+	auth["openai-codex"] = {
+		type: "oauth",
+		access: "test-only-codex-access",
+		refresh: "test-only-codex-refresh",
+		expires: Date.now() + 60 * 60 * 1000,
+	};
+	writeFileSync(authPath, JSON.stringify(auth, null, 2), "utf8");
+
+	return () => {
+		if (existed && previous) writeFileSync(authPath, previous);
+		else rmSync(authPath, { force: true });
+	};
+}

--- a/tests/unit/core/assistant-stream-delta.unit.test.ts
+++ b/tests/unit/core/assistant-stream-delta.unit.test.ts
@@ -69,6 +69,71 @@ function roundTrip(events: AnyObject[]): AnyObject[] {
 }
 
 describe("assistant stream delta compaction", () => {
+	it("applies Pi 0.85 cumulative usage without mutating old-frame fallback state", () => {
+		const normalizer = new PiAssistantStreamNormalizer();
+		const baseline = message([]);
+		normalizer.normalize({ type: "message_start", message: baseline });
+
+		const oldFrame = normalizer.normalize({
+			type: "message_update",
+			assistantMessageEvent: { type: "text_start", contentIndex: 0 },
+		}) as AnyObject;
+		assert.deepEqual(oldFrame.message.usage, usage);
+
+		const cumulativeUsage = {
+			input: 8,
+			output: 2,
+			cacheRead: 1,
+			cacheWrite: 0,
+			totalTokens: 11,
+			cost: { input: 0.08, output: 0.04, cacheRead: 0.001, cacheWrite: 0, total: 0.121 },
+		};
+		const updateFrame: AnyObject = {
+			type: "message_update",
+			usage: cumulativeUsage,
+			assistantMessageEvent: { type: "text_delta", contentIndex: 0, delta: "new" },
+		};
+		const normalized = normalizer.normalize(updateFrame) as AnyObject;
+		assert.strictEqual(normalized.usage, cumulativeUsage, "outer Pi usage remains on the event");
+		assert.deepEqual(normalized.message.usage, cumulativeUsage);
+		assert.deepEqual(normalized.assistantMessageEvent.partial.usage, cumulativeUsage);
+		assert.notStrictEqual(normalized.message.usage, cumulativeUsage, "reconstructed state clones Pi-owned usage");
+
+		cumulativeUsage.output = 99;
+		assert.equal(normalized.message.usage.output, 2);
+	});
+
+	it("seeds Pi 0.85 tool identity while retaining conservative old-frame fallbacks", () => {
+		const normalizer = new PiAssistantStreamNormalizer();
+		normalizer.normalize({ type: "message_start", message: message([]) });
+
+		const identified = normalizer.normalize({
+			type: "message_update",
+			assistantMessageEvent: {
+				type: "toolcall_start",
+				contentIndex: 0,
+				id: "call-astra-1",
+				toolName: "read",
+			},
+		}) as AnyObject;
+		assert.deepEqual(identified.message.content[0], {
+			type: "toolCall",
+			id: "call-astra-1",
+			name: "read",
+			arguments: {},
+			partialJson: "",
+		});
+
+		const legacy = new PiAssistantStreamNormalizer();
+		legacy.normalize({ type: "message_start", message: message([]) });
+		const fallback = legacy.normalize({
+			type: "message_update",
+			assistantMessageEvent: { type: "toolcall_start", contentIndex: 0, id: 7, toolName: null },
+		}) as AnyObject;
+		assert.equal(fallback.message.content[0].id, "");
+		assert.equal(fallback.message.content[0].name, "");
+	});
+
 	it("reconstructs Pi delta-only text and defers final content to terminal authority", () => {
 		const normalizer = new PiAssistantStreamNormalizer();
 		const baseline = message([]);
@@ -125,6 +190,32 @@ describe("assistant stream delta compaction", () => {
 		assert.equal(compact[0].assistantMessageBaseline.timestamp, 1_735_000_000_000);
 	});
 
+	it("round-trips authoritative cumulative usage through compact frames", () => {
+		const previous = message([{ type: "text", text: "old" }]);
+		const current = message([{ type: "text", text: "old plus" }]);
+		const cumulativeUsage = {
+			input: 50,
+			output: 8,
+			cacheRead: 4,
+			cacheWrite: 0,
+			totalTokens: 62,
+			cost: { input: 0.5, output: 0.4, cacheRead: 0.004, cacheWrite: 0, total: 0.904 },
+		};
+		current.usage = cumulativeUsage;
+		const original: AnyObject = {
+			...update(current, { type: "text_delta", contentIndex: 0, delta: " plus" }),
+			usage: structuredClone(cumulativeUsage),
+		};
+
+		const compact = compactAssistantStreamDelta(original, previous) as AnyObject;
+		assert.equal(compact.assistantStreamDelta, 1);
+		assert.deepEqual(compact.usage, cumulativeUsage);
+		const reconstructed = reconstructAssistantStreamDelta(compact, previous) as AnyObject;
+		assert.deepEqual(reconstructed, original);
+		assert.deepEqual(reconstructed.message.usage, cumulativeUsage);
+		assert.deepEqual(reconstructed.assistantMessageEvent.partial.usage, cumulativeUsage);
+	});
+
 	it("round-trips thinking blocks including end-only metadata", () => {
 		const current = message([{ type: "thinking", thinking: "" }]);
 		const events = [update(current, { type: "thinking_start", contentIndex: 0 })];
@@ -148,7 +239,12 @@ describe("assistant stream delta compaction", () => {
 
 		const tool: AnyObject = { type: "toolCall", id: "call-1", name: "edit", arguments: {} };
 		const current = message([tool]);
-		const events = [update(current, { type: "toolcall_start", contentIndex: 0 })];
+		const events = [update(current, {
+			type: "toolcall_start",
+			contentIndex: 0,
+			id: "call-1",
+			toolName: "edit",
+		})];
 		let json = "";
 		for (const delta of ['{"path":"src/assi', 'stant-stream.ts","flags":[tru', 'e,2],"nested":{"ok":"yes"}}']) {
 			json += delta;
@@ -163,7 +259,9 @@ describe("assistant stream delta compaction", () => {
 			toolCall: structuredClone(tool),
 		}));
 
-		roundTrip(events);
+		const compact = roundTrip(events);
+		assert.equal(compact[0].assistantMessageEvent.id, "call-1");
+		assert.equal(compact[0].assistantMessageEvent.toolName, "edit");
 	});
 
 	it("forces a self-contained progressive tool baseline from reconstructed session state", () => {

--- a/tests/unit/core/assistant-stream-session-broadcast.unit.test.ts
+++ b/tests/unit/core/assistant-stream-session-broadcast.unit.test.ts
@@ -32,14 +32,24 @@ class FakeWebSocket extends EventEmitter {
 }
 
 function makeAssistantUpdate(text: string, delta: string) {
+	const usage = {
+		input: 10,
+		output: text.length,
+		cacheRead: 0,
+		cacheWrite: 0,
+		totalTokens: 10 + text.length,
+		cost: { input: 0.1, output: text.length / 100, cacheRead: 0, cacheWrite: 0, total: 0.1 + text.length / 100 },
+	};
 	const message = {
 		role: "assistant",
 		id: "stream-1",
 		content: [{ type: "text", text }],
+		usage: structuredClone(usage),
 		timestamp: 1_735_000_000_000,
 	};
 	return {
 		type: "message_update",
+		usage,
 		message,
 		assistantMessageEvent: {
 			type: "text_delta",
@@ -63,6 +73,7 @@ function makeToolUpdate(argumentsValue: Record<string, unknown>, type: "toolcall
 		assistantMessageEvent: {
 			type,
 			contentIndex: 0,
+			...(type === "toolcall_start" ? { id: "call-1", toolName: "edit" } : {}),
 			...(delta === undefined ? {} : { delta }),
 			partial: structuredClone(message),
 		},
@@ -228,7 +239,9 @@ describe("assistant stream session broadcast", () => {
 		assert.equal(capableFirst.assistantStreamDelta, 1);
 		assert.equal("message" in capableFirst, false);
 		assert.equal(capableFirst.assistantMessageBaseline.content[0].text, "");
+		assert.deepEqual(capableFirst.usage, first.usage);
 		assert.equal(legacyFirst.message.content[0].text, "Hello");
+		assert.deepEqual(legacyFirst.message.usage, first.usage);
 
 		const second = makeAssistantUpdate("Hello world", " world");
 		emitSessionEvent(session, second);
@@ -237,7 +250,13 @@ describe("assistant stream session broadcast", () => {
 		const legacySecond = eventFrames(legacy)[1].data;
 		assert.equal(capableSecond.assistantStreamDelta, 1);
 		assert.equal("assistantMessageBaseline" in capableSecond, false);
+		assert.deepEqual(capableSecond.usage, second.usage);
+		const reconstructedFirst = reconstructAssistantStreamDelta(capableFirst) as any;
+		const reconstructedSecond = reconstructAssistantStreamDelta(capableSecond, reconstructedFirst.message) as any;
+		assert.deepEqual(reconstructedSecond.message.usage, second.usage);
+		assert.deepEqual(reconstructedSecond.assistantMessageEvent.partial.usage, second.usage);
 		assert.equal(legacySecond.message.content[0].text, "Hello world");
+		assert.deepEqual(legacySecond.message.usage, second.usage);
 
 		assert.deepEqual(
 			session.eventBuffer.getAll().map((entry: any) => entry.event.message.content[0].text),
@@ -277,9 +296,13 @@ describe("assistant stream session broadcast", () => {
 		}
 
 		let previous: any;
-		for (const frame of eventFrames(capable)) {
+		for (const [index, frame] of eventFrames(capable).entries()) {
 			assert.equal(frame.data.assistantStreamDelta, 1, "every capable tool frame stays compact");
 			assert.equal("message" in frame.data, false);
+			if (index === 0) {
+				assert.equal(frame.data.assistantMessageEvent.id, "call-1");
+				assert.equal(frame.data.assistantMessageEvent.toolName, "edit");
+			}
 			const reconstructed = reconstructAssistantStreamDelta(frame.data, previous) as any;
 			previous = reconstructed.message;
 		}

--- a/tests/unit/core/compaction-types.unit.test.ts
+++ b/tests/unit/core/compaction-types.unit.test.ts
@@ -9,14 +9,17 @@
  */
 import { describe, it } from "vitest";
 import assert from "node:assert/strict";
-import type {
-	BranchBounds,
-	BranchSummaryEntry as HarnessBranchSummaryEntry,
-	CompactionEntry as HarnessCompactionEntry,
-	EntryCursor,
-	EntryQuery,
-	HarnessSpanStartAttributes,
-	SessionStorage,
+import {
+	TODO_CONTEXT,
+	type Branch,
+	type BranchScan,
+	type BranchSummaryEntry as HarnessBranchSummaryEntry,
+	type CompactionEntry as HarnessCompactionEntry,
+	type Context,
+	type EntryCursor,
+	type EntryQuery,
+	type HarnessSpanStartAttributes,
+	type Session,
 } from "@earendil-works/pi-agent-core";
 import type { AgentSessionEvent } from "@earendil-works/pi-coding-agent";
 import {
@@ -111,8 +114,8 @@ describe("compaction-types", () => {
 	});
 });
 
-describe("Pi 0.84 compaction contracts", () => {
-	it("accepts retained-tail checkpoints, summary usage, and the current SessionStorage query API", async () => {
+describe("Pi 0.85 compaction contracts", () => {
+	it("accepts retained-tail checkpoints, summary usage, and the current Session query API", async () => {
 		const compaction: HarnessCompactionEntry = {
 			type: "compaction",
 			id: "compact",
@@ -124,6 +127,7 @@ describe("Pi 0.84 compaction contracts", () => {
 			retainedTail: [{ role: "user", content: "kept", timestamp: 1 }],
 			usage: RICH_USAGE,
 			details: { additive: true },
+			fromHook: false,
 		};
 		const branchSummary: HarnessBranchSummaryEntry = {
 			type: "branch_summary",
@@ -134,38 +138,36 @@ describe("Pi 0.84 compaction contracts", () => {
 			fromId: "abandoned",
 			summary: "branch summary",
 			usage: RICH_USAGE,
+			fromHook: false,
 		};
-		const cursor = { afterSeq: 4 } satisfies EntryCursor;
-		const entryQuery = { cursor, limit: 2, order: "oldestFirst" } satisfies EntryQuery;
+		const cursor = { seq: 4 } satisfies EntryCursor;
+		const entryQuery = { cursor, limit: 2, order: "asc" } satisfies EntryQuery;
 		const branchQuery = {
 			start: "branch",
 			stopAtType: "compaction",
 			order: "oldestFirst",
-		} satisfies EntryQuery & BranchBounds & { start: string };
-		const storage = {
-			getName: async () => "fixture",
-			getStats: async () => ({
+		} satisfies BranchScan;
+		const findBranchEntries: Branch["findEntries"] = async (_query, _context) => [
+			compaction,
+			branchSummary,
+		];
+		const session = {
+			getName: async (_context: Context) => "fixture",
+			getStats: async (_context: Context) => ({
 				messageCount: 1,
-				cachedTokens: 3,
-				uncachedTokens: 13,
-				totalTokens: 23,
-				costTotal: 0.33,
+				usage: RICH_USAGE,
 			}),
-			findEntriesOnBranch: async (_query: EntryQuery & BranchBounds & { start: string }) => [
-				compaction,
-				branchSummary,
-			],
-			findEntries: async (_query?: EntryQuery) => [compaction, branchSummary],
-		} satisfies Pick<SessionStorage, "getName" | "getStats" | "findEntriesOnBranch" | "findEntries">;
+			findEntries: async (_query: EntryQuery | undefined, _context: Context) => [compaction, branchSummary],
+		} satisfies Pick<Session, "getName" | "getStats" | "findEntries">;
 
 		assert.equal("firstKeptEntryId" in compaction, false, "retainedTail replaces the legacy boundary");
 		assert.equal(compaction.retainedTail[0].role, "user");
 		assert.equal(branchSummary.usage?.reasoning, 4);
-		assert.deepEqual(entryQuery, { cursor: { afterSeq: 4 }, limit: 2, order: "oldestFirst" });
-		assert.equal(await storage.getName(), "fixture");
-		assert.equal((await storage.getStats()).totalTokens, 23);
-		assert.deepEqual(await storage.findEntriesOnBranch(branchQuery), [compaction, branchSummary]);
-		assert.deepEqual(await storage.findEntries(entryQuery), [compaction, branchSummary]);
+		assert.deepEqual(entryQuery, { cursor: { seq: 4 }, limit: 2, order: "asc" });
+		assert.equal(await session.getName(TODO_CONTEXT), "fixture");
+		assert.equal((await session.getStats(TODO_CONTEXT)).usage.totalTokens, 23);
+		assert.deepEqual(await findBranchEntries(branchQuery, TODO_CONTEXT), [compaction, branchSummary]);
+		assert.deepEqual(await session.findEntries(entryQuery, TODO_CONTEXT), [compaction, branchSummary]);
 	});
 
 	it("accepts compaction and branch-summary retry lifecycle events without dropping terminal usage", () => {

--- a/tests/unit/core/google-code-assist-registry.unit.test.ts
+++ b/tests/unit/core/google-code-assist-registry.unit.test.ts
@@ -174,7 +174,7 @@ describe("Google account model emission + auth isolation", () => {
 	it("emits the supported Code Assist Gemini models", () => {
 		const accountIds = new Set(snapshots.oauth.filter((m) => m.provider === "google-gemini-cli").map((m) => m.id));
 		// These are confirmed-serving ids that are also present in pi-ai's catalog.
-		for (const supported of ["gemini-2.5-flash", "gemini-2.5-pro", "gemini-3-pro-preview", "gemini-3.1-pro-preview"]) {
+		for (const supported of ["gemini-2.5-flash", "gemini-2.5-pro", "gemini-3.1-pro-preview"]) {
 			assert.equal(accountIds.has(supported), true, `${supported} must be emitted (Code Assist supported)`);
 		}
 	});

--- a/tests/unit/core/model-state-meta-resolver.unit.test.ts
+++ b/tests/unit/core/model-state-meta-resolver.unit.test.ts
@@ -31,9 +31,11 @@ const AUTHORITATIVE_CAPACITY_ROWS = [
 	["openai", "gpt-5.6-luna"],
 	["openai", "gpt-5.6-sol"],
 	["openai", "gpt-5.6-terra"],
+	["openai", "gpt-6-astra"],
 	["openai-codex", "gpt-5.6-luna"],
 	["openai-codex", "gpt-5.6-sol"],
 	["openai-codex", "gpt-5.6-terra"],
+	["openai-codex", "gpt-6-astra"],
 ] as const;
 
 describe("resolveModelStateMeta", () => {

--- a/tests/unit/core/model-utils.unit.test.ts
+++ b/tests/unit/core/model-utils.unit.test.ts
@@ -13,7 +13,10 @@ import { describe, it } from "vitest";
 import assert from "node:assert/strict";
 import { getBuiltinModels } from "@earendil-works/pi-ai/providers/all";
 import { inferLegacyAigwMeta } from "../../../src/server/agent/aigw-manager.ts";
-import { modelRecencyRank as serverModelRecencyRank } from "../../../src/server/agent/model-registry.ts";
+import {
+	modelRecencyRank as serverModelRecencyRank,
+	resolveAuthoritativeModelCapacity,
+} from "../../../src/server/agent/model-registry.ts";
 import { modelRecencyRank } from "../../../src/shared/model-ranks.ts";
 
 // ── Legacy /v1/models inference tests ─────────────────────────────
@@ -215,7 +218,7 @@ describe("inferLegacyAigwMeta()", () => {
 // ── Pi model catalog tests ─────────────────────────────────────────
 
 describe("pi-ai model catalog", () => {
-	it("exposes Pi 0.84.1's authoritative direct Claude Opus 5 metadata", () => {
+	it("exposes Pi 0.85.1's authoritative direct Claude Opus 5 metadata", () => {
 		const model = getBuiltinModels("anthropic").find((candidate) => candidate.id === "claude-opus-5");
 		assert.ok(model, "anthropic/claude-opus-5 should exist in the Pi catalog");
 		assert.equal(model.name, "Claude Opus 5");
@@ -227,12 +230,22 @@ describe("pi-ai model catalog", () => {
 		assert.equal(model.reasoning, true);
 		assert.deepEqual(model.input, ["text", "image"]);
 		assert.deepEqual(model.cost, { input: 5, output: 25, cacheRead: 0.5, cacheWrite: 6.25 });
-		assert.deepEqual(model.thinkingLevelMap, { xhigh: "xhigh", max: "max" });
+		assert.deepEqual(model.thinkingLevelMap, { off: null, xhigh: "xhigh", max: "max" });
 		assert.deepEqual((model as any).compat, {
+			supportsMidConvoEffort: true,
 			forceAdaptiveThinking: true,
 			supportsTemperature: false,
 			supportsStrictTools: true,
 		});
+	});
+
+	it("assigns Astra display capacity only to reviewed exact catalog tuples", () => {
+		for (const provider of ["openai", "openai-codex"]) {
+			assert.equal(resolveAuthoritativeModelCapacity(provider, "gpt-6-astra", 272_000), 1_050_000);
+			assert.equal(resolveAuthoritativeModelCapacity(provider, "gpt-6-astra", 1_050_000), undefined);
+		}
+		assert.equal(resolveAuthoritativeModelCapacity("openrouter", "gpt-6-astra", 272_000), undefined);
+		assert.equal(resolveAuthoritativeModelCapacity("openai", "gpt-6-astra-preview", 272_000), undefined);
 	});
 });
 

--- a/tests/unit/core/models-api.unit.test.ts
+++ b/tests/unit/core/models-api.unit.test.ts
@@ -8,23 +8,50 @@
  * Validates model structure from built-in providers without needing
  * a full gateway. Replaces the slower E2E version in tests/e2e/models-api.spec.ts.
  */
-import { describe, it } from "vitest";
+import { guardProcessEnv } from "../../../tests/support/helpers/unit/env-guard.js";
+guardProcessEnv();
+
+import { afterAll, describe, it } from "vitest";
 import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import path from "node:path";
 import { getBuiltinModel, getBuiltinModels } from "@earendil-works/pi-ai/providers/all";
 import { createMemFs } from "../../../tests/support/harnesses/shared/mem-fs.js";
+import { pinAgentDirForTest, resetAgentDirForTest } from "../../../tests/helpers/agent-dir.js";
 
 const memfs = createMemFs();
 const stateDir = path.resolve("/memfs/models-test");
+const agentDir = mkdtempSync(path.join(tmpdir(), "bobbit-models-api-"));
+process.env.BOBBIT_AGENT_DIR = agentDir;
+pinAgentDirForTest(agentDir);
+writeFileSync(
+	path.join(agentDir, "auth.json"),
+	JSON.stringify({ "openai-codex": { type: "oauth", access: "fake-test-token" } }),
+	"utf-8",
+);
 
-// Import after setup
+// Import after the isolated fake account state is installed.
 const { PreferencesStore } = await import("../../../src/server/agent/preferences-store.ts");
-const { findSessionSelectableModel, getAvailableModels, getBuiltInProviderIds, invalidateModelCache } = await import("../../../src/server/agent/model-registry.ts");
+const {
+	clearOAuthCache,
+	findSessionSelectableModel,
+	getAvailableModels,
+	getBuiltInProviderIds,
+	invalidateModelCache,
+} = await import("../../../src/server/agent/model-registry.ts");
 
 const prefs = new PreferencesStore(stateDir, memfs);
+clearOAuthCache();
 
-// Fetch models once — all tests validate the same snapshot
+// Fetch models once — all tests validate the same snapshot.
 const models = await getAvailableModels(prefs);
+
+afterAll(() => {
+	clearOAuthCache();
+	resetAgentDirForTest();
+	rmSync(agentDir, { recursive: true, force: true });
+});
 
 // ── Structure tests ─────────────────────────────────────────────────
 
@@ -82,7 +109,59 @@ describe("Model registry", () => {
 		}
 	});
 
-	it("preserves exact Pi 0.84.1 Anthropic and Bedrock Claude Opus 5 catalog metadata", () => {
+	it("exposes Pi's exact authenticated and session-selectable OpenAI Codex Astra row", () => {
+		const pi = getBuiltinModel("openai-codex", "gpt-6-astra");
+		assert.ok(pi, "Pi should contain openai-codex/gpt-6-astra");
+		const matches = models.filter(model => model.provider === "openai-codex" && model.id === "gpt-6-astra");
+		assert.equal(matches.length, 1, "Astra should occur exactly once");
+		const model = matches[0];
+		assert.equal(model.authenticated, true, "isolated Codex OAuth state should authenticate Astra");
+		assert.equal(findSessionSelectableModel(models, "openai-codex", "gpt-6-astra"), model);
+		assert.equal(model.modelCapacity, 1_050_000);
+
+		const { authenticated, modelCapacity, ...authoritativeFields } = model;
+		assert.equal(authenticated, true);
+		assert.equal(modelCapacity, 1_050_000);
+		assert.deepEqual(authoritativeFields, pi, "Bobbit must preserve Pi's Astra row without an overlay");
+		assert.deepEqual(authoritativeFields, {
+			id: "gpt-6-astra",
+			name: "GPT-6 Astra",
+			api: "openai-codex-responses",
+			provider: "openai-codex",
+			baseUrl: "https://chatgpt.com/backend-api",
+			reasoning: true,
+			input: ["text", "image"],
+			cost: {
+				input: 10,
+				output: 50,
+				cacheRead: 1,
+				cacheWrite: 12.5,
+				tiers: [{ inputTokensAbove: 272_000, input: 20, output: 75, cacheRead: 2, cacheWrite: 25 }],
+			},
+			contextWindow: 272_000,
+			maxTokens: 128_000,
+			thinkingLevelMap: {
+				off: null,
+				minimal: "low",
+				low: "low",
+				medium: "medium",
+				high: "high",
+				xhigh: "xhigh",
+				max: "max",
+			},
+			compat: {
+				supportsOpenAIGrammarTools: true,
+				supportsAdditionalTools: true,
+				supportsToolSearch: true,
+			},
+		});
+
+		const direct = models.filter(model => model.provider === "openai" && model.id === "gpt-6-astra");
+		assert.equal(direct.length, 1, "direct OpenAI Astra should also occur exactly once");
+		assert.equal(direct[0].modelCapacity, 1_050_000);
+	});
+
+	it("preserves exact Pi 0.85.1 Anthropic and Bedrock Claude Opus 5 catalog metadata", () => {
 		const cases = [
 			{ provider: "anthropic", id: "claude-opus-5", name: "Claude Opus 5", api: "anthropic-messages", baseUrl: "https://api.anthropic.com", cost: { input: 5, output: 25, cacheRead: 0.5, cacheWrite: 6.25 } },
 			{ provider: "amazon-bedrock", id: "au.anthropic.claude-opus-5", name: "Claude Opus 5 (AU)", api: "bedrock-converse-stream", baseUrl: "https://bedrock-runtime.us-east-1.amazonaws.com", cost: { input: 5, output: 25, cacheRead: 0.5, cacheWrite: 6.25 } },
@@ -104,7 +183,12 @@ describe("Model registry", () => {
 			assert.equal(model.reasoning, true);
 			assert.deepEqual(model.input, ["text", "image"]);
 			assert.deepEqual(model.cost, expected.cost);
-			assert.deepEqual(model.thinkingLevelMap, { xhigh: "xhigh", max: "max" });
+			assert.deepEqual(
+				model.thinkingLevelMap,
+				expected.provider === "anthropic"
+					? { off: null, xhigh: "xhigh", max: "max" }
+					: { xhigh: "xhigh", max: "max" },
+			);
 			assert.notEqual(model.sessionSelectable, false);
 			if (expected.provider === "amazon-bedrock") {
 				assert.equal(model.compat, undefined, "Bedrock rows must not gain invented compat metadata");
@@ -113,6 +197,7 @@ describe("Model registry", () => {
 
 		const anthropic = models.find((model) => model.provider === "anthropic" && model.id === "claude-opus-5")!;
 		assert.deepEqual(anthropic.compat, {
+			supportsMidConvoEffort: true,
 			forceAdaptiveThinking: true,
 			supportsTemperature: false,
 			supportsStrictTools: true,
@@ -143,7 +228,7 @@ describe("Model registry", () => {
 		assert.equal(model.contextWindow, 272_000);
 	});
 
-	it("retains Pi 0.84.1 GPT-5.6 catalog entries including corrected Codex metadata", () => {
+	it("retains Pi 0.85.1 GPT-5.6 catalog entries including corrected Codex metadata", () => {
 		const requireModel = (provider: string, id: string) => {
 			const model = models.find((m) => m.provider === provider && m.id === id);
 			assert.ok(model, `${provider}/${id} should be available`);
@@ -181,7 +266,7 @@ describe("Model registry", () => {
 		}
 	});
 
-	it("retains supported Pi 0.84.1 catalog and routing fixes through the synchronous registry", () => {
+	it("retains supported Pi 0.85.1 catalog and routing fixes through the synchronous registry", () => {
 		const requireModel = (provider: string, id: string) => {
 			const model = models.find((m) => m.provider === provider && m.id === id);
 			assert.ok(model, `${provider}/${id} should be available`);
@@ -202,9 +287,9 @@ describe("Model registry", () => {
 			assert.equal(compat(provider, "kimi-k3")?.supportsReasoningEffort, true);
 		}
 
-		const openCodeGo = requireModel("opencode-go", "grok-4.5");
+		const openCodeGo = requireModel("opencode-go", "grok-4.6");
 		assert.equal(openCodeGo.api, "openai-responses");
-		assert.equal(compat("opencode-go", "grok-4.5")?.sessionAffinityFormat, "openai-nosession");
+		assert.equal(compat("opencode-go", "grok-4.6")?.sessionAffinityFormat, "openai-nosession");
 
 		const xai = requireModel("xai", "grok-4.5");
 		assert.equal(xai.api, "openai-responses");

--- a/tests/unit/core/node-modules-ring-fence.unit.test.ts
+++ b/tests/unit/core/node-modules-ring-fence.unit.test.ts
@@ -342,10 +342,11 @@ describe.skipIf(!desiredContractAvailable)("direct-host Pi resolution without a 
 		const modulesDir = path.join(root, "node_modules");
 		const packageRoot = path.join(modulesDir, "@earendil-works", "pi-coding-agent");
 		const entryPath = path.join(packageRoot, "dist", "index.js");
-		const cliPath = path.join(packageRoot, "dist", "cli.js");
+		const cliPath = path.join(packageRoot, "dist", "bundle", "cli.js");
 		fs.mkdirSync(path.dirname(entryPath), { recursive: true });
+		fs.mkdirSync(path.dirname(cliPath), { recursive: true });
 		fs.writeFileSync(entryPath, "export {};\n", "utf-8");
-		fs.writeFileSync(cliPath, "// fake Pi CLI\n", "utf-8");
+		fs.writeFileSync(cliPath, "// fake Pi bundled CLI\n", "utf-8");
 		writeJson(path.join(packageRoot, "package.json"), { name: PI_PACKAGE, type: "module" });
 
 		const specifiers: string[] = [];
@@ -382,11 +383,13 @@ describe.skipIf(!desiredContractAvailable)("direct-host Pi resolution without a 
 		const beforeStat = statIdentity(sentinel);
 
 		const modulesDir = path.join(root, "installed", "node_modules");
-		const entryPath = path.join(modulesDir, "@earendil-works", "pi-coding-agent", "dist", "index.js");
-		const cliPath = path.join(path.dirname(entryPath), "cli.js");
+		const packageRoot = path.join(modulesDir, "@earendil-works", "pi-coding-agent");
+		const entryPath = path.join(packageRoot, "dist", "index.js");
+		const cliPath = path.join(packageRoot, "dist", "bundle", "cli.js");
 		fs.mkdirSync(path.dirname(entryPath), { recursive: true });
+		fs.mkdirSync(path.dirname(cliPath), { recursive: true });
 		fs.writeFileSync(entryPath, "export {};\n", "utf-8");
-		fs.writeFileSync(cliPath, "// fake Pi CLI\n", "utf-8");
+		fs.writeFileSync(cliPath, "// fake Pi bundled CLI\n", "utf-8");
 
 		const observer = observeLegacyRuntimeAccess(runtimeDir);
 		const spawnCalls: Array<{ command: string; args: readonly string[] }> = [];
@@ -466,12 +469,12 @@ describe.skipIf(!desiredContractAvailable)("direct-host Pi resolution without a 
 
 	it.each([
 		{ unavailable: "resolved package entry", entryAvailable: false },
-		{ unavailable: "derived dist/cli.js", entryAvailable: true },
+		{ unavailable: "derived dist/bundle/cli.js", entryAvailable: true },
 	])("turns an unavailable $unavailable into actionable partial-install guidance", async ({ entryAvailable }) => {
 		const root = makeTempDir("bobbit-partial-pi-");
 		const packageRoot = path.join(root, "node_modules", "@earendil-works", "pi-coding-agent");
 		const entryPath = path.join(packageRoot, "dist", "index.js");
-		const cliPath = path.join(packageRoot, "dist", "cli.js");
+		const cliPath = path.join(packageRoot, "dist", "bundle", "cli.js");
 		const availabilityChecks: string[] = [];
 
 		await expect(async () => Promise.resolve(directRuntimeResolver()({

--- a/tests/unit/core/pi-installed-contract.unit.test.ts
+++ b/tests/unit/core/pi-installed-contract.unit.test.ts
@@ -7,7 +7,7 @@ import { AgentSession } from "@earendil-works/pi-coding-agent";
 import { describe, expect, it, vi } from "vitest";
 import { PiAssistantStreamNormalizer } from "../../../src/shared/assistant-stream-delta.ts";
 
-const SELECTED_PI_VERSION = "0.84.1";
+const SELECTED_PI_VERSION = "0.85.1";
 const PI_PACKAGES = [
 	"@earendil-works/pi-ai",
 	"@earendil-works/pi-agent-core",
@@ -41,11 +41,14 @@ function installedPackageRoot(packageName: string): string {
 	}
 }
 
-function installedVersion(packageName: string): string {
-	const metadata = JSON.parse(
+function installedPackageMetadata(packageName: string): any {
+	return JSON.parse(
 		fs.readFileSync(path.join(installedPackageRoot(packageName), "package.json"), "utf8"),
-	) as { version: string };
-	return metadata.version;
+	);
+}
+
+function installedVersion(packageName: string): string {
+	return installedPackageMetadata(packageName).version;
 }
 
 function userMessage(text: string): any {
@@ -68,20 +71,40 @@ async function loadInstalledJsonEventAdapter(): Promise<{ toJsonEvent(event: any
 }
 
 describe("installed Pi runtime contract for reliable agent turns", () => {
-	it("keeps the installed Pi trio on the selected common compatible release", () => {
+	it("keeps the installed Pi trio on the selected common compatible release and Node floor", () => {
 		const versions = Object.fromEntries(PI_PACKAGES.map((name) => [name, installedVersion(name)]));
 		expect(versions, "PI_CONTRACT_VERSION_MISMATCH: upgrade the Pi trio together").toEqual({
 			"@earendil-works/pi-ai": SELECTED_PI_VERSION,
 			"@earendil-works/pi-agent-core": SELECTED_PI_VERSION,
 			"@earendil-works/pi-coding-agent": SELECTED_PI_VERSION,
 		});
+		for (const packageName of PI_PACKAGES) {
+			expect(installedPackageMetadata(packageName).engines?.node).toBe(">=22.19.0");
+		}
+		const bobbitPackage = JSON.parse(fs.readFileSync(path.resolve("package.json"), "utf8"));
+		expect(bobbitPackage.engines?.node).toBe(">=22.19.0");
+
+		const codingAgent = installedPackageMetadata("@earendil-works/pi-coding-agent");
+		expect(codingAgent.bin?.pi).toBe("dist/bundle/cli.js");
+		expect(codingAgent.exports?.["./rpc-entry"]?.import).toBe("./dist/bundle/rpc-entry.js");
+		expect(fs.existsSync(path.join(installedPackageRoot("@earendil-works/pi-coding-agent"), codingAgent.bin.pi))).toBe(true);
+		expect(fs.existsSync(path.join(installedPackageRoot("@earendil-works/pi-coding-agent"), codingAgent.exports["./rpc-entry"].import))).toBe(true);
 	});
 
 	it("emits delta-only JSON message_update frames and preserves exact terminal authority", async () => {
 		const { toJsonEvent } = await loadInstalledJsonEventAdapter();
+		const cumulativeUsage = {
+			input: 12,
+			output: 3,
+			cacheRead: 2,
+			cacheWrite: 0,
+			totalTokens: 17,
+			cost: { input: 0.12, output: 0.15, cacheRead: 0.002, cacheWrite: 0, total: 0.272 },
+		};
 		const cumulativePartial = {
 			role: "assistant",
 			content: [{ type: "text", text: "cumulative text that must stay off the wire" }],
+			usage: cumulativeUsage,
 		};
 		const update = toJsonEvent({
 			type: "message_update",
@@ -96,10 +119,29 @@ describe("installed Pi runtime contract for reliable agent turns", () => {
 
 		expect(update, "PI_CONTRACT_MESSAGE_UPDATE_NOT_DELTA_ONLY").toEqual({
 			type: "message_update",
+			usage: cumulativeUsage,
 			assistantMessageEvent: { type: "text_delta", contentIndex: 0, delta: "delta only" },
 		});
 		expect(update).not.toHaveProperty("message");
 		expect(update.assistantMessageEvent).not.toHaveProperty("partial");
+
+		const toolCall = { type: "toolCall", id: "contract-call-1", name: "read", arguments: {} };
+		const toolPartial = { ...cumulativePartial, content: [toolCall] };
+		const toolStart = toJsonEvent({
+			type: "message_update",
+			message: toolPartial,
+			assistantMessageEvent: { type: "toolcall_start", contentIndex: 0, partial: toolPartial },
+		});
+		expect(toolStart, "PI_CONTRACT_TOOLCALL_START_IDENTITY_MISSING").toEqual({
+			type: "message_update",
+			usage: cumulativeUsage,
+			assistantMessageEvent: {
+				type: "toolcall_start",
+				contentIndex: 0,
+				id: "contract-call-1",
+				toolName: "read",
+			},
+		});
 
 		const exactTerminal = {
 			type: "message_end",
@@ -179,6 +221,7 @@ describe("installed Pi runtime contract for reliable agent turns", () => {
 		const receiver: any = Object.create(AgentSession.prototype);
 		Object.assign(receiver, {
 			_isAgentRunActive: false,
+			_pendingCustomMessages: [],
 			_eventListeners: [
 				(event: any) => observations.push({
 					observer: "session",
@@ -217,15 +260,21 @@ describe("installed Pi runtime contract for reliable agent turns", () => {
 		expect(receiver.isIdle).toBe(true);
 	});
 
-	it("orders manual compaction events and releases its controller before compaction_end", async () => {
+	it("orders manual compaction events, reports the 0.85 failure hook, and releases its controller", async () => {
 		const observations: Array<{ event: any; controllerReleased: boolean }> = [];
-		const receiver: any = {
+		const extensionEvents: any[] = [];
+		const receiver: any = Object.create(AgentSession.prototype);
+		Object.assign(receiver, {
 			abort: vi.fn(async () => undefined),
-			model: undefined,
+			agent: { state: { model: undefined } },
+			_extensionRunner: {
+				hasHandlers: (name: string) => name === "session_compact_failed",
+				emit: vi.fn(async (event: any) => extensionEvents.push(event)),
+			},
 			_emit(event: any) {
 				observations.push({ event, controllerReleased: receiver._compactionAbortController === undefined });
 			},
-		};
+		});
 
 		await expect((AgentSession.prototype as any).compact.call(receiver)).rejects.toThrow(/model/i);
 
@@ -238,6 +287,14 @@ describe("installed Pi runtime contract for reliable agent turns", () => {
 			controllerReleased: true,
 			event: { reason: "manual", aborted: false, willRetry: false },
 		});
+		expect(extensionEvents).toEqual([{
+			type: "session_compact_failed",
+			reason: "manual",
+			errorMessage: expect.stringContaining("No model selected"),
+			aborted: false,
+			willRetry: false,
+			fromExtension: false,
+		}]);
 	});
 
 	it("rejects direct prompt submission while manual compaction is active", async () => {
@@ -269,16 +326,26 @@ describe("installed Pi runtime contract for reliable agent turns", () => {
 		};
 		const priorUser = userMessage("original interrupted input");
 		const events: any[] = [];
+		const extensionEvents: any[] = [];
 		const runAutoCompaction = vi.fn(async (_reason: string, _willRetry: boolean) => true);
-		const receiver: any = {
+		const receiver: any = Object.create(AgentSession.prototype);
+		Object.assign(receiver, {
 			settingsManager: { getCompactionSettings: () => ({ enabled: true }) },
-			model: { provider: "faux", id: "faux-1", contextWindow: 1_000_000, maxTokens: 100 },
+			_extensionRunner: {
+				hasHandlers: (name: string) => name === "session_compact_failed",
+				emit: vi.fn(async (event: any) => extensionEvents.push(event)),
+			},
 			sessionManager: { getBranch: () => [] },
-			agent: { state: { messages: [priorUser, firstTail] } },
+			agent: {
+				state: {
+					messages: [priorUser, firstTail],
+					model: { provider: "faux", id: "faux-1", contextWindow: 1_000_000, maxTokens: 100 },
+				},
+			},
 			_overflowRecoveryAttempted: false,
 			_runAutoCompaction: runAutoCompaction,
 			_emit: (event: any) => events.push(event),
-		};
+		});
 		const checkCompaction = (AgentSession.prototype as any)._checkCompaction;
 
 		await expect(checkCompaction.call(receiver, firstTail)).resolves.toBe(true);
@@ -300,6 +367,12 @@ describe("installed Pi runtime contract for reliable agent turns", () => {
 			willRetry: false,
 			errorMessage: expect.stringContaining("failed after one compact-and-retry attempt"),
 		}));
+		expect(extensionEvents).toEqual([expect.objectContaining({
+			type: "session_compact_failed",
+			reason: "overflow",
+			willRetry: false,
+			fromExtension: false,
+		})]);
 	});
 
 	it("emits overflow compaction start/end with willRetry and removes a restored truncated tail", async () => {
@@ -334,9 +407,8 @@ describe("installed Pi runtime contract for reliable agent turns", () => {
 			},
 		];
 		const events: any[] = [];
-		const receiver: any = {
-			model: { provider: "faux", id: "faux-1", contextWindow: 8_192, maxTokens: 100 },
-			thinkingLevel: "off",
+		const receiver: any = Object.create(AgentSession.prototype);
+		Object.assign(receiver, {
 			settingsManager: {
 				getCompactionSettings: () => ({ enabled: true, reserveTokens: 0, keepRecentTokens: 1 }),
 			},
@@ -369,12 +441,16 @@ describe("installed Pi runtime contract for reliable agent turns", () => {
 				} : undefined),
 			},
 			agent: {
-				state: { messages: [priorUser] },
+				state: {
+					messages: [priorUser],
+					model: { provider: "faux", id: "faux-1", contextWindow: 8_192, maxTokens: 100 },
+					thinkingLevel: "off",
+				},
 				streamFunction: vi.fn(),
 				hasQueuedMessages: () => false,
 			},
 			_emit: (event: any) => events.push(event),
-		};
+		});
 
 		await expect(
 			(AgentSession.prototype as any)._runAutoCompaction.call(receiver, "overflow", true),

--- a/tests/unit/core/pi-packed-consumer-offline.unit.test.ts
+++ b/tests/unit/core/pi-packed-consumer-offline.unit.test.ts
@@ -38,6 +38,9 @@ const WORKFLOW_SOURCE = readFileSync(
 );
 const REPO_ROOT = fileURLToPath(new URL("../../..", import.meta.url));
 const PACKAGE_MANIFEST = JSON.parse(readFileSync(join(REPO_ROOT, "package.json"), "utf8")) as { files: string[] };
+const PACKAGE_LOCK = JSON.parse(readFileSync(join(REPO_ROOT, "package-lock.json"), "utf8")) as {
+	packages?: Record<string, { version?: string; gypfile?: boolean }>;
+};
 
 type WorkflowStep = {
 	name: string;
@@ -91,6 +94,13 @@ function invokeTimer(callback: (() => void) | undefined, message: string): void 
 }
 
 describe("packed-consumer offline install contract", () => {
+	it("retains better-sqlite3's published no-gyp-install metadata in the root lock", () => {
+		const lockedPackage = PACKAGE_LOCK.packages?.["node_modules/better-sqlite3"];
+		assert.equal(lockedPackage?.version, "13.0.3");
+		assert.equal(lockedPackage?.gypfile, false,
+			"npm ci must not synthesize node-gyp rebuild for the prebuilt native package");
+	});
+
 	it("resolves checkout-only support before creating a clean packed consumer", () => {
 		const supportRoot = join(REPO_ROOT, "tests", "support");
 		const canonicalBudget = join(supportRoot, "data", "quality", "budgets", "budgets.json");

--- a/tests/unit/core/pi-packed-consumer-offline.unit.test.ts
+++ b/tests/unit/core/pi-packed-consumer-offline.unit.test.ts
@@ -599,7 +599,15 @@ describe("packed-consumer offline install contract", () => {
 		assert.match(packedConsumer, /"consumer install must create its own lockfile"/);
 		assert.match(packedConsumer, /"published pi-coding-agent must include its dependency-owned shrinkwrap"/);
 		assert.match(packedConsumer, /"npm ls must have no invalid, missing, stale, or extraneous edges"/);
+		assert.match(packedConsumer, /const REQUIRED_PI_VERSION = "0\.85\.1";/,
+			"the packed consumer must pin the selected Pi compatibility line");
+		assert.match(packedConsumer, /const MINIMUM_PI_NODE_VERSION = "22\.19\.0";/,
+			"the packed consumer must enforce Pi's Node engine floor");
 		assert.match(packedConsumer, /"packed Bobbit must pin Pi exactly to the supported version"/);
+		assert.match(packedConsumer, /installedPiManifest\.bin\?\.pi[^\n]+\.toBe\("dist\/bundle\/cli\.js"\)/,
+			"the packed consumer must resolve Pi's declared bundled entrypoint");
+		assert.match(packedConsumer, /runPiPackedConsumerCommand\(process\.execPath, \[declaredPiCli, "--version"\]/,
+			"the declared Pi entrypoint must execute under the compatible consumer runtime");
 		assert.match(packedConsumer, /`every brace-expansion edge must be 5\.0\.7\+:/);
 		assert.match(packedConsumer, /`Pi \$\{selectedPiVersion\} must resolve every protobufjs edge to 7\.6\.5\+:/);
 		assert.match(packedConsumer, /expect\(resolution\.source, `\$\{tool\} must resolve from \$\{expectedBinaryPackage\}`\)\.toBe\("bundled"\)/);

--- a/tests/unit/core/rpc-bridge-spawn-args.unit.test.ts
+++ b/tests/unit/core/rpc-bridge-spawn-args.unit.test.ts
@@ -18,8 +18,11 @@
 
 import { describe, it } from "vitest";
 import assert from "node:assert/strict";
+import type { ChildProcess } from "node:child_process";
+import { EventEmitter } from "node:events";
+import { PassThrough } from "node:stream";
 
-import { buildAgentArgs, resolveEffectivePiSelection } from "../../../src/server/agent/rpc-bridge.ts";
+import { buildAgentArgs, resolveEffectivePiSelection, RpcBridge } from "../../../src/server/agent/rpc-bridge.ts";
 
 describe("resolveEffectivePiSelection", () => {
 	it("resolves repeated raw flags with Pi last-wins semantics and strips selection args", () => {
@@ -79,6 +82,51 @@ describe("resolveEffectivePiSelection", () => {
 		assert.throws(() => resolveEffectivePiSelection({ args: ["--provider"] }), /expected a non-empty value/);
 		assert.throws(() => resolveEffectivePiSelection({ args: ["--model", "--tools"] }), /expected a non-empty value/);
 		assert.throws(() => resolveEffectivePiSelection({ args: ["--thinking", "turbo"] }), /unknown level/);
+	});
+});
+
+describe("RpcBridge Pi entrypoint selection", () => {
+	it("spawns the declared Pi 0.85 bundled CLI inside Docker", async () => {
+		let capturedCommand = "";
+		let capturedArgs: string[] = [];
+		const child = new EventEmitter() as ChildProcess;
+		Object.assign(child, {
+			pid: 123,
+			stdin: new PassThrough(),
+			stdout: new PassThrough(),
+			stderr: new PassThrough(),
+			kill: () => true,
+		});
+		const bridge = new RpcBridge({
+			containerId: "container-123",
+			sessionId: "session-123",
+			env: { BOBBIT_SESSION_ID: "session-123" },
+			args: ["--no-extensions"],
+			clock: {
+				now: () => 0,
+				setTimeout: (callback: () => void) => { callback(); return 0 as any; },
+				setInterval: () => 0 as any,
+				clearTimeout: () => undefined,
+				clearInterval: () => undefined,
+			},
+		}, {
+			spawnDocker: ((command: string, args: readonly string[] = []) => {
+				capturedCommand = command;
+				capturedArgs = [...args];
+				return child;
+			}) as typeof import("node:child_process").spawn,
+		});
+
+		await bridge.start();
+
+		assert.equal(capturedCommand, "docker");
+		const containerIndex = capturedArgs.indexOf("container-123");
+		assert.deepEqual(capturedArgs.slice(containerIndex, containerIndex + 4), [
+			"container-123",
+			"node",
+			"--disable-warning=DEP0123",
+			"/node_modules/@earendil-works/pi-coding-agent/dist/bundle/cli.js",
+		]);
 	});
 });
 
@@ -244,7 +292,7 @@ describe("buildAgentArgs", () => {
 	});
 
 	it("does not retain the initial provider for Pi's qualified model-only raw override", () => {
-		// Pi 0.84.1 parses the supported spelling `--model <provider>/<id>` and
+		// Pi 0.85.1 parses the supported spelling `--model <provider>/<id>` and
 		// infers the provider only when no explicit --provider remains. Retaining
 		// the injected Anthropic provider would instead select the synthetic model
 		// anthropic/openai/gpt-4.1.

--- a/tests/unit/core/session-manager-spawn-tuple-boundary-repro.unit.test.ts
+++ b/tests/unit/core/session-manager-spawn-tuple-boundary-repro.unit.test.ts
@@ -1020,15 +1020,15 @@ describe("actual SessionManager spawn tuple boundaries", () => {
 				liveThinking: thinkingLevel,
 				durableThinking: store.get(sessionId)?.effectiveThinkingLevel,
 				lateXhighMutation: setThinkingLevel.mock.calls
-					.slice(setThinkingLevel.mock.calls.findIndex(([level]) => level === "off") + 1)
+					.slice(setThinkingLevel.mock.calls.findIndex(([level]) => level === "minimal") + 1)
 					.some(([level]) => level === "xhigh"),
 			},
 			{
-				liveThinking: "off",
-				durableThinking: "off",
+				liveThinking: "minimal",
+				durableThinking: "minimal",
 				lateXhighMutation: false,
 			},
-			"STARTUP_THINKING_STALE_WRITE: a detached startup xhigh verification must not mutate live or durable state after a newer runtime off selection commits",
+			"STARTUP_THINKING_STALE_WRITE: a detached startup xhigh verification must not mutate live or durable state after a newer runtime off request commits as verified minimal",
 		);
 	});
 });

--- a/tests/unit/core/thinking-levels.unit.test.ts
+++ b/tests/unit/core/thinking-levels.unit.test.ts
@@ -1,5 +1,6 @@
 import { test } from "vitest";
 import assert from "node:assert/strict";
+import { getBuiltinModel } from "@earendil-works/pi-ai/providers/all";
 import {
 	THINKING_LEVELS,
 	clampThinkingLevel,
@@ -57,6 +58,14 @@ test("only explicit non-null map entries grant extended levels", () => {
 	};
 	assert.equal(supportsXHigh(denied), false);
 	assert.deepEqual(getSupportedThinkingLevels(denied), BASE);
+});
+
+test("Pi's Astra row exposes minimal through max and clamps off upward", () => {
+	const astra = getBuiltinModel("openai-codex", "gpt-6-astra");
+	assert.ok(astra, "Pi should contain openai-codex/gpt-6-astra");
+	assert.deepEqual(getSupportedThinkingLevels(astra), ["minimal", "low", "medium", "high", "xhigh", "max"]);
+	assert.equal(clampThinkingLevel("off", astra), "minimal");
+	assert.equal(clampThinkingLevel("max", astra), "max");
 });
 
 test("exact maps retain absent base tiers and drop explicit null tiers", () => {


### PR DESCRIPTION
## Summary
- upgrade the aligned Pi runtime packages and sandbox runtime to 0.85.1
- expose Pi's authoritative OpenAI Codex GPT-6 Astra catalog row through existing OAuth, selection, and persistence flows
- adapt Pi 0.85 streaming and compaction contracts while preserving existing runtime behavior
- add exact metadata, thinking clamp, reload/restart, packed-runtime, browser, and gateway regression coverage
- update current compatibility and operational documentation

## Verification
- build, type check, unit, browser, and E2E workflow verification passed
- spec, integrated implementation, security, and documentation reviews passed
- live Astra tool-use canary was not run because suitable live credentials/model entitlement were not available to this isolated workflow; the reproducible manual canary is documented
- Docker daemon-dependent live image build was unavailable locally; Node/Pi image contracts and packaged runtime checks passed

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)