### PR TITLE
Harden release script analysis

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -27,10 +27,22 @@ name: "CodeQL config"
 queries:
   - uses: security-extended
 
-# Non-production code is not attack surface. Alerts here are pure noise.
+# Ordinary development and test tooling is not attack surface. Release-control
+# scripts are different: they authorize npm publication and are publication
+# control-plane code, so scripts/release/**/*.mjs must remain analyzed.
+#
+# CodeQL exclusions override inclusions, and `!` is not a supported path-filter
+# operator. Exclude direct files and dev-only subdirectories separately instead
+# of excluding `scripts`, which would also prune the release-control subtree.
 paths-ignore:
   - tests
-  - scripts
+  - "scripts/*.*" # direct development scripts only; `*` does not cross `/`
+  - scripts/benchmarks
+  - scripts/lib
+  - scripts/metrics
+  - scripts/qa-seed
+  - scripts/testing
+  - scripts/testing-v2
   - tools          # dev-only tooling (e.g. tools/dummy-aigw test double)
   - "**/*.test.ts"
   - "**/*.spec.ts"

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -25,6 +25,17 @@ For a release commit, `verify` then enforces the whole contract, in [`scripts/re
 
 Only then does the run build and type-check the commit, and pack the resulting files into an immutable workflow artifact. The serialized publishing job publishes that exact tarball with provenance, the tag job then creates `v<version>`, and the GitHub release follows. Pre-release versions (`0.16.0-rc.1`) go to the `next` dist-tag and are marked as prereleases; stable versions go to `latest`.
 
+### Static analysis of the release control plane
+
+The modules under [`scripts/release/`](../scripts/release/) are publication control-plane code, not ordinary development scripts. They decide whether a commit may publish, validate its release contract and npm provenance, prevent a dist-tag from moving backwards, make reruns safe, and select the reviewed changelog text that becomes the public release. A defect in this code can therefore weaken an authorization or integrity boundary even though the files use `.mjs` and live outside `src/`.
+
+They receive two complementary forms of static analysis:
+
+- CodeQL includes `scripts/release/**/*.mjs` in JavaScript/TypeScript analysis. Tests, fixtures, and unrelated development scripts remain excluded because broadening analysis to those paths would add noise without protecting the publication boundary.
+- The dedicated strict JavaScript TypeScript project checks `dist-tag-guard.mjs`, `release-contract.mjs`, `validate-release-commit.mjs`, and `changelog-section.mjs`, including their module graph, with `allowJs`, `checkJs`, and `noEmit`. `npm run check` owns this check, so the required PR build gate and the post-merge verification of the exact release commit both execute it.
+
+These checks provide defense in depth; they do not replace or relax the runtime release contract. Validation still runs before dependency installation, publish/tag/release jobs retain separate least-privilege permissions, npm provenance remains the authority for an already-published version, dist-tags must advance from the value verified before publication, and recovery still requires a full rerun so those facts are checked again.
+
 The post-merge build is deliberate because it produces the exact tarball that ships. The test suites are not repeated after publication approval: the release PR's required GitHub checks already ran the full unit, browser, and E2E matrices against the mergeable tree. The local release pre-flight installs dependencies, builds, and type-checks so basic failures are caught before the PR opens without duplicating the hosted suites.
 
 **The same contract also runs before the merge.** `build-unit-gate.yml` runs `validate-release-commit.mjs --mode pre-merge` on every pull request. It decides whether a PR is a release the same way `detect` does — by comparing `package.json` against the base — and exits immediately when the version is unchanged. Every content rule then runs against that base, including the append-only changelog check and the version-increase check, so a wrong branch name, title, lockfile, changelog entry, backwards version or unpublished binary pin fails while it still costs one push — rather than after the merge, when the version is on `main` and the number is spent. The post-merge run is the authority; the pre-merge run is there so the authority rarely has to say no.

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "start": "node dist/server/cli.js --cwd .",
     "test:layout": "node scripts/testing/check-layout.mjs",
     "test:new": "node scripts/testing/create-test.mjs",
-    "check": "npm run test:layout && shx mkdir -p .profiles && tsc -p tsconfig.server.json --noEmit --incremental --tsBuildInfoFile .profiles/check-server.tsbuildinfo && tsc -p tsconfig.web.json --noEmit --incremental --tsBuildInfoFile .profiles/check-web.tsbuildinfo && tsc -p tsconfig.tests.json --noEmit --incremental --tsBuildInfoFile .profiles/check-tests.tsbuildinfo",
+    "check": "npm run test:layout && shx mkdir -p .profiles && tsc -p tsconfig.server.json --noEmit --incremental --tsBuildInfoFile .profiles/check-server.tsbuildinfo && tsc -p tsconfig.web.json --noEmit --incremental --tsBuildInfoFile .profiles/check-web.tsbuildinfo && tsc -p tsconfig.tests.json --noEmit --incremental --tsBuildInfoFile .profiles/check-tests.tsbuildinfo && tsc -p tsconfig.release.json",
     "test:v2": "node scripts/testing-v2/run-v2.mjs",
     "test:v2:core": "vitest run --config vitest.config.ts --silent=passed-only",
     "test:v2:changed": "vitest --config vitest.config.ts --changed --silent=passed-only",

--- a/scripts/release/dist-tag-guard.mjs
+++ b/scripts/release/dist-tag-guard.mjs
@@ -7,10 +7,15 @@ const VERSION_PATTERN = new RegExp(
 		String.raw`(?:\+${BUILD_ID}(?:\.${BUILD_ID})*)?$`,
 );
 
+/**
+ * @param {unknown} value
+ * @returns {value is string}
+ */
 export function isExactVersion(value) {
 	return typeof value === "string" && VERSION_PATTERN.test(value);
 }
 
+/** @param {string} value */
 function parseVersion(value) {
 	const match = VERSION_PATTERN.exec(value);
 	if (!match) throw new Error(`invalid version: ${value}`);
@@ -22,6 +27,10 @@ function parseVersion(value) {
 
 // SemVer gives numeric identifiers lower precedence than non-numeric ones;
 // build metadata is parsed but intentionally does not affect ordering.
+/**
+ * @param {string[]} left
+ * @param {string[]} right
+ */
 function comparePrerelease(left, right) {
 	if (left.length === 0 || right.length === 0) {
 		return left.length === right.length ? 0 : left.length === 0 ? 1 : -1;
@@ -38,6 +47,10 @@ function comparePrerelease(left, right) {
 	return 0;
 }
 
+/**
+ * @param {string} leftValue
+ * @param {string} rightValue
+ */
 export function compareReleaseVersions(leftValue, rightValue) {
 	const [left, right] = [parseVersion(leftValue), parseVersion(rightValue)];
 	for (let index = 0; index < 3; index += 1) {
@@ -46,6 +59,9 @@ export function compareReleaseVersions(leftValue, rightValue) {
 	return comparePrerelease(left.prerelease, right.prerelease);
 }
 
+/**
+ * @param {{ packageName: string, distTag: string, version: string, fetchImpl?: typeof fetch }} options
+ */
 export async function assertDistTagAdvances({ packageName, distTag, version, fetchImpl = fetch }) {
 	const url = `https://registry.npmjs.org/${encodeURIComponent(packageName)}/${encodeURIComponent(distTag)}`;
 	const response = await fetchImpl(url, { headers: { accept: "application/json" } });
@@ -55,7 +71,7 @@ export async function assertDistTagAdvances({ packageName, distTag, version, fet
 	}
 	if (!response.ok) throw new Error(`dist-tag lookup returned ${response.status}`);
 
-	const current = (await response.json()).version;
+	const { version: current } = /** @type {{ version: string }} */ (await response.json());
 	if (compareReleaseVersions(version, current) <= 0) {
 		throw new Error(`refusing to move ${distTag} backwards: ${current} -> ${version}`);
 	}

--- a/scripts/release/release-contract.mjs
+++ b/scripts/release/release-contract.mjs
@@ -9,21 +9,47 @@ const MIN_RELEASE_NOTES_CHARS = 80;
 
 export const CHANGELOG_PATH = "CHANGELOG.md";
 
+/** @typedef {{ version: string, body: string, raw: string }} ChangelogSection */
+/** @typedef {{ version: string, optionalDependencies?: Record<string, string> }} PackageManifest */
+/** @typedef {{ version?: unknown, packages?: { ""?: { version?: unknown } } }} LockfileManifest */
+/**
+ * @typedef {{
+ *   number?: unknown,
+ *   merged_at?: unknown,
+ *   merge_commit_sha?: unknown,
+ *   base?: { ref?: unknown },
+ *   head?: { ref?: unknown, repo?: { full_name?: unknown } },
+ *   title?: unknown
+ * }} PullRequest
+ */
+/** @typedef {{ sha: string | null, repository: string | null, path: string | null }} ProvenanceSource */
+/** @typedef {{ status: number | null, stdout: string, stderr: string }} GitResult */
+
 export class ReleaseContractError extends Error {
+	/** @param {string} message */
 	constructor(message) {
 		super(message);
 		this.name = "ReleaseContractError";
 	}
 }
 
+/**
+ * @param {string} message
+ * @returns {never}
+ */
 function fail(message) {
 	throw new ReleaseContractError(message);
 }
 
+/** @param {string} version */
 export function releaseTagFor(version) {
 	return `v${version}`;
 }
 
+/**
+ * @param {unknown} changelog
+ * @returns {{ preamble: string, sections: ChangelogSection[] }}
+ */
 function parseChangelog(changelog) {
 	const text = String(changelog ?? "");
 	const headings = [...text.matchAll(/^## v(\S+)[^\S\n]*$/gm)];
@@ -42,14 +68,20 @@ function parseChangelog(changelog) {
 	};
 }
 
+/** @param {unknown} changelog */
 export function changelogSections(changelog) {
 	return parseChangelog(changelog).sections.map(({ version, body }) => ({ version, body }));
 }
 
+/**
+ * @param {unknown} changelog
+ * @param {string} version
+ */
 export function changelogSectionFor(changelog, version) {
 	return changelogSections(changelog).find(section => section.version === version)?.body ?? null;
 }
 
+/** @param {ChangelogSection[]} sections */
 function assertUniqueChangelogVersions(sections) {
 	const seen = new Set();
 	for (const { version } of sections) {
@@ -60,6 +92,10 @@ function assertUniqueChangelogVersions(sections) {
 	}
 }
 
+/**
+ * @param {unknown} changelog
+ * @param {string} version
+ */
 export function assertChangelogSection(changelog, version) {
 	const { sections } = parseChangelog(changelog);
 	assertUniqueChangelogVersions(sections);
@@ -86,6 +122,10 @@ export function assertChangelogSection(changelog, version) {
 	return section.body;
 }
 
+/**
+ * @param {unknown} previousChangelog
+ * @param {unknown} currentChangelog
+ */
 export function assertChangelogAppendOnly(previousChangelog, currentChangelog) {
 	const previous = parseChangelog(previousChangelog);
 	const current = parseChangelog(currentChangelog);
@@ -109,6 +149,11 @@ export function assertChangelogAppendOnly(previousChangelog, currentChangelog) {
 	}
 }
 
+/**
+ * @param {string} rev
+ * @param {string} path
+ * @param {(args: string[]) => GitResult} run
+ */
 export function fileAtCommit(rev, path, run) {
 	const resolved = run(["rev-parse", "--verify", `${rev}^{commit}`]);
 	if (resolved.status !== 0) {
@@ -121,18 +166,22 @@ export function fileAtCommit(rev, path, run) {
 	return shown.status === 0 ? shown.stdout : null;
 }
 
+/** @param {string} version */
 export function releaseBranchFor(version) {
 	return `release/v${version}`;
 }
 
+/** @param {string} version */
 export function releaseTitleFor(version) {
 	return `chore(release): v${version}`;
 }
 
+/** @param {string} version */
 export function distTagFor(version) {
 	return version.includes("-") ? "next" : "latest";
 }
 
+/** @param {unknown} version */
 export function assertReleaseVersion(version) {
 	if (!isExactVersion(version) || version.includes("+")) {
 		fail(`package.json version is not a release version: ${version}`);
@@ -140,6 +189,10 @@ export function assertReleaseVersion(version) {
 	return version;
 }
 
+/**
+ * @param {PackageManifest} pkg
+ * @param {LockfileManifest} lock
+ */
 export function assertLockfileAgreement(pkg, lock) {
 	const root = lock?.packages?.[""]?.version;
 	if (lock?.version !== pkg?.version || root !== pkg?.version) {
@@ -150,6 +203,7 @@ export function assertLockfileAgreement(pkg, lock) {
 	}
 }
 
+/** @param {PackageManifest} pkg */
 export function assertExactOptionalDependencyPins(pkg) {
 	for (const [name, version] of Object.entries(pkg?.optionalDependencies ?? {})) {
 		if (!isExactVersion(version)) {
@@ -161,6 +215,11 @@ export function assertExactOptionalDependencyPins(pkg) {
 	}
 }
 
+/**
+ * @param {string} parentVersion
+ * @param {string} version
+ * @param {string} sha
+ */
 export function assertVersionBump(parentVersion, version, sha) {
 	const order = compareReleaseVersions(version, parentVersion);
 	if (order === 0) {
@@ -177,6 +236,10 @@ export function assertVersionBump(parentVersion, version, sha) {
 	}
 }
 
+/**
+ * @param {PullRequest | null | undefined} pr
+ * @param {{ version: string, repository: string, sha: string }} release
+ */
 export function assertPullRequestContract(pr, { version, repository, sha }) {
 	if (!pr) {
 		fail(
@@ -208,14 +271,26 @@ export function assertPullRequestContract(pr, { version, repository, sha }) {
 
 export const RELEASE_WORKFLOW_PATH = ".github/workflows/release-publish.yml";
 
+/**
+ * @param {unknown} response
+ * @returns {ProvenanceSource | null}
+ */
 export function extractProvenanceSource(response) {
-	const attestations = Array.isArray(response?.attestations) ? response.attestations : [];
+	const data = /** @type {{ attestations?: Array<{
+	 * predicateType?: unknown,
+	 * bundle?: { dsseEnvelope?: { payload?: unknown } }
+	 * } | null | undefined> }} */ (response);
+	const attestations = Array.isArray(data?.attestations) ? data.attestations : [];
 	const provenance = attestations.find(entry =>
 		String(entry?.predicateType ?? "").startsWith("https://slsa.dev/provenance/"),
 	);
 	const payload = provenance?.bundle?.dsseEnvelope?.payload;
 	if (typeof payload !== "string") return null;
 
+	/** @type {{ predicate?: { buildDefinition?: {
+	 * resolvedDependencies?: Array<{ digest?: { gitCommit?: unknown }, uri?: unknown } | null | undefined>,
+	 * externalParameters?: { workflow?: { repository?: unknown, path?: unknown } }
+	 * } } }} */
 	let statement;
 	try {
 		statement = JSON.parse(Buffer.from(payload, "base64").toString("utf8"));
@@ -225,7 +300,7 @@ export function extractProvenanceSource(response) {
 
 	const build = statement?.predicate?.buildDefinition ?? {};
 	const dependencies = Array.isArray(build.resolvedDependencies) ? build.resolvedDependencies : [];
-	const workflow = build?.externalParameters?.workflow ?? {};
+	const workflow = build.externalParameters?.workflow ?? {};
 	const repository = typeof workflow.repository === "string" ? workflow.repository : null;
 	const source = repository
 		? dependencies.find(
@@ -237,12 +312,16 @@ export function extractProvenanceSource(response) {
 		: null;
 
 	return {
-		sha: source?.digest?.gitCommit ?? null,
+		sha: typeof source?.digest?.gitCommit === "string" ? source.digest.gitCommit : null,
 		repository,
 		path: typeof workflow.path === "string" ? workflow.path : null,
 	};
 }
 
+/**
+ * @param {ProvenanceSource | null} source
+ * @param {{ spec: string, repository: string, sha: string }} expected
+ */
 export function assertPublishedArtifactMatches(source, { spec, repository, sha }) {
 	const recover =
 		`${spec} is already on the registry and npm versions are immutable. ` +
@@ -268,11 +347,21 @@ export function assertPublishedArtifactMatches(source, { spec, repository, sha }
 	return true;
 }
 
+/**
+ * @param {string} name
+ * @param {string} version
+ */
 export function npmAttestationUrl(name, version) {
 	return `${PUBLIC_NPM_REGISTRY}/-/npm/v1/attestations/${encodeURIComponent(name)}@${encodeURIComponent(version)}`;
 }
 
+/**
+ * @param {string} url
+ * @param {{ headers?: Record<string, string>, fetchImpl?: typeof fetch, attempts?: number }} [options]
+ * @returns {Promise<{ status: number, body: unknown }>}
+ */
 export async function fetchJson(url, { headers = {}, fetchImpl = fetch, attempts = 3 } = {}) {
+	/** @type {unknown} */
 	let lastError;
 	for (let attempt = 1; attempt <= attempts; attempt += 1) {
 		try {
@@ -291,6 +380,7 @@ export async function fetchJson(url, { headers = {}, fetchImpl = fetch, attempts
 	throw new Error(`request failed after ${attempts} attempts: ${url}`, { cause: lastError });
 }
 
+/** @param {string | undefined} token */
 export function githubHeaders(token) {
 	return {
 		accept: "application/vnd.github+json",
@@ -299,6 +389,10 @@ export function githubHeaders(token) {
 	};
 }
 
+/**
+ * @param {string} name
+ * @param {string} version
+ */
 export function npmPackageUrl(name, version) {
 	return `${PUBLIC_NPM_REGISTRY}/${encodeURIComponent(name)}/${encodeURIComponent(version)}`;
 }

--- a/scripts/release/validate-release-commit.mjs
+++ b/scripts/release/validate-release-commit.mjs
@@ -30,7 +30,27 @@ import {
 
 const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
 
+/** @typedef {Record<string, string | undefined> & { mode?: string }} ReleaseArgs */
+/** @typedef {{ name: string, version: string, optionalDependencies?: Record<string, string> }} PackageManifest */
+/** @typedef {{ status: number | null, stdout: string, stderr: string }} GitResult */
+/**
+ * @typedef {{
+ *   number?: unknown,
+ *   merged_at?: unknown,
+ *   merge_commit_sha?: unknown,
+ *   base?: { ref?: unknown },
+ *   head?: { ref?: unknown, repo?: { full_name?: unknown } },
+ *   title?: unknown
+ * }} PullRequest
+ */
+/** @typedef {{ root?: string, fetchImpl?: typeof fetch, runGit?: (args: string[]) => GitResult }} ValidatorOptions */
+
+/**
+ * @param {string[]} argv
+ * @returns {ReleaseArgs}
+ */
 function parseArgs(argv) {
+	/** @type {ReleaseArgs} */
 	const args = { mode: "merged" };
 	for (let i = 0; i < argv.length; i += 1) {
 		const flag = argv[i];
@@ -42,25 +62,40 @@ function parseArgs(argv) {
 	return args;
 }
 
+/**
+ * @param {{
+ *   repository: string,
+ *   sha: string,
+ *   number?: string,
+ *   token?: string,
+ *   fetchImpl: typeof fetch
+ * }} options
+ * @returns {Promise<PullRequest | null>}
+ */
 async function resolvePullRequest({ repository, sha, number, token, fetchImpl }) {
 	if (number) {
 		const { body } = await fetchJson(`${GITHUB_API}/repos/${repository}/pulls/${number}`, {
 			headers: githubHeaders(token),
 			fetchImpl,
 		});
-		return body;
+		return /** @type {PullRequest | null} */ (body);
 	}
 	const { body } = await fetchJson(`${GITHUB_API}/repos/${repository}/commits/${sha}/pulls`, {
 		headers: githubHeaders(token),
 		fetchImpl,
 	});
-	const candidates = Array.isArray(body) ? body : [];
+	const candidates = Array.isArray(body) ? /** @type {PullRequest[]} */ (body) : [];
 	return (
 		candidates.find(pr => pr.merged_at && pr.base?.ref === "main" && pr.merge_commit_sha === sha) ??
 		null
 	);
 }
 
+/**
+ * @param {string} name
+ * @param {string} version
+ * @param {typeof fetch} fetchImpl
+ */
 async function isPublished(name, version, fetchImpl) {
 	const { status } = await fetchJson(npmPackageUrl(name, version), { fetchImpl });
 	if (status === 404) return false;
@@ -68,6 +103,10 @@ async function isPublished(name, version, fetchImpl) {
 	throw new Error(`registry lookup for ${name}@${version} returned ${status}`);
 }
 
+/**
+ * @param {PackageManifest} pkg
+ * @param {typeof fetch} fetchImpl
+ */
 async function assertOptionalDependenciesPublished(pkg, fetchImpl) {
 	const pins = Object.entries(pkg.optionalDependencies ?? {});
 	const missing = [];
@@ -82,6 +121,9 @@ async function assertOptionalDependenciesPublished(pkg, fetchImpl) {
 	}
 }
 
+/**
+ * @param {{ repository: string, tag: string, token?: string, fetchImpl: typeof fetch }} options
+ */
 async function releaseExists({ repository, tag, token, fetchImpl }) {
 	const { status } = await fetchJson(`${GITHUB_API}/repos/${repository}/releases/tags/${tag}`, {
 		headers: githubHeaders(token),
@@ -92,11 +134,18 @@ async function releaseExists({ repository, tag, token, fetchImpl }) {
 	throw new Error(`release lookup for ${tag} returned ${status}`);
 }
 
+/**
+ * @param {ReleaseArgs} args
+ * @param {NodeJS.ProcessEnv} [env]
+ * @param {ValidatorOptions} [options]
+ */
 export async function validateReleaseCommit(args, env = process.env, options = {}) {
 	const root = options.root ?? REPO_ROOT;
 	const fetchImpl = options.fetchImpl ?? fetch;
+	/** @type {(args: string[]) => GitResult} */
 	const runGit =
 		options.runGit ?? (gitArgs => spawnSync("git", gitArgs, { cwd: root, encoding: "utf8" }));
+	/** @param {string[]} gitArgs */
 	const git = (...gitArgs) => {
 		const result = runGit(gitArgs);
 		if (result.status !== 0) {
@@ -104,6 +153,10 @@ export async function validateReleaseCommit(args, env = process.env, options = {
 		}
 		return result.stdout;
 	};
+	/**
+	 * @param {string} relativePath
+	 * @returns {unknown}
+	 */
 	const readJson = relativePath => JSON.parse(readFileSync(join(root, relativePath), "utf8"));
 
 	const mode = args.mode ?? "merged";
@@ -117,19 +170,26 @@ export async function validateReleaseCommit(args, env = process.env, options = {
 	if (!repository) throw new Error("--repository or GITHUB_REPOSITORY is required");
 	if (!sha) throw new Error("--sha or GITHUB_SHA is required");
 
-	const pkg = readJson("package.json");
+	const pkg = /** @type {PackageManifest} */ (readJson("package.json"));
 	const version = assertReleaseVersion(pkg.version);
 	const tag = releaseTagFor(version);
 
 	const baseRev = mode === "pre-merge" ? "HEAD^1" : `${sha}^`;
-	const baseVersion = JSON.parse(git("show", `${baseRev}:package.json`)).version;
+	const { version: baseVersion } = /** @type {{ version: string }} */ (
+		JSON.parse(git("show", `${baseRev}:package.json`))
+	);
 
 	if (mode === "pre-merge" && baseVersion === version) {
 		console.log(`package.json is unchanged at ${version}; not a release pull request`);
 		return null;
 	}
 
-	assertLockfileAgreement(pkg, readJson("package-lock.json"));
+	assertLockfileAgreement(
+		pkg,
+		/** @type {{ version?: unknown, packages?: { ""?: { version?: unknown } } }} */ (
+			readJson("package-lock.json")
+		),
+	);
 	assertExactOptionalDependencyPins(pkg);
 
 	let changelog = "";

--- a/tests/unit/core/release-static-analysis-ownership.unit.test.ts
+++ b/tests/unit/core/release-static-analysis-ownership.unit.test.ts
@@ -1,10 +1,10 @@
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
+import { readFileSync, readdirSync } from "node:fs";
 import { resolve } from "node:path";
 import { describe, it } from "vitest";
 import YAML from "yaml";
 
-const RELEASE_CONTROL_FILES = [
+const REQUIRED_CORE_RELEASE_FILES = [
 	"scripts/release/changelog-section.mjs",
 	"scripts/release/dist-tag-guard.mjs",
 	"scripts/release/release-contract.mjs",
@@ -12,8 +12,13 @@ const RELEASE_CONTROL_FILES = [
 ] as const;
 
 const CODEQL_CONFIG_PATH = resolve(process.cwd(), ".github/codeql/codeql-config.yml");
+const RELEASE_DIRECTORY_PATH = resolve(process.cwd(), "scripts/release");
 const RELEASE_TSCONFIG_PATH = resolve(process.cwd(), "tsconfig.release.json");
 const PACKAGE_JSON_PATH = resolve(process.cwd(), "package.json");
+const RELEASE_MODULE_FILES = readdirSync(RELEASE_DIRECTORY_PATH, { withFileTypes: true })
+	.filter(entry => entry.isFile() && entry.name.endsWith(".mjs"))
+	.map(entry => `scripts/release/${entry.name}`)
+	.sort();
 
 interface CodeQlConfig {
 	paths?: string[];
@@ -84,7 +89,10 @@ describe("release static-analysis ownership", () => {
 	it("keeps release controls in CodeQL while excluding ordinary tooling and test assets", () => {
 		const config = YAML.parse(readFileSync(CODEQL_CONFIG_PATH, "utf8")) as CodeQlConfig;
 
-		for (const file of RELEASE_CONTROL_FILES) {
+		for (const file of REQUIRED_CORE_RELEASE_FILES) {
+			assert.ok(RELEASE_MODULE_FILES.includes(file), `required publication control ${file} must remain present`);
+		}
+		for (const file of RELEASE_MODULE_FILES) {
 			assert.equal(isAnalyzed(config, file), true, `CodeQL must analyze publication control ${file}`);
 		}
 
@@ -100,7 +108,7 @@ describe("release static-analysis ownership", () => {
 		}
 	});
 
-	it("strictly type-checks exactly the four release-control modules", () => {
+	it("strictly type-checks every release-control module", () => {
 		const config = readJson<ReleaseTsConfig>(RELEASE_TSCONFIG_PATH);
 		assert.equal(config.compilerOptions?.allowJs, true, "release type-check must load JavaScript modules");
 		assert.equal(config.compilerOptions?.checkJs, true, "release JavaScript must receive type diagnostics");
@@ -108,8 +116,8 @@ describe("release static-analysis ownership", () => {
 		assert.equal(config.compilerOptions?.strict, true, "publication controls require strict checking");
 		assert.deepEqual(
 			[...(config.files ?? [])].sort(),
-			[...RELEASE_CONTROL_FILES].sort(),
-			"the dedicated config must explicitly own the complete release-control graph",
+			RELEASE_MODULE_FILES,
+			"the dedicated config must explicitly own every current release module",
 		);
 		assert.equal(config.include, undefined, "the narrow release config must not acquire unrelated files through include globs");
 	});

--- a/tests/unit/core/release-static-analysis-ownership.unit.test.ts
+++ b/tests/unit/core/release-static-analysis-ownership.unit.test.ts
@@ -1,0 +1,141 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, it } from "vitest";
+import YAML from "yaml";
+
+const RELEASE_CONTROL_FILES = [
+	"scripts/release/changelog-section.mjs",
+	"scripts/release/dist-tag-guard.mjs",
+	"scripts/release/release-contract.mjs",
+	"scripts/release/validate-release-commit.mjs",
+] as const;
+
+const CODEQL_CONFIG_PATH = resolve(process.cwd(), ".github/codeql/codeql-config.yml");
+const RELEASE_TSCONFIG_PATH = resolve(process.cwd(), "tsconfig.release.json");
+const PACKAGE_JSON_PATH = resolve(process.cwd(), "package.json");
+
+interface CodeQlConfig {
+	paths?: string[];
+	"paths-ignore"?: string[];
+}
+
+interface ReleaseTsConfig {
+	compilerOptions?: Record<string, unknown>;
+	files?: string[];
+	include?: string[];
+}
+
+interface WorkflowStep {
+	name?: string;
+	run?: string;
+}
+
+interface Workflow {
+	jobs?: Record<string, { steps?: WorkflowStep[] }>;
+}
+
+function readJson<T>(path: string): T {
+	return JSON.parse(readFileSync(path, "utf8")) as T;
+}
+
+/** Match the documented CodeQL path-filter subset used by this repository. */
+function codeQlPatternMatches(file: string, rawPattern: string): boolean {
+	const normalize = (value: string): string => value.replaceAll("\\", "/").replace(/^\.\//, "").replace(/\/$/, "");
+	const path = normalize(file);
+	const pattern = normalize(rawPattern);
+	if (!pattern.includes("*")) return path === pattern || path.startsWith(`${pattern}/`);
+
+	const pathSegments = path.split("/");
+	const patternSegments = pattern.split("/");
+	const matchFrom = (patternIndex: number, pathIndex: number): boolean => {
+		if (patternIndex === patternSegments.length) return pathIndex === pathSegments.length;
+		const segment = patternSegments[patternIndex];
+		if (segment === "**") {
+			if (patternIndex === patternSegments.length - 1) return true;
+			for (let next = pathIndex; next <= pathSegments.length; next += 1) {
+				if (matchFrom(patternIndex + 1, next)) return true;
+			}
+			return false;
+		}
+		if (pathIndex === pathSegments.length) return false;
+		const expression = new RegExp(
+			`^${segment.replace(/[.+^${}()|[\]\\]/g, "\\$&").replaceAll("*", "[^/]*")}$`,
+		);
+		return expression.test(pathSegments[pathIndex]) && matchFrom(patternIndex + 1, pathIndex + 1);
+	};
+	return matchFrom(0, 0);
+}
+
+function isAnalyzed(config: CodeQlConfig, file: string): boolean {
+	const included = !config.paths || config.paths.length === 0 || config.paths.some(pattern => codeQlPatternMatches(file, pattern));
+	const ignored = (config["paths-ignore"] ?? []).some(pattern => codeQlPatternMatches(file, pattern));
+	return included && !ignored;
+}
+
+function workflowStep(path: string, jobName: string, stepName: string): WorkflowStep {
+	const workflow = YAML.parse(readFileSync(resolve(process.cwd(), path), "utf8")) as Workflow;
+	const step = workflow.jobs?.[jobName]?.steps?.find(candidate => candidate.name === stepName);
+	assert.ok(step, `${path} must retain ${jobName}'s ${stepName} step`);
+	return step;
+}
+
+describe("release static-analysis ownership", () => {
+	it("keeps release controls in CodeQL while excluding ordinary tooling and test assets", () => {
+		const config = YAML.parse(readFileSync(CODEQL_CONFIG_PATH, "utf8")) as CodeQlConfig;
+
+		for (const file of RELEASE_CONTROL_FILES) {
+			assert.equal(isAnalyzed(config, file), true, `CodeQL must analyze publication control ${file}`);
+		}
+
+		for (const file of [
+			"scripts/build-server.mjs",
+			"scripts/benchmarks/event-stream/fixture.mjs",
+			"scripts/testing/check-layout.mjs",
+			"tests/unit/core/example.unit.test.ts",
+			"tests/support/fixtures/release/example.json",
+			"tools/dummy-aigw/server.js",
+		]) {
+			assert.equal(isAnalyzed(config, file), false, `CodeQL must continue excluding non-production path ${file}`);
+		}
+	});
+
+	it("strictly type-checks exactly the four release-control modules", () => {
+		const config = readJson<ReleaseTsConfig>(RELEASE_TSCONFIG_PATH);
+		assert.equal(config.compilerOptions?.allowJs, true, "release type-check must load JavaScript modules");
+		assert.equal(config.compilerOptions?.checkJs, true, "release JavaScript must receive type diagnostics");
+		assert.equal(config.compilerOptions?.noEmit, true, "release checking must not rewrite runtime modules");
+		assert.equal(config.compilerOptions?.strict, true, "publication controls require strict checking");
+		assert.deepEqual(
+			[...(config.files ?? [])].sort(),
+			[...RELEASE_CONTROL_FILES].sort(),
+			"the dedicated config must explicitly own the complete release-control graph",
+		);
+		assert.equal(config.include, undefined, "the narrow release config must not acquire unrelated files through include globs");
+	});
+
+	it("routes the release type-check through npm check inherited by PR and publish verification", () => {
+		const packageJson = readJson<{ scripts?: Record<string, string> }>(PACKAGE_JSON_PATH);
+		const check = packageJson.scripts?.check ?? "";
+		assert.match(
+			check,
+			/(?:^|&&)\s*tsc\s+-p\s+tsconfig\.release\.json(?:\s|$)/,
+			"npm run check must invoke the dedicated release-control config",
+		);
+		assert.equal(
+			(check.match(/tsconfig\.release\.json/g) ?? []).length,
+			1,
+			"npm run check must have one authoritative release type-check",
+		);
+		assert.equal(
+			workflowStep(".github/workflows/build-unit-gate.yml", "verify", "Type-check").run,
+			"npm run check",
+			"the PR build gate must inherit release checking from npm run check",
+		);
+		assert.equal(
+			workflowStep(".github/workflows/release-publish.yml", "verify", "Type-check").run,
+			"npm run check",
+			"post-merge release verification must inherit release checking before publication",
+		);
+	});
+});

--- a/tsconfig.release.json
+++ b/tsconfig.release.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022"],
+    "types": ["node"],
+    "allowJs": true,
+    "checkJs": true,
+    "noEmit": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true
+  },
+  "files": [
+    "scripts/release/dist-tag-guard.mjs",
+    "scripts/release/release-contract.mjs",
+    "scripts/release/validate-release-commit.mjs",
+    "scripts/release/changelog-section.mjs"
+  ]
+}


### PR DESCRIPTION
## Summary
- restore CodeQL analysis for npm release-control scripts while keeping development tooling excluded
- add strict checkJs coverage for the four-module release graph through npm run check
- pin CI/static-analysis ownership with focused tests and document the publication control-plane boundary

## Validation
- workflow implementation gate: build, type check, unit, browser, E2E, code review, bug review, and security review passed
- focused release type-check and ownership regression passed

🤖 Generated with [Bobbit](https://github.com/SuuBro/bobbit)